### PR TITLE
rosdistro sync, Fri Sep 12 12:59:29 2025

### DIFF
--- a/distros/humble/compressed-depth-image-transport/default.nix
+++ b/distros/humble/compressed-depth-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-humble-compressed-depth-image-transport";
-  version = "2.5.3-r1";
+  version = "2.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/humble/compressed_depth_image_transport/2.5.3-1.tar.gz";
-    name = "2.5.3-1.tar.gz";
-    sha256 = "6638e8f3a835bd9a1307720ffcb73be6a030384712d621efe8edf8690cd40619";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/humble/compressed_depth_image_transport/2.5.4-1.tar.gz";
+    name = "2.5.4-1.tar.gz";
+    sha256 = "80ef886f2692cae7d8d617453acfd906e118de09c41c54a46a49b467f4e07ec6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/compressed-image-transport/default.nix
+++ b/distros/humble/compressed-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-humble-compressed-image-transport";
-  version = "2.5.3-r1";
+  version = "2.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/humble/compressed_image_transport/2.5.3-1.tar.gz";
-    name = "2.5.3-1.tar.gz";
-    sha256 = "dd5064a50d23ac0d31d0407c9943a1b7fad63e3265e88a4bdfaf09f3e751bd4a";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/humble/compressed_image_transport/2.5.4-1.tar.gz";
+    name = "2.5.4-1.tar.gz";
+    sha256 = "e25838caaf802588c7e9ef9c69bbda85bc8745390fd22952cd96f35d2b8850f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dynamixel-hardware-interface/default.nix
+++ b/distros/humble/dynamixel-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-interfaces, dynamixel-sdk, hardware-interface, pluginlib, rclcpp, realtime-tools, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-dynamixel-hardware-interface";
-  version = "1.4.13-r1";
+  version = "1.4.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/humble/dynamixel_hardware_interface/1.4.13-1.tar.gz";
-    name = "1.4.13-1.tar.gz";
-    sha256 = "fee268ccc6d5d89d8546a5d1b0f631bdaca1fd4ae1ee3862c3bc72e35ae3fa50";
+    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/humble/dynamixel_hardware_interface/1.4.14-1.tar.gz";
+    name = "1.4.14-1.tar.gz";
+    sha256 = "1497aa4655cfe36f31b9cfaa74bad267c24b5aaef8c1186ba15e488e4ef5b9eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -2202,6 +2202,8 @@ self: super: {
 
  nerian-stereo = self.callPackage ./nerian-stereo {};
 
+ network-bridge = self.callPackage ./network-bridge {};
+
  network-interface = self.callPackage ./network-interface {};
 
  nicla-vision-ros2 = self.callPackage ./nicla-vision-ros2 {};
@@ -3503,6 +3505,10 @@ self: super: {
  tf2-sensor-msgs = self.callPackage ./tf2-sensor-msgs {};
 
  tf2-tools = self.callPackage ./tf2-tools {};
+
+ tf2-web-republisher = self.callPackage ./tf2-web-republisher {};
+
+ tf2-web-republisher-interfaces = self.callPackage ./tf2-web-republisher-interfaces {};
 
  tf-transformations = self.callPackage ./tf-transformations {};
 

--- a/distros/humble/image-transport-plugins/default.nix
+++ b/distros/humble/image-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, compressed-depth-image-transport, compressed-image-transport, theora-image-transport }:
 buildRosPackage {
   pname = "ros-humble-image-transport-plugins";
-  version = "2.5.3-r1";
+  version = "2.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/humble/image_transport_plugins/2.5.3-1.tar.gz";
-    name = "2.5.3-1.tar.gz";
-    sha256 = "da360e3b5e25680fcfb00b9e99ae20a5649117881924fae3be39a40ee2f9d697";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/humble/image_transport_plugins/2.5.4-1.tar.gz";
+    name = "2.5.4-1.tar.gz";
+    sha256 = "aa521fc469bd306b3d4b871b88eb188e1d0256ed88acfd972f6571f374a9256a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/libmavconn/default.nix
+++ b/distros/humble/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-libmavconn";
-  version = "2.10.1-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/libmavconn/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "56acf5403a076f70d5b76b6d16b99cc5e3f4c2bf232983998aa14bb4a7667c09";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/libmavconn/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "5e5273da2f8e57fda3ce0f8e0ca9636e23d803d1d26f8bcea8a59fb51aa557f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mavlink/default.nix
+++ b/distros/humble/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mavlink";
-  version = "2025.6.6-r1";
+  version = "2025.9.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/humble/mavlink/2025.6.6-1.tar.gz";
-    name = "2025.6.6-1.tar.gz";
-    sha256 = "104b9d77c7bb7e3f73846ef9578bb26244b51c98ec3792cd79e427bddc0d431a";
+    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/humble/mavlink/2025.9.9-1.tar.gz";
+    name = "2025.9.9-1.tar.gz";
+    sha256 = "7f6fc5fbf50663ba4226dc614ae1b93fbf2ff7e3b72ece964195cef2fcf0c140";
   };
 
   buildType = "cmake";

--- a/distros/humble/mavros-extras/default.nix
+++ b/distros/humble/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-mavros-extras";
-  version = "2.10.1-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros_extras/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "992f5531e664a4ea888d043afe06e1b512d124b9c2d15548cc09d3e41027a7fb";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros_extras/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "753438921360ae4ea707c02ef11ed2a3695e057ac0a311fcbf50c0f35dd9f6f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mavros-msgs/default.nix
+++ b/distros/humble/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-mavros-msgs";
-  version = "2.10.1-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros_msgs/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "0ef29ea5717f92db4ca6b92c43777925fe8924412ad6502b4fb5424cdbcd315c";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros_msgs/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "e44ce041147be3ad10ccfac0e6657819340995b3208fae5f9e5a7a7135b9d78f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mavros/default.nix
+++ b/distros/humble/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-mavros";
-  version = "2.10.1-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "4565c881f2131178fc479110a9b691fc2047e88d3fa5038ba1b2d305c2f64c3b";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "57fc8d066c0f3cd9145cead3c0054cd22cd1dc603ba77695d6047b7457621466";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-common/default.nix
+++ b/distros/humble/mola-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-common";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/humble/mola_common/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "ad4ff1775446f1de973cc46622f6a823bae4a31ad500ab3d6698897e70647961";
+    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/humble/mola_common/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "5bd5e3311be10943cb871f38ffd931bfb2a4c37dce7c85e98823206cf22abf1e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-imu-preintegration/default.nix
+++ b/distros/humble/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-imu-preintegration";
-  version = "1.9.0-r1";
+  version = "1.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_imu_preintegration/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "b39fbf41327f5ce8fd6d3c9e2c0d3b306587d7a682dc66fb8d04c9eea615629f";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_imu_preintegration/1.10.0-1.tar.gz";
+    name = "1.10.0-1.tar.gz";
+    sha256 = "d672fb6219649681acb4b59d910847ba2bccc71e17c6d5a4e6417bbc19fb97c4";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-state-estimation-simple/default.nix
+++ b/distros/humble/mola-state-estimation-simple/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-state-estimation-simple";
-  version = "1.9.0-r1";
+  version = "1.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation_simple/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "8ea046f2baa1049346c9bc2736a68cac40eb24038b87952ba6d6acf3a12d9222";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation_simple/1.10.0-1.tar.gz";
+    name = "1.10.0-1.tar.gz";
+    sha256 = "271a62d1b31ad7579e4b151bae1b1cac20beb925973b764c50a1008c98d92374";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-state-estimation-smoother/default.nix
+++ b/distros/humble/mola-state-estimation-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-state-estimation-smoother";
-  version = "1.9.0-r1";
+  version = "1.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation_smoother/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "2bfb0ea6cd23aada2c1c649cd0bdcd3b8f30e2b01d635f04325b567a9b64dc15";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation_smoother/1.10.0-1.tar.gz";
+    name = "1.10.0-1.tar.gz";
+    sha256 = "969dcf04b578c622a0d653dc6d689a3ccd500bfd8c4a1f481981a833140b83c5";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-state-estimation/default.nix
+++ b/distros/humble/mola-state-estimation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, mola-imu-preintegration, mola-state-estimation-simple, mola-state-estimation-smoother }:
 buildRosPackage {
   pname = "ros-humble-mola-state-estimation";
-  version = "1.9.0-r1";
+  version = "1.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "7205ab1c9991de6d88709a9bc5401a9f36fcb49119589ad00e5cb931f81dac35";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation/1.10.0-1.tar.gz";
+    name = "1.10.0-1.tar.gz";
+    sha256 = "24d6a5075b49f0b6bd1c93c6ae0042385f8a78a32ddbab875a6be4e1cdefb3bd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/network-bridge/default.nix
+++ b/distros/humble/network-bridge/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, boost, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pkg-config, pluginlib, rclcpp, std-msgs, zstd }:
+buildRosPackage {
+  pname = "ros-humble-network-bridge";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/network_bridge-release/archive/release/humble/network_bridge/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "c44d9814a1db59897dd9a9b5bb017d7028dacdc2155dddb839000e8d8b22ad91";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake pkg-config ];
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common launch-testing launch-testing-ament-cmake launch-testing-ros ];
+  propagatedBuildInputs = [ boost pluginlib rclcpp std-msgs zstd ];
+  nativeBuildInputs = [ ament-cmake pkg-config ];
+
+  meta = {
+    description = "Allows for arbitrary network links (UDP, TCP, etc) to bridge ROS2 messages";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/rclcpp-action/default.nix
+++ b/distros/humble/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclcpp-action";
-  version = "16.0.14-r1";
+  version = "16.0.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_action/16.0.14-1.tar.gz";
-    name = "16.0.14-1.tar.gz";
-    sha256 = "875dad0e4b524953d4132cd41e6f1ba32d2680989da0adb13d365bdda75b73b6";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_action/16.0.15-1.tar.gz";
+    name = "16.0.15-1.tar.gz";
+    sha256 = "47c3b8026320fa3276ab04f9507169b1545b8c9b7bd530124002dd381ddc0a20";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclcpp-components/default.nix
+++ b/distros/humble/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclcpp-components";
-  version = "16.0.14-r1";
+  version = "16.0.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_components/16.0.14-1.tar.gz";
-    name = "16.0.14-1.tar.gz";
-    sha256 = "743d6c42678a2268b5f45cc90e8fbf1fc10e4a3cc623ebe3cb69a8d0ccbce451";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_components/16.0.15-1.tar.gz";
+    name = "16.0.15-1.tar.gz";
+    sha256 = "c155c56dce991b6f0e207977b0d0d7f36b27f1162ec9b5dd30a9a1fd2dca135a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclcpp-lifecycle/default.nix
+++ b/distros/humble/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclcpp-lifecycle";
-  version = "16.0.14-r1";
+  version = "16.0.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_lifecycle/16.0.14-1.tar.gz";
-    name = "16.0.14-1.tar.gz";
-    sha256 = "ea1871c99737831befba444a713a8d5ba5780ec3b1e88d68f5d1e2831a54910a";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_lifecycle/16.0.15-1.tar.gz";
+    name = "16.0.15-1.tar.gz";
+    sha256 = "051e9f392c23720e8e023ddf22bf070ee9ab659dc73b8b534c4cb0c2be42d2bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclcpp/default.nix
+++ b/distros/humble/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-humble-rclcpp";
-  version = "16.0.14-r1";
+  version = "16.0.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp/16.0.14-1.tar.gz";
-    name = "16.0.14-1.tar.gz";
-    sha256 = "5c5cbaff961023dc11693eaea1fb3474ebe2fc3fb672a70660c8f96e6cfd31ea";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp/16.0.15-1.tar.gz";
+    name = "16.0.15-1.tar.gz";
+    sha256 = "8d5df359fe1bba54028ad822a941a137f04eb6196de20b117cf5ae9b26c4f549";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmw-zenoh-cpp/default.nix
+++ b/distros/humble/rmw-zenoh-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, fastcdr, rcpputils, rcutils, rmw, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, tracetools, zenoh-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rmw-zenoh-cpp";
-  version = "0.1.5-r1";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/humble/rmw_zenoh_cpp/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "0e7c5e67047b1ed421a2298ac5b0e22b2d57c2b15e9d9c5e6fceea4abd5f8dc5";
+    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/humble/rmw_zenoh_cpp/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "b348b6fabb8f49dfc636ebdf53a910059c3fd06a809fd4768bc2cfb1c70697fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2action/default.nix
+++ b/distros/humble/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2action";
-  version = "0.18.13-r1";
+  version = "0.18.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2action/0.18.13-1.tar.gz";
-    name = "0.18.13-1.tar.gz";
-    sha256 = "6dcb687c64656194591360d458c8638f413b9a5d3b6e70b8eab802bf4c9cc1b1";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2action/0.18.14-1.tar.gz";
+    name = "0.18.14-1.tar.gz";
+    sha256 = "e31162d0455bf8ccd903a3861a91b6b762415d124165c46ad73a4490b7028f78";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2cli-test-interfaces/default.nix
+++ b/distros/humble/ros2cli-test-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-ros2cli-test-interfaces";
-  version = "0.18.13-r1";
+  version = "0.18.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2cli_test_interfaces/0.18.13-1.tar.gz";
-    name = "0.18.13-1.tar.gz";
-    sha256 = "5284fc4922b6b88858d8fd95a85391434df89c5f00ba833835a72f5cba6a9a09";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2cli_test_interfaces/0.18.14-1.tar.gz";
+    name = "0.18.14-1.tar.gz";
+    sha256 = "9d6374c3bdfba2407bdb6ccab3fcce3a75cd8f1c63a2be16b4d02c445c239c1b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2cli/default.nix
+++ b/distros/humble/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, rclpy, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2cli";
-  version = "0.18.13-r1";
+  version = "0.18.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2cli/0.18.13-1.tar.gz";
-    name = "0.18.13-1.tar.gz";
-    sha256 = "e5c1eca2812ce7e55bda8071cd5e8a3dff7fb19803e0046ebc9325827697fcbd";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2cli/0.18.14-1.tar.gz";
+    name = "0.18.14-1.tar.gz";
+    sha256 = "ca2098e5755532cf764607edc65044b040875d638100b456b47658c3e6ed20f4";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2component/default.nix
+++ b/distros/humble/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, python3Packages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-humble-ros2component";
-  version = "0.18.13-r1";
+  version = "0.18.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2component/0.18.13-1.tar.gz";
-    name = "0.18.13-1.tar.gz";
-    sha256 = "63ff33349dcd3e90aed7d391f572e4db297452588d1f695d184923bdbb690b60";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2component/0.18.14-1.tar.gz";
+    name = "0.18.14-1.tar.gz";
+    sha256 = "47fb0562d3e8fb1c3236f9f0ab62eb8c72310706ff106737bdaf4525df8f6118";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2doctor/default.nix
+++ b/distros/humble/ros2doctor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros-environment, ros2cli, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2doctor";
-  version = "0.18.13-r1";
+  version = "0.18.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2doctor/0.18.13-1.tar.gz";
-    name = "0.18.13-1.tar.gz";
-    sha256 = "8d7a03904cc19f0310ea3353a7956f24173ce4ae077bba6aa667e4f7803df3f1";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2doctor/0.18.14-1.tar.gz";
+    name = "0.18.14-1.tar.gz";
+    sha256 = "1757be7f7b415ee24e419d1881fd88332ddfceb504c2e4b665357bae10db6153";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2interface/default.nix
+++ b/distros/humble/ros2interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, ros2cli, ros2cli-test-interfaces, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2interface";
-  version = "0.18.13-r1";
+  version = "0.18.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2interface/0.18.13-1.tar.gz";
-    name = "0.18.13-1.tar.gz";
-    sha256 = "503f8c48ba11decbc6046654a16229622f9d882d9fb4e4ce355c8b741e56bd0d";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2interface/0.18.14-1.tar.gz";
+    name = "0.18.14-1.tar.gz";
+    sha256 = "befd2f1695f2640a7e51079498ec79aa7f18f8a3771de1d0177e11850f11a3a6";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2lifecycle-test-fixtures/default.nix
+++ b/distros/humble/ros2lifecycle-test-fixtures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-humble-ros2lifecycle-test-fixtures";
-  version = "0.18.13-r1";
+  version = "0.18.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2lifecycle_test_fixtures/0.18.13-1.tar.gz";
-    name = "0.18.13-1.tar.gz";
-    sha256 = "61c180143116c30619f5411bb18d463c60111426358f7e5f494b29c5b30e2e42";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2lifecycle_test_fixtures/0.18.14-1.tar.gz";
+    name = "0.18.14-1.tar.gz";
+    sha256 = "c96a5cca8cc724da380fcee4d3b68e4257529ba00f12cfcc4f4aa027c3867af9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2lifecycle/default.nix
+++ b/distros/humble/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, lifecycle-msgs, python3Packages, rclpy, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-humble-ros2lifecycle";
-  version = "0.18.13-r1";
+  version = "0.18.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2lifecycle/0.18.13-1.tar.gz";
-    name = "0.18.13-1.tar.gz";
-    sha256 = "836ff43d02a8c1792ce37d68f277b4ae66b596e4609cd50a472d355b58cbb1eb";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2lifecycle/0.18.14-1.tar.gz";
+    name = "0.18.14-1.tar.gz";
+    sha256 = "e2a93e64b28141939c6bfbe39f83199dc76ea72d9036f590a2317e0b5e4100ce";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2multicast/default.nix
+++ b/distros/humble/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, ros2cli }:
 buildRosPackage {
   pname = "ros-humble-ros2multicast";
-  version = "0.18.13-r1";
+  version = "0.18.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2multicast/0.18.13-1.tar.gz";
-    name = "0.18.13-1.tar.gz";
-    sha256 = "9c30a470855fe50369a1f6066cd34d4db924ac29471795e2a292f9feacc6c163";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2multicast/0.18.14-1.tar.gz";
+    name = "0.18.14-1.tar.gz";
+    sha256 = "3cea5012409558a97db7463e869089a1c73be479ed2eee528e77f5c55422ca93";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2node/default.nix
+++ b/distros/humble/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2node";
-  version = "0.18.13-r1";
+  version = "0.18.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2node/0.18.13-1.tar.gz";
-    name = "0.18.13-1.tar.gz";
-    sha256 = "3fb4bf5bdd0075fa5d2fde338e7dc88f146e7543846183bf7cfa3d22fd32893e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2node/0.18.14-1.tar.gz";
+    name = "0.18.14-1.tar.gz";
+    sha256 = "f0707b6e2717d25978062cdb6e2f60d75cf8299d0b4abf070ddadb061565c9f2";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2param/default.nix
+++ b/distros/humble/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-humble-ros2param";
-  version = "0.18.13-r1";
+  version = "0.18.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2param/0.18.13-1.tar.gz";
-    name = "0.18.13-1.tar.gz";
-    sha256 = "92827ce7c7903dee6f889247a90fdc43bbb58b0902a52560ae18f079645f20b9";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2param/0.18.14-1.tar.gz";
+    name = "0.18.14-1.tar.gz";
+    sha256 = "6b9071f876288ac422a23a66dbdf8b7f902f22fccaaedde96f1b823cc507b9f2";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2pkg/default.nix
+++ b/distros/humble/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, ros2cli }:
 buildRosPackage {
   pname = "ros-humble-ros2pkg";
-  version = "0.18.13-r1";
+  version = "0.18.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2pkg/0.18.13-1.tar.gz";
-    name = "0.18.13-1.tar.gz";
-    sha256 = "fe9fef0839fc1781818314cb8ed05b8576f3baad65b5ec063f2100aa3e19f240";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2pkg/0.18.14-1.tar.gz";
+    name = "0.18.14-1.tar.gz";
+    sha256 = "d814eda43f23286abce1c0b3b54737814753a23611f6bb027a588cbbd7a59c72";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2run/default.nix
+++ b/distros/humble/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-humble-ros2run";
-  version = "0.18.13-r1";
+  version = "0.18.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2run/0.18.13-1.tar.gz";
-    name = "0.18.13-1.tar.gz";
-    sha256 = "1d11025836150c106f790bd6a4c189aea8a0517c728946409a12985a1bc493ae";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2run/0.18.14-1.tar.gz";
+    name = "0.18.14-1.tar.gz";
+    sha256 = "7574038c52a25dccb08f7f590aeb6d7a5c561a07bc65155346c030ce925b425c";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2service/default.nix
+++ b/distros/humble/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2service";
-  version = "0.18.13-r1";
+  version = "0.18.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2service/0.18.13-1.tar.gz";
-    name = "0.18.13-1.tar.gz";
-    sha256 = "51e0d915124b8130a8e280cdabb9348ae385d42d04bb88e5c465c7a2d1e3e2bd";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2service/0.18.14-1.tar.gz";
+    name = "0.18.14-1.tar.gz";
+    sha256 = "76e569b13e58b2a76fe0c623217c3e8dd94214d4d1ab60c39bce20ed57a7108b";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2topic/default.nix
+++ b/distros/humble/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosgraph-msgs, rosidl-runtime-py, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2topic";
-  version = "0.18.13-r1";
+  version = "0.18.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2topic/0.18.13-1.tar.gz";
-    name = "0.18.13-1.tar.gz";
-    sha256 = "82895f9e084eeb9433263f9d6590e08fe131762201a87f8df7e328842f7b06c7";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2topic/0.18.14-1.tar.gz";
+    name = "0.18.14-1.tar.gz";
+    sha256 = "459b0f9bb7db8b4126443d726d27fd2c96fb5f6977c71dacf3e4cc00d1d69c9c";
   };
 
   buildType = "ament_python";

--- a/distros/humble/tf2-web-republisher-interfaces/default.nix
+++ b/distros/humble/tf2-web-republisher-interfaces/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-humble-tf2-web-republisher-interfaces";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/tf2_web_republisher-release/archive/release/humble/tf2_web_republisher_interfaces/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "c0f46d7d987eb2e0a805b258e4b16d95d93292a02b33236a9fddd5fe290581e1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces geometry-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Interface definitions for tf2_web_republisher";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/tf2-web-republisher/default.nix
+++ b/distros/humble/tf2-web-republisher/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, geometry-msgs, rclcpp, rclcpp-action, rclcpp-components, tf2, tf2-ros, tf2-web-republisher-interfaces }:
+buildRosPackage {
+  pname = "ros-humble-tf2-web-republisher";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/tf2_web_republisher-release/archive/release/humble/tf2_web_republisher/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "17709304ed22b173edca1c675d03b40e7db523b5946ca88985e1ef543f09bf7e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gmock ];
+  propagatedBuildInputs = [ geometry-msgs rclcpp rclcpp-action rclcpp-components tf2 tf2-ros tf2-web-republisher-interfaces ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Republishing of Selected TFs";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/theora-image-transport/default.nix
+++ b/distros/humble/theora-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, cv-bridge, image-transport, libogg, libtheora, opencv, pkg-config, pluginlib, rclcpp, rcutils, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-theora-image-transport";
-  version = "2.5.3-r1";
+  version = "2.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/humble/theora_image_transport/2.5.3-1.tar.gz";
-    name = "2.5.3-1.tar.gz";
-    sha256 = "8363d257c8b4a68a202bc5bd16657ef8a907267e6e43fd3604d79670f26e130f";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/humble/theora_image_transport/2.5.4-1.tar.gz";
+    name = "2.5.4-1.tar.gz";
+    sha256 = "d362b8d8732aac82cc134fa7faf1cb821d3de888036f2f4e511cec483b3ab9ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/zenoh-cpp-vendor/default.nix
+++ b/distros/humble/zenoh-cpp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, cargo, clang, git }:
 buildRosPackage {
   pname = "ros-humble-zenoh-cpp-vendor";
-  version = "0.1.5-r1";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/humble/zenoh_cpp_vendor/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "880cbb781e8214068597141c22545df1ba2752fd28f8ac3540b2dd057b5a4bd8";
+    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/humble/zenoh_cpp_vendor/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "b976b32af2b8090c11e6823376baa06f97244a7caed0bbcda5e11a40b64a84eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/zenoh-security-tools/default.nix
+++ b/distros/humble/zenoh-security-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, nlohmann_json, rcpputils, rcutils, rmw, rmw-dds-common, tinyxml2-vendor, zenoh-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-zenoh-security-tools";
-  version = "0.1.5-r1";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/humble/zenoh_security_tools/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "cbea9dbd1ad23ba217027dcdb242a17a73bb96f9298122404b1463ab5feb8e59";
+    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/humble/zenoh_security_tools/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "c0f02cff9597ed7776e6b2a8dba965f084c01ad3e88d0fa5546056f4f05eba41";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-bt-joy/default.nix
+++ b/distros/jazzy/clearpath-bt-joy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, bluez, joy-linux, python3Packages, twist-mux }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-bt-joy";
-  version = "2.7.0-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bt_joy/2.7.0-1.tar.gz";
-    name = "2.7.0-1.tar.gz";
-    sha256 = "51e76061943d0c49248ca5948bccfc6345b6859fb4245e319b49b0cd5219fbf3";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bt_joy/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "01e4581cfcbf15a7291e0b554317c7caca5b90f20bebd0fa8708b9586e75bdf0";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/clearpath-common/default.nix
+++ b/distros/jazzy/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-common";
-  version = "2.7.0-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_common/2.7.0-1.tar.gz";
-    name = "2.7.0-1.tar.gz";
-    sha256 = "3a7011ef6415078f48b053bae94ea622184069a3ee733b2cbeafa9d586e528fd";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_common/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "6ceb5b05b36ec96ee2b59c2c52849bb84fb92e6870d99858e0fd3ec58ac57c26";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-config/default.nix
+++ b/distros/jazzy/clearpath-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-config";
-  version = "2.7.0-r1";
+  version = "2.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/jazzy/clearpath_config/2.7.0-1.tar.gz";
-    name = "2.7.0-1.tar.gz";
-    sha256 = "ffb7665ce273ec61dab464fdc21661fbfeb3c0b58f6784c06676c3397c3591b1";
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/jazzy/clearpath_config/2.7.1-1.tar.gz";
+    name = "2.7.1-1.tar.gz";
+    sha256 = "81640466e07f5d28bec074ce2dca33a69552fcf1256198de99b2e93b5b940106";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/clearpath-control/default.nix
+++ b/distros/jazzy/clearpath-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-bt-joy, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, mecanum-drive-controller, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-control";
-  version = "2.7.0-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_control/2.7.0-1.tar.gz";
-    name = "2.7.0-1.tar.gz";
-    sha256 = "338484874fc73ac5457cfa7c09e0e2d9fe4ad82c0cffd9e5f5134399cd302099";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_control/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "dee7064ae16cc0ce5f0e7741ce5dc216a6f7a1740bc580344d4f4f17d5fc4fbe";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-customization/default.nix
+++ b/distros/jazzy/clearpath-customization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-customization";
-  version = "2.7.0-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_customization/2.7.0-1.tar.gz";
-    name = "2.7.0-1.tar.gz";
-    sha256 = "e772e854685037c2cabcb1da8188a76b0920e0e8ada0b7f14689d4cd8b993436";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_customization/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "91a1033aac648962f06ce390d851e46d3bc658dc9f51e2596dc427d65d7b8444";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-description/default.nix
+++ b/distros/jazzy/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-description";
-  version = "2.7.0-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_description/2.7.0-1.tar.gz";
-    name = "2.7.0-1.tar.gz";
-    sha256 = "d770cf290e2fdb4c591282c7355e940dddf0f35dabd95637f5eab529a16084d5";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_description/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "ab5c1797b93e0bb3759880e335dab8197ec71b2dfed195bdbafafdb0e524a7c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-diagnostics/default.nix
+++ b/distros/jazzy/clearpath-diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-platform-msgs, diagnostic-aggregator, diagnostic-updater, foxglove-bridge, rclcpp, ros2launch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-diagnostics";
-  version = "2.7.0-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_diagnostics/2.7.0-1.tar.gz";
-    name = "2.7.0-1.tar.gz";
-    sha256 = "818c7d4fd24bd57a187171a3368cff66baf34bfe9163fd8e56161f9e89047bf1";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_diagnostics/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "718847deda919dade5053bd67f60fd52e6acf60c41fabfa3a1455544506441a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-generator-common/default.nix
+++ b/distros/jazzy/clearpath-generator-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-diagnostics, clearpath-manipulators, moveit-setup-srdf-plugins }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-generator-common";
-  version = "2.7.0-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_generator_common/2.7.0-1.tar.gz";
-    name = "2.7.0-1.tar.gz";
-    sha256 = "be8523064c068038001118fbc280aee394e410526cda36322193b8773c9bfa85";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_generator_common/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "53843e72579feaa0336a8d6553b34d886c64cf42a90877fde3afff1964542d20";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-manipulators-description/default.nix
+++ b/distros/jazzy/clearpath-manipulators-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ewellix-description, robot-state-publisher, robotiq-description, ur-description, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-manipulators-description";
-  version = "2.7.0-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators_description/2.7.0-1.tar.gz";
-    name = "2.7.0-1.tar.gz";
-    sha256 = "87f26ec13568687c67041ddd944cc228da3d3f1d0e9b20d460a68888548c4094";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators_description/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "2582fd238fd28c164fb75694ac847354b657bbdb851270eb2f02ad8a7bba04f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-manipulators/default.nix
+++ b/distros/jazzy/clearpath-manipulators/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, gripper-controllers, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-warehouse, moveit-setup-srdf-plugins, moveit-simple-controller-manager, position-controllers, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-manipulators";
-  version = "2.7.0-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators/2.7.0-1.tar.gz";
-    name = "2.7.0-1.tar.gz";
-    sha256 = "17840a952b93ce8b35070a8e0954c30d928b3cee5168c7bd62d63f7a7f97e0c1";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "acae321889aefb2141d66e0acc9d3ada077dbf14587622819023da26ef9fb3e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-mounts-description/default.nix
+++ b/distros/jazzy/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-mounts-description";
-  version = "2.7.0-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_mounts_description/2.7.0-1.tar.gz";
-    name = "2.7.0-1.tar.gz";
-    sha256 = "650c5af17b0cccea2337214be2e3bb34cf53828a526a3e686821f8e21866bb67";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_mounts_description/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "4c0777e04e29325a354bd66cf0709438f3048b9d5f6a192fce755ad11934b894";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-nav2-demos/default.nix
+++ b/distros/jazzy/clearpath-nav2-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-config, nav2-bringup, slam-toolbox }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-nav2-demos";
-  version = "2.7.0-r1";
+  version = "2.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_nav2_demos-release/archive/release/jazzy/clearpath_nav2_demos/2.7.0-1.tar.gz";
-    name = "2.7.0-1.tar.gz";
-    sha256 = "2edf2d35855059c19c07296422e9aa2ffd5de132eba9b3c6c9dcf3a867eb0b2a";
+    url = "https://github.com/clearpath-gbp/clearpath_nav2_demos-release/archive/release/jazzy/clearpath_nav2_demos/2.7.1-1.tar.gz";
+    name = "2.7.1-1.tar.gz";
+    sha256 = "cbaab946e64cdcb5b17b670a917b10641223ef416ccaa06e67f4ecef17482e3b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-platform-description/default.nix
+++ b/distros/jazzy/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-platform-description";
-  version = "2.7.0-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_platform_description/2.7.0-1.tar.gz";
-    name = "2.7.0-1.tar.gz";
-    sha256 = "5c5bfb176f7aca3582fed448be99b695d37de4157d3c82983502bd8315d1c33c";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_platform_description/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "6c3301081ad5fb19b0181546fdaf56024b51d42729e83cc29d1912f4190b147a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-sensors-description/default.nix
+++ b/distros/jazzy/clearpath-sensors-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, axis-description, microstrain-inertial-description, realsense2-description, velodyne-description }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-sensors-description";
-  version = "2.7.0-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_sensors_description/2.7.0-1.tar.gz";
-    name = "2.7.0-1.tar.gz";
-    sha256 = "3ddc3b934c673cfe17ace355517ca69700ee58c9127cac4657ed6de66c787efc";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_sensors_description/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "6fe632f1a457074e80fedf3ded3b9bb4c58994769deda0228408410fb9926b2c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/compressed-depth-image-transport/default.nix
+++ b/distros/jazzy/compressed-depth-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-jazzy-compressed-depth-image-transport";
-  version = "4.0.5-r1";
+  version = "4.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/compressed_depth_image_transport/4.0.5-1.tar.gz";
-    name = "4.0.5-1.tar.gz";
-    sha256 = "487c458a1d8bbfbdad95f35c2330512e6d77c693dcacdb09c7612d57254cb488";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/compressed_depth_image_transport/4.0.6-1.tar.gz";
+    name = "4.0.6-1.tar.gz";
+    sha256 = "516d96ecaa8245c124aeb484fa66419f436840bd38e1352e1bbe527689238355";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/compressed-image-transport/default.nix
+++ b/distros/jazzy/compressed-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-jazzy-compressed-image-transport";
-  version = "4.0.5-r1";
+  version = "4.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/compressed_image_transport/4.0.5-1.tar.gz";
-    name = "4.0.5-1.tar.gz";
-    sha256 = "acc9f4c66ec277cec42007bdf2fa5821937f9dbe5f3c43101de9309bd73829cd";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/compressed_image_transport/4.0.6-1.tar.gz";
+    name = "4.0.6-1.tar.gz";
+    sha256 = "b68a6da8db6dd6a53b5a1f46490fe298e8420c7c859f526964904d1d935b5055";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dynamixel-hardware-interface/default.nix
+++ b/distros/jazzy/dynamixel-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-interfaces, dynamixel-sdk, hardware-interface, pluginlib, rclcpp, realtime-tools, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-dynamixel-hardware-interface";
-  version = "1.4.13-r1";
+  version = "1.4.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/jazzy/dynamixel_hardware_interface/1.4.13-1.tar.gz";
-    name = "1.4.13-1.tar.gz";
-    sha256 = "9809f87b327b1869da94ee4a2f0739d2f4c94a7cf4fdb6db6a728838853d52ce";
+    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/jazzy/dynamixel_hardware_interface/1.4.14-1.tar.gz";
+    name = "1.4.14-1.tar.gz";
+    sha256 = "9d3e9f957dba2ab72c073cb41b8bc2da2b7d63b6b6b9421595b19c7c0c716a4b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -2774,6 +2774,8 @@ self: super: {
 
  rti-connext-dds-cmake-module = self.callPackage ./rti-connext-dds-cmake-module {};
 
+ rtsp-image-transport = self.callPackage ./rtsp-image-transport {};
+
  rttest = self.callPackage ./rttest {};
 
  ruckig = self.callPackage ./ruckig {};
@@ -3033,6 +3035,10 @@ self: super: {
  tf2-sensor-msgs = self.callPackage ./tf2-sensor-msgs {};
 
  tf2-tools = self.callPackage ./tf2-tools {};
+
+ tf2-web-republisher = self.callPackage ./tf2-web-republisher {};
+
+ tf2-web-republisher-interfaces = self.callPackage ./tf2-web-republisher-interfaces {};
 
  tf-transformations = self.callPackage ./tf-transformations {};
 

--- a/distros/jazzy/image-transport-plugins/default.nix
+++ b/distros/jazzy/image-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, compressed-depth-image-transport, compressed-image-transport, theora-image-transport, zstd-image-transport }:
 buildRosPackage {
   pname = "ros-jazzy-image-transport-plugins";
-  version = "4.0.5-r1";
+  version = "4.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/image_transport_plugins/4.0.5-1.tar.gz";
-    name = "4.0.5-1.tar.gz";
-    sha256 = "6fd7cea8734c395e30c7ecd2a20d9e98de336cc12e1315f7ce3c8cd95e2cda1d";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/image_transport_plugins/4.0.6-1.tar.gz";
+    name = "4.0.6-1.tar.gz";
+    sha256 = "f72ec18902d5867f362cba7487d74fde868b78a0615068b769ad4b2ee94313e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/libmavconn/default.nix
+++ b/distros/jazzy/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-libmavconn";
-  version = "2.10.1-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/libmavconn/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "bae49c5d3c261c462554608c29a4ab048eb63be740e6946dbf1655019c402e2f";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/libmavconn/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "e1430d92de7c1c9fcb0b206f5d86f15458ff2bbc441149f1be9ca4aa092994c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mavlink/default.nix
+++ b/distros/jazzy/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mavlink";
-  version = "2025.6.6-r1";
+  version = "2025.9.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/jazzy/mavlink/2025.6.6-1.tar.gz";
-    name = "2025.6.6-1.tar.gz";
-    sha256 = "1298be2f9ae940d2bf0d466f312553ce06da2c4b653af3407a8634685d8686ba";
+    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/jazzy/mavlink/2025.9.9-1.tar.gz";
+    name = "2025.9.9-1.tar.gz";
+    sha256 = "0d31c16825c789836ae22058f36b0e05b73ecc4038f38cc3a59efd20285a1a0a";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mavros-extras/default.nix
+++ b/distros/jazzy/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-mavros-extras";
-  version = "2.10.1-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros_extras/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "4abc199e3407f3c6e6e22ade046b8d1da23d50adae86d71688df59eb07569d34";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros_extras/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "6a2c2400b7b719f4f8dd507881f3fcc1911517330727183d8c277abf31ac9ef9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mavros-msgs/default.nix
+++ b/distros/jazzy/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mavros-msgs";
-  version = "2.10.1-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros_msgs/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "f0a034df334e862dd643edb7823b95fa40f8ed865715ac03710e4bc6739413ed";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros_msgs/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "afa70de23081110982b62d8359d057b24991760a19733e5c54f46a583f5d5696";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mavros/default.nix
+++ b/distros/jazzy/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mavros";
-  version = "2.10.1-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "ea6b237570b67b901cb338df4753ca7ec0c42682a2887ca0a3c27368e8d647aa";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "21e87d39c915f83f6a8d8d8bf12a2a2592704a7cdf4d25fdf5e3710948f571f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-common/default.nix
+++ b/distros/jazzy/mola-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-common";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/jazzy/mola_common/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "4c6c18ec031a19940ae6a7ae638b83eb54f1b53181e2d5766f0d68839779ad20";
+    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/jazzy/mola_common/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "731793731d8569033153c55ffcaa80491a84cf5d773d377470df3627ff2fd24d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-imu-preintegration/default.nix
+++ b/distros/jazzy/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-imu-preintegration";
-  version = "1.9.0-r1";
+  version = "1.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_imu_preintegration/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "3276b5d96605541c393d1ff8af5278815e2f22ad97fe070c7989a5fb167e12cf";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_imu_preintegration/1.10.0-1.tar.gz";
+    name = "1.10.0-1.tar.gz";
+    sha256 = "be81ca748f10ba076d05e610da6dbe3c72bf644398d0c710f831d442b1f9c879";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-state-estimation-simple/default.nix
+++ b/distros/jazzy/mola-state-estimation-simple/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-state-estimation-simple";
-  version = "1.9.0-r1";
+  version = "1.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation_simple/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "ef3aff256093b85593542a5dccfd8b9458721e2e3dd6a8222876d80c977423b3";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation_simple/1.10.0-1.tar.gz";
+    name = "1.10.0-1.tar.gz";
+    sha256 = "1d6da955116dfd3966f34dd6aa01d9cb71174b4de227e3c6eed5e7732f8bcffa";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-state-estimation-smoother/default.nix
+++ b/distros/jazzy/mola-state-estimation-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-state-estimation-smoother";
-  version = "1.9.0-r1";
+  version = "1.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation_smoother/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "8798f5fca51a6b734c8a90114fc3702bd21139c7c52bc2b05510c7c00fd9bf10";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation_smoother/1.10.0-1.tar.gz";
+    name = "1.10.0-1.tar.gz";
+    sha256 = "8eb6c0080bb72acd067fd9c82e779c05c59af4f0ae1989cce626a3dcd459e3db";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-state-estimation/default.nix
+++ b/distros/jazzy/mola-state-estimation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, mola-imu-preintegration, mola-state-estimation-simple, mola-state-estimation-smoother }:
 buildRosPackage {
   pname = "ros-jazzy-mola-state-estimation";
-  version = "1.9.0-r1";
+  version = "1.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "2959d175083d627ba601a94c79fff7bd6f8e1e2541ddfae10c8f84e31461d8df";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation/1.10.0-1.tar.gz";
+    name = "1.10.0-1.tar.gz";
+    sha256 = "6bea69846e23db6606ba4a9a5cef6c4eee0d0f012603575d43d388722607f0db";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/network-bridge/default.nix
+++ b/distros/jazzy/network-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, boost, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pkg-config, pluginlib, rclcpp, std-msgs, zstd }:
 buildRosPackage {
   pname = "ros-jazzy-network-bridge";
-  version = "1.0.2-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/network_bridge-release/archive/release/jazzy/network_bridge/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "485f38bfde87b65e4eec39d780ffbd085cd750c1891b3ae87a71b1312cc1b208";
+    url = "https://github.com/ros2-gbp/network_bridge-release/archive/release/jazzy/network_bridge/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "8391c19919ccbce655490a5583d90ca5765d524eba75a60637c320b4e72b1bbb";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/om-gravity-compensation-controller/default.nix
+++ b/distros/jazzy/om-gravity-compensation-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, backward-ros, control-msgs, control-toolbox, controller-interface, generate-parameter-library, hardware-interface, kdl-parser, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, rsl, tl-expected, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-om-gravity-compensation-controller";
-  version = "4.0.7-r1";
+  version = "4.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/om_gravity_compensation_controller/4.0.7-1.tar.gz";
-    name = "4.0.7-1.tar.gz";
-    sha256 = "0d9c632f539554f66841198666ddc5a55ab6ae1e03056a15f1e2215df8fffdf9";
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/om_gravity_compensation_controller/4.0.8-1.tar.gz";
+    name = "4.0.8-1.tar.gz";
+    sha256 = "40ae0f654b31b0b8f1db2d74ea7a93a550a53ba07817581f4d65fd03dbf21bf5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/om-joint-trajectory-command-broadcaster/default.nix
+++ b/distros/jazzy/om-joint-trajectory-command-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, backward-ros, builtin-interfaces, control-msgs, controller-interface, generate-parameter-library, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, sensor-msgs, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-om-joint-trajectory-command-broadcaster";
-  version = "4.0.7-r1";
+  version = "4.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/om_joint_trajectory_command_broadcaster/4.0.7-1.tar.gz";
-    name = "4.0.7-1.tar.gz";
-    sha256 = "97f8724c03074b3cc91aa61de229892d4090c2182f356b6413fd91d320836e92";
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/om_joint_trajectory_command_broadcaster/4.0.8-1.tar.gz";
+    name = "4.0.8-1.tar.gz";
+    sha256 = "d4158599df87725ccc9dcd6219a37b057af542d6612949380ce92a8d472aac52";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/om-spring-actuator-controller/default.nix
+++ b/distros/jazzy/om-spring-actuator-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-om-spring-actuator-controller";
-  version = "4.0.7-r1";
+  version = "4.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/om_spring_actuator_controller/4.0.7-1.tar.gz";
-    name = "4.0.7-1.tar.gz";
-    sha256 = "29b5ec608050ec1b5d90d33706f010573aa156cbc4c759de199ec115d3d450b2";
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/om_spring_actuator_controller/4.0.8-1.tar.gz";
+    name = "4.0.8-1.tar.gz";
+    sha256 = "59927d9232456ec4794e96ef50442713ddcccce92125d2fa262d5b2bc5add977";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/open-manipulator-bringup/default.nix
+++ b/distros/jazzy/open-manipulator-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, dynamixel-hardware-interface, gz-ros2-control, open-manipulator-description, rclpy, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, ros2-control, ros2-controllers, rviz2, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-open-manipulator-bringup";
-  version = "4.0.7-r1";
+  version = "4.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/open_manipulator_bringup/4.0.7-1.tar.gz";
-    name = "4.0.7-1.tar.gz";
-    sha256 = "d57a0c1be07b788b7877c8ef5881049c33313729dddf6583ac72b515d2f7e960";
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/open_manipulator_bringup/4.0.8-1.tar.gz";
+    name = "4.0.8-1.tar.gz";
+    sha256 = "44ebe8dec5240936700f79bd44fd5711b91cf590a2b655507a3b64fd0ea4067e";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/open-manipulator-collision/default.nix
+++ b/distros/jazzy/open-manipulator-collision/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, fcl, kdl-parser, rclcpp, sensor-msgs, std-msgs, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-open-manipulator-collision";
-  version = "4.0.7-r1";
+  version = "4.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/open_manipulator_collision/4.0.7-1.tar.gz";
-    name = "4.0.7-1.tar.gz";
-    sha256 = "eb649c9c34397e30581228e2ed3760bff6f4bcbe43e9edb7f4cfa27f411d1590";
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/open_manipulator_collision/4.0.8-1.tar.gz";
+    name = "4.0.8-1.tar.gz";
+    sha256 = "75ee87945689f274e5742bfb6f7255e17ae7bb660dbbf028376545f611e3591e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/open-manipulator-description/default.nix
+++ b/distros/jazzy/open-manipulator-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, rviz2 }:
 buildRosPackage {
   pname = "ros-jazzy-open-manipulator-description";
-  version = "4.0.7-r1";
+  version = "4.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/open_manipulator_description/4.0.7-1.tar.gz";
-    name = "4.0.7-1.tar.gz";
-    sha256 = "d752bc68336f81a5e004710eada0832ec010e96d8214a44e836b26b133f6e705";
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/open_manipulator_description/4.0.8-1.tar.gz";
+    name = "4.0.8-1.tar.gz";
+    sha256 = "6bdf090743668b9e486641700b41dc3254042905b484bb33633381456d2ee508";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/open-manipulator-gui/default.nix
+++ b/distros/jazzy/open-manipulator-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen3-cmake-module, geometry-msgs, moveit-core, moveit-msgs, moveit-ros-planning, moveit-ros-planning-interface, qt5, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-open-manipulator-gui";
-  version = "4.0.7-r1";
+  version = "4.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/open_manipulator_gui/4.0.7-1.tar.gz";
-    name = "4.0.7-1.tar.gz";
-    sha256 = "8bed860d764b15017333e23b3b9189de29758300acf28306c9545390813a08e4";
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/open_manipulator_gui/4.0.8-1.tar.gz";
+    name = "4.0.8-1.tar.gz";
+    sha256 = "b9f67245fb6c7d37a80c19ab5323dec558129a40575a65ed3668c625646b6490";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/open-manipulator-moveit-config/default.nix
+++ b/distros/jazzy/open-manipulator-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, joint-state-publisher, joint-state-publisher-gui, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, open-manipulator-description, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, tf2-ros, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-open-manipulator-moveit-config";
-  version = "4.0.7-r1";
+  version = "4.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/open_manipulator_moveit_config/4.0.7-1.tar.gz";
-    name = "4.0.7-1.tar.gz";
-    sha256 = "741a18907ac8f8a3e59550f18cb76cb4c4e3ca962c4a98995a80bfcda49cdb77";
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/open_manipulator_moveit_config/4.0.8-1.tar.gz";
+    name = "4.0.8-1.tar.gz";
+    sha256 = "d6a0c99a5d56f99413f967f51131e28cce8e2293a09dd841d84dc5deaa865c65";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/open-manipulator-playground/default.nix
+++ b/distros/jazzy/open-manipulator-playground/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-ros-planning-interface, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-open-manipulator-playground";
-  version = "4.0.7-r1";
+  version = "4.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/open_manipulator_playground/4.0.7-1.tar.gz";
-    name = "4.0.7-1.tar.gz";
-    sha256 = "ad37d262da413f599344a310c8402b6bea72998aabeae5d1f29a3e120d26d179";
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/open_manipulator_playground/4.0.8-1.tar.gz";
+    name = "4.0.8-1.tar.gz";
+    sha256 = "2542d35516ea6981fd50d74ffeac3935d968f1269370f161b2d99b469f8d165d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/open-manipulator-teleop/default.nix
+++ b/distros/jazzy/open-manipulator-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-open-manipulator-teleop";
-  version = "4.0.7-r1";
+  version = "4.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/open_manipulator_teleop/4.0.7-1.tar.gz";
-    name = "4.0.7-1.tar.gz";
-    sha256 = "d3f4a2333570907f0b38946aa4e676da403e52bdeb369ebcf78952570de815ef";
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/open_manipulator_teleop/4.0.8-1.tar.gz";
+    name = "4.0.8-1.tar.gz";
+    sha256 = "89209368acfe4c91ddc4b469a2d2d8048ecd84803a942e24fd5502fe547ab8b7";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/open-manipulator/default.nix
+++ b/distros/jazzy/open-manipulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, om-gravity-compensation-controller, om-joint-trajectory-command-broadcaster, om-spring-actuator-controller, open-manipulator-bringup, open-manipulator-collision, open-manipulator-description, open-manipulator-gui, open-manipulator-moveit-config, open-manipulator-playground, open-manipulator-teleop }:
 buildRosPackage {
   pname = "ros-jazzy-open-manipulator";
-  version = "4.0.7-r1";
+  version = "4.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/open_manipulator/4.0.7-1.tar.gz";
-    name = "4.0.7-1.tar.gz";
-    sha256 = "38ff4c75339db079c02ec74c825f47a943b5ab235c58f4e1ad94b993deb58cc5";
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/open_manipulator/4.0.8-1.tar.gz";
+    name = "4.0.8-1.tar.gz";
+    sha256 = "c2a0a42bb8a0423f07de6193773c792a6ad8d9b5eb7e27572189db54205204f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rclcpp-action/default.nix
+++ b/distros/jazzy/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rclcpp-action";
-  version = "28.1.11-r1";
+  version = "28.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp_action/28.1.11-1.tar.gz";
-    name = "28.1.11-1.tar.gz";
-    sha256 = "f8d400c3c26bfb8bf8ce1608811640733aa74be5be3b2e9cc8df52c7ed22bd2c";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp_action/28.1.12-1.tar.gz";
+    name = "28.1.12-1.tar.gz";
+    sha256 = "f3c98b74bc2695cb678d87b2488d392f79a90f0137df9ea5e0052096e6f60a8d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rclcpp-components/default.nix
+++ b/distros/jazzy/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rclcpp-components";
-  version = "28.1.11-r1";
+  version = "28.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp_components/28.1.11-1.tar.gz";
-    name = "28.1.11-1.tar.gz";
-    sha256 = "8cffdc7f5ff939f20d2113af84a6da9438059b19da9265cae6bd3f89f0294c8d";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp_components/28.1.12-1.tar.gz";
+    name = "28.1.12-1.tar.gz";
+    sha256 = "e76b31d51ae9d128073f02a440995a5a313df338c8906df688184180c5a07b75";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rclcpp-lifecycle/default.nix
+++ b/distros/jazzy/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rclcpp-lifecycle";
-  version = "28.1.11-r1";
+  version = "28.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp_lifecycle/28.1.11-1.tar.gz";
-    name = "28.1.11-1.tar.gz";
-    sha256 = "1798fc31fcff7e0dccbc6bf5984e371424295cf389622684aacd13564cedb8f8";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp_lifecycle/28.1.12-1.tar.gz";
+    name = "28.1.12-1.tar.gz";
+    sha256 = "4ec6374656ecdd326a648d441da93a8636747f8384b83ebd2504a2a0644be9d0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rclcpp/default.nix
+++ b/distros/jazzy/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-jazzy-rclcpp";
-  version = "28.1.11-r1";
+  version = "28.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp/28.1.11-1.tar.gz";
-    name = "28.1.11-1.tar.gz";
-    sha256 = "624a823f751bf5c73b1fe641ffddc9c81115c009a84673132efb3ce941bf88e2";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp/28.1.12-1.tar.gz";
+    name = "28.1.12-1.tar.gz";
+    sha256 = "a2feebdfc7000ecf949807e1db2fec3a822119338e984349c36a0b41546c4b63";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/realtime-tools/default.nix
+++ b/distros/jazzy/realtime-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, boost, libcap, lifecycle-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2-control-cmake, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-realtime-tools";
-  version = "3.7.0-r1";
+  version = "3.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/jazzy/realtime_tools/3.7.0-1.tar.gz";
-    name = "3.7.0-1.tar.gz";
-    sha256 = "1f3d3673ba20e4d569ea8614ef3107db651bfefeb79383365812a8ce5b4a90f6";
+    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/jazzy/realtime_tools/3.8.0-1.tar.gz";
+    name = "3.8.0-1.tar.gz";
+    sha256 = "7fe2c44a1cc1108376ca3b845c1d121910ce102f05bb94e5646440801b3efc1a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rmw-zenoh-cpp/default.nix
+++ b/distros/jazzy/rmw-zenoh-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, fastcdr, rcpputils, rcutils, rmw, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, tracetools, zenoh-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-rmw-zenoh-cpp";
-  version = "0.2.6-r1";
+  version = "0.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/jazzy/rmw_zenoh_cpp/0.2.6-1.tar.gz";
-    name = "0.2.6-1.tar.gz";
-    sha256 = "61e6543dd75490ad987b55ffae847ddade9a8432d6414cc27dca87da25fe3a34";
+    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/jazzy/rmw_zenoh_cpp/0.2.7-1.tar.gz";
+    name = "0.2.7-1.tar.gz";
+    sha256 = "b108d1ef8da0ef538e4c6cf5853cd069812d94606f0365859a9f8fd25a693fc3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2action/default.nix
+++ b/distros/jazzy/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2action";
-  version = "0.32.5-r1";
+  version = "0.32.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2action/0.32.5-1.tar.gz";
-    name = "0.32.5-1.tar.gz";
-    sha256 = "dc55bee36624120754ec362c0ca52f14cc3b1992a2d65a2b6f0d1a8b5438873e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2action/0.32.6-1.tar.gz";
+    name = "0.32.6-1.tar.gz";
+    sha256 = "79c1cfa50cd440df75c6b6a1dc2e822eba05871dcdee6b1b0c00af483fb6a0a3";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2cli-test-interfaces/default.nix
+++ b/distros/jazzy/ros2cli-test-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-ros2cli-test-interfaces";
-  version = "0.32.5-r1";
+  version = "0.32.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2cli_test_interfaces/0.32.5-1.tar.gz";
-    name = "0.32.5-1.tar.gz";
-    sha256 = "039af222b38accb717bf2d89423cca403f224af67850afd8dcdecaa94220eee2";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2cli_test_interfaces/0.32.6-1.tar.gz";
+    name = "0.32.6-1.tar.gz";
+    sha256 = "e3d7036b83a05a6190c03dec07a46c7cb726db79fb3908722922db40935d323c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2cli/default.nix
+++ b/distros/jazzy/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, rclpy, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2cli";
-  version = "0.32.5-r1";
+  version = "0.32.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2cli/0.32.5-1.tar.gz";
-    name = "0.32.5-1.tar.gz";
-    sha256 = "9bbb93bbd65923f78ba8c0d7b603772bffc78558ca410ae3c339a5c69309f840";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2cli/0.32.6-1.tar.gz";
+    name = "0.32.6-1.tar.gz";
+    sha256 = "ca530706428f11b9ddc5b165716056cd078817513bcded01fda2a6fdf41813b3";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2component/default.nix
+++ b/distros/jazzy/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, python3Packages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-jazzy-ros2component";
-  version = "0.32.5-r1";
+  version = "0.32.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2component/0.32.5-1.tar.gz";
-    name = "0.32.5-1.tar.gz";
-    sha256 = "6345c35a758b571fccb4c6fd9d21a9cccfa24334b9242a5be38ba9421e260fdb";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2component/0.32.6-1.tar.gz";
+    name = "0.32.6-1.tar.gz";
+    sha256 = "9e01f89d4ff86a76e7bf11731c4a589582d551289e52091ce0e8241689f2d788";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2doctor/default.nix
+++ b/distros/jazzy/ros2doctor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros-environment, ros2cli, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2doctor";
-  version = "0.32.5-r1";
+  version = "0.32.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2doctor/0.32.5-1.tar.gz";
-    name = "0.32.5-1.tar.gz";
-    sha256 = "ee9111fba06eeb0bf8b489892d205986e5d82b2434e0de5938bbdd8d3180109b";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2doctor/0.32.6-1.tar.gz";
+    name = "0.32.6-1.tar.gz";
+    sha256 = "928fa272c3f088c4347301397841cc91d9edb4b0eab1315415535f07b33c3fc9";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2interface/default.nix
+++ b/distros/jazzy/ros2interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, ros2cli, ros2cli-test-interfaces, rosidl-adapter, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2interface";
-  version = "0.32.5-r1";
+  version = "0.32.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2interface/0.32.5-1.tar.gz";
-    name = "0.32.5-1.tar.gz";
-    sha256 = "e916a452f034d14fe5fa6f4f101c6ab0919b68f7bb81ea1bcacebdfffc1ec2b4";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2interface/0.32.6-1.tar.gz";
+    name = "0.32.6-1.tar.gz";
+    sha256 = "e0ab6c0e05d95e952db81bee985618c32b16ae9b777da08954520944f47e4248";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2lifecycle-test-fixtures/default.nix
+++ b/distros/jazzy/ros2lifecycle-test-fixtures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-jazzy-ros2lifecycle-test-fixtures";
-  version = "0.32.5-r1";
+  version = "0.32.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2lifecycle_test_fixtures/0.32.5-1.tar.gz";
-    name = "0.32.5-1.tar.gz";
-    sha256 = "f9d90f005dfdfd806da775b5de684ac55ee684bf46586af562ef5ca3b00a7cc5";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2lifecycle_test_fixtures/0.32.6-1.tar.gz";
+    name = "0.32.6-1.tar.gz";
+    sha256 = "eaebc6fafac0f7ec36f29002346a6ad0afd003d1a8e913e14ae5b3ef51e5fa33";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2lifecycle/default.nix
+++ b/distros/jazzy/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, lifecycle-msgs, python3Packages, rclpy, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-jazzy-ros2lifecycle";
-  version = "0.32.5-r1";
+  version = "0.32.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2lifecycle/0.32.5-1.tar.gz";
-    name = "0.32.5-1.tar.gz";
-    sha256 = "0e418a9f7f5c43c5319b39e80d368a5269ead9ac3a336dc536093164b39436d6";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2lifecycle/0.32.6-1.tar.gz";
+    name = "0.32.6-1.tar.gz";
+    sha256 = "9af445f7343284ab46153ed789f863bd59f7ba51b4f0f2ed437d8b4d9b749c59";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2multicast/default.nix
+++ b/distros/jazzy/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, ros2cli }:
 buildRosPackage {
   pname = "ros-jazzy-ros2multicast";
-  version = "0.32.5-r1";
+  version = "0.32.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2multicast/0.32.5-1.tar.gz";
-    name = "0.32.5-1.tar.gz";
-    sha256 = "baacd2bf55214ba87dec435798e2610c656d14d5cd54eb71dd1f65b75a674b39";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2multicast/0.32.6-1.tar.gz";
+    name = "0.32.6-1.tar.gz";
+    sha256 = "6893c511487c26d8d8efd44e47b02993adbf7d634547825c397eafc5008c91bb";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2node/default.nix
+++ b/distros/jazzy/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2node";
-  version = "0.32.5-r1";
+  version = "0.32.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2node/0.32.5-1.tar.gz";
-    name = "0.32.5-1.tar.gz";
-    sha256 = "f22d964e25f9b535a95a2204d6532c1855a12b232e2bd2a44385d5e324a0d256";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2node/0.32.6-1.tar.gz";
+    name = "0.32.6-1.tar.gz";
+    sha256 = "aa9a55cf993a0cea41c61b70dec74713a24c767ebf8f0153aae84187b7123af7";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2param/default.nix
+++ b/distros/jazzy/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-jazzy-ros2param";
-  version = "0.32.5-r1";
+  version = "0.32.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2param/0.32.5-1.tar.gz";
-    name = "0.32.5-1.tar.gz";
-    sha256 = "6bf6d3916928de399e6571e38d7eff101ad6bd57bc640e65cba74ca73689fb1c";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2param/0.32.6-1.tar.gz";
+    name = "0.32.6-1.tar.gz";
+    sha256 = "40bbd6340c2db6f1f6e283d3529118b8a738f474bccf0093ab07f31bbe29d1dc";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2pkg/default.nix
+++ b/distros/jazzy/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, ros2cli }:
 buildRosPackage {
   pname = "ros-jazzy-ros2pkg";
-  version = "0.32.5-r1";
+  version = "0.32.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2pkg/0.32.5-1.tar.gz";
-    name = "0.32.5-1.tar.gz";
-    sha256 = "8cede1e3fda4afbaf5d616d5fa1c1a98aea3a23d70e79887f3b8ff89d2a82cb1";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2pkg/0.32.6-1.tar.gz";
+    name = "0.32.6-1.tar.gz";
+    sha256 = "01e577c9fb45c70c71d400bb8e560a7295941416b2a86f4cbacc1611f8c92409";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2run/default.nix
+++ b/distros/jazzy/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-jazzy-ros2run";
-  version = "0.32.5-r1";
+  version = "0.32.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2run/0.32.5-1.tar.gz";
-    name = "0.32.5-1.tar.gz";
-    sha256 = "b5f8db36d8d303be25b288de3a2ab53b3dae52f734372bc76b8440ada9330883";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2run/0.32.6-1.tar.gz";
+    name = "0.32.6-1.tar.gz";
+    sha256 = "fd473944f19ab535f6fe8bab1c03b91955b27f64dd99317cd2443afab35a3950";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2service/default.nix
+++ b/distros/jazzy/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, ros2topic, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2service";
-  version = "0.32.5-r1";
+  version = "0.32.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2service/0.32.5-1.tar.gz";
-    name = "0.32.5-1.tar.gz";
-    sha256 = "021e84062b685ac1634d96fd1c39f37c16b8386f2f41b91b1edfbfe6ce9df193";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2service/0.32.6-1.tar.gz";
+    name = "0.32.6-1.tar.gz";
+    sha256 = "2bfb1bb356eb625f486add8a6f29e02d1712cb75955454ad5f3d2cba38a10717";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2topic/default.nix
+++ b/distros/jazzy/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosgraph-msgs, rosidl-runtime-py, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2topic";
-  version = "0.32.5-r1";
+  version = "0.32.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2topic/0.32.5-1.tar.gz";
-    name = "0.32.5-1.tar.gz";
-    sha256 = "8963bdab5c6490ac4789be0c93a6cfacb9d89204ab0f532951cdd200069b266c";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2topic/0.32.6-1.tar.gz";
+    name = "0.32.6-1.tar.gz";
+    sha256 = "a02c32624530512c66cc0cee9e9211d57429e48252093080009ed6c51906ca53";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rosidlcpp-generator-c/default.nix
+++ b/distros/jazzy/rosidlcpp-generator-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-ros, fmt, nlohmann_json, rcutils, ros-environment, rosidl-cmake, rosidl-generator-type-description, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-jazzy-rosidlcpp-generator-c";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp_generator_c/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "44a6dfc4a9cbdde049c36cc2c34c6c48bae0591a4818487da8cd86dc6d7673d0";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp_generator_c/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "a081aca3a733382648a33a1777eda6c78961c3b9d755a173d4fd1a45ac33a3b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidlcpp-generator-core/default.nix
+++ b/distros/jazzy/rosidlcpp-generator-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, fmt, nlohmann_json, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-jazzy-rosidlcpp-generator-core";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp_generator_core/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "bac07a75ea97f349f607988998dabd09777686a3f32ab9c543b91fb5e67c85a4";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp_generator_core/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "07b995ddeb4a30c9d3b395e387c7c95ff0fe426ce6fbc6dcaab0b771ef185f29";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidlcpp-generator-cpp/default.nix
+++ b/distros/jazzy/rosidlcpp-generator-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, fmt, nlohmann_json, rcutils, rosidl-cmake, rosidl-generator-type-description, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-jazzy-rosidlcpp-generator-cpp";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp_generator_cpp/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "ebf70c4c6b973355dab428321692b4eee89ab28b224aeac2853884806d0d4ca9";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp_generator_cpp/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "04c969594de51f30b2c9785d6015b7d0e5c7a521e01bf7d923ca364a8728ca1d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidlcpp-generator-py/default.nix
+++ b/distros/jazzy/rosidlcpp-generator-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, fmt, nlohmann_json, python-cmake-module, rmw, rosidl-generator-c, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-c, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-jazzy-rosidlcpp-generator-py";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp_generator_py/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "b23bcdd01bbcea22645f24c757d69c9255b7424e0a1a7c88c11558dd09e3bd53";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp_generator_py/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "0f4a8ebf2f5fc097a5fb4a7152cc68b25ab8cf5af9bbe369d7430e168dca1012";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidlcpp-generator-type-description/default.nix
+++ b/distros/jazzy/rosidlcpp-generator-type-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, fmt, nlohmann_json, rcutils, rosidl-runtime-c, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-jazzy-rosidlcpp-generator-type-description";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp_generator_type_description/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "85e51b2018d3fbe6a9e505fccdd106733ac2876f0477df83b5876f1ce6be9991";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp_generator_type_description/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "ba2c928a5a9ce58584d2caea5927f20647ca6b8d5a5f8b3b677c1f13f94a2c7f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidlcpp-parser/default.nix
+++ b/distros/jazzy/rosidlcpp-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, fmt, nlohmann_json }:
 buildRosPackage {
   pname = "ros-jazzy-rosidlcpp-parser";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp_parser/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "7392177433d164d6506e1ffaef107a8c85dc59218a7b498e9e03cbab7dc65c6c";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp_parser/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "5fd84f8b0425909cadd1c6172b308d2749cf359950bcd0fb45b97a410fa79d6e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidlcpp-typesupport-c/default.nix
+++ b/distros/jazzy/rosidlcpp-typesupport-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-ros, ament-index-python, fmt, nlohmann_json, rcpputils, rcutils, ros-environment, rosidl-cli, rosidl-generator-c, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-c, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-jazzy-rosidlcpp-typesupport-c";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp_typesupport_c/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "688ddfba4a7646c2591c495fea6dba6a730e6b36e3c8c93f3ea52c5ecd3d31f1";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp_typesupport_c/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "6c4169a37ceebe0f8cfb759552337a98e9b5a99487e54df716611430ef0114ed";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidlcpp-typesupport-cpp/default.nix
+++ b/distros/jazzy/rosidlcpp-typesupport-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-ros, ament-index-python, fmt, nlohmann_json, rcpputils, rcutils, ros-environment, rosidl-cli, rosidl-generator-c, rosidl-generator-type-description, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-cpp, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-jazzy-rosidlcpp-typesupport-cpp";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp_typesupport_cpp/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "80a65281e57205df849eac7b57f949a76a990ee912010f9fbd7f6c3d2090a1ae";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp_typesupport_cpp/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "325a679005c8f9f7c6a3efef15c49897dcf5ce59848f38c78fa2a2d5d6b444d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidlcpp-typesupport-fastrtps-c/default.nix
+++ b/distros/jazzy/rosidlcpp-typesupport-fastrtps-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-cmake-ros, fastcdr, fmt, nlohmann_json, rmw, rosidl-generator-c, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-jazzy-rosidlcpp-typesupport-fastrtps-c";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp_typesupport_fastrtps_c/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "b369a404597b6886cf0bed4fa75a7c7ad48ca2b3392b9ca3615c68461f92c984";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp_typesupport_fastrtps_c/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "189285b5654163af4cd2b9d0ceaf0051dae8e4159432d60627c3c4b3d50dea93";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidlcpp-typesupport-fastrtps-cpp/default.nix
+++ b/distros/jazzy/rosidlcpp-typesupport-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-cmake-ros, fastcdr, fmt, nlohmann_json, rmw, rosidl-generator-c, rosidl-generator-cpp, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-jazzy-rosidlcpp-typesupport-fastrtps-cpp";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp_typesupport_fastrtps_cpp/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "61f2c08142a9034e518025a19de8f3ac0db70cbbdd63c159daa0a5f0558ae8f7";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp_typesupport_fastrtps_cpp/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "8a142ad54d3847be4c4df629351a5a7270af5965dce894962d23a1aaecbae5e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidlcpp-typesupport-introspection-c/default.nix
+++ b/distros/jazzy/rosidlcpp-typesupport-introspection-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, fmt, nlohmann_json, ros-environment, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-jazzy-rosidlcpp-typesupport-introspection-c";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp_typesupport_introspection_c/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "0bed4d0d7685f2b67274493c951e5e7f50526440277c84f27b79f90d81d72975";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp_typesupport_introspection_c/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "8faf07647260e7a658f523b1ce4b6083dfea6d4a379fe4579ab4cb4c53ffb067";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidlcpp-typesupport-introspection-cpp/default.nix
+++ b/distros/jazzy/rosidlcpp-typesupport-introspection-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, fmt, nlohmann_json, ros-environment, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidl-typesupport-introspection-c, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-jazzy-rosidlcpp-typesupport-introspection-cpp";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp_typesupport_introspection_cpp/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "ff6731917001b0993c2080193be60ec730352325b100ca593230c5909ae6be6d";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp_typesupport_introspection_cpp/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "d6b0d47fac8ab840228e2fdb5c719de329404f33dc89807e8734cfab4ec4c1bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidlcpp/default.nix
+++ b/distros/jazzy/rosidlcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, rosidlcpp-generator-c, rosidlcpp-generator-cpp, rosidlcpp-generator-py, rosidlcpp-generator-type-description, rosidlcpp-typesupport-c, rosidlcpp-typesupport-cpp, rosidlcpp-typesupport-fastrtps-c, rosidlcpp-typesupport-fastrtps-cpp, rosidlcpp-typesupport-introspection-c, rosidlcpp-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-rosidlcpp";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "82f4f3b72ba0de3735635497c276ff25c5c89a2df31ff03d34193ea4892f334c";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/jazzy/rosidlcpp/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "0b3d6cb3221a913beb29e64f277eedadc2b0a411964ff1b949183d0595bc5d45";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rtsp-image-transport/default.nix
+++ b/distros/jazzy/rtsp-image-transport/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, ffmpeg, image-transport, live555-vendor, pluginlib, rclcpp }:
+buildRosPackage {
+  pname = "ros-jazzy-rtsp-image-transport";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rtsp_image_transport-release/archive/release/jazzy/rtsp_image_transport/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "3dd26b383fc4295e8b0ba715d36a691f2e556d672a02b4acd076cae746be2ad9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cv-bridge ffmpeg image-transport live555-vendor pluginlib rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Transmit video streams with the Real-Time Streaming Protocol";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/tf2-web-republisher-interfaces/default.nix
+++ b/distros/jazzy/tf2-web-republisher-interfaces/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-jazzy-tf2-web-republisher-interfaces";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/tf2_web_republisher-release/archive/release/jazzy/tf2_web_republisher_interfaces/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "564b7617e256e14a020ab5be6f7afa1e6b0ed0e128333c3ef1f0cc7a305e1db0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces geometry-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Interface definitions for tf2_web_republisher";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/tf2-web-republisher/default.nix
+++ b/distros/jazzy/tf2-web-republisher/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, geometry-msgs, rclcpp, rclcpp-action, rclcpp-components, tf2, tf2-ros, tf2-web-republisher-interfaces }:
+buildRosPackage {
+  pname = "ros-jazzy-tf2-web-republisher";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/tf2_web_republisher-release/archive/release/jazzy/tf2_web_republisher/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "691075e22031f81b2a28f28a1206019a4438583765619060c4fb317947b884d7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gmock ];
+  propagatedBuildInputs = [ geometry-msgs rclcpp rclcpp-action rclcpp-components tf2 tf2-ros tf2-web-republisher-interfaces ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Republishing of Selected TFs";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/theora-image-transport/default.nix
+++ b/distros/jazzy/theora-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, libogg, libtheora, opencv, pkg-config, pluginlib, rclcpp, rcutils, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-theora-image-transport";
-  version = "4.0.5-r1";
+  version = "4.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/theora_image_transport/4.0.5-1.tar.gz";
-    name = "4.0.5-1.tar.gz";
-    sha256 = "b99d6370eb4fb5b4e666b8a736f0f65783ab2cc97cf2da3eb41a7f96f82533cd";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/theora_image_transport/4.0.6-1.tar.gz";
+    name = "4.0.6-1.tar.gz";
+    sha256 = "0e1737a2e020628d1122ebc48a6ee37b9b1eb0cd1735e30b37d75217760a1f47";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/turtlebot4-description/default.nix
+++ b/distros/jazzy/turtlebot4-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, irobot-create-description, joint-state-publisher, robot-state-publisher, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-turtlebot4-description";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/jazzy/turtlebot4_description/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "ba74fab5a2b295f9c1ec450a03a36e3f8cb375757cd416ecdf29484e06d4a18b";
+    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/jazzy/turtlebot4_description/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "da534b94c45e781891d217dcb40cb41131d9acd545d795d9e03364855f3e01b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/turtlebot4-msgs/default.nix
+++ b/distros/jazzy/turtlebot4-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-turtlebot4-msgs";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/jazzy/turtlebot4_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "a436419a294e7a1684c0ae5a2f225de848d1f9decfa08d4c04f63e711dc5e4e1";
+    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/jazzy/turtlebot4_msgs/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "19f91d70874925aa769f849d2172c8290650185173f71ae0f81f918da05f7a24";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/turtlebot4-navigation/default.nix
+++ b/distros/jazzy/turtlebot4-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, nav2-bringup, nav2-simple-commander, slam-toolbox }:
 buildRosPackage {
   pname = "ros-jazzy-turtlebot4-navigation";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/jazzy/turtlebot4_navigation/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "d25383d9989aaadbb190c061fca03c249731bfa3f0a1401d9557d56a697595c8";
+    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/jazzy/turtlebot4_navigation/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "a589f6385e08002b7b4917f9681e7eb40a823e56a30f2286697a3fa80ec2fc8b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/turtlebot4-node/default.nix
+++ b/distros/jazzy/turtlebot4-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, irobot-create-msgs, rclcpp, rclcpp-action, rcutils, sensor-msgs, std-msgs, std-srvs, turtlebot4-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-turtlebot4-node";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/jazzy/turtlebot4_node/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "7854f5ad4f5f9276fcd3003d47ff55145072ec709f525816159967656b5a4268";
+    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/jazzy/turtlebot4_node/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "2030b08b9d505e0dea523ba188003a0d49c9e06685020850343b79cb3705e70c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/zenoh-cpp-vendor/default.nix
+++ b/distros/jazzy/zenoh-cpp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, cargo, clang, git }:
 buildRosPackage {
   pname = "ros-jazzy-zenoh-cpp-vendor";
-  version = "0.2.6-r1";
+  version = "0.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/jazzy/zenoh_cpp_vendor/0.2.6-1.tar.gz";
-    name = "0.2.6-1.tar.gz";
-    sha256 = "bfece0987933b89d59a9b0967f8f0fc25c4f2355fa9611c4133552f62438d47c";
+    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/jazzy/zenoh_cpp_vendor/0.2.7-1.tar.gz";
+    name = "0.2.7-1.tar.gz";
+    sha256 = "7184577d4dcb10ccfd64224ee4695eccc5d8522392efd83b327fd69dbb010cf6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/zenoh-cpp-vendor/vendored-source.json
+++ b/distros/jazzy/zenoh-cpp-vendor/vendored-source.json
@@ -1,12 +1,12 @@
 {
   "zenoh_c_vendor": {
     "url": "https://github.com/eclipse-zenoh/zenoh-c.git",
-    "rev": "71af32739394bc3200aa1bea32206dc28216e04e",
-    "hash": "sha256-HhbOg86CQAnuc4k6pQAxuVYYjGbC/JUyTLeN9Mi91Hw="
+    "rev": "8f9ce70e4c4b55d150632730fd4c48abffbde765",
+    "hash": "sha256-kbDIatj4GFhUyDo9yCc6FzPYszHE+Vd79w4r452p77Y="
   },
   "zenoh_cpp_vendor": {
     "url": "https://github.com/eclipse-zenoh/zenoh-cpp",
-    "rev": "d0eae207c6cfee8df9fb8622812a297ef9bfd18e",
-    "hash": "sha256-KaooEqZZU5WibH5aQByMGA37MiZ070SiSLqDBYUyUaU="
+    "rev": "05533d20db70ffc1d53a0e07f39caa999e82febd",
+    "hash": "sha256-lEicWShyKo5NSFyDeMqItZIweY3syXKF629x7woSQ0o="
   }
 }

--- a/distros/jazzy/zenoh-security-tools/default.nix
+++ b/distros/jazzy/zenoh-security-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, nlohmann_json, rcpputils, rcutils, rmw, rmw-dds-common, tinyxml2-vendor, zenoh-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-zenoh-security-tools";
-  version = "0.2.6-r1";
+  version = "0.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/jazzy/zenoh_security_tools/0.2.6-1.tar.gz";
-    name = "0.2.6-1.tar.gz";
-    sha256 = "c7b298e1de19bf7602cfccbabc823f5efe62ff83d928d302c5b863d22eadee06";
+    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/jazzy/zenoh_security_tools/0.2.7-1.tar.gz";
+    name = "0.2.7-1.tar.gz";
+    sha256 = "e42860a8e5f1f5cb779d4050e43ec97ba8613c2ca1c680c55798c31e029bfce1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/zstd-image-transport/default.nix
+++ b/distros/jazzy/zstd-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, image-transport, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-zstd-image-transport";
-  version = "4.0.5-r1";
+  version = "4.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/zstd_image_transport/4.0.5-1.tar.gz";
-    name = "4.0.5-1.tar.gz";
-    sha256 = "90c2d4c0585d364165288abaecc254c454664ceda77cc557122bda9dec052fc2";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/zstd_image_transport/4.0.6-1.tar.gz";
+    name = "4.0.6-1.tar.gz";
+    sha256 = "5b7206630b5304f89e116d00d2d133888c5e08121df5b65a6a71a12ac67c36b9";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/catch-ros2/default.nix
+++ b/distros/kilted/catch-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, ros2launch, std-srvs }:
 buildRosPackage {
   pname = "ros-kilted-catch-ros2";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/catch_ros2-release/archive/release/kilted/catch_ros2/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "73c19482706ce555d58f3ea764ad7553c8e0fb0243ee06513e7cf5eab438b399";
+    url = "https://github.com/ros2-gbp/catch_ros2-release/archive/release/kilted/catch_ros2/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "9d2557137d837c4d722e61b9a7b3840a62cdf5d78ffbef6784a84558427c1bc6";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/chomp-motion-planner/default.nix
+++ b/distros/kilted/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-common, moveit-core, rclcpp, rsl, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kilted-chomp-motion-planner";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/chomp_motion_planner/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "ab599c404064615fe04617a473d720f4d5d8944ad2c3f1457987d0ef533ed22a";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/chomp_motion_planner/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "6c6d4b78f4666a40408b87a185468975d5e0343a93487f4e4881e6d3b4ab1fd9";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/compressed-depth-image-transport/default.nix
+++ b/distros/kilted/compressed-depth-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-kilted-compressed-depth-image-transport";
-  version = "5.1.0-r1";
+  version = "5.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/kilted/compressed_depth_image_transport/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "266e0480051bb046f0a3d738b9b4f21947330f55d2da5d2297267347324d237b";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/kilted/compressed_depth_image_transport/5.1.1-1.tar.gz";
+    name = "5.1.1-1.tar.gz";
+    sha256 = "e2770fca37cc62d3f61339574c2233284cf6e689214194535aba37167a87da40";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/compressed-image-transport/default.nix
+++ b/distros/kilted/compressed-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-kilted-compressed-image-transport";
-  version = "5.1.0-r1";
+  version = "5.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/kilted/compressed_image_transport/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "df7ca02a3bca20e87e4b718e86b48f193503dd2ff50411a0049aefed5e521305";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/kilted/compressed_image_transport/5.1.1-1.tar.gz";
+    name = "5.1.1-1.tar.gz";
+    sha256 = "04e529b89cc8aa782bf4b67eff3a62236fad69b2600e5f802add855a865bf967";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/depthai/default.nix
+++ b/distros/kilted/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, curl, libtar, libusb1, nlohmann_json, opencv, ros-environment, udev, unzip, zip }:
 buildRosPackage {
   pname = "ros-kilted-depthai";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/kilted/depthai/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "5081413da7ea72bba54ab3881c9b61b960d1c160810ef46b01f5c5aec1e82a86";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/kilted/depthai/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "93128bb2044eeb2ccf755a0b02e20e1dbef59b3eeffbb3a4bbbd63039396b001";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/dynamixel-hardware-interface/default.nix
+++ b/distros/kilted/dynamixel-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-interfaces, dynamixel-sdk, hardware-interface, pluginlib, rclcpp, realtime-tools, std-srvs }:
 buildRosPackage {
   pname = "ros-kilted-dynamixel-hardware-interface";
-  version = "1.4.13-r1";
+  version = "1.4.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/kilted/dynamixel_hardware_interface/1.4.13-1.tar.gz";
-    name = "1.4.13-1.tar.gz";
-    sha256 = "5b0ff6edd433ae14674c817dae7d8525a005d828fa8d709cc82ad150f0289578";
+    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/kilted/dynamixel_hardware_interface/1.4.14-1.tar.gz";
+    name = "1.4.14-1.tar.gz";
+    sha256 = "66c3d92ccef8022d50e1778f4ed9d4eab623dd84832554e956347c49e82dd94e";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/generated.nix
+++ b/distros/kilted/generated.nix
@@ -1564,6 +1564,8 @@ self: super: {
 
  neobotix-usboard-msgs = self.callPackage ./neobotix-usboard-msgs {};
 
+ network-bridge = self.callPackage ./network-bridge {};
+
  nlohmann-json-schema-validator-vendor = self.callPackage ./nlohmann-json-schema-validator-vendor {};
 
  nmea-hardware-interface = self.callPackage ./nmea-hardware-interface {};
@@ -2683,6 +2685,10 @@ self: super: {
  tf2-sensor-msgs = self.callPackage ./tf2-sensor-msgs {};
 
  tf2-tools = self.callPackage ./tf2-tools {};
+
+ tf2-web-republisher = self.callPackage ./tf2-web-republisher {};
+
+ tf2-web-republisher-interfaces = self.callPackage ./tf2-web-republisher-interfaces {};
 
  tf-transformations = self.callPackage ./tf-transformations {};
 

--- a/distros/kilted/gz-dartsim-vendor/vendored-source.json
+++ b/distros/kilted/gz-dartsim-vendor/vendored-source.json
@@ -1,0 +1,7 @@
+{
+  "gz_dartsim_vendor": {
+    "url": "https://github.com/dartsim/dart.git",
+    "rev": "v6.13.2",
+    "hash": "sha256-AfKPqUiW6BsM98TIzTY2ZcFP1WvURs8/dGOzanIiB9g="
+  }
+}

--- a/distros/kilted/image-transport-plugins/default.nix
+++ b/distros/kilted/image-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, compressed-depth-image-transport, compressed-image-transport, theora-image-transport, zstd-image-transport }:
 buildRosPackage {
   pname = "ros-kilted-image-transport-plugins";
-  version = "5.1.0-r1";
+  version = "5.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/kilted/image_transport_plugins/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "ff05e71a5c24fcd1b8341285d60222dbc056c3c774ba6da5537959b5b6bd7913";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/kilted/image_transport_plugins/5.1.1-1.tar.gz";
+    name = "5.1.1-1.tar.gz";
+    sha256 = "9c2c9e91da41edc34f51ef800c0e2cfd6f303f1bcdc7249ed08c5c62cf0e531e";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/launch-pytest/default.nix
+++ b/distros/kilted/launch-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, osrf-pycommon, python3Packages }:
 buildRosPackage {
   pname = "ros-kilted-launch-pytest";
-  version = "3.8.2-r1";
+  version = "3.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/kilted/launch_pytest/3.8.2-1.tar.gz";
-    name = "3.8.2-1.tar.gz";
-    sha256 = "26ef1575aaa53f474e9e9375958f9692af625cc5ba8a589d548b354c51f4e9c4";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/kilted/launch_pytest/3.8.3-1.tar.gz";
+    name = "3.8.3-1.tar.gz";
+    sha256 = "52c935768f7f2130a061d40b903946793fe724bdd1aa6dc81641f924f8aff35c";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/launch-testing-ament-cmake/default.nix
+++ b/distros/kilted/launch-testing-ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-test, launch-testing }:
 buildRosPackage {
   pname = "ros-kilted-launch-testing-ament-cmake";
-  version = "3.8.2-r1";
+  version = "3.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/kilted/launch_testing_ament_cmake/3.8.2-1.tar.gz";
-    name = "3.8.2-1.tar.gz";
-    sha256 = "1f6b641e63541fe86a3199c9034860dab7182e928effb53bd4945fb29d545525";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/kilted/launch_testing_ament_cmake/3.8.3-1.tar.gz";
+    name = "3.8.3-1.tar.gz";
+    sha256 = "f99b79f55e25536ae0ffb2d81c85f366751058ca318b8897807bad16580cc4ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/launch-testing/default.nix
+++ b/distros/kilted/launch-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-xml, launch-yaml, osrf-pycommon, python3Packages }:
 buildRosPackage {
   pname = "ros-kilted-launch-testing";
-  version = "3.8.2-r1";
+  version = "3.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/kilted/launch_testing/3.8.2-1.tar.gz";
-    name = "3.8.2-1.tar.gz";
-    sha256 = "8f7b43b544c98e02a7e9dd5a693ea3f4686dcfa70ccd779586884e1456a41ed8";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/kilted/launch_testing/3.8.3-1.tar.gz";
+    name = "3.8.3-1.tar.gz";
+    sha256 = "7d7b622e9a5b406b567c785ea786b41c273655d46a58f33f9c0cb17767e6f96f";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/launch-xml/default.nix
+++ b/distros/kilted/launch-xml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, python3Packages }:
 buildRosPackage {
   pname = "ros-kilted-launch-xml";
-  version = "3.8.2-r1";
+  version = "3.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/kilted/launch_xml/3.8.2-1.tar.gz";
-    name = "3.8.2-1.tar.gz";
-    sha256 = "b46dc9ae7c593abae27764330cf96b40a8894bc2aa3ec10467efc99b6c3b6eac";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/kilted/launch_xml/3.8.3-1.tar.gz";
+    name = "3.8.3-1.tar.gz";
+    sha256 = "949f719b30dcded3d5da110d75119d67c73f09e8cbd66102936eed33c84c2a67";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/launch-yaml/default.nix
+++ b/distros/kilted/launch-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, python3Packages }:
 buildRosPackage {
   pname = "ros-kilted-launch-yaml";
-  version = "3.8.2-r1";
+  version = "3.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/kilted/launch_yaml/3.8.2-1.tar.gz";
-    name = "3.8.2-1.tar.gz";
-    sha256 = "a46c1f42c5f5a4d659f350bc6c75c359b5558fdbc3841643ee4b8905e95fe01d";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/kilted/launch_yaml/3.8.3-1.tar.gz";
+    name = "3.8.3-1.tar.gz";
+    sha256 = "c0d269830b9be86bc1c717f7508e0648f3fe86b1702d9331d99e40ac1f3a4d69";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/launch/default.nix
+++ b/distros/kilted/launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-mypy, ament-pep257, ament-xmllint, osrf-pycommon, python3Packages }:
 buildRosPackage {
   pname = "ros-kilted-launch";
-  version = "3.8.2-r1";
+  version = "3.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/kilted/launch/3.8.2-1.tar.gz";
-    name = "3.8.2-1.tar.gz";
-    sha256 = "753beefde1c525e1a7af092ae511d5bd3494191c25d2df282a0b7275c1e8675b";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/kilted/launch/3.8.3-1.tar.gz";
+    name = "3.8.3-1.tar.gz";
+    sha256 = "f9a17206ccd356483d65a891a5a12c2ce0bfc922f2b756154ed689f96eddb10f";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/libmavconn/default.nix
+++ b/distros/kilted/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
 buildRosPackage {
   pname = "ros-kilted-libmavconn";
-  version = "2.10.1-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/libmavconn/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "52a743135e7e9aeebabc241228b6cec0d355967063afecb75b10163071a2039b";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/libmavconn/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "05d77ac1ae102309341d98dc9013c22445bd1f8c7176f41124a22a4ea79d71ed";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mavlink/default.nix
+++ b/distros/kilted/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-kilted-mavlink";
-  version = "2025.6.6-r1";
+  version = "2025.9.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/kilted/mavlink/2025.6.6-1.tar.gz";
-    name = "2025.6.6-1.tar.gz";
-    sha256 = "02b36998260e7f0b04a4e5656fafa3a3415bf9a7bf01c0deca62a1f6a635dbc4";
+    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/kilted/mavlink/2025.9.9-1.tar.gz";
+    name = "2025.9.9-1.tar.gz";
+    sha256 = "e793262611fdd1ce82ec2f1144f0ca1b8c57ab16e0f4ccd5b0d0c40d09b88a1d";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mavros-extras/default.nix
+++ b/distros/kilted/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-kilted-mavros-extras";
-  version = "2.10.1-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/mavros_extras/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "ae38f9469233fcddf4fc55728875b5142f14ba16e8fdcd14f9444bbb2744186a";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/mavros_extras/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "86b668040b6c938a99ad3a2eb263bc426c0abcf6ec9aa0206c3b5a95c8df0fef";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mavros-msgs/default.nix
+++ b/distros/kilted/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mavros-msgs";
-  version = "2.10.1-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/mavros_msgs/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "0efff3dfc3fc13833f361ad7edbeb9c6001d617137164940af67961a3546bb32";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/mavros_msgs/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "7cfa8a9c7e598096053da02ef37483f4c3779c243af344440307feaeb1506cf6";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mavros/default.nix
+++ b/distros/kilted/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mavros";
-  version = "2.10.1-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/mavros/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "932c4ce9c86a12962e4c5c395104ebc076ab5b64c448b46fde3ab13821a6e583";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/mavros/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "88caee5623a0f0b0335fee745790b7b05553ea740bcd6b6e6da03ddd63d325e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mola-common/default.nix
+++ b/distros/kilted/mola-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-kilted-mola-common";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/kilted/mola_common/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "f00d6e4141c9bb05b917b7fe0909b32fe4be6983eae9682392f92f0f065bd960";
+    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/kilted/mola_common/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "635f9f022e914f7ff610e50fdb5f67e4a5d2ba37fce954b449de74fd7aa6b05f";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mola-imu-preintegration/default.nix
+++ b/distros/kilted/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-kilted-mola-imu-preintegration";
-  version = "1.9.0-r1";
+  version = "1.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/kilted/mola_imu_preintegration/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "55c123430e99a92a0e1891ed83b006c448d40bacb98063be1706f2e18a54148b";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/kilted/mola_imu_preintegration/1.10.0-1.tar.gz";
+    name = "1.10.0-1.tar.gz";
+    sha256 = "a84c915bfdd125d57cb99b5dc6fa6a7c48076232ceafb4d453f4112318a8bacb";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-state-estimation-simple/default.nix
+++ b/distros/kilted/mola-state-estimation-simple/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-kilted-mola-state-estimation-simple";
-  version = "1.9.0-r1";
+  version = "1.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/kilted/mola_state_estimation_simple/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "1c02e0cb59e53af94fe50d22835d7bc417c218839df4fa1cd60b76f1fa293a9e";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/kilted/mola_state_estimation_simple/1.10.0-1.tar.gz";
+    name = "1.10.0-1.tar.gz";
+    sha256 = "5b30ea3893910f5074a3f0461902cd37c72a5d659954e7c0ee8d3ade2c357bd1";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-state-estimation-smoother/default.nix
+++ b/distros/kilted/mola-state-estimation-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-kilted-mola-state-estimation-smoother";
-  version = "1.9.0-r1";
+  version = "1.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/kilted/mola_state_estimation_smoother/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "c92759046025abfed89a54d30b838bf15a8df690e8f72a848beef0e9f9e80d32";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/kilted/mola_state_estimation_smoother/1.10.0-1.tar.gz";
+    name = "1.10.0-1.tar.gz";
+    sha256 = "6623b65882bd8aceeee6a893fa512b7302b0dce700419a879d5672b70444cd4d";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-state-estimation/default.nix
+++ b/distros/kilted/mola-state-estimation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, mola-imu-preintegration, mola-state-estimation-simple, mola-state-estimation-smoother }:
 buildRosPackage {
   pname = "ros-kilted-mola-state-estimation";
-  version = "1.9.0-r1";
+  version = "1.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/kilted/mola_state_estimation/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "69dbe8e11d29f1eb9f8112bf35f5369f4c132c2974c379aceba7f7b7780433a1";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/kilted/mola_state_estimation/1.10.0-1.tar.gz";
+    name = "1.10.0-1.tar.gz";
+    sha256 = "07209f05c5b8e69d562f4eb63d5cbd4e051709939a9c9e19881b217d38d32dd8";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-common/default.nix
+++ b/distros/kilted/moveit-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, backward-ros }:
 buildRosPackage {
   pname = "ros-kilted-moveit-common";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_common/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "c66ff737da1e5d4b3425010e3a386d196a56a5935a0863015b7c784b59f5c19c";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_common/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "c662d3c368a3fdcac7373d4988f0ca522197b7b85f5b0e4b1224f6259d0e4f5d";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-configs-utils/default.nix
+++ b/distros/kilted/moveit-configs-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, launch, launch-param-builder, launch-ros, srdfdom }:
 buildRosPackage {
   pname = "ros-kilted-moveit-configs-utils";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_configs_utils/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "a9a6bfa40de0523bb416b774bad13c1a9a545e847256446271a9c44da03cd4b5";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_configs_utils/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "6e53f91940cf09b549af1d275a57ab1022dda1af7e0d046b7b90776d07871e9b";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/moveit-core/default.nix
+++ b/distros/kilted/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-index-cpp, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, generate-parameter-library, geometric-shapes, geometry-msgs, google-benchmark-vendor, kdl-parser, launch-testing-ament-cmake, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl-vendor, osqp-vendor, pkg-config, pluginlib, random-numbers, rcl-interfaces, rclcpp, rclpy, rsl, ruckig, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-moveit-core";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_core/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "2c46b04eac19111ec4f45a378c60bee5d24dbf23de42d9d0c84cc6fa4571ae13";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_core/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "a0175d2d23b96a0a46e320fefb4f9b0303fb270304e22b769f3660df4b7d64df";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-hybrid-planning/default.nix
+++ b/distros/kilted/moveit-hybrid-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, controller-manager, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, moveit-simple-controller-manager, pluginlib, position-controllers, rclcpp, rclcpp-action, rclcpp-components, robot-state-publisher, ros-testing, rviz2, std-msgs, std-srvs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kilted-moveit-hybrid-planning";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_hybrid_planning/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "ce8bc6d3b62696fdf9f5de3b9054391ec5d3a19d53eba5660b1a88b988261bd8";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_hybrid_planning/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "25bab157de5680a36b210816b0c21117886be59a97afefbbc0bf4a45f2dab044";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-kinematics/default.nix
+++ b/distros/kilted/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, class-loader, eigen, generate-parameter-library, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl-vendor, pluginlib, python3Packages, ros-testing, rsl, tf2, tf2-kdl, urdfdom }:
 buildRosPackage {
   pname = "ros-kilted-moveit-kinematics";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_kinematics/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "b79bbadbeb2bbc8190e2a482c6d06842d297f2f06c388796223349395047e9c7";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_kinematics/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "59f05557a9e0fc60979027316e31c11f9fdd2cdedc32dcd777dd1d10851482c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-planners-chomp/default.nix
+++ b/distros/kilted/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, chomp-motion-planner, moveit-common, moveit-core, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-kilted-moveit-planners-chomp";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_planners_chomp/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "3e082e5985b5b8ec2812fe5ae2ea4924e9691a9bdc94d82e64bfa2635ac21477";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_planners_chomp/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "89c7b487e224a1c05006f6cdc2e01c382f83203cd5ff6c82833f54d5dd21bac0";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-planners-ompl/default.nix
+++ b/distros/kilted/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module, llvmPackages, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rclcpp, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-moveit-planners-ompl";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_planners_ompl/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "080af97cb5676ba0490b8173a76f0344e379706fa810311b44b79337ca002f93";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_planners_ompl/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "28f9230aa65cdef393c11f7192eef2c7d65f4c1e7e4482f79676cb92b76102a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-planners-stomp/default.nix
+++ b/distros/kilted/moveit-planners-stomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, generate-parameter-library, moveit-common, moveit-core, rsl, std-msgs, stomp, tf2-eigen, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-moveit-planners-stomp";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_planners_stomp/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "df774b9be5c567d18ef8c2f4bea4e3981d1f6a5999683c3248253e487d86994d";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_planners_stomp/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "5aa9158d75fc39ad598d56227e025f20541f52e7cfd27ff40250dffb18cdfdd4";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-planners/default.nix
+++ b/distros/kilted/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-planners-chomp, moveit-planners-ompl, moveit-planners-stomp, pilz-industrial-motion-planner }:
 buildRosPackage {
   pname = "ros-kilted-moveit-planners";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_planners/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "d91e88bd7082f7d157ede73d85ec41f46b97f8951f8c71cd256d23af83cae5c1";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_planners/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "39aaa0da19c131d374d7883838df446d7d6122b8fa8039ff3caf6f0d63e74f42";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-plugins/default.nix
+++ b/distros/kilted/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-kilted-moveit-plugins";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_plugins/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "8a2e8c403dadcf1cf719068851634209517b3f564aad2394e0916749ecad3e6a";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_plugins/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "68fa26e1f7c2bbdf7669118456b570f01978392ffdba1f860b291c81b28b9eac";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-py/default.nix
+++ b/distros/kilted/moveit-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, geometry-msgs, moveit-core, moveit-ros-planning, moveit-ros-planning-interface, octomap-msgs, pybind11-vendor, python3Packages, rclcpp, rclpy }:
 buildRosPackage {
   pname = "ros-kilted-moveit-py";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_py/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "b81f8ec420171eb8b07137fd4a07c3413b48654015c8c3297e2b485980f70abd";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_py/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "f973e5571405aa5c9179cf1faef97138c5b6b5e2849b339d51cbdd4f801630a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
+++ b/distros/kilted/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, generate-parameter-library, moveit-core, pluginlib, rclcpp, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl }:
 buildRosPackage {
   pname = "ros-kilted-moveit-resources-prbt-ikfast-manipulator-plugin";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_resources_prbt_ikfast_manipulator_plugin/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "be91c9f096152777740ba0883f15aa5d5847439f19a5860ac38edcbcb62e508c";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_resources_prbt_ikfast_manipulator_plugin/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "8ef5e7629a4c1f0d684fb00c78cda7bc14ef8c9ac98bf927b02cedf7bb3ad3ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-resources-prbt-moveit-config/default.nix
+++ b/distros/kilted/moveit-resources-prbt-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-support, moveit-ros-move-group, robot-state-publisher, rviz2, xacro }:
 buildRosPackage {
   pname = "ros-kilted-moveit-resources-prbt-moveit-config";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_resources_prbt_moveit_config/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "5ac438b688e1c9ea24c3c23f8bf1030eb07f0dbf8833f921a0ea5dd2e66eafde";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_resources_prbt_moveit_config/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "7c6e921b1c1221ff8701bb3a938bfda6519d1393cd71718546696c14070a7768";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-resources-prbt-pg70-support/default.nix
+++ b/distros/kilted/moveit-resources-prbt-pg70-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-moveit-config, moveit-resources-prbt-support, xacro }:
 buildRosPackage {
   pname = "ros-kilted-moveit-resources-prbt-pg70-support";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_resources_prbt_pg70_support/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "1602881de6c07e8b45fd5ac4677ce26978c4e56bee92dd0d860ce47a237f879d";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_resources_prbt_pg70_support/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "b93efa85909cc7024f1654f4455f3bba7f021c0a9bc3d05ef7c01dfb0a02d285";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-resources-prbt-support/default.nix
+++ b/distros/kilted/moveit-resources-prbt-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, xacro }:
 buildRosPackage {
   pname = "ros-kilted-moveit-resources-prbt-support";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_resources_prbt_support/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "b153bd629640881911a90756d79b4b37fa8f6c581378b7d05fbbc97e61e8611a";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_resources_prbt_support/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "01fdeadb51532109196d87d93e60d331ca4ca69609c08d7b23bd6dfbabd6db34";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-ros-benchmarks/default.nix
+++ b/distros/kilted/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-kilted-moveit-ros-benchmarks";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros_benchmarks/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "2fe4b7c57867a4ee478b969cfb32c7abdcf104fccd735a9fe756be49670b14ae";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros_benchmarks/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "93a0db174fb40638e588aecc66805d8ee40cf68a2dbeb69421a4baf0f28ef781";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-ros-control-interface/default.nix
+++ b/distros/kilted/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager-msgs, moveit-common, moveit-core, moveit-simple-controller-manager, pluginlib, rclcpp-action, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kilted-moveit-ros-control-interface";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros_control_interface/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "32b49066fc91f6706999293b7364d2d775b003eb620f5e51db030d1e8ec7bd0c";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros_control_interface/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "feffc41ab2aac9a478783b462225055cb93c75a048ba97ffdd64d38894bc5c8b";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-ros-move-group/default.nix
+++ b/distros/kilted/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, fmt, moveit-common, moveit-configs-utils, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, ros-testing, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-moveit-ros-move-group";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros_move_group/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "807c486715db97c7455742f90f25782297cf8a56d7263d042b638e1552225a08";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros_move_group/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "d15df6cbd89146b3283835408393b17839704dbe49b2b82cc7c38120106d3dd2";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/kilted/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-moveit-ros-occupancy-map-monitor";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros_occupancy_map_monitor/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "9a234da13eead4d97b94b6fc91ed66ecfd90a92007e9259d3efa05347c4aedcc";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros_occupancy_map_monitor/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "cb7ebe959dc810c3a3b3b8cab08bf509be16060e8c05d192b6fdab6d5ba2d4f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-ros-perception/default.nix
+++ b/distros/kilted/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, object-recognition-msgs, pluginlib, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-kilted-moveit-ros-perception";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros_perception/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "c6fb708eefc265e6754b7537ed46d16236365e86ae64f36cbe689f3f9dd39526";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros_perception/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "78fd2a8b18799c4061cadec6216e50df57730eb353e41c2af48d7983365638db";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-ros-planning-interface/default.nix
+++ b/distros/kilted/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-moveit-ros-planning-interface";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros_planning_interface/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "5c17d17e3172c1a46d2675d7e34253f245e6b36489863ea400a789821922341b";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros_planning_interface/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "f5fd4109ad67c44955a788ef3539f1f14b58fea6b83221a2b3c82b5970564a26";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-ros-planning/default.nix
+++ b/distros/kilted/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, eigen, eigen3-cmake-module, fmt, generate-parameter-library, launch-testing-ament-cmake, message-filters, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, rclcpp-components, ros-testing, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-kilted-moveit-ros-planning";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros_planning/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "71111128204d1280a211a158664bd9b45af1d4f685559904084bec498cdcbdad";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros_planning/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "6b7040a86d1f53734ec218f826f02ebc436e8430204487ad2523973512679046";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-ros-robot-interaction/default.nix
+++ b/distros/kilted/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, interactive-markers, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-moveit-ros-robot-interaction";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros_robot_interaction/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "4d9a8a9211812fc7919b4d766016b47ddf3f0b151b86b08b970231d406059982";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros_robot_interaction/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "0b0123b28ef49ac3558cbdce515ee72c23be2cb556b20c30308af5fc7e1fe875";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-ros-tests/default.nix
+++ b/distros/kilted/moveit-ros-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, moveit-common, moveit-configs-utils, moveit-core, moveit-planners-chomp, moveit-planners-ompl, moveit-planners-stomp, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-simple-controller-manager, pilz-industrial-motion-planner, rclcpp, ros-testing, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-moveit-ros-tests";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros_tests/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "2ebaa061fb3d5931139ecc03f89b5f427d92cef3a3cc83f8277ca0accc008509";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros_tests/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "a7c361d37a1d43c62f13bb337aea5d806a652894734bfb56b08f4d024daa488e";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-ros-trajectory-cache/default.nix
+++ b/distros/kilted/moveit-ros-trajectory-cache/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-uncrustify, geometry-msgs, launch-pytest, launch-testing-ament-cmake, moveit-common, moveit-configs-utils, moveit-planners-ompl, moveit-resources, moveit-ros, moveit-ros-planning-interface, python3Packages, rclcpp, rclcpp-action, rmf-utils, robot-state-publisher, ros2-control, tf2-ros, trajectory-msgs, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-kilted-moveit-ros-trajectory-cache";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros_trajectory_cache/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "ef487e4e567e5d56788465ad86e23a4964354c484d03b084a2bb2bdb443e6d37";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros_trajectory_cache/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "bb3bb4438f57198e3c434dd1ae25da8d6c87514b2300bf039bd4175d9559e7c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-ros-visualization/default.nix
+++ b/distros/kilted/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-kilted-moveit-ros-visualization";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros_visualization/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "2fbfa4f10c2c37bae3dadaa92a466db802cd1830b963d217a6268f66d242d1b3";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros_visualization/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "f317829115c8420646ee97971b0261b76478a9084fec169db5deea4bbee5cd7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-ros-warehouse/default.nix
+++ b/distros/kilted/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmt, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-kilted-moveit-ros-warehouse";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros_warehouse/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "4a879e3ec9891b02ad7361d20287f43604d6efed8781a4b28036f4e3f04d890b";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros_warehouse/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "67134b6eb6f8b4e88901e53822e2e229928cd89c0b8a00fcf0314069d85d1d2e";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-ros/default.nix
+++ b/distros/kilted/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-kilted-moveit-ros";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "94c0fcbf206aa9803b9cd5c90570eaf49fbccbfd750a4ddb6f4d7aca0097214e";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_ros/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "9f75de3e854f0c5aef0ab2ec61a7df0ca65ef6dec8c2624203006ace3873f1ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-runtime/default.nix
+++ b/distros/kilted/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-core, moveit-planners, moveit-plugins, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-kilted-moveit-runtime";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_runtime/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "ce95a28e1f8a99b4c09e4cea5b41c1e9b5cf4a059ce1203646b6ce2a5be1cdcf";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_runtime/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "f032bbb2010600a6cce4ec2c08ac552dc12d24e0b6dd6e81590d9fa2a7c54580";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-servo/default.nix
+++ b/distros/kilted/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, control-msgs, controller-manager, generate-parameter-library, geometry-msgs, joint-state-broadcaster, joint-trajectory-controller, joy, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-visualization, pluginlib, realtime-tools, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kilted-moveit-servo";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_servo/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "3bf5b3f6872ab6011a92fadc3ad80e39d5c6d4f8e190c5a552432942173c38bf";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_servo/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "61315978b7d3d3bf8ea630331ef254c3f078e2b11048a2421bb5aaf59e26793b";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-setup-app-plugins/default.nix
+++ b/distros/kilted/moveit-setup-app-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, moveit-configs-utils, moveit-ros-visualization, moveit-setup-framework, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-kilted-moveit-setup-app-plugins";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_setup_app_plugins/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "ef639d09bba44a1d0afc792cdcb4d406ffa3ecbe00dc5ee7405c75643da0a00e";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_setup_app_plugins/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "064a01d2987eb23b14c189acb08a26add80b61905d4aa032a33b71871d4e36a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-setup-assistant/default.nix
+++ b/distros/kilted/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, moveit-configs-utils, moveit-resources-panda-moveit-config, moveit-setup-app-plugins, moveit-setup-controllers, moveit-setup-core-plugins, moveit-setup-framework, moveit-setup-srdf-plugins, pluginlib, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-kilted-moveit-setup-assistant";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_setup_assistant/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "a1ba8ce45ebfcf9a47fe8987b27c9ba33c045851542d40a93795a209d5cc9b45";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_setup_assistant/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "f0a53535e17f426913545ac2f20ca35bf90286dbda0ce1b763cc92f8472b3b33";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-setup-controllers/default.nix
+++ b/distros/kilted/moveit-setup-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, moveit-configs-utils, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-setup-framework, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-kilted-moveit-setup-controllers";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_setup_controllers/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "ba0fa4df165808020fd99602e4764f7be8a63665932b0339daff390ffe3d06d0";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_setup_controllers/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "daf21e59536f3a5d5425f20dfadbd1c8b3a178f1f322c818959849f8fe2a1ce9";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-setup-core-plugins/default.nix
+++ b/distros/kilted/moveit-setup-core-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-index-cpp, moveit-ros-visualization, moveit-setup-framework, pluginlib, rclcpp, srdfdom, urdf }:
 buildRosPackage {
   pname = "ros-kilted-moveit-setup-core-plugins";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_setup_core_plugins/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "58c41f302c7f9f9c1ddbd0e08b85c88339b17c8f29be316a14b878414af7b13a";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_setup_core_plugins/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "a4106d10e1dc39c98e4005016ec9e0eb87a120654ae8de186858d8165b447f98";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-setup-framework/default.nix
+++ b/distros/kilted/moveit-setup-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-index-cpp, fmt, moveit-common, moveit-core, moveit-ros-planning, moveit-ros-visualization, pluginlib, rclcpp, rviz-common, rviz-rendering, srdfdom, urdf }:
 buildRosPackage {
   pname = "ros-kilted-moveit-setup-framework";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_setup_framework/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "60b5d4bf226988055b58ec742662030f715b84e320ef453019da9116f8b23988";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_setup_framework/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "50e5ce4a6731a233b4948a6136aeb8aac68716f580b2f2f1b562802c320302cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-setup-srdf-plugins/default.nix
+++ b/distros/kilted/moveit-setup-srdf-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, moveit-resources-fanuc-description, moveit-setup-framework, pluginlib }:
 buildRosPackage {
   pname = "ros-kilted-moveit-setup-srdf-plugins";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_setup_srdf_plugins/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "01e2b3f593688a4593e90f67dde0fedcfd91e843291a63c799cc16ff1631abdb";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_setup_srdf_plugins/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "50fcc54067895ceffe6cc9208a3c8a63b4a4d0089c3f381631973de2249b554d";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-simple-controller-manager/default.nix
+++ b/distros/kilted/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-kilted-moveit-simple-controller-manager";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_simple_controller_manager/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "0127e3a366c0cebb595ca4743d47ad798f321da0402d36d9a70407a6ebbd15e7";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit_simple_controller_manager/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "392923fb082e749dab4b0c2a68e0ca18cae18d4c33725ff7b66b75a049758faa";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit/default.nix
+++ b/distros/kilted/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-core, moveit-planners, moveit-plugins, moveit-ros, moveit-setup-assistant }:
 buildRosPackage {
   pname = "ros-kilted-moveit";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "8073c3f8d7e06efc272945a385efea7c48e2adfeece9b850bfce8c394d3c2622";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/moveit/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "709be0233a2e83ca4ebb33d06b56d5e0cee54ab7950d12eec69b4d1d2922a955";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/network-bridge/default.nix
+++ b/distros/kilted/network-bridge/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, boost, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pkg-config, pluginlib, rclcpp, std-msgs, zstd }:
+buildRosPackage {
+  pname = "ros-kilted-network-bridge";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/network_bridge-release/archive/release/kilted/network_bridge/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "be2146a83e767c1b329370fa9a3b9d750885654d9606761f0fe38744cdba9b52";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake pkg-config ];
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common launch-testing launch-testing-ament-cmake launch-testing-ros ];
+  propagatedBuildInputs = [ boost pluginlib rclcpp std-msgs zstd ];
+  nativeBuildInputs = [ ament-cmake pkg-config ];
+
+  meta = {
+    description = "Allows for arbitrary network links (UDP, TCP, etc) to bridge ROS2 messages";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kilted/ntpd-driver/default.nix
+++ b/distros/kilted/ntpd-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, poco, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ntpd-driver";
-  version = "2.2.0-r4";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ntpd_driver-release/archive/release/kilted/ntpd_driver/2.2.0-4.tar.gz";
-    name = "2.2.0-4.tar.gz";
-    sha256 = "26955019a4f9c2e62e9d03427e46f17519bbcce532cc75be8e350f582ea577bc";
+    url = "https://github.com/ros2-gbp/ntpd_driver-release/archive/release/kilted/ntpd_driver/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "5a5c35bef9aceedcf1951fc740a5179cd8f00b588746d0df78aa7931f9ef5532";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/om-gravity-compensation-controller/default.nix
+++ b/distros/kilted/om-gravity-compensation-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, backward-ros, control-msgs, control-toolbox, controller-interface, generate-parameter-library, hardware-interface, kdl-parser, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, rsl, tl-expected, urdf }:
 buildRosPackage {
   pname = "ros-kilted-om-gravity-compensation-controller";
-  version = "4.0.7-r1";
+  version = "4.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/kilted/om_gravity_compensation_controller/4.0.7-1.tar.gz";
-    name = "4.0.7-1.tar.gz";
-    sha256 = "61068fe9ce471aeb237731e08827196a459ff539545019b14000a3195b613d5a";
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/kilted/om_gravity_compensation_controller/4.0.8-1.tar.gz";
+    name = "4.0.8-1.tar.gz";
+    sha256 = "bdc8279dd40b7bc5f4e89c51cc040429cb9d521f045a5596cd4929ff04e4c3d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/om-joint-trajectory-command-broadcaster/default.nix
+++ b/distros/kilted/om-joint-trajectory-command-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, backward-ros, builtin-interfaces, control-msgs, controller-interface, generate-parameter-library, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, sensor-msgs, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-kilted-om-joint-trajectory-command-broadcaster";
-  version = "4.0.7-r1";
+  version = "4.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/kilted/om_joint_trajectory_command_broadcaster/4.0.7-1.tar.gz";
-    name = "4.0.7-1.tar.gz";
-    sha256 = "133f4a89036aad567ea48124ae2708a16cb04fd726807378c953d237710af57f";
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/kilted/om_joint_trajectory_command_broadcaster/4.0.8-1.tar.gz";
+    name = "4.0.8-1.tar.gz";
+    sha256 = "2c9a2be162e2cf295c5849f5f455fed5c500ed757dd387d5d3e1f23fa3b79655";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/om-spring-actuator-controller/default.nix
+++ b/distros/kilted/om-spring-actuator-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, urdf }:
 buildRosPackage {
   pname = "ros-kilted-om-spring-actuator-controller";
-  version = "4.0.7-r1";
+  version = "4.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/kilted/om_spring_actuator_controller/4.0.7-1.tar.gz";
-    name = "4.0.7-1.tar.gz";
-    sha256 = "adf1d86bfe9e17613e6a8a875c54de2bd1badead61a6e7d9a0a3ba82fdb2b6ac";
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/kilted/om_spring_actuator_controller/4.0.8-1.tar.gz";
+    name = "4.0.8-1.tar.gz";
+    sha256 = "37b1cd7222fb4a7501746396f4906097e7754e4e878d554025085a228d6e5962";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/open-manipulator-bringup/default.nix
+++ b/distros/kilted/open-manipulator-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, dynamixel-hardware-interface, gz-ros2-control, open-manipulator-description, rclpy, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, ros2-control, ros2-controllers, rviz2, xacro }:
 buildRosPackage {
   pname = "ros-kilted-open-manipulator-bringup";
-  version = "4.0.7-r1";
+  version = "4.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/kilted/open_manipulator_bringup/4.0.7-1.tar.gz";
-    name = "4.0.7-1.tar.gz";
-    sha256 = "e5ba67d509c8c5748031ae026488dac7972cd7ce480f6b9afdf96f36ff7737cf";
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/kilted/open_manipulator_bringup/4.0.8-1.tar.gz";
+    name = "4.0.8-1.tar.gz";
+    sha256 = "fc27bfc0c9796a0b57cdb0278f1353af06f8760b2a3c0e420d5cfe4082836223";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/open-manipulator-collision/default.nix
+++ b/distros/kilted/open-manipulator-collision/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, fcl, kdl-parser, rclcpp, sensor-msgs, std-msgs, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-open-manipulator-collision";
-  version = "4.0.7-r1";
+  version = "4.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/kilted/open_manipulator_collision/4.0.7-1.tar.gz";
-    name = "4.0.7-1.tar.gz";
-    sha256 = "412fa4369aef531a7d37e841480437f5f1ca8b743d2a301873cb47af9c7a0b5c";
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/kilted/open_manipulator_collision/4.0.8-1.tar.gz";
+    name = "4.0.8-1.tar.gz";
+    sha256 = "7b264215b27c2d3bed82835707f2a0265e16a010da46be8af0f5dc539d9c9cb4";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/open-manipulator-description/default.nix
+++ b/distros/kilted/open-manipulator-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, rviz2 }:
 buildRosPackage {
   pname = "ros-kilted-open-manipulator-description";
-  version = "4.0.7-r1";
+  version = "4.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/kilted/open_manipulator_description/4.0.7-1.tar.gz";
-    name = "4.0.7-1.tar.gz";
-    sha256 = "1f9d395530155fcf50bccee6c1525065519be67ad23b726eb25e8a33f6a728e6";
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/kilted/open_manipulator_description/4.0.8-1.tar.gz";
+    name = "4.0.8-1.tar.gz";
+    sha256 = "b19c087fbc358d7669099fde4f7286381b8400de82ff3f71fee8c72fd26cc456";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/open-manipulator-gui/default.nix
+++ b/distros/kilted/open-manipulator-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen3-cmake-module, geometry-msgs, moveit-core, moveit-msgs, moveit-ros-planning, moveit-ros-planning-interface, qt5, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-open-manipulator-gui";
-  version = "4.0.7-r1";
+  version = "4.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/kilted/open_manipulator_gui/4.0.7-1.tar.gz";
-    name = "4.0.7-1.tar.gz";
-    sha256 = "8a1b563236bb886b70bb85e60e768175cd1887e61d822110cb8f3837db8455b8";
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/kilted/open_manipulator_gui/4.0.8-1.tar.gz";
+    name = "4.0.8-1.tar.gz";
+    sha256 = "6e51996e4ecd6e3cd8c2d112c9cdd5708dcaf380ea84de0eb6afa910c7c73933";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/open-manipulator-moveit-config/default.nix
+++ b/distros/kilted/open-manipulator-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, joint-state-publisher, joint-state-publisher-gui, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, open-manipulator-description, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, tf2-ros, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-kilted-open-manipulator-moveit-config";
-  version = "4.0.7-r1";
+  version = "4.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/kilted/open_manipulator_moveit_config/4.0.7-1.tar.gz";
-    name = "4.0.7-1.tar.gz";
-    sha256 = "be93c70f3d1db8a9aded0f5cd198b9f9a29c7a9511b7231b1bf530db30bf06bf";
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/kilted/open_manipulator_moveit_config/4.0.8-1.tar.gz";
+    name = "4.0.8-1.tar.gz";
+    sha256 = "192d263f59d18bd4f8c58958ec1d36d0ae46a91bc94c88e58bf18a43a447f50e";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/open-manipulator-playground/default.nix
+++ b/distros/kilted/open-manipulator-playground/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-ros-planning-interface, rclcpp }:
 buildRosPackage {
   pname = "ros-kilted-open-manipulator-playground";
-  version = "4.0.7-r1";
+  version = "4.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/kilted/open_manipulator_playground/4.0.7-1.tar.gz";
-    name = "4.0.7-1.tar.gz";
-    sha256 = "065f43d92d4d4c4daed7648d9345469f043cdc18be81fcb29a7c7b9e43b22b82";
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/kilted/open_manipulator_playground/4.0.8-1.tar.gz";
+    name = "4.0.8-1.tar.gz";
+    sha256 = "c73f95dee536c8dbe003726f2ca29dee744ba0d910c00b4580caa7d8a8206f13";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/open-manipulator-teleop/default.nix
+++ b/distros/kilted/open-manipulator-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kilted-open-manipulator-teleop";
-  version = "4.0.7-r1";
+  version = "4.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/kilted/open_manipulator_teleop/4.0.7-1.tar.gz";
-    name = "4.0.7-1.tar.gz";
-    sha256 = "9296c9e9175b13f82da56b698c0318d56c6ca30f98279dd0b4c72592e2eb0454";
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/kilted/open_manipulator_teleop/4.0.8-1.tar.gz";
+    name = "4.0.8-1.tar.gz";
+    sha256 = "9379089c120ff6c6852a46e854f0acb0d624a8cc650f8c0e1c11a176345823a3";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/open-manipulator/default.nix
+++ b/distros/kilted/open-manipulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, om-gravity-compensation-controller, om-joint-trajectory-command-broadcaster, om-spring-actuator-controller, open-manipulator-bringup, open-manipulator-collision, open-manipulator-description, open-manipulator-gui, open-manipulator-moveit-config, open-manipulator-playground, open-manipulator-teleop }:
 buildRosPackage {
   pname = "ros-kilted-open-manipulator";
-  version = "4.0.7-r1";
+  version = "4.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/kilted/open_manipulator/4.0.7-1.tar.gz";
-    name = "4.0.7-1.tar.gz";
-    sha256 = "14d7a78083f7f34812f7d76eb35be5a201c9fc950063dc9604600cb8b1828d99";
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/kilted/open_manipulator/4.0.8-1.tar.gz";
+    name = "4.0.8-1.tar.gz";
+    sha256 = "e4afba67dbe038bdef8bc5b5a0851a61b33d10c9f923034e56cf01f52b7a5008";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/pilz-industrial-motion-planner-testutils/default.nix
+++ b/distros/kilted/pilz-industrial-motion-planner-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen3-cmake-module, moveit-common, moveit-core, moveit-msgs, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-kilted-pilz-industrial-motion-planner-testutils";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/pilz_industrial_motion_planner_testutils/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "557505d721270220a0c0671ff8f08d766b4d3c243adfafd07c4da5ea67b3c68e";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/pilz_industrial_motion_planner_testutils/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "84c83d99ff929bcdb5a9647dc18fc85581cc4a1d04770901bc520d6750af6e33";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/pilz-industrial-motion-planner/default.nix
+++ b/distros/kilted/pilz-industrial-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, boost, eigen3-cmake-module, generate-parameter-library, geometry-msgs, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-prbt-moveit-config, moveit-resources-prbt-pg70-support, moveit-resources-prbt-support, moveit-ros-move-group, moveit-ros-planning, orocos-kdl-vendor, pilz-industrial-motion-planner-testutils, pluginlib, rclcpp, ros-testing, tf2, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-pilz-industrial-motion-planner";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/pilz_industrial_motion_planner/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "9901d46902beab78577fb2afa238d7e883d72b2f305fdcf107bc957c09dc0f5e";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/kilted/pilz_industrial_motion_planner/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "59e9b47233536aaa6fff3107eb60c123c60dfd7bde26054bc4b7be7dcf0a862a";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rclcpp-action/default.nix
+++ b/distros/kilted/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-kilted-rclcpp-action";
-  version = "29.5.2-r1";
+  version = "29.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/kilted/rclcpp_action/29.5.2-1.tar.gz";
-    name = "29.5.2-1.tar.gz";
-    sha256 = "c98cfc8a72207a7cd34130843e24dd3f579d540564e5abe7e7ce7ce51d6b1be0";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/kilted/rclcpp_action/29.5.3-1.tar.gz";
+    name = "29.5.3-1.tar.gz";
+    sha256 = "f1e4f241d75ef29b16a3bcc4e5e2d42d5e4f5ac0090a91541f99ee9a2cc16f74";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rclcpp-components/default.nix
+++ b/distros/kilted/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-rclcpp-components";
-  version = "29.5.2-r1";
+  version = "29.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/kilted/rclcpp_components/29.5.2-1.tar.gz";
-    name = "29.5.2-1.tar.gz";
-    sha256 = "834c82cbcf66d709449ccb6cd06178836ebe21292995ed7f767e85f23d46c73b";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/kilted/rclcpp_components/29.5.3-1.tar.gz";
+    name = "29.5.3-1.tar.gz";
+    sha256 = "e92d3362c3c90fe3919a96e8f6ade17ec088c1a68f650ea0376b6f7729e33b03";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rclcpp-lifecycle/default.nix
+++ b/distros/kilted/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-kilted-rclcpp-lifecycle";
-  version = "29.5.2-r1";
+  version = "29.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/kilted/rclcpp_lifecycle/29.5.2-1.tar.gz";
-    name = "29.5.2-1.tar.gz";
-    sha256 = "07a5df17f575ed719606bf46dfe2306765d01ee89f0cc2e749d4ee479a9d0bbc";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/kilted/rclcpp_lifecycle/29.5.3-1.tar.gz";
+    name = "29.5.3-1.tar.gz";
+    sha256 = "c496bb7d91e5042891d687eba0e03ab7b06499d7ae88109010872ab2ab012c27";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rclcpp/default.nix
+++ b/distros/kilted/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-kilted-rclcpp";
-  version = "29.5.2-r1";
+  version = "29.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/kilted/rclcpp/29.5.2-1.tar.gz";
-    name = "29.5.2-1.tar.gz";
-    sha256 = "0a5a6579e9a9b9da56f71a06f7b972e3cd36a23066e4627a09d4ce8360e8a84d";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/kilted/rclcpp/29.5.3-1.tar.gz";
+    name = "29.5.3-1.tar.gz";
+    sha256 = "93c0812aa4da8968bf54d65dfac075f253c414691c1796d753452e5d11abd092";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/realtime-tools/default.nix
+++ b/distros/kilted/realtime-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, boost, libcap, lifecycle-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2-control-cmake, test-msgs }:
 buildRosPackage {
   pname = "ros-kilted-realtime-tools";
-  version = "4.4.0-r1";
+  version = "4.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/kilted/realtime_tools/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "61d9cef38b8713818133328fd34e546fe444bddfd8caac996ea768115a9ce1fa";
+    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/kilted/realtime_tools/4.5.0-1.tar.gz";
+    name = "4.5.0-1.tar.gz";
+    sha256 = "f70e6869c1d32a8707521958514b06fb902fbbab0b4004469a0043e058e56be5";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rmw-zenoh-cpp/default.nix
+++ b/distros/kilted/rmw-zenoh-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, fastcdr, nlohmann_json, rcpputils, rcutils, rmw, rmw-test-fixture, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, tracetools, zenoh-cpp-vendor }:
 buildRosPackage {
   pname = "ros-kilted-rmw-zenoh-cpp";
-  version = "0.6.3-r1";
+  version = "0.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/kilted/rmw_zenoh_cpp/0.6.3-1.tar.gz";
-    name = "0.6.3-1.tar.gz";
-    sha256 = "c9c0e27d473e717e99fad130511810659e1cc26670fc4f737e1fb222affcee6d";
+    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/kilted/rmw_zenoh_cpp/0.6.4-1.tar.gz";
+    name = "0.6.4-1.tar.gz";
+    sha256 = "3a0ba7ac070f202ba5d588f6a206e58e12359fe4d02779eaadde0ea8672a35db";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros2action/default.nix
+++ b/distros/kilted/ros2action/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, ros2topic, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ros2action";
-  version = "0.38.0-r1";
+  version = "0.38.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2action/0.38.0-1.tar.gz";
-    name = "0.38.0-1.tar.gz";
-    sha256 = "e975acb8159222ab733f2edd7d78fc7cb9464be6d0fa91c1afdd5fb8de40e0c9";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2action/0.38.1-1.tar.gz";
+    name = "0.38.1-1.tar.gz";
+    sha256 = "66de3be86298cb1a4a060f4859e82b3b7aeeda779546b1add1f29f3b029ceb4c";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint launch launch-testing launch-testing-ros python3Packages.pytest python3Packages.pytest-timeout test-msgs ];
-  propagatedBuildInputs = [ action-msgs ament-index-python rclpy ros2cli rosidl-runtime-py ];
+  propagatedBuildInputs = [ action-msgs ament-index-python rclpy ros2cli ros2topic rosidl-runtime-py ];
 
   meta = {
     description = "The action command for ROS 2 command line tools.";

--- a/distros/kilted/ros2cli-test-interfaces/default.nix
+++ b/distros/kilted/ros2cli-test-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-kilted-ros2cli-test-interfaces";
-  version = "0.38.0-r1";
+  version = "0.38.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2cli_test_interfaces/0.38.0-1.tar.gz";
-    name = "0.38.0-1.tar.gz";
-    sha256 = "c2ed7e5d1c02129f114e180a66005389c52db0249c5f51065c973b2ea43825ba";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2cli_test_interfaces/0.38.1-1.tar.gz";
+    name = "0.38.1-1.tar.gz";
+    sha256 = "9c7ce04613a6e011cb23aaeb87d7c06a7e28579c21d2fc6154b5b4721a293e9d";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros2cli/default.nix
+++ b/distros/kilted/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, rclpy, test-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ros2cli";
-  version = "0.38.0-r1";
+  version = "0.38.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2cli/0.38.0-1.tar.gz";
-    name = "0.38.0-1.tar.gz";
-    sha256 = "a34f85c3ad24780feaaa9e208ee5ca7a92de505c5b72ae0490176890c85a1303";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2cli/0.38.1-1.tar.gz";
+    name = "0.38.1-1.tar.gz";
+    sha256 = "b925f82eb4be47081065a5b99a7222418aede715c347579794d5f5950b8e44d0";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/ros2component/default.nix
+++ b/distros/kilted/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, python3Packages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-kilted-ros2component";
-  version = "0.38.0-r1";
+  version = "0.38.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2component/0.38.0-1.tar.gz";
-    name = "0.38.0-1.tar.gz";
-    sha256 = "4b55c0b3a3bd1b430cbaf0f8b423f378d64ea1acd523e3f1503181ae47064244";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2component/0.38.1-1.tar.gz";
+    name = "0.38.1-1.tar.gz";
+    sha256 = "92cde51e9709ad7f8fe6ddac7935256e0905a789d1d4f27af557edb6ba6cda3a";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/ros2doctor/default.nix
+++ b/distros/kilted/ros2doctor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros-environment, ros2cli, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ros2doctor";
-  version = "0.38.0-r1";
+  version = "0.38.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2doctor/0.38.0-1.tar.gz";
-    name = "0.38.0-1.tar.gz";
-    sha256 = "b9a9953e6f592c234814baab0533147fe17ecdc523bcf53c3aee1a3b94a87360";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2doctor/0.38.1-1.tar.gz";
+    name = "0.38.1-1.tar.gz";
+    sha256 = "9449c68c1771ae4cb01932ddb636387f2f34aeb41192a3147dce456e14bee6bb";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/ros2interface/default.nix
+++ b/distros/kilted/ros2interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, ros2cli, ros2cli-test-interfaces, rosidl-adapter, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ros2interface";
-  version = "0.38.0-r1";
+  version = "0.38.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2interface/0.38.0-1.tar.gz";
-    name = "0.38.0-1.tar.gz";
-    sha256 = "a24c0ddc64f64eedabfe5f8d55ddd267fcea43b31ca9c810f5a03ee00a698e01";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2interface/0.38.1-1.tar.gz";
+    name = "0.38.1-1.tar.gz";
+    sha256 = "a3803a9250f26006cab36d6a79096bacf0c27d1fb46a25588526daf1e72655d3";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/ros2lifecycle-test-fixtures/default.nix
+++ b/distros/kilted/ros2lifecycle-test-fixtures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-kilted-ros2lifecycle-test-fixtures";
-  version = "0.38.0-r1";
+  version = "0.38.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2lifecycle_test_fixtures/0.38.0-1.tar.gz";
-    name = "0.38.0-1.tar.gz";
-    sha256 = "7ea0f598cca24dbdcc0e3c06af9e76c0d0d2f9e5cbbdb0f8d75adfb8a500c4bc";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2lifecycle_test_fixtures/0.38.1-1.tar.gz";
+    name = "0.38.1-1.tar.gz";
+    sha256 = "15a5d1e493cba05b9e442904899efd543ef41bbdb335d2a7f36cdb3430abdc72";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros2lifecycle/default.nix
+++ b/distros/kilted/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, lifecycle-msgs, python3Packages, rclpy, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-kilted-ros2lifecycle";
-  version = "0.38.0-r1";
+  version = "0.38.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2lifecycle/0.38.0-1.tar.gz";
-    name = "0.38.0-1.tar.gz";
-    sha256 = "69d46641c102d8a2c70479c7ffd1d74bdbaa4c5319d6c02b00852bab2663857f";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2lifecycle/0.38.1-1.tar.gz";
+    name = "0.38.1-1.tar.gz";
+    sha256 = "3de3a98073e02f469184b02450315262d5d8489ac69d9f18c4c4caade06c7d35";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/ros2multicast/default.nix
+++ b/distros/kilted/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, ros2cli }:
 buildRosPackage {
   pname = "ros-kilted-ros2multicast";
-  version = "0.38.0-r1";
+  version = "0.38.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2multicast/0.38.0-1.tar.gz";
-    name = "0.38.0-1.tar.gz";
-    sha256 = "1b3fbdb0f81e3503e990a51aff7f93f9399adeaca15b522c3ecc022834039fd2";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2multicast/0.38.1-1.tar.gz";
+    name = "0.38.1-1.tar.gz";
+    sha256 = "4fd13fdfcb735da815dd96beb902729ce0dd41b14c74ee90280352e1b8d55870";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/ros2node/default.nix
+++ b/distros/kilted/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ros2node";
-  version = "0.38.0-r1";
+  version = "0.38.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2node/0.38.0-1.tar.gz";
-    name = "0.38.0-1.tar.gz";
-    sha256 = "7b37bd63bf62e6924f762ede92e7aab2e7eea525a8ee6eefc186ccf0f02e964d";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2node/0.38.1-1.tar.gz";
+    name = "0.38.1-1.tar.gz";
+    sha256 = "3951b528b1be7dd0bd3499062d7df3eb69055b2cfce648cb2b6ec8daa8884f01";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/ros2param/default.nix
+++ b/distros/kilted/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-kilted-ros2param";
-  version = "0.38.0-r1";
+  version = "0.38.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2param/0.38.0-1.tar.gz";
-    name = "0.38.0-1.tar.gz";
-    sha256 = "b9fec4889345fe86733d9fb3121aed3c66dd6ee936b3a4d9f60e1d2b64bdb04e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2param/0.38.1-1.tar.gz";
+    name = "0.38.1-1.tar.gz";
+    sha256 = "775f81383cc2e88ae28a630f2f2794bf593f4043154d93e74f13a1f11d401d27";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/ros2pkg/default.nix
+++ b/distros/kilted/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, ros2cli }:
 buildRosPackage {
   pname = "ros-kilted-ros2pkg";
-  version = "0.38.0-r1";
+  version = "0.38.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2pkg/0.38.0-1.tar.gz";
-    name = "0.38.0-1.tar.gz";
-    sha256 = "6e21a20122a0b3243352b3dc7310af85d326da8662a67ede58ec3f4c824c111f";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2pkg/0.38.1-1.tar.gz";
+    name = "0.38.1-1.tar.gz";
+    sha256 = "e94f962d06424196bbf75db6175f6cf69c4dd9a702c83de49ce9aec92beffa52";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/ros2run/default.nix
+++ b/distros/kilted/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-kilted-ros2run";
-  version = "0.38.0-r1";
+  version = "0.38.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2run/0.38.0-1.tar.gz";
-    name = "0.38.0-1.tar.gz";
-    sha256 = "ff08a445d36c984ccb79aa0fdb4df2c205ea7ff533a7b963229349338263377e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2run/0.38.1-1.tar.gz";
+    name = "0.38.1-1.tar.gz";
+    sha256 = "7be7d82bb587172d9fd9e4fb2395a65e977d608a61a10297f346307dad366620";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/ros2service/default.nix
+++ b/distros/kilted/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, ros2topic, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ros2service";
-  version = "0.38.0-r1";
+  version = "0.38.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2service/0.38.0-1.tar.gz";
-    name = "0.38.0-1.tar.gz";
-    sha256 = "ab7c4705ebf18658de85d7a6785068bf0fc964a775e0548ddfd3c806312d5100";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2service/0.38.1-1.tar.gz";
+    name = "0.38.1-1.tar.gz";
+    sha256 = "fa1c782b4170d97c4f630fcda2329b135afc9910ceef21ff7738533c6146b744";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/ros2topic/default.nix
+++ b/distros/kilted/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosgraph-msgs, rosidl-runtime-py, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ros2topic";
-  version = "0.38.0-r1";
+  version = "0.38.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2topic/0.38.0-1.tar.gz";
-    name = "0.38.0-1.tar.gz";
-    sha256 = "149947c6063ad3c42288fdfd16904010e6d1feb6c37777e9f6d8bae0d0ea7004";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/kilted/ros2topic/0.38.1-1.tar.gz";
+    name = "0.38.1-1.tar.gz";
+    sha256 = "6dee757be68c23368102934fdd39b2e1b7e68f96c1035ca74a9778ca3c1af52c";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/rosidlcpp-generator-c/default.nix
+++ b/distros/kilted/rosidlcpp-generator-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-ros-core, fmt, nlohmann_json, rcutils, ros-environment, rosidl-cmake, rosidl-generator-type-description, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-kilted-rosidlcpp-generator-c";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp_generator_c/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "1d773df474381415be3a7b729a24a031b5d028ea8c58e2a3a6cf313eb545c23e";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp_generator_c/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "00411ff81a1a1753f716a3611add82478e89102915684127d9bbdef0f7022e61";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rosidlcpp-generator-core/default.nix
+++ b/distros/kilted/rosidlcpp-generator-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, fmt, nlohmann_json, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-kilted-rosidlcpp-generator-core";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp_generator_core/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "c76cd4158b4948eed42b43f3b4c0b4ce88933f6304c777c478197ed8d7e089be";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp_generator_core/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "0a9a2054f9582908a940fc6681ea95e64f9bbb988b67b96e48368b7a9be82f87";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rosidlcpp-generator-cpp/default.nix
+++ b/distros/kilted/rosidlcpp-generator-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, fmt, nlohmann_json, rcutils, rosidl-cmake, rosidl-generator-type-description, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-kilted-rosidlcpp-generator-cpp";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp_generator_cpp/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "06f1c55de3ed2da1e783630dc38a793df42ff012959aca49aa432bbf007a032e";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp_generator_cpp/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "3c7c4fdfcfab0fe9315aa6dd7f81b3c1894161ad82a0ddd35b5bf37696d48304";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rosidlcpp-generator-py/default.nix
+++ b/distros/kilted/rosidlcpp-generator-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, fmt, nlohmann_json, python-cmake-module, rmw, rosidl-generator-c, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-c, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-kilted-rosidlcpp-generator-py";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp_generator_py/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "d4600851d5e2c1ddd29ae57843955eb29b110d0a51e2c8f016fe39c5d96f6da7";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp_generator_py/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "aa20bb30ee55cd8cdf0889dee3fe53f0e28f5909db97558c1e88a61408eaecb4";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rosidlcpp-generator-type-description/default.nix
+++ b/distros/kilted/rosidlcpp-generator-type-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, fmt, nlohmann_json, rcutils, rosidl-runtime-c, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-kilted-rosidlcpp-generator-type-description";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp_generator_type_description/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "63b97627a70bb5cdc77c8a451cf3941d39b330dc35d49e2ee834acbd417256f2";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp_generator_type_description/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "edb24a3cb49befaf3202958742b19eb0ca667b0be8741e049db387b4b4ec7da4";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rosidlcpp-parser/default.nix
+++ b/distros/kilted/rosidlcpp-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, fmt, nlohmann_json }:
 buildRosPackage {
   pname = "ros-kilted-rosidlcpp-parser";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp_parser/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "248552791936111b519ccc144dfd33f9d57032694dd7aa566cabfc65369d1787";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp_parser/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "d88d54aa6f04d302e1d44de2b58d44e0c70e5ae7a3d06d39a61ebd1c82fd2b40";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rosidlcpp-typesupport-c/default.nix
+++ b/distros/kilted/rosidlcpp-typesupport-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-ros-core, ament-index-python, fmt, nlohmann_json, rcpputils, rcutils, ros-environment, rosidl-cli, rosidl-generator-c, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-c, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-kilted-rosidlcpp-typesupport-c";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp_typesupport_c/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "b0b7c00597658e93cf668630143632d3ceb89598ac2e1f832a76a06e0dce3975";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp_typesupport_c/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "d8baefdadba8a833d697178df6f876d9e263db4861a0bc6cea05b2ffc629a152";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rosidlcpp-typesupport-cpp/default.nix
+++ b/distros/kilted/rosidlcpp-typesupport-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-ros-core, ament-index-python, fmt, nlohmann_json, rcpputils, rcutils, ros-environment, rosidl-cli, rosidl-generator-c, rosidl-generator-type-description, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-cpp, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-kilted-rosidlcpp-typesupport-cpp";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp_typesupport_cpp/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "09b19b2e30aea810aed0883786bc41bdc2c84090dcb61674d6ba2b7f7e674dff";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp_typesupport_cpp/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "10c066ca72f52a20e43bd4c465299b02837cfee013c2543ce74959f7adf75c2c";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rosidlcpp-typesupport-fastrtps-c/default.nix
+++ b/distros/kilted/rosidlcpp-typesupport-fastrtps-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-cmake-ros, fastcdr, fmt, nlohmann_json, rmw, rosidl-generator-c, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-kilted-rosidlcpp-typesupport-fastrtps-c";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp_typesupport_fastrtps_c/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "cd9be6562b8498fb2238aeebcb9a35434f6ff4108ee9755ece662167eafe5e3d";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp_typesupport_fastrtps_c/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "3141be4d415f2c18d0a2808d67384668704fb20343ae934ff1f347101b9c4ac9";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rosidlcpp-typesupport-fastrtps-cpp/default.nix
+++ b/distros/kilted/rosidlcpp-typesupport-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-cmake-ros, fastcdr, fmt, nlohmann_json, rmw, rosidl-generator-c, rosidl-generator-cpp, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-kilted-rosidlcpp-typesupport-fastrtps-cpp";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp_typesupport_fastrtps_cpp/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "c5b4700cc3a6587943a129e9924a08675ac93a3dec8427eacc656a1617a366fe";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp_typesupport_fastrtps_cpp/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "405df65356772a9cdf6ce4590321ba53b58ca9360f61cf5dddd8a2be419ef0c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rosidlcpp-typesupport-introspection-c/default.nix
+++ b/distros/kilted/rosidlcpp-typesupport-introspection-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros-core, ament-index-python, fmt, nlohmann_json, ros-environment, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-kilted-rosidlcpp-typesupport-introspection-c";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp_typesupport_introspection_c/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "844722b5328ba5076e7c42335d35b2675743a2ad29b6e209c0b5ec01c9f68eda";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp_typesupport_introspection_c/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "0d75550aaaccc6a473e87e23ac4ac15a72230e592660eb388609cd3d0759f230";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rosidlcpp-typesupport-introspection-cpp/default.nix
+++ b/distros/kilted/rosidlcpp-typesupport-introspection-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros-core, ament-index-python, fmt, nlohmann_json, ros-environment, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidl-typesupport-introspection-c, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-kilted-rosidlcpp-typesupport-introspection-cpp";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp_typesupport_introspection_cpp/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "d6bd29fcc485cce4fbbdfa75020dea00b61ca507b11ea35871562e0f40458c7e";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp_typesupport_introspection_cpp/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "e010d8c8626f15a9e67b832f6df6d55d462df7dedf3560d52638cbe064fdbd42";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rosidlcpp/default.nix
+++ b/distros/kilted/rosidlcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, rosidlcpp-generator-c, rosidlcpp-generator-cpp, rosidlcpp-generator-py, rosidlcpp-generator-type-description, rosidlcpp-typesupport-c, rosidlcpp-typesupport-cpp, rosidlcpp-typesupport-fastrtps-c, rosidlcpp-typesupport-fastrtps-cpp, rosidlcpp-typesupport-introspection-c, rosidlcpp-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-kilted-rosidlcpp";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "a37b26017479fe0a15e66f1cc743baa63f65a2033af9baf3e76f0c8c96508526";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/kilted/rosidlcpp/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "54e545e47693cc19720fc84a11f79c124fe9060d7d79ead138c77bbe72b6ddbf";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/sdformat-vendor/vendored-source.json
+++ b/distros/kilted/sdformat-vendor/vendored-source.json
@@ -1,0 +1,7 @@
+{
+  "sdformat_vendor": {
+    "url": "https://github.com/gazebosim/sdformat.git",
+    "rev": "sdformat15_15.3.0",
+    "hash": "sha256-5EGAypmWiUHvGpAXTIWJi8ChWkafK1li1C0/C1GIfkA="
+  }
+}

--- a/distros/kilted/tf2-web-republisher-interfaces/default.nix
+++ b/distros/kilted/tf2-web-republisher-interfaces/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-kilted-tf2-web-republisher-interfaces";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/tf2_web_republisher-release/archive/release/kilted/tf2_web_republisher_interfaces/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "15acd80077b3e8289cf466d0db8e5aa803e51cd38d124aba7b66d3bf54ed5cb4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces geometry-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Interface definitions for tf2_web_republisher";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/tf2-web-republisher/default.nix
+++ b/distros/kilted/tf2-web-republisher/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, geometry-msgs, rclcpp, rclcpp-action, rclcpp-components, tf2, tf2-ros, tf2-web-republisher-interfaces }:
+buildRosPackage {
+  pname = "ros-kilted-tf2-web-republisher";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/tf2_web_republisher-release/archive/release/kilted/tf2_web_republisher/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "bc46e3252b5feba0222c777fe42ade8d62a6fb5256ab5053bf51756b09a4c173";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gmock ];
+  propagatedBuildInputs = [ geometry-msgs rclcpp rclcpp-action rclcpp-components tf2 tf2-ros tf2-web-republisher-interfaces ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Republishing of Selected TFs";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/theora-image-transport/default.nix
+++ b/distros/kilted/theora-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, libogg, libtheora, opencv, pkg-config, pluginlib, rclcpp, rcutils, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-theora-image-transport";
-  version = "5.1.0-r1";
+  version = "5.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/kilted/theora_image_transport/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "2a170ec982fabddd372d65cf3232bf3da16ea9f79199640a6f92e55df6b8aa69";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/kilted/theora_image_transport/5.1.1-1.tar.gz";
+    name = "5.1.1-1.tar.gz";
+    sha256 = "7e221ca09417c056034b9e396cf74c5739f24353747e4dc6c8de8ea9e722d571";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/zenoh-cpp-vendor/default.nix
+++ b/distros/kilted/zenoh-cpp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, cargo, clang, git }:
 buildRosPackage {
   pname = "ros-kilted-zenoh-cpp-vendor";
-  version = "0.6.3-r1";
+  version = "0.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/kilted/zenoh_cpp_vendor/0.6.3-1.tar.gz";
-    name = "0.6.3-1.tar.gz";
-    sha256 = "bab9219756fe829bf20d2a0dfe0b733929ca317afa77e28a2f74cecdc63fef9e";
+    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/kilted/zenoh_cpp_vendor/0.6.4-1.tar.gz";
+    name = "0.6.4-1.tar.gz";
+    sha256 = "8758cf0a0a9152e0e2bdef0984867b1ed211e1485acbdd05c76befd03a998df5";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/zenoh-security-tools/default.nix
+++ b/distros/kilted/zenoh-security-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, nlohmann_json, rcpputils, rcutils, rmw, rmw-security-common, tinyxml2-vendor, zenoh-cpp-vendor }:
 buildRosPackage {
   pname = "ros-kilted-zenoh-security-tools";
-  version = "0.6.3-r1";
+  version = "0.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/kilted/zenoh_security_tools/0.6.3-1.tar.gz";
-    name = "0.6.3-1.tar.gz";
-    sha256 = "fe8365d1ad8d6f6697daf329c02221da7feaf72ea9e42a0100402afed102217d";
+    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/kilted/zenoh_security_tools/0.6.4-1.tar.gz";
+    name = "0.6.4-1.tar.gz";
+    sha256 = "7b738d16df14fe162cf6b51db108ad290c5a1ebc7299578eb8034214dc8f9d4b";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/zstd-image-transport/default.nix
+++ b/distros/kilted/zstd-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, image-transport, zlib }:
 buildRosPackage {
   pname = "ros-kilted-zstd-image-transport";
-  version = "5.1.0-r1";
+  version = "5.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/kilted/zstd_image_transport/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "2e0a2a133506c98ae4ca44a4663e6e222d6ab18ce9be40cd4e07d1a3de10605e";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/kilted/zstd_image_transport/5.1.1-1.tar.gz";
+    name = "5.1.1-1.tar.gz";
+    sha256 = "d6071e6e93d6999afd6b9e9dc94a748f989e3e5676d74fc16d0ca74c323e7958";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/chomp-motion-planner/default.nix
+++ b/distros/rolling/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-common, moveit-core, rclcpp, rsl, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-chomp-motion-planner";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/chomp_motion_planner/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "08e1fc026ebc4a984b87f2ca0275e531e2fc616c71cfd272533322524f80a7b8";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/chomp_motion_planner/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "22131dce4486a03d3bf45291c3d6f5f615f7e80b55dcb1f0ded43e5e3d94a5c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/compressed-depth-image-transport/default.nix
+++ b/distros/rolling/compressed-depth-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, opencv, pluginlib, rcl-interfaces, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-compressed-depth-image-transport";
-  version = "6.2.0-r1";
+  version = "6.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/compressed_depth_image_transport/6.2.0-1.tar.gz";
-    name = "6.2.0-1.tar.gz";
-    sha256 = "5aabce2b804f778bef2da7b3519b49ba51313ccff9b94a26cdd67f192919a948";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/compressed_depth_image_transport/6.2.1-1.tar.gz";
+    name = "6.2.1-1.tar.gz";
+    sha256 = "647d85ccfa8a19a9637546a533f95f53cd8d4a72bab2eb342eabaf90ff2664cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/compressed-image-transport/default.nix
+++ b/distros/rolling/compressed-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-rolling-compressed-image-transport";
-  version = "6.2.0-r1";
+  version = "6.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/compressed_image_transport/6.2.0-1.tar.gz";
-    name = "6.2.0-1.tar.gz";
-    sha256 = "44c5cb5539a7e31eaddf485bcc1ea283b22ab7e678e989d32371016f8135275b";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/compressed_image_transport/6.2.1-1.tar.gz";
+    name = "6.2.1-1.tar.gz";
+    sha256 = "be1cf1f7851f96769535d36359543b08101cb9ea1dfaf088b4f15b95c70379a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dynamixel-hardware-interface/default.nix
+++ b/distros/rolling/dynamixel-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-interfaces, dynamixel-sdk, hardware-interface, pluginlib, rclcpp, realtime-tools, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-dynamixel-hardware-interface";
-  version = "1.4.13-r1";
+  version = "1.4.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/rolling/dynamixel_hardware_interface/1.4.13-1.tar.gz";
-    name = "1.4.13-1.tar.gz";
-    sha256 = "f649fe8f064e471123cd335f2ee70490fd2fd5454019e99a7f021539c24a26fe";
+    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/rolling/dynamixel_hardware_interface/1.4.14-1.tar.gz";
+    name = "1.4.14-1.tar.gz";
+    sha256 = "7e1cebadcf6d69f0ba3486cc97bbc2ce52d1d9e54829c63c9405420ea71fd4c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -826,8 +826,6 @@ self: super: {
 
  gz-fuel-tools-vendor = self.callPackage ./gz-fuel-tools-vendor {};
 
- gz-gui-vendor = self.callPackage ./gz-gui-vendor {};
-
  gz-launch-vendor = self.callPackage ./gz-launch-vendor {};
 
  gz-math-vendor = self.callPackage ./gz-math-vendor {};
@@ -847,8 +845,6 @@ self: super: {
  gz-ros2-control-demos = self.callPackage ./gz-ros2-control-demos {};
 
  gz-sensors-vendor = self.callPackage ./gz-sensors-vendor {};
-
- gz-sim-vendor = self.callPackage ./gz-sim-vendor {};
 
  gz-tools-vendor = self.callPackage ./gz-tools-vendor {};
 
@@ -1081,8 +1077,6 @@ self: super: {
  libcaer-vendor = self.callPackage ./libcaer-vendor {};
 
  libcamera = self.callPackage ./libcamera {};
-
- libcurl-vendor = self.callPackage ./libcurl-vendor {};
 
  libg2o = self.callPackage ./libg2o {};
 
@@ -1450,6 +1444,8 @@ self: super: {
 
  neobotix-usboard-msgs = self.callPackage ./neobotix-usboard-msgs {};
 
+ network-bridge = self.callPackage ./network-bridge {};
+
  nlohmann-json-schema-validator-vendor = self.callPackage ./nlohmann-json-schema-validator-vendor {};
 
  nmea-hardware-interface = self.callPackage ./nmea-hardware-interface {};
@@ -1471,8 +1467,6 @@ self: super: {
  ntpd-driver = self.callPackage ./ntpd-driver {};
 
  ntrip-client = self.callPackage ./ntrip-client {};
-
- ntrip-client-node = self.callPackage ./ntrip-client-node {};
 
  object-recognition-msgs = self.callPackage ./object-recognition-msgs {};
 
@@ -2296,6 +2290,8 @@ self: super: {
 
  rti-connext-dds-cmake-module = self.callPackage ./rti-connext-dds-cmake-module {};
 
+ rtsp-image-transport = self.callPackage ./rtsp-image-transport {};
+
  rttest = self.callPackage ./rttest {};
 
  ruckig = self.callPackage ./ruckig {};
@@ -2519,6 +2515,10 @@ self: super: {
  tf2-sensor-msgs = self.callPackage ./tf2-sensor-msgs {};
 
  tf2-tools = self.callPackage ./tf2-tools {};
+
+ tf2-web-republisher = self.callPackage ./tf2-web-republisher {};
+
+ tf2-web-republisher-interfaces = self.callPackage ./tf2-web-republisher-interfaces {};
 
  tf-transformations = self.callPackage ./tf-transformations {};
 

--- a/distros/rolling/gz-cmake-vendor/default.nix
+++ b/distros/rolling/gz-cmake-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, pkg-config }:
 buildRosPackage {
   pname = "ros-rolling-gz-cmake-vendor";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_cmake_vendor-release/archive/release/rolling/gz_cmake_vendor/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "7e70bb669e611e4cf2d5abd0884eff181ece8bd0a8b7b2c003f94d384d84913d";
+    url = "https://github.com/ros2-gbp/gz_cmake_vendor-release/archive/release/rolling/gz_cmake_vendor/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "158a344618d09c6b251f8939d23c9ccfd9ebd5a2a26388db494d28ea31806e06";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake pkg-config ];
 
   meta = {
-    description = "Vendor package for: gz-cmake4 4.2.0
+    description = "Vendor package for: gz-cmake 5.0.0
 
     Gazebo CMake : CMake Modules for Gazebo Projects";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-cmake-vendor/vendored-source.json
+++ b/distros/rolling/gz-cmake-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_cmake_vendor": {
     "url": "https://github.com/gazebosim/gz-cmake.git",
-    "rev": "gz-cmake4_4.2.0",
-    "hash": "sha256-+bMOcGWfcwPhxR9CBp4iH02CZC4oplCjsTDpPDsDnSs="
+    "rev": "gz-cmake5_5.0.0-pre1",
+    "hash": "sha256-EiEtnGqLDwGXFfcq/hidN2HI70OxLRi4HsacHf0WGT4="
   }
 }

--- a/distros/rolling/gz-common-vendor/default.nix
+++ b/distros/rolling/gz-common-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, assimp, cmake, ffmpeg, freeimage, gdal, gz-cmake-vendor, gz-math-vendor, gz-utils-vendor, pkg-config, spdlog-vendor, tinyxml-2, util-linux }:
 buildRosPackage {
   pname = "ros-rolling-gz-common-vendor";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_common_vendor-release/archive/release/rolling/gz_common_vendor/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "92b5d2ca7a6ab4709f6d1ed48ed7eaad9506ea8cd24fe08619a1600cdede410f";
+    url = "https://github.com/ros2-gbp/gz_common_vendor-release/archive/release/rolling/gz_common_vendor/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "3c3510a5b24cd3245127664af084e0f66b87e05ce833844c8299735d6366c7c4";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake pkg-config ];
 
   meta = {
-    description = "Vendor package for: gz-common6 6.1.0
+    description = "Vendor package for: gz-common 7.0.0
 
     Gazebo Common : AV, Graphics, Events, and much more.";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-common-vendor/vendored-source.json
+++ b/distros/rolling/gz-common-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_common_vendor": {
     "url": "https://github.com/gazebosim/gz-common.git",
-    "rev": "gz-common6_6.1.0",
-    "hash": "sha256-D70bKjbSgg5Baye4hXWeAdeTSxgP157nQtZedY7cljE="
+    "rev": "gz-common7_7.0.0-pre1",
+    "hash": "sha256-j3hPmUoXGefXNk+YUlpwx8XHZDPAqvz0vpUhs9xx0Kg="
   }
 }

--- a/distros/rolling/gz-fuel-tools-vendor/default.nix
+++ b/distros/rolling/gz-fuel-tools-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, curl, gflags, gz-cmake-vendor, gz-common-vendor, gz-math-vendor, gz-msgs-vendor, gz-tools-vendor, gz-utils-vendor, jsoncpp, libyaml, libzip, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-rolling-gz-fuel-tools-vendor";
-  version = "0.2.2-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_fuel_tools_vendor-release/archive/release/rolling/gz_fuel_tools_vendor/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "7938dff7f317bb98e9f7308b945d4caa05152e10b3f264f5ca68fff734e56dc8";
+    url = "https://github.com/ros2-gbp/gz_fuel_tools_vendor-release/archive/release/rolling/gz_fuel_tools_vendor/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "9066e408662e6cf94cb06fc10034716a6332c489872577db62c51008c33ee04f";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-fuel_tools10 10.1.0
+    description = "Vendor package for: gz-fuel_tools 11.0.0
 
     Gazebo Fuel Tools: Classes and tools for interacting with Gazebo Fuel";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-fuel-tools-vendor/vendored-source.json
+++ b/distros/rolling/gz-fuel-tools-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_fuel_tools_vendor": {
     "url": "https://github.com/gazebosim/gz-fuel-tools.git",
-    "rev": "gz-fuel-tools10_10.1.0",
-    "hash": "sha256-ONo0zmKHSu1i6GAouDzFD5T2PUNXJ4IjhgPSoORRzao="
+    "rev": "gz-fuel-tools11_11.0.0-pre1",
+    "hash": "sha256-XQG8nRB/YkxOGeRaAh0wmb+bEhh1GrF6Vsc+G8dCPpk="
   }
 }

--- a/distros/rolling/gz-launch-vendor/default.nix
+++ b/distros/rolling/gz-launch-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, binutils, cmake, gflags, gz-cmake-vendor, gz-common-vendor, gz-gui-vendor, gz-math-vendor, gz-msgs-vendor, gz-plugin-vendor, gz-sim-vendor, gz-tools-vendor, gz-transport-vendor, libwebsockets, libyaml, tinyxml-2, util-linux, xorg }:
 buildRosPackage {
   pname = "ros-rolling-gz-launch-vendor";
-  version = "0.2.1-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_launch_vendor-release/archive/release/rolling/gz_launch_vendor/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "7e7f7e96b3ca2e86698b293d4af4cee61c78ea4b1021159a757758d55cb7fa29";
+    url = "https://github.com/ros2-gbp/gz_launch_vendor-release/archive/release/rolling/gz_launch_vendor/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "3a9be17112b8c51867457f327e356784511892762d83083cc946ff5b20caad00";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-launch8 8.0.1
+    description = "Vendor package for: gz-launch 9.0.0
 
     Gazebo Launch : Run and manage programs and plugins";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-math-vendor/default.nix
+++ b/distros/rolling/gz-math-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, eigen, gz-cmake-vendor, gz-utils-vendor, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-gz-math-vendor";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_math_vendor-release/archive/release/rolling/gz_math_vendor/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "878c833cc319c83187cadf5d32063dcf12b5fad2abc286a1988d95a06cd2c2fe";
+    url = "https://github.com/ros2-gbp/gz_math_vendor-release/archive/release/rolling/gz_math_vendor/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "6eeb2142716babc8053eb0536c80ffd66fc4ef9c9157c8806e30dd2c92f61d7b";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-math8 8.2.0
+    description = "Vendor package for: gz-math 9.0.0
 
     Gazebo Math : Math classes and functions for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-math-vendor/vendored-source.json
+++ b/distros/rolling/gz-math-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_math_vendor": {
     "url": "https://github.com/gazebosim/gz-math.git",
-    "rev": "gz-math8_8.2.0",
-    "hash": "sha256-UpwgQrQrFuBe/ls9HtZy+UgO8b2ObHLCmCS6epEwOPo="
+    "rev": "gz-math9_9.0.0-pre1",
+    "hash": "sha256-htdoBQjaLUYhlAVAIznVGdyJkquuXRbBlBE1PTT04sE="
   }
 }

--- a/distros/rolling/gz-msgs-vendor/default.nix
+++ b/distros/rolling/gz-msgs-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, gz-math-vendor, gz-tools-vendor, protobuf, python3, python3Packages, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-rolling-gz-msgs-vendor";
-  version = "0.2.3-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_msgs_vendor-release/archive/release/rolling/gz_msgs_vendor/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "200fb2e6ecc7e98165815a6d35d8188fdd3a6a729507cb8e91858909d8fc8cba";
+    url = "https://github.com/ros2-gbp/gz_msgs_vendor-release/archive/release/rolling/gz_msgs_vendor/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "7948f7d0f83ab75454e6dcf240aecf74f55166952a12c573813b17d3f125511c";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-msgs11 11.1.0
+    description = "Vendor package for: gz-msgs 12.0.0
 
     Gazebo Messages: Protobuf messages and functions for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-msgs-vendor/vendored-source.json
+++ b/distros/rolling/gz-msgs-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_msgs_vendor": {
     "url": "https://github.com/gazebosim/gz-msgs.git",
-    "rev": "gz-msgs11_11.1.0",
-    "hash": "sha256-M/rzUrL6uzpaRNLWJsGViY6Jk0bLtooEe+0eEEPS7PA="
+    "rev": "gz-msgs12_12.0.0-pre1",
+    "hash": "sha256-tXh/sqwISjkEgrVL7pQ010Qb2GAn54SbDbOJHSFsKi0="
   }
 }

--- a/distros/rolling/gz-physics-vendor/default.nix
+++ b/distros/rolling/gz-physics-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, bullet, cmake, eigen, gbenchmark, gz-cmake-vendor, gz-common-vendor, gz-dartsim-vendor, gz-math-vendor, gz-plugin-vendor, gz-utils-vendor, sdformat-vendor }:
 buildRosPackage {
   pname = "ros-rolling-gz-physics-vendor";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_physics_vendor-release/archive/release/rolling/gz_physics_vendor/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "9bbb02f21b7bf41aad4cc8b5df18947aaacffa9dce063b283e6e80d05219e485";
+    url = "https://github.com/ros2-gbp/gz_physics_vendor-release/archive/release/rolling/gz_physics_vendor/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "9202fbd2b34ea19d7402940b52ab029890d0aa49d5c99678af82dc62365d9d77";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-physics8 8.3.0
+    description = "Vendor package for: gz-physics 9.0.0
 
     Gazebo Physics : Physics classes and functions for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-physics-vendor/vendored-source.json
+++ b/distros/rolling/gz-physics-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_physics_vendor": {
     "url": "https://github.com/gazebosim/gz-physics.git",
-    "rev": "gz-physics8_8.1.0",
-    "hash": "sha256-FnVKVbPCn3B6/sZKiPJqUjUgVilwoeP/H97eg/dirz8="
+    "rev": "gz-physics9_9.0.0-pre1",
+    "hash": "sha256-BMLbjbYR8+nmbE1xI0BzmMxHTR4roBMwndj9+Y+jYTs="
   }
 }

--- a/distros/rolling/gz-plugin-vendor/default.nix
+++ b/distros/rolling/gz-plugin-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, gz-tools-vendor, gz-utils-vendor }:
 buildRosPackage {
   pname = "ros-rolling-gz-plugin-vendor";
-  version = "0.2.2-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_plugin_vendor-release/archive/release/rolling/gz_plugin_vendor/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "8cc4f9bb5c61cda937f640769cec55e60073ae53b4dbef902c3d1e14673111c4";
+    url = "https://github.com/ros2-gbp/gz_plugin_vendor-release/archive/release/rolling/gz_plugin_vendor/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "67759416e6ebc4a4cb369b810698c41a7d968483ccb9984284e9a4066e3e14e6";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-plugin3 3.1.0
+    description = "Vendor package for: gz-plugin 4.0.0
 
     Gazebo Plugin : Cross-platform C++ library for dynamically loading plugins.";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-plugin-vendor/vendored-source.json
+++ b/distros/rolling/gz-plugin-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_plugin_vendor": {
     "url": "https://github.com/gazebosim/gz-plugin.git",
-    "rev": "gz-plugin3_3.1.0",
-    "hash": "sha256-3La9TqxljV1Lko6ju+b8CCspDbhXGPLOGMivqYElTXM="
+    "rev": "gz-plugin4_4.0.0-pre1",
+    "hash": "sha256-/T0Gav0b9BG39qm8v8J7qnpYdLSwsRZVar4i5zUyF5M="
   }
 }

--- a/distros/rolling/gz-rendering-vendor/default.nix
+++ b/distros/rolling/gz-rendering-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, freeglut, freeimage, glew, gz-cmake-vendor, gz-common-vendor, gz-math-vendor, gz-ogre-next-vendor, gz-plugin-vendor, gz-utils-vendor, ogre1_9, util-linux, vulkan-loader, xorg }:
 buildRosPackage {
   pname = "ros-rolling-gz-rendering-vendor";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_rendering_vendor-release/archive/release/rolling/gz_rendering_vendor/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "987f6b0740e23d1019cfeb08df9dee675c2f9694930b888f48e74e1bb2ebb52a";
+    url = "https://github.com/ros2-gbp/gz_rendering_vendor-release/archive/release/rolling/gz_rendering_vendor/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "99e16d856dbf7b4f8a0b9c33efc0f8a7b3a6e841eb01915f6261237692724bcb";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-rendering9 9.3.0
+    description = "Vendor package for: gz-rendering 10.0.0
 
     Gazebo Rendering: Rendering library for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-rendering-vendor/vendored-source.json
+++ b/distros/rolling/gz-rendering-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_rendering_vendor": {
     "url": "https://github.com/gazebosim/gz-rendering.git",
-    "rev": "gz-rendering9_9.3.0",
-    "hash": "sha256-mNDjqp54Y13BzZQdKvIfZkxXPq2Kn26sO9Gf+/aCaPk="
+    "rev": "gz-rendering10_10.0.0-pre1",
+    "hash": "sha256-tVRKcMfNThrgyC0vLLOVipdo77HIPl72CN/PsXvtMbg="
   }
 }

--- a/distros/rolling/gz-sensors-vendor/default.nix
+++ b/distros/rolling/gz-sensors-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, gz-common-vendor, gz-math-vendor, gz-msgs-vendor, gz-rendering-vendor, gz-tools-vendor, gz-transport-vendor, sdformat-vendor, xorg }:
 buildRosPackage {
   pname = "ros-rolling-gz-sensors-vendor";
-  version = "0.2.2-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_sensors_vendor-release/archive/release/rolling/gz_sensors_vendor/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "a11ba0b281e53dcfc445ee110e1f0bd0c02d6cd015eff9bbcce347ff705ad2ce";
+    url = "https://github.com/ros2-gbp/gz_sensors_vendor-release/archive/release/rolling/gz_sensors_vendor/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "ebceacd777255c0a548be4e320dd61e52eaf2e9c6e06d659007203e5a6354085";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-sensors9 9.2.0
+    description = "Vendor package for: gz-sensors 10.0.0
 
     Gazebo Sensors : Sensor models for simulation";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-tools-vendor/default.nix
+++ b/distros/rolling/gz-tools-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, ruby }:
 buildRosPackage {
   pname = "ros-rolling-gz-tools-vendor";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_tools_vendor-release/archive/release/rolling/gz_tools_vendor/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "c7400c958843631c66f94c47dc037437ecde5cda278dd531caa908f5fade4d0e";
+    url = "https://github.com/ros2-gbp/gz_tools_vendor-release/archive/release/rolling/gz_tools_vendor/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "7298413cde13a340b48e1a708b9c150f24229dbbe1468798fcda1acf667f1fe1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-transport-vendor/default.nix
+++ b/distros/rolling/gz-transport-vendor/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, cppzmq, gz-cmake-vendor, gz-math-vendor, gz-msgs-vendor, gz-tools-vendor, gz-utils-vendor, pkg-config, protobuf, python3, python3Packages, sqlite, util-linux }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, cppzmq, gz-cmake-vendor, gz-math-vendor, gz-msgs-vendor, gz-tools-vendor, gz-utils-vendor, pkg-config, protobuf, python3, python3Packages, sqlite, util-linux, zenoh-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-gz-transport-vendor";
-  version = "0.2.2-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_transport_vendor-release/archive/release/rolling/gz_transport_vendor/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "ce68e43cbd460abe291f41fd5dbb26cd4813d3335d6bab91d16fbda54393e220";
+    url = "https://github.com/ros2-gbp/gz_transport_vendor-release/archive/release/rolling/gz_transport_vendor/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "9029db299481cf03ac3e81d211da36110ddf238d44c16444857221632b4d5db3";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint ];
-  propagatedBuildInputs = [ cppzmq gz-cmake-vendor gz-math-vendor gz-msgs-vendor gz-tools-vendor gz-utils-vendor pkg-config protobuf python3 python3Packages.psutil python3Packages.pybind11 python3Packages.pytest sqlite util-linux ];
+  propagatedBuildInputs = [ cppzmq gz-cmake-vendor gz-math-vendor gz-msgs-vendor gz-tools-vendor gz-utils-vendor pkg-config protobuf python3 python3Packages.psutil python3Packages.pybind11 python3Packages.pytest sqlite util-linux zenoh-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-transport14 14.1.0
+    description = "Vendor package for: gz-transport 15.0.0
 
     Gazebo Transport: Provides fast and efficient asynchronous message passing, services, and data logging.";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-utils-vendor/default.nix
+++ b/distros/rolling/gz-utils-vendor/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, spdlog-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cli11, cmake, gz-cmake-vendor, spdlog-vendor }:
 buildRosPackage {
   pname = "ros-rolling-gz-utils-vendor";
-  version = "0.3.0-r1";
+  version = "0.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_utils_vendor-release/archive/release/rolling/gz_utils_vendor/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "c439b68a4a3b9d450bb83fbbc707f7a9af0fa0a59b84a82e1bcf63273cc287a7";
+    url = "https://github.com/ros2-gbp/gz_utils_vendor-release/archive/release/rolling/gz_utils_vendor/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "40b9cc6699e0bcc2b3893c9bf03c6d2709f8e43f89c2658a63002fb9230f11ae";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint ];
-  propagatedBuildInputs = [ gz-cmake-vendor spdlog-vendor ];
+  propagatedBuildInputs = [ cli11 gz-cmake-vendor spdlog-vendor ];
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-utils3 3.1.1
+    description = "Vendor package for: gz-utils 4.0.0
 
     Gazebo Utils : Classes and functions for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-utils-vendor/vendored-source.json
+++ b/distros/rolling/gz-utils-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_utils_vendor": {
     "url": "https://github.com/gazebosim/gz-utils.git",
-    "rev": "gz-utils3_3.1.1",
-    "hash": "sha256-fYzysdB608jfMb/EbqiGD4hXmPxcaVTUrt9Wx0dBlto="
+    "rev": "gz-utils4_4.0.0-pre1",
+    "hash": "sha256-UZh4d+WngOWFJepHGD3JLWtf1hz8yWJ5EaQ/1iXlZc0="
   }
 }

--- a/distros/rolling/image-transport-plugins/default.nix
+++ b/distros/rolling/image-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, compressed-depth-image-transport, compressed-image-transport, theora-image-transport, zstd-image-transport }:
 buildRosPackage {
   pname = "ros-rolling-image-transport-plugins";
-  version = "6.2.0-r1";
+  version = "6.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/image_transport_plugins/6.2.0-1.tar.gz";
-    name = "6.2.0-1.tar.gz";
-    sha256 = "e647a503944ecc8c6185dcd6cd98ae1256fd596616b82cd116a53f24f3e50da1";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/image_transport_plugins/6.2.1-1.tar.gz";
+    name = "6.2.1-1.tar.gz";
+    sha256 = "8105f8930108503980aef34f29220ae9b96cba0d0a890051bed8e0982503aa07";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/libmavconn/default.nix
+++ b/distros/rolling/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-libmavconn";
-  version = "2.10.1-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/libmavconn/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "dab60e13856e361fbcb376f5b163bbb9c529dbdccfc0edf20096eebc114f44bf";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/libmavconn/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "111fd03bef4f51056871148c2cec439b9e8e93bd9b1e90a5c390c1cb80004a55";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mavlink/default.nix
+++ b/distros/rolling/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mavlink";
-  version = "2025.6.6-r1";
+  version = "2025.9.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/rolling/mavlink/2025.6.6-1.tar.gz";
-    name = "2025.6.6-1.tar.gz";
-    sha256 = "dc3818136afbd41c2ca2ec405f82e2f61739d014e3975621c4faef3507111b8e";
+    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/rolling/mavlink/2025.9.9-1.tar.gz";
+    name = "2025.9.9-1.tar.gz";
+    sha256 = "aff16c3158477cd2ceff9e4937d321d86f83a7d8596f1e889fa2cb17d881d97c";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mavros-extras/default.nix
+++ b/distros/rolling/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-mavros-extras";
-  version = "2.10.1-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros_extras/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "90432d0ff4672ade296ee4db5bf73fd715e8eb5cf9d5d71047cfb61c6faede6a";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros_extras/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "cdbd2df1a55fdcdda870bf67cedb733e2129d7dd70f740b2867bdd0abb970594";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mavros-msgs/default.nix
+++ b/distros/rolling/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mavros-msgs";
-  version = "2.10.1-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros_msgs/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "bf1c1f50b34b82a4e0d9393b40a75dd3620991f29fdd15d47fbe2cb076a60d4f";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros_msgs/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "d3dac4de62c8b5fb0b93f7f18b58d4c4cb5d9236becc122fbc2d10ef8279b194";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mavros/default.nix
+++ b/distros/rolling/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mavros";
-  version = "2.10.1-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "e07370abbdaea63f7aa36dfbc756fe0193052e7d27e0b5a3566f89e638785b54";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "2b70af3c66e4d6adfe58e1a6d4ad145a4a13504abeade6de1a234c8c3232d724";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-common/default.nix
+++ b/distros/rolling/mola-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-common";
-  version = "0.5.0-r1";
+  version = "0.5.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/rolling/mola_common/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "625fb59dd6bef533806677577f4e8cb0d8f51ec759b9aca4fc434dbc6ed87a5d";
+    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/rolling/mola_common/0.5.1-2.tar.gz";
+    name = "0.5.1-2.tar.gz";
+    sha256 = "37345bf76ce29c54105afd9c9144c0a6884b735a4d04e7ebe9f5dbb008d2e77f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-imu-preintegration/default.nix
+++ b/distros/rolling/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-imu-preintegration";
-  version = "1.9.0-r1";
+  version = "1.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_imu_preintegration/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "fce0dae539bce163cff011d0b8b2602d4c8be8b831660ccbfd74e982b4b92c6c";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_imu_preintegration/1.10.0-1.tar.gz";
+    name = "1.10.0-1.tar.gz";
+    sha256 = "2a428c71f70a2712691eb040c197ad92f7ea43c0541001c88aca444bc6e20e67";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-state-estimation-simple/default.nix
+++ b/distros/rolling/mola-state-estimation-simple/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-state-estimation-simple";
-  version = "1.9.0-r1";
+  version = "1.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation_simple/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "401416f7f4253b377b0b126d2ce8e34c15f5c0763a68d2a8f4f51a2d93d8f7ae";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation_simple/1.10.0-1.tar.gz";
+    name = "1.10.0-1.tar.gz";
+    sha256 = "c461ab32e9166e418f5c6398275e828f1a66ca361a8cf8a7d0fb6d9eeece2877";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-state-estimation-smoother/default.nix
+++ b/distros/rolling/mola-state-estimation-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-state-estimation-smoother";
-  version = "1.9.0-r1";
+  version = "1.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation_smoother/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "1802e1b249c5737cabbc6cb5e19e63d9a2fc3d9e3edf4f53d8b6d00b8b17d8b6";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation_smoother/1.10.0-1.tar.gz";
+    name = "1.10.0-1.tar.gz";
+    sha256 = "436c32c6807c88786e38205604c4390cf8ff476c1fc7a85de110a315f382e6c4";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-state-estimation/default.nix
+++ b/distros/rolling/mola-state-estimation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, mola-imu-preintegration, mola-state-estimation-simple, mola-state-estimation-smoother }:
 buildRosPackage {
   pname = "ros-rolling-mola-state-estimation";
-  version = "1.9.0-r1";
+  version = "1.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "e0ed7e9cc0954155c89cbde0763bc32036bd79b0954139d1c99a40a04c34be72";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation/1.10.0-1.tar.gz";
+    name = "1.10.0-1.tar.gz";
+    sha256 = "2afde0ad1c9feeb30467f075d4539dd9f90418ff9a443a769fa752d9ef52dcbc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-common/default.nix
+++ b/distros/rolling/moveit-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, backward-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-common";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_common/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "a65094669aeb2fa2fe2b78121005e330241999afd88dcf127b3429d8bd5f68c7";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_common/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "62cee8d3a469b72a800d1861ae41aaa2f82203e3051b09dc5abb1fc8e2840e00";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-configs-utils/default.nix
+++ b/distros/rolling/moveit-configs-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, launch, launch-param-builder, launch-ros, srdfdom }:
 buildRosPackage {
   pname = "ros-rolling-moveit-configs-utils";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_configs_utils/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "4e64db1d5c189a8698f403e13f39558f141d90a59a37246b93dabcd96bbdaa60";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_configs_utils/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "1ea47c890377fc2d52ce7308ac45b5711d5dee5c6438070b72c413521eb40894";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/moveit-core/default.nix
+++ b/distros/rolling/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-index-cpp, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, generate-parameter-library, geometric-shapes, geometry-msgs, google-benchmark-vendor, kdl-parser, launch-testing-ament-cmake, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl-vendor, osqp-vendor, pkg-config, pluginlib, random-numbers, rcl-interfaces, rclcpp, rclpy, rsl, ruckig, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-core";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_core/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "044ff75618feef392b0f204cdbc454d910270079ca3322a076e1f924b6e280e5";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_core/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "3a7c6d828fc91162957c21e177ed53794e7be0f9d5a5f9371ae962055aff2377";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-hybrid-planning/default.nix
+++ b/distros/rolling/moveit-hybrid-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, controller-manager, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, moveit-simple-controller-manager, pluginlib, position-controllers, rclcpp, rclcpp-action, rclcpp-components, robot-state-publisher, ros-testing, rviz2, std-msgs, std-srvs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-hybrid-planning";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_hybrid_planning/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "30d366f7b48e7b5e96d2317f46a2337ebd3e5429ac26696273d82a6f9a4fd615";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_hybrid_planning/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "8d4a923f05d63840806940af0b9e49e81d90d3cec461b7345b22b4cbe6d78c3a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-kinematics/default.nix
+++ b/distros/rolling/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, class-loader, eigen, generate-parameter-library, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl-vendor, pluginlib, python3Packages, ros-testing, rsl, tf2, tf2-kdl, urdfdom }:
 buildRosPackage {
   pname = "ros-rolling-moveit-kinematics";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_kinematics/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "635307d653ae2e750ad55c9a85c031b02572b54d0c91622838d5665580c42d7f";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_kinematics/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "be73ad87f6cb20011639a1e49feb934c4309919f7b68f50fdd110e621d725603";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-planners-chomp/default.nix
+++ b/distros/rolling/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, chomp-motion-planner, moveit-common, moveit-core, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-moveit-planners-chomp";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners_chomp/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "db75e0a35b0e62cbe71148bc0bd3f867026db042dc26e52399afd0a98a456d64";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners_chomp/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "70c932ef000f6d2c267e63cd91dcb482bb5c4a0dc941e30751425043ee7c76e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-planners-ompl/default.nix
+++ b/distros/rolling/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module, llvmPackages, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rclcpp, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-planners-ompl";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners_ompl/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "39edd167ac4e4b5e249a73c3a8ce91ebbd37029f4f37ec66fce96d44a114be11";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners_ompl/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "53a84ed97232e24ee8551901667932588bf1968f40451f4b891080e762ff9a8a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-planners-stomp/default.nix
+++ b/distros/rolling/moveit-planners-stomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, generate-parameter-library, moveit-common, moveit-core, rsl, std-msgs, stomp, tf2-eigen, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-planners-stomp";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners_stomp/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "9854cc7a5848c539cf588522995f951239a52bf89023a1eb58a6d181467319f1";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners_stomp/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "6bfeb2f48e5a72cbc4ad857e5d803b1cc78e380e37d16ff8ade286614e1c8171";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-planners/default.nix
+++ b/distros/rolling/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-planners-chomp, moveit-planners-ompl, moveit-planners-stomp, pilz-industrial-motion-planner }:
 buildRosPackage {
   pname = "ros-rolling-moveit-planners";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "4283d9a3c13a227a8040358e2d8e28efc901f42f2eab368235c37b404d5c2c9d";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "293e3d203531ebb314c4d3049371d151f5158d5b687b2e8a0bdaac6d6c9ce551";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-plugins/default.nix
+++ b/distros/rolling/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-rolling-moveit-plugins";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_plugins/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "931693c581129f2e7daa32ec1a553d2d433d5fb4b2397ab57bd35ce380dc1262";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_plugins/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "16d13cd5dcfdb7f3dcb33d49fe67315b96fe5e4df163bd8b160869d925db092f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-py/default.nix
+++ b/distros/rolling/moveit-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, geometry-msgs, moveit-core, moveit-ros-planning, moveit-ros-planning-interface, octomap-msgs, pybind11-vendor, python3Packages, rclcpp, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-moveit-py";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_py/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "a5677d72e608f072b3d869e096045e8e93e3da8ee6911d9314d54b20a5d1f40c";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_py/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "90c8f9e5ba99d5fcda046676f43d499000315b35fd717515f6ed20e90f76eb96";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
+++ b/distros/rolling/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, generate-parameter-library, moveit-core, pluginlib, rclcpp, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl }:
 buildRosPackage {
   pname = "ros-rolling-moveit-resources-prbt-ikfast-manipulator-plugin";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_ikfast_manipulator_plugin/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "5714d5956adeae929d19dda938d4e64696b6624276802358239a2461402f89ca";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_ikfast_manipulator_plugin/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "75cf21edf7637052fa584988e0cbe4cf8fb8e15d9cdbd28e608972e51efca112";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-resources-prbt-moveit-config/default.nix
+++ b/distros/rolling/moveit-resources-prbt-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-support, moveit-ros-move-group, robot-state-publisher, rviz2, xacro }:
 buildRosPackage {
   pname = "ros-rolling-moveit-resources-prbt-moveit-config";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_moveit_config/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "0393651be045ddb80ee889170ef691da830124bdcb8ee5e9d4d1155f2076b9ca";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_moveit_config/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "30c7d8502c5edffa4ab7eb6e39c4706a1beef52cf466a50a688cc5127e41c5fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-resources-prbt-pg70-support/default.nix
+++ b/distros/rolling/moveit-resources-prbt-pg70-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-moveit-config, moveit-resources-prbt-support, xacro }:
 buildRosPackage {
   pname = "ros-rolling-moveit-resources-prbt-pg70-support";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_pg70_support/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "29c964183ad8553913ccc19ab1988777338f6a62758f1b6aee12f368ad4a16da";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_pg70_support/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "78eca3fa7250c8fbd0bc83e1aebfe550580263391c88f6570cd54427a7410a14";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-resources-prbt-support/default.nix
+++ b/distros/rolling/moveit-resources-prbt-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, xacro }:
 buildRosPackage {
   pname = "ros-rolling-moveit-resources-prbt-support";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_support/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "6076701dd3ad172dfa76de149a4d64782612fcebfe059a39d973df1ebba02052";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_support/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "3e95deaab84e6833586c4519f5f46d52a58b54e2f1bd394b31ac282dd652b7a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-benchmarks/default.nix
+++ b/distros/rolling/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-benchmarks";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_benchmarks/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "ffc972c89b41d89870abbefd7d07ce5062ce7d85ab4251b36a4edde18d2257a0";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_benchmarks/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "88d0030884b71f45a8b1e591c960e3c1a4e190e52bdd72488f1fb3688a366bfe";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-control-interface/default.nix
+++ b/distros/rolling/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager-msgs, moveit-common, moveit-core, moveit-simple-controller-manager, pluginlib, rclcpp-action, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-control-interface";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_control_interface/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "a9373eead1606b0f6f380348ce853bd3dded27335644d3ecd8de061ea0518c56";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_control_interface/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "ad711bd271e66046aa65bfe8dad1c4d3700ae1f6d5c39b65755ee55f0686d0e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-move-group/default.nix
+++ b/distros/rolling/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, fmt, moveit-common, moveit-configs-utils, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, ros-testing, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-move-group";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_move_group/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "00f41bfc27a700a2350e49456a2c2a2077f5558ea888b9ed5f6aa5fac7b24fe1";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_move_group/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "5e954a8115aa4d053ba629ab475ed0fbd5a8786de7e414307a636534e43958c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/rolling/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-occupancy-map-monitor";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_occupancy_map_monitor/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "f4097ccaf60e6064775b6eee000982f3afe1c62c4075c872e33887e730e425c4";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_occupancy_map_monitor/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "0d5511287b27c15faa03c9566757de0c373659d5a3b4f8965f784322560577cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-perception/default.nix
+++ b/distros/rolling/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, object-recognition-msgs, pluginlib, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-perception";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_perception/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "f0c2029a15f2cd6941cd9a1ca0f4f0aa77247b772eb4ce174a14d8fa2930db8a";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_perception/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "9e58825f82b4d8e0b3dfd08c45222cfd8e60c06b12c58d1cea76f1f9709a7251";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-planning-interface/default.nix
+++ b/distros/rolling/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-planning-interface";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_planning_interface/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "43e0ea130ffd82e47cfbec53a9b102fbf3cb8589f17ab449a59cb59a9cf7cb00";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_planning_interface/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "43f128c99c73633105f482cf62fa5672598a545bb27b5ad866f2be7cb97a6317";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-planning/default.nix
+++ b/distros/rolling/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, eigen, eigen3-cmake-module, fmt, generate-parameter-library, launch-testing-ament-cmake, message-filters, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, rclcpp-components, ros-testing, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-planning";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_planning/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "af94d2a25595f794fdb304eabcb46499c4a4de8af8c449a477df3cb0884174b9";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_planning/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "ebf66ea43058736ffcf3e7798c0176670d737e40c6913bdec082c82b368b3f7e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-robot-interaction/default.nix
+++ b/distros/rolling/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, interactive-markers, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-robot-interaction";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_robot_interaction/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "26835323d999579696179790f5aa2ef23cc9a54418fd675a3570f3f253a4dc81";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_robot_interaction/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "3fd0427b20797312bc0fd36da458ece5b706c1e04d4b50eced4eb6de62cbb9eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-tests/default.nix
+++ b/distros/rolling/moveit-ros-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, moveit-common, moveit-configs-utils, moveit-core, moveit-planners-chomp, moveit-planners-ompl, moveit-planners-stomp, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-simple-controller-manager, pilz-industrial-motion-planner, rclcpp, ros-testing, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-tests";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_tests/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "b7b4eef8dab76bd0130b44c8ca36e4e8baa62a19eca664dbe1c6dca1a36a45f8";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_tests/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "ec5b01e970d76c530ad1a18aa8a34ab8e8ed9b3f561cb9cc108805910f4b1604";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-trajectory-cache/default.nix
+++ b/distros/rolling/moveit-ros-trajectory-cache/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-uncrustify, geometry-msgs, launch-pytest, launch-testing-ament-cmake, moveit-common, moveit-configs-utils, moveit-planners-ompl, moveit-resources, moveit-ros, moveit-ros-planning-interface, python3Packages, rclcpp, rclcpp-action, rmf-utils, robot-state-publisher, ros2-control, tf2-ros, trajectory-msgs, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-trajectory-cache";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_trajectory_cache/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "a78fe81c1ff1ef54093377107553ef0f5e99a14168fc065905c9ea42a5aede72";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_trajectory_cache/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "61d607589471aad3b971c7885bd177df7b47c964c6bb20040ef728792e49c045";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-visualization/default.nix
+++ b/distros/rolling/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-visualization";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_visualization/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "35c6b86d6de0fb0f63b62bda0c8875e951f9e189b20058c7cbf7dddd37757564";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_visualization/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "5ece67731c51f5ad1782098c9d16478dc32ff023aac52a8dbf639879ba2f4096";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-warehouse/default.nix
+++ b/distros/rolling/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmt, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-warehouse";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_warehouse/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "b73bb00be7b990c80b41539ddc7980bb3196046780cedd2404f06dde84954c60";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_warehouse/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "ecf2318bfd4079db354b3dd89e85a762a9f42941ebf5ce41db68c6cead6ba0f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros/default.nix
+++ b/distros/rolling/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "f2f9233fee4c4212758e2bda8f4985cffac5fe5bd8025241e0c11ffd17e24f34";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "971ba0a747cf2c7660ab8e64038bbe76e818fd508656cbd98d7fe3e30cbd8665";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-runtime/default.nix
+++ b/distros/rolling/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-core, moveit-planners, moveit-plugins, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-rolling-moveit-runtime";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_runtime/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "656263eea37448118768806b7556ef28bc2f65441954fe34e01110ad172d7894";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_runtime/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "fba871c6cb60ebc9d2101c7309fdff7788715bc165f42ab34881ccccc0f021de";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-servo/default.nix
+++ b/distros/rolling/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, control-msgs, controller-manager, generate-parameter-library, geometry-msgs, joint-state-broadcaster, joint-trajectory-controller, joy, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-visualization, pluginlib, realtime-tools, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-servo";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_servo/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "f2bd4999df74404d7e9dc78e8fef36984f5ee869562de2974b613a88bef2dbe2";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_servo/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "b22c071cf7a39e00b4591b4624f8da44078c18635f9745f561b80f4d608236d2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-setup-app-plugins/default.nix
+++ b/distros/rolling/moveit-setup-app-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, moveit-configs-utils, moveit-ros-visualization, moveit-setup-framework, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-moveit-setup-app-plugins";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_app_plugins/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "5e83bafced655be3665e4177b413100bd57e303f81de82310716cba0b563834e";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_app_plugins/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "fddab9cc57e3f0a5df9e6cc2c09da6241760a2e70b7c1743028593ac6abd1670";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-setup-assistant/default.nix
+++ b/distros/rolling/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, moveit-configs-utils, moveit-resources-panda-moveit-config, moveit-setup-app-plugins, moveit-setup-controllers, moveit-setup-core-plugins, moveit-setup-framework, moveit-setup-srdf-plugins, pluginlib, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-moveit-setup-assistant";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_assistant/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "1a038b1eb6a72dde0900c9ae056e08f1e5d59b291b8792bd4f40833c12bdc7b2";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_assistant/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "18cae99229949cd62b3ae33fbe35effb4ff682418a24de06f5f396d1cc1b7181";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-setup-controllers/default.nix
+++ b/distros/rolling/moveit-setup-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, moveit-configs-utils, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-setup-framework, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-moveit-setup-controllers";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_controllers/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "653ea3a5be3a86254066bdb87a43bc0d2e05185550e5773789dffd37ee06f89e";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_controllers/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "6213a8c59e3fe2d24dc6a41a8a7195fd20b8b310c0b7e510367cdefa8d001a22";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-setup-core-plugins/default.nix
+++ b/distros/rolling/moveit-setup-core-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-index-cpp, moveit-ros-visualization, moveit-setup-framework, pluginlib, rclcpp, srdfdom, urdf }:
 buildRosPackage {
   pname = "ros-rolling-moveit-setup-core-plugins";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_core_plugins/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "30b2d5fbf430d8e8aad119a79e2f8249e0e1005ea5b3c5fd676b8158c2439f2f";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_core_plugins/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "8daf183f29e6c6ac46006794b3c3033a44d73365e02c5ff09a00c9a26fde5baa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-setup-framework/default.nix
+++ b/distros/rolling/moveit-setup-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-index-cpp, fmt, moveit-common, moveit-core, moveit-ros-planning, moveit-ros-visualization, pluginlib, rclcpp, rviz-common, rviz-rendering, srdfdom, urdf }:
 buildRosPackage {
   pname = "ros-rolling-moveit-setup-framework";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_framework/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "743b910b0fdc38542db044d7fda4608476de23db453632750ae4d2b368d6a5a6";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_framework/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "d09271d3f7ac88e776772d60dd08d68e06e56cf6e5c252d2d6c505e68fe75752";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-setup-srdf-plugins/default.nix
+++ b/distros/rolling/moveit-setup-srdf-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, moveit-resources-fanuc-description, moveit-setup-framework, pluginlib }:
 buildRosPackage {
   pname = "ros-rolling-moveit-setup-srdf-plugins";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_srdf_plugins/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "65ad54d8c7c3b0dc99d8313c52d2db77fe3c1640d1b2cf89905ddd9031cbd334";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_srdf_plugins/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "e1971e35e7fda9e86ae8f02931b60ec5f446f63449c359a37d1421f9a381b7f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-simple-controller-manager/default.nix
+++ b/distros/rolling/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-rolling-moveit-simple-controller-manager";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_simple_controller_manager/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "72d20b275de5cfe475bce9770e89d9ddae50d368c2b6b6fcc1dfad2dea185bbc";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_simple_controller_manager/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "48eb1590e20bdb43236289de6b14cb958b20e23f105273570ea2f19845a0de65";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit/default.nix
+++ b/distros/rolling/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-core, moveit-planners, moveit-plugins, moveit-ros, moveit-setup-assistant }:
 buildRosPackage {
   pname = "ros-rolling-moveit";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "837b0ac678283c94f8a908d03c14532fea81207727264490f89d1df362d77254";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "9d7f5d0e51e7a4720be3a3697540cf02f32379fd63f958c9a0aa7242eb84a5f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/network-bridge/default.nix
+++ b/distros/rolling/network-bridge/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, boost, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pkg-config, pluginlib, rclcpp, std-msgs, zstd }:
+buildRosPackage {
+  pname = "ros-rolling-network-bridge";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/network_bridge-release/archive/release/rolling/network_bridge/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "ed020eb3c22aba3941e4a064a0c49a6d5b5be696bf2d6944fc0166c7900867fd";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake pkg-config ];
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common launch-testing launch-testing-ament-cmake launch-testing-ros ];
+  propagatedBuildInputs = [ boost pluginlib rclcpp std-msgs zstd ];
+  nativeBuildInputs = [ ament-cmake pkg-config ];
+
+  meta = {
+    description = "Allows for arbitrary network links (UDP, TCP, etc) to bridge ROS2 messages";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/ntpd-driver/default.nix
+++ b/distros/rolling/ntpd-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, poco, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ntpd-driver";
-  version = "2.2.0-r3";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ntpd_driver-release/archive/release/rolling/ntpd_driver/2.2.0-3.tar.gz";
-    name = "2.2.0-3.tar.gz";
-    sha256 = "edf811f6297e7fd32bfde6e8a352d57b2596ddcb823db453affa3799f4f10bb0";
+    url = "https://github.com/ros2-gbp/ntpd_driver-release/archive/release/rolling/ntpd_driver/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "e4344eb087537ee9aa636e6ee2ea8c8bdf3d99eb980cdd623197d2c948bc3dc4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -215,8 +215,8 @@ in {
       # Fix CMake relative install dir assumptions
       # https://github.com/ros/urdfdom/pull/142
       (self.fetchpatch {
-        url = "https://github.com/ros/urdfdom/commit/61a7e35cd5abece97259e76aed8504052b2f5b53.patch";
-        hash = "sha256-b3bEbbaSUDkwTEHJ8gVPEb+AR/zuWwLqiAW5g1T1dPU=";
+        url = "https://github.com/ros/urdfdom/commit/229c3ae867ba770dcade50b3ee520d81ff3b0413.patch";
+        hash = "sha256-cfPnSux7qmTDngzwPYIayYIvddhOXfmSsvgKwltFT5Q=";
       })
     ];
   });
@@ -228,8 +228,8 @@ in {
       # Fix CMake relative install dir assumptions
       # https://github.com/ros/urdfdom_headers/pull/66
       (self.fetchpatch {
-        url = "https://github.com/ros/urdfdom_headers/commit/6e0cea148c3a7123f8367cd48d5709a4490c32f1.patch";
-        hash = "sha256-LC2TACGma/k6+WE9fTkzY98SgJYKsVuj5O9v84Q5mQ4=";
+        url = "https://github.com/ros/urdfdom_headers/commit/90efa6072dc239f78d37288a49f24d8aee1aaad2.patch";
+        hash = "sha256-3q3K+fiINvS9eUrkHS3cgnn8GuA0Nz+FvVBMpsRAcFM=";
       })
     ];
   });

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -42,9 +42,9 @@ in {
     fetchgitArgs.hash = "sha256-gztnxui9Fe/FTieMjdvfJjWHjkImtlsHn6fM1FruyME=";
   };
 
-  gz-cmake-vendor = lib.patchGzAmentVendorGit rosSuper.gz-cmake-vendor { };
+  gz-cmake-vendor = lib.patchAmentVendorGit rosSuper.gz-cmake-vendor { };
 
-  gz-common-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-common-vendor { }).overrideAttrs ({
+  gz-common-vendor = (lib.patchAmentVendorGit rosSuper.gz-common-vendor { }).overrideAttrs ({
     nativeBuildInputs ? [], ...
   }: {
     # https://github.com/gazebo-release/gz_common_vendor/pull/2
@@ -53,7 +53,7 @@ in {
 
   gz-dartsim-vendor = lib.patchAmentVendorGit rosSuper.gz-dartsim-vendor { };
 
-  gz-fuel-tools-vendor = lib.patchGzAmentVendorGit rosSuper.gz-fuel-tools-vendor { };
+  gz-fuel-tools-vendor = lib.patchAmentVendorGit rosSuper.gz-fuel-tools-vendor { };
 
   gz-gui-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-gui-vendor { }).overrideAttrs ({
     postInstall ? "", ...
@@ -67,25 +67,25 @@ in {
 
   gz-launch-vendor = lib.patchGzAmentVendorGit rosSuper.gz-launch-vendor { };
 
-  gz-math-vendor = lib.patchGzAmentVendorGit rosSuper.gz-math-vendor { };
+  gz-math-vendor = lib.patchAmentVendorGit rosSuper.gz-math-vendor { };
 
-  gz-msgs-vendor = lib.patchGzAmentVendorGit rosSuper.gz-msgs-vendor { };
+  gz-msgs-vendor = lib.patchAmentVendorGit rosSuper.gz-msgs-vendor { };
 
   gz-ogre-next-vendor = (lib.patchAmentVendorGit rosSuper.gz-ogre-next-vendor { }).overrideAttrs({ ... }: {
     dontFixCmake = true;
   });
 
-  gz-physics-vendor = lib.patchGzAmentVendorGit rosSuper.gz-physics-vendor { };
+  gz-physics-vendor = lib.patchAmentVendorGit rosSuper.gz-physics-vendor { };
 
-  gz-plugin-vendor = lib.patchGzAmentVendorGit rosSuper.gz-plugin-vendor { };
+  gz-plugin-vendor = lib.patchAmentVendorGit rosSuper.gz-plugin-vendor { };
 
-  gz-rendering-vendor = lib.patchGzAmentVendorGit rosSuper.gz-rendering-vendor { };
+  gz-rendering-vendor = lib.patchAmentVendorGit rosSuper.gz-rendering-vendor { };
 
   gz-sensors-vendor = lib.patchGzAmentVendorGit rosSuper.gz-sensors-vendor { };
 
   gz-sim-vendor = lib.patchGzAmentVendorGit rosSuper.gz-sim-vendor { };
 
-  gz-tools-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-tools-vendor { }).overrideAttrs({
+  gz-tools-vendor = (lib.patchAmentVendorGit rosSuper.gz-tools-vendor { }).overrideAttrs({
     nativeBuildInputs ? [],
     propagatedNativeBuildInputs ? [],
     qtWrapperArgs ? [],
@@ -113,7 +113,7 @@ in {
     buildInputs = buildInputs ++ [ self.libsodium ];
   });
 
-  gz-utils-vendor = lib.patchGzAmentVendorGit rosSuper.gz-utils-vendor { };
+  gz-utils-vendor = lib.patchAmentVendorGit rosSuper.gz-utils-vendor { };
 
   iceoryx-hoofs = rosSuper.iceoryx-hoofs.overrideAttrs ({
     patches ? [], ...
@@ -201,7 +201,7 @@ in {
     '';
   });
 
-  sdformat-vendor = lib.patchGzAmentVendorGit rosSuper.sdformat-vendor { };
+  sdformat-vendor = lib.patchAmentVendorGit rosSuper.sdformat-vendor { };
 
   shared-queues-vendor = lib.patchVendorUrl rosSuper.shared-queues-vendor {
     url = "https://github.com/cameron314/readerwriterqueue/archive/ef7dfbf553288064347d51b8ac335f1ca489032a.zip";

--- a/distros/rolling/pilz-industrial-motion-planner-testutils/default.nix
+++ b/distros/rolling/pilz-industrial-motion-planner-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen3-cmake-module, moveit-common, moveit-core, moveit-msgs, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-rolling-pilz-industrial-motion-planner-testutils";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/pilz_industrial_motion_planner_testutils/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "78471d303ac8bcb3d5f84c6fec550bf8d3ce825b8ce70cb6c09303d544052bc5";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/pilz_industrial_motion_planner_testutils/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "7ed2230637ddc9e7fe49fb629edff7077c0ac53c06a05a38598b1ecef11150b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pilz-industrial-motion-planner/default.nix
+++ b/distros/rolling/pilz-industrial-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, boost, eigen3-cmake-module, generate-parameter-library, geometry-msgs, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-prbt-moveit-config, moveit-resources-prbt-pg70-support, moveit-resources-prbt-support, moveit-ros-move-group, moveit-ros-planning, orocos-kdl-vendor, pilz-industrial-motion-planner-testutils, pluginlib, rclcpp, ros-testing, tf2, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-pilz-industrial-motion-planner";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/pilz_industrial_motion_planner/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "01ee67fe671c6eccfb3d90b08ae35c86d0d62dae3b1ad0c858b009eccf5d8846";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/pilz_industrial_motion_planner/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "af342d13b048841fd8b0a2280a93700569f3e7e230113792e765038be3a7109a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pointcloud-to-laserscan/default.nix
+++ b/distros/rolling/pointcloud-to-laserscan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, laser-geometry, launch, launch-ros, message-filters, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-ros, tf2-sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-pointcloud-to-laserscan";
-  version = "2.0.2-r2";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pointcloud_to_laserscan-release/archive/release/rolling/pointcloud_to_laserscan/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "96fd9f38e97c533573ad361f055eb23b89db3e6c0b9918c4508f6346b2aa7977";
+    url = "https://github.com/ros2-gbp/pointcloud_to_laserscan-release/archive/release/rolling/pointcloud_to_laserscan/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "1a28a897c39b216b2b4155305a4c708dae574c80bfa2d39165beec0c2e19c378";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-action/default.nix
+++ b/distros/rolling/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-action";
-  version = "30.1.0-r1";
+  version = "30.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/30.1.0-1.tar.gz";
-    name = "30.1.0-1.tar.gz";
-    sha256 = "d2c89bc8ed2c9b58dc63a2853175dcc074d87c6bbfb879d5de96a6e53e6c8215";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/30.1.1-1.tar.gz";
+    name = "30.1.1-1.tar.gz";
+    sha256 = "7934c06428757621cd9f3ed2cab03382a17cf4e8b309fd2787284cb91df28a51";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-components/default.nix
+++ b/distros/rolling/rclcpp-components/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, rcl-interfaces, rclcpp, rcpputils, rmw }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-components";
-  version = "30.1.0-r1";
+  version = "30.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/30.1.0-1.tar.gz";
-    name = "30.1.0-1.tar.gz";
-    sha256 = "9c93065f3ecf3ea89f3c1d6d3606aa06492436f3bc8e7fb4a22ec6ee20edde4c";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/30.1.1-1.tar.gz";
+    name = "30.1.1-1.tar.gz";
+    sha256 = "af2c290b8c95cc0efd29920178879b7a1e8cb1224ec3d3e58ac87b2c36929c1e";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros rcpputils ];
-  checkInputs = [ ament-cmake-google-benchmark ament-cmake-gtest ament-lint-auto ament-lint-common launch-testing std-msgs ];
-  propagatedBuildInputs = [ ament-index-cpp class-loader composition-interfaces rclcpp ];
+  buildInputs = [ ament-cmake-ros ];
+  checkInputs = [ ament-cmake-google-benchmark ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-cpp class-loader composition-interfaces rcl-interfaces rclcpp rcpputils rmw ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/rolling/rclcpp-lifecycle/default.nix
+++ b/distros/rolling/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-lifecycle";
-  version = "30.1.0-r1";
+  version = "30.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/30.1.0-1.tar.gz";
-    name = "30.1.0-1.tar.gz";
-    sha256 = "3b9691132af332015f6537ff054bae9743f899306e8f10a54052a66c4146839c";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/30.1.1-1.tar.gz";
+    name = "30.1.1-1.tar.gz";
+    sha256 = "843bae6068e6b8ee6451767835bbe939acb1fb1aade0a0b84f2f50f3874cb813";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp/default.nix
+++ b/distros/rolling/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, python3Packages, rcl, rcl-interfaces, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp";
-  version = "30.1.0-r1";
+  version = "30.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/30.1.0-1.tar.gz";
-    name = "30.1.0-1.tar.gz";
-    sha256 = "8d256102275de12f00ec41f5560c921f820868f4a7dc165b8ec89b38eb0acd10";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/30.1.1-1.tar.gz";
+    name = "30.1.1-1.tar.gz";
+    sha256 = "b0e02e1d13de6f0e212be4e3fd546637576a7f66054c8dacd14eaed820896459";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/realtime-tools/default.nix
+++ b/distros/rolling/realtime-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, boost, libcap, lifecycle-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2-control-cmake, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-realtime-tools";
-  version = "4.4.0-r1";
+  version = "4.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/rolling/realtime_tools/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "476be9f92429779c82ebd6a2af1d96ae63e08a61db887b98dd6608c06c0d1de3";
+    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/rolling/realtime_tools/4.5.0-1.tar.gz";
+    name = "4.5.0-1.tar.gz";
+    sha256 = "3376710a874418406dcbf9eac765fdb6a1e56b31675b86344499110a466edf5e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/resource-retriever/default.nix
+++ b/distros/rolling/resource-retriever/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-index-cpp, ament-index-python, ament-lint-auto, ament-lint-common, libcurl-vendor, python3Packages }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-index-cpp, ament-index-python, ament-lint-auto, ament-lint-common, curl, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-resource-retriever";
-  version = "3.8.2-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/resource_retriever-release/archive/release/rolling/resource_retriever/3.8.2-1.tar.gz";
-    name = "3.8.2-1.tar.gz";
-    sha256 = "1f9c550db29cc60432d9fa18b0ddbdf1a7c64be74019032a5c6637547b54d492";
+    url = "https://github.com/ros2-gbp/resource_retriever-release/archive/release/rolling/resource_retriever/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "2d4ffb34ad3045e281f384fdc6af6c9db38692d846030d7a20b287e4d739c427";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common python3Packages.pytest ];
-  propagatedBuildInputs = [ ament-index-cpp ament-index-python libcurl-vendor ];
+  propagatedBuildInputs = [ ament-index-cpp ament-index-python curl ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/rolling/rmw-zenoh-cpp/default.nix
+++ b/distros/rolling/rmw-zenoh-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, fastcdr, nlohmann_json, rcpputils, rcutils, rmw, rmw-test-fixture, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, tracetools, zenoh-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rmw-zenoh-cpp";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/rolling/rmw_zenoh_cpp/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "e230d810fe1070a247785cabc661ddfcfee919550683a0c78ca87a495bb75cac";
+    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/rolling/rmw_zenoh_cpp/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "2852e06e25aa65972e9746a61c4d687a02858e3864a7b968a1328dfd52cab32c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2action/default.nix
+++ b/distros/rolling/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2action";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2action/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "bb59af8015a2c4a69de9606a7fb7f206db52331436827a2ff75dda9e3aef43b6";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2action/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "93087c90f2bbe8403869d294d7d269f7ec6ce77a0ff19761ac83286783ded398";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2cli-test-interfaces/default.nix
+++ b/distros/rolling/ros2cli-test-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-ros2cli-test-interfaces";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli_test_interfaces/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "cb345afa78553cc0d8a4b36375492aaa79a7c98e222e5acc9df75f13167ed439";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli_test_interfaces/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "7c294b0655abc4b8db52d3acaeaca30cd47b5df4ee4f271484aee646c3db8fcc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2cli/default.nix
+++ b/distros/rolling/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, rclpy, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2cli";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "a8097df9abe28675be3bf419ad5a5515ea2f6353cc31e4d7bad8050f696f684d";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "64a194583945dc7c6671e783979c73b4d46505106fa515740209819d8e5cb0ba";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2component/default.nix
+++ b/distros/rolling/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, python3Packages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-rolling-ros2component";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2component/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "aca425c30c0002ce1fd7dc4df790f042881e91c57ccdbf71cb943c7344132d39";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2component/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "150285ff92256e1c2c851ddda13d12fa9561dc9ade27dbfa4064d1fae9c669fc";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2doctor/default.nix
+++ b/distros/rolling/ros2doctor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros-environment, ros2action, ros2cli, std-msgs, std-srvs, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2doctor";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2doctor/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "dcc7765296765611d436e9973319f284c926833d94d967ff36390a65c138487e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2doctor/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "53ac9209bf80865d27be2c4615484ea458a7e8dc70d5c0b109921ffaf7f6ea44";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2interface/default.nix
+++ b/distros/rolling/ros2interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, ros2cli, ros2cli-test-interfaces, rosidl-adapter, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2interface";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2interface/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "62984c82cd4633cb0ac6b3faf8748beefe573278e4a809dfbd025e85b6f106ae";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2interface/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "8ae75cec4bbf6a8758a80980c7979ceb901bd14236df0369d25a849c4837e52e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2lifecycle-test-fixtures/default.nix
+++ b/distros/rolling/ros2lifecycle-test-fixtures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-rolling-ros2lifecycle-test-fixtures";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle_test_fixtures/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "2f156c1ac8e60111709977c76f4169922d071b749ab829b3ea9e2e8f04aaea5c";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle_test_fixtures/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "980524683cddbd4c4a1f3ee666acd9abc250715a3eff097411f1d59cc708b7cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2lifecycle/default.nix
+++ b/distros/rolling/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, lifecycle-msgs, python3Packages, rclpy, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-rolling-ros2lifecycle";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "48968f7ea07ff99944502211143be672f0ec4c1c3151600b9e07e5593d70ec3d";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "7db8680202bfff107aea41b757ed7819a7750fb2f370d92e951a84126ae3018d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2multicast/default.nix
+++ b/distros/rolling/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, ros2cli }:
 buildRosPackage {
   pname = "ros-rolling-ros2multicast";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2multicast/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "d6fcc76d0b92b56e14df1e541148e2af78e87cb2aaf83a254818dbcf72d1db95";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2multicast/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "8a9304f2f66a0aa1b9df54a2fbd729859bf8fd6cbd5d4e3c4567a91f10312cd8";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2node/default.nix
+++ b/distros/rolling/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2node";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2node/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "cb283e22f0fbcc939084615c74af4e313bf1297a7493a66871249a9f6cb1a6b3";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2node/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "bb8311739fb305047c857e363a3c171e797a38b2182981e46adca338dc9cfa44";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2param/default.nix
+++ b/distros/rolling/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-rolling-ros2param";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2param/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "1e4c169459a15c5c01f3172f262c45b51d2b8ebadaf4b0779f1475005ff7d26d";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2param/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "79a2e795fdcf9813af9293d77cffbcf00e012c1d2416080ea14d96da77369c4c";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2pkg/default.nix
+++ b/distros/rolling/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, ros2cli }:
 buildRosPackage {
   pname = "ros-rolling-ros2pkg";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2pkg/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "d6585fd49ccd795c5ff501cec77d756aaa7325266ed07a848e69d36b6b72b54e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2pkg/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "a6afb0d048a16aeaa67e9360f5ffda9527a028a209d07e691d52efc912a1f49c";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2run/default.nix
+++ b/distros/rolling/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-rolling-ros2run";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2run/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "6d0030f219d835ba58d18075bbd2ed57c9d140ba21ec133eb5b56e808c14d420";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2run/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "24d8cd90c215c78dca2a337822c1b8c3c9739fdd3797d6a98fc44c9bb7d9b5b8";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2service/default.nix
+++ b/distros/rolling/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2service";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2service/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "4de069208580471ef73ecb42f89db9d7be53826ca5747044bddca83d7fc08371";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2service/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "7d35598518c890d5cac56718bcad3a8a8b079ed3fcb95cf17c0020bcb9948d76";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2topic/default.nix
+++ b/distros/rolling/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosgraph-msgs, rosidl-runtime-py, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2topic";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2topic/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "09d82c739f2a242bd3ae340ba9ba48c9e88ea6d72080154627c69b7f12477d75";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2topic/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "7a214cf85249ed8edf75fdffa7a8659860e3e751dd8714fdf2c84964f762a3e1";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosidlcpp-generator-c/default.nix
+++ b/distros/rolling/rosidlcpp-generator-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-ros-core, fmt, nlohmann_json, rcutils, ros-environment, rosidl-cmake, rosidl-generator-type-description, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp-generator-c";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_generator_c/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "2a1a31d40fdec7e06761844e96c965265205c636afa36e0db8e7c9afb2b36a90";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_generator_c/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "2dde5806153322206fb91f9a3bdd95dfc2dc8266f1c8f66b5e415a6891efadc5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidlcpp-generator-core/default.nix
+++ b/distros/rolling/rosidlcpp-generator-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, fmt, nlohmann_json, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp-generator-core";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_generator_core/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "2bf2aae9cba266e16bf7a2441ab6dabeffc328d2a01d30665797639f5a7aeca9";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_generator_core/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "78c8d4340f02fc8779f958aa948b35f5cec9fd653733bcd4335b1db727fae57a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidlcpp-generator-cpp/default.nix
+++ b/distros/rolling/rosidlcpp-generator-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, fmt, nlohmann_json, rcutils, rosidl-cmake, rosidl-generator-type-description, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp-generator-cpp";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_generator_cpp/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "f511577140ec650af79f8b60df849eb5716e9528d2e0b109a61cfd25e47681b5";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_generator_cpp/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "feabe2df99d64805798c36ace8515741c70b0444b21b2b275e5f836085fc426d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidlcpp-generator-py/default.nix
+++ b/distros/rolling/rosidlcpp-generator-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, fmt, nlohmann_json, python-cmake-module, rmw, rosidl-generator-c, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-c, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp-generator-py";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_generator_py/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "49845d579317bdba613fb84b2debe4cfc9615c77d470dcb94174a0cc14dc4588";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_generator_py/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "3353738d8f2de47da11ea4248873d4b8bbd8fd55ab5857f1dffb6afd9a80aaf4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidlcpp-generator-type-description/default.nix
+++ b/distros/rolling/rosidlcpp-generator-type-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, fmt, nlohmann_json, rcutils, rosidl-runtime-c, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp-generator-type-description";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_generator_type_description/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "06838d110a1476c0f8bb548b53811c60880500a3a5f4aa3b7c4c9b0d06487d14";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_generator_type_description/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "0f28c966b87091b3a46b0187718c2c2a138b21f8955469d16aa21e2be2861ddc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidlcpp-parser/default.nix
+++ b/distros/rolling/rosidlcpp-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, fmt, nlohmann_json }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp-parser";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_parser/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "c2de0126816dd84c9d20503e648e42a6993d4fbcdd4811adca59605076e5c32f";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_parser/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "76d206cf4517a74f632b4ced1259c09597e573da812e09876475d418d5711bdb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidlcpp-typesupport-c/default.nix
+++ b/distros/rolling/rosidlcpp-typesupport-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-ros-core, ament-index-python, fmt, nlohmann_json, rcpputils, rcutils, ros-environment, rosidl-cli, rosidl-generator-c, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-c, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp-typesupport-c";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_typesupport_c/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "381231b42dc19370d5542397fef1ec77373a8f2fb432c590ccd496e07e07b067";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_typesupport_c/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "87ae2403f35c1741583eea984dd40e5e07870263aab7553e18a2c65652b7be7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidlcpp-typesupport-cpp/default.nix
+++ b/distros/rolling/rosidlcpp-typesupport-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-ros-core, ament-index-python, fmt, nlohmann_json, rcpputils, rcutils, ros-environment, rosidl-cli, rosidl-generator-c, rosidl-generator-type-description, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-cpp, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp-typesupport-cpp";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_typesupport_cpp/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "da974f3f315722db207c7ad3a86930756d906dc8a568eaa8c7519a56de53489f";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_typesupport_cpp/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "3f4789c42195d482b73d615a0210fc31fa45342d33447e9acd6e8f81ecfce6da";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidlcpp-typesupport-fastrtps-c/default.nix
+++ b/distros/rolling/rosidlcpp-typesupport-fastrtps-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-cmake-ros, fastcdr, fmt, nlohmann_json, rmw, rosidl-generator-c, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp-typesupport-fastrtps-c";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_typesupport_fastrtps_c/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "953cbc2f489053dbef1d4f9c10699a24c97694fd73bf1153cee8ffd889f38291";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_typesupport_fastrtps_c/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "0c9b2a40f2fdaa344c99ed608d4d94154f41d4f9b3722d6f51eea5846b01b8c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidlcpp-typesupport-fastrtps-cpp/default.nix
+++ b/distros/rolling/rosidlcpp-typesupport-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-cmake-ros, fastcdr, fmt, nlohmann_json, rmw, rosidl-generator-c, rosidl-generator-cpp, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp-typesupport-fastrtps-cpp";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_typesupport_fastrtps_cpp/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "f3733786af76ee99b4c0be512a35d8ede1fac1c35f5579f880f9fe9efd8fef36";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_typesupport_fastrtps_cpp/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "88c43a86c3648cabf501cf675da2d84bbe73886bca6655ec5b0b2225df38e908";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidlcpp-typesupport-introspection-c/default.nix
+++ b/distros/rolling/rosidlcpp-typesupport-introspection-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros-core, ament-index-python, fmt, nlohmann_json, ros-environment, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp-typesupport-introspection-c";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_typesupport_introspection_c/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "857c05a01046f4609a3e1af9b6a9e8d438167827c1adab34ebca387308cec40c";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_typesupport_introspection_c/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "22da2199f5e0877f9599e0f72c8d90e60a02b8991f74016715148efa7e643043";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidlcpp-typesupport-introspection-cpp/default.nix
+++ b/distros/rolling/rosidlcpp-typesupport-introspection-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros-core, ament-index-python, fmt, nlohmann_json, ros-environment, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidl-typesupport-introspection-c, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp-typesupport-introspection-cpp";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_typesupport_introspection_cpp/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "c101d03add4e8dbb198515799357de5547e02d3e8d9865b59654b96e1997f06d";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_typesupport_introspection_cpp/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "90f7a8728c517610a8010358a59b360fcfa1edd8043be95c3425003d1984d32c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidlcpp/default.nix
+++ b/distros/rolling/rosidlcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, rosidlcpp-generator-c, rosidlcpp-generator-cpp, rosidlcpp-generator-py, rosidlcpp-generator-type-description, rosidlcpp-typesupport-c, rosidlcpp-typesupport-cpp, rosidlcpp-typesupport-fastrtps-c, rosidlcpp-typesupport-fastrtps-cpp, rosidlcpp-typesupport-introspection-c, rosidlcpp-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "6a55775098ef30e957444767a139106de8360cef1195c69fbbda10adaefde635";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "8f59841d0ef64833887a9a768e0ee0c31f3c42fbdb52f91e2d10feb3f2fecb11";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rtsp-image-transport/default.nix
+++ b/distros/rolling/rtsp-image-transport/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, ffmpeg, image-transport, live555-vendor, pluginlib, rclcpp }:
+buildRosPackage {
+  pname = "ros-rolling-rtsp-image-transport";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rtsp_image_transport-release/archive/release/rolling/rtsp_image_transport/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "b2b60ba6d1d8a642d6f52e6b84fe1151d4213c839a8460ef78bc2c2b1f20605d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cv-bridge ffmpeg image-transport live555-vendor pluginlib rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Transmit video streams with the Real-Time Streaming Protocol";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/sdformat-vendor/default.nix
+++ b/distros/rolling/sdformat-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, gz-math-vendor, gz-tools-vendor, gz-utils-vendor, libxml2, python3Packages, tinyxml-2, urdfdom }:
 buildRosPackage {
   pname = "ros-rolling-sdformat-vendor";
-  version = "0.2.5-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sdformat_vendor-release/archive/release/rolling/sdformat_vendor/0.2.5-1.tar.gz";
-    name = "0.2.5-1.tar.gz";
-    sha256 = "d299b73138af336efded790cf74ac2d4b80d2fad4ca51ca3201dec5c853f3ea8";
+    url = "https://github.com/ros2-gbp/sdformat_vendor-release/archive/release/rolling/sdformat_vendor/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "1de225a392e414429d636d1e4eba33fe374b49edde94ff7f0c901380b77417a6";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: sdformat15 15.3.0
+    description = "Vendor package for: sdformat 16.0.0
 
     SDFormat is an XML file format that describes environments, objects, and robots
 in a manner suitable for robotic applications";

--- a/distros/rolling/sdformat-vendor/vendored-source.json
+++ b/distros/rolling/sdformat-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "sdformat_vendor": {
     "url": "https://github.com/gazebosim/sdformat.git",
-    "rev": "sdformat15_15.2.0",
-    "hash": "sha256-RarpOKoJ9w+yJw5HU5exZYjx1zVdtkE05+8PBADhOwY="
+    "rev": "sdformat16_16.0.0-pre1",
+    "hash": "sha256-hLpIXhteWNhUrk6zs9FLZF4ScmNpkvplwW9laF42tqs="
   }
 }

--- a/distros/rolling/tf2-web-republisher-interfaces/default.nix
+++ b/distros/rolling/tf2-web-republisher-interfaces/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-rolling-tf2-web-republisher-interfaces";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/tf2_web_republisher-release/archive/release/rolling/tf2_web_republisher_interfaces/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "4ebaf2afa897e8b3f69d630cedeab321f652b27f16699a7374f469b40be61433";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces geometry-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Interface definitions for tf2_web_republisher";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/tf2-web-republisher/default.nix
+++ b/distros/rolling/tf2-web-republisher/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, geometry-msgs, rclcpp, rclcpp-action, rclcpp-components, tf2, tf2-ros, tf2-web-republisher-interfaces }:
+buildRosPackage {
+  pname = "ros-rolling-tf2-web-republisher";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/tf2_web_republisher-release/archive/release/rolling/tf2_web_republisher/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "12c47f7e9343fe1d756ded8ef4d41612215a8f004cdfb1de35aa51dee5555042";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gmock ];
+  propagatedBuildInputs = [ geometry-msgs rclcpp rclcpp-action rclcpp-components tf2 tf2-ros tf2-web-republisher-interfaces ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Republishing of Selected TFs";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/theora-image-transport/default.nix
+++ b/distros/rolling/theora-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, libogg, libtheora, opencv, pkg-config, pluginlib, rclcpp, rcutils, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-theora-image-transport";
-  version = "6.2.0-r1";
+  version = "6.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/theora_image_transport/6.2.0-1.tar.gz";
-    name = "6.2.0-1.tar.gz";
-    sha256 = "ae5798ee206a6fc5270802f07ab89be36c9b9461b2ad0c35dbc9dfef532b0238";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/theora_image_transport/6.2.1-1.tar.gz";
+    name = "6.2.1-1.tar.gz";
+    sha256 = "45f9f5ae9848e57953481be3cbc34212bdd00ae6d2fd0fcb6d1132317ec9497e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/zenoh-cpp-vendor/default.nix
+++ b/distros/rolling/zenoh-cpp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, cargo, clang, git }:
 buildRosPackage {
   pname = "ros-rolling-zenoh-cpp-vendor";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/rolling/zenoh_cpp_vendor/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "ecde21558ede022c2923f6be8db58dd1d8bbca00ab03d516d67bd5a4f28d6036";
+    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/rolling/zenoh_cpp_vendor/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "e321bbcc9f7e903e6d948c5fe054abd346024f24622aeda4e399dedf5c28324b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/zenoh-security-tools/default.nix
+++ b/distros/rolling/zenoh-security-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, nlohmann_json, rcpputils, rcutils, rmw, rmw-security-common, tinyxml2-vendor, zenoh-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-zenoh-security-tools";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/rolling/zenoh_security_tools/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "8d87d216f421e48939d9a1ce92cedfa8aea5963c989b536c2376b55f07c65d76";
+    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/rolling/zenoh_security_tools/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "b624f4969f3cc2baba4fa2362a8ab9cf59cdc3a241a1f184d74be796d3334b65";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/zstd-image-transport/default.nix
+++ b/distros/rolling/zstd-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, image-transport, zlib }:
 buildRosPackage {
   pname = "ros-rolling-zstd-image-transport";
-  version = "6.2.0-r1";
+  version = "6.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/zstd_image_transport/6.2.0-1.tar.gz";
-    name = "6.2.0-1.tar.gz";
-    sha256 = "ea488ba1dd09414187dcc131237fe04839e401a8bd60ca78f202c326f99a30bb";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/zstd_image_transport/6.2.1-1.tar.gz";
+    name = "6.2.1-1.tar.gz";
+    sha256 = "995b7677d330236f5b04a4b0d623a26bbd1136165b7d3c7ff427fc532c430fa3";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'kilted', 'rolling'] from nix-ros-overlay commit 6fa4f71e24c5a698efad8320448daf3f4fea3ff7.
This pull request was generated by running the following command:

```
superflore-gen-nix --dry-run --output-repository-path . --all --tar-archive-dir /home/runner/.ros/tar --upstream-branch develop
```

Changes:
========
Humble Changes:
---------------
* *compressed-depth-image-transport 2.5.3-r1 --> 2.5.4-r1*
* *compressed-image-transport 2.5.3-r1 --> 2.5.4-r1*
* *dynamixel-hardware-interface 1.4.13-r1 --> 1.4.14-r1*
* *image-transport-plugins 2.5.3-r1 --> 2.5.4-r1*
* *libmavconn 2.10.1-r1 --> 2.11.0-r1*
* *mavlink 2025.6.6-r1 --> 2025.9.9-r1*
* *mavros 2.10.1-r1 --> 2.11.0-r1*
* *mavros-extras 2.10.1-r1 --> 2.11.0-r1*
* *mavros-msgs 2.10.1-r1 --> 2.11.0-r1*
* *mola-common 0.5.0-r1 --> 0.5.1-r1*
* *mola-imu-preintegration 1.9.0-r1 --> 1.10.0-r1*
* *mola-state-estimation 1.9.0-r1 --> 1.10.0-r1*
* *mola-state-estimation-simple 1.9.0-r1 --> 1.10.0-r1*
* *mola-state-estimation-smoother 1.9.0-r1 --> 1.10.0-r1*
* *network-bridge 2.0.0-r1*
* *rclcpp 16.0.14-r1 --> 16.0.15-r1*
* *rclcpp-action 16.0.14-r1 --> 16.0.15-r1*
* *rclcpp-components 16.0.14-r1 --> 16.0.15-r1*
* *rclcpp-lifecycle 16.0.14-r1 --> 16.0.15-r1*
* *rmw-zenoh-cpp 0.1.5-r1 --> 0.1.6-r1*
* *ros2action 0.18.13-r1 --> 0.18.14-r1*
* *ros2cli 0.18.13-r1 --> 0.18.14-r1*
* *ros2cli-test-interfaces 0.18.13-r1 --> 0.18.14-r1*
* *ros2component 0.18.13-r1 --> 0.18.14-r1*
* *ros2doctor 0.18.13-r1 --> 0.18.14-r1*
* *ros2interface 0.18.13-r1 --> 0.18.14-r1*
* *ros2lifecycle 0.18.13-r1 --> 0.18.14-r1*
* *ros2lifecycle-test-fixtures 0.18.13-r1 --> 0.18.14-r1*
* *ros2multicast 0.18.13-r1 --> 0.18.14-r1*
* *ros2node 0.18.13-r1 --> 0.18.14-r1*
* *ros2param 0.18.13-r1 --> 0.18.14-r1*
* *ros2pkg 0.18.13-r1 --> 0.18.14-r1*
* *ros2run 0.18.13-r1 --> 0.18.14-r1*
* *ros2service 0.18.13-r1 --> 0.18.14-r1*
* *ros2topic 0.18.13-r1 --> 0.18.14-r1*
* *tf2-web-republisher 1.0.0-r1*
* *tf2-web-republisher-interfaces 1.0.0-r1*
* *theora-image-transport 2.5.3-r1 --> 2.5.4-r1*
* *zenoh-cpp-vendor 0.1.5-r1 --> 0.1.6-r1*
* *zenoh-security-tools 0.1.5-r1 --> 0.1.6-r1*

Jazzy Changes:
--------------
* *clearpath-bt-joy 2.7.0-r1 --> 2.7.2-r1*
* *clearpath-common 2.7.0-r1 --> 2.7.2-r1*
* *clearpath-config 2.7.0-r1 --> 2.7.1-r1*
* *clearpath-control 2.7.0-r1 --> 2.7.2-r1*
* *clearpath-customization 2.7.0-r1 --> 2.7.2-r1*
* *clearpath-description 2.7.0-r1 --> 2.7.2-r1*
* *clearpath-diagnostics 2.7.0-r1 --> 2.7.2-r1*
* *clearpath-generator-common 2.7.0-r1 --> 2.7.2-r1*
* *clearpath-manipulators 2.7.0-r1 --> 2.7.2-r1*
* *clearpath-manipulators-description 2.7.0-r1 --> 2.7.2-r1*
* *clearpath-mounts-description 2.7.0-r1 --> 2.7.2-r1*
* *clearpath-nav2-demos 2.7.0-r1 --> 2.7.1-r1*
* *clearpath-platform-description 2.7.0-r1 --> 2.7.2-r1*
* *clearpath-sensors-description 2.7.0-r1 --> 2.7.2-r1*
* *compressed-depth-image-transport 4.0.5-r1 --> 4.0.6-r1*
* *compressed-image-transport 4.0.5-r1 --> 4.0.6-r1*
* *dynamixel-hardware-interface 1.4.13-r1 --> 1.4.14-r1*
* *image-transport-plugins 4.0.5-r1 --> 4.0.6-r1*
* *libmavconn 2.10.1-r1 --> 2.11.0-r1*
* *mavlink 2025.6.6-r1 --> 2025.9.9-r1*
* *mavros 2.10.1-r1 --> 2.11.0-r1*
* *mavros-extras 2.10.1-r1 --> 2.11.0-r1*
* *mavros-msgs 2.10.1-r1 --> 2.11.0-r1*
* *mola-common 0.5.0-r1 --> 0.5.1-r1*
* *mola-imu-preintegration 1.9.0-r1 --> 1.10.0-r1*
* *mola-state-estimation 1.9.0-r1 --> 1.10.0-r1*
* *mola-state-estimation-simple 1.9.0-r1 --> 1.10.0-r1*
* *mola-state-estimation-smoother 1.9.0-r1 --> 1.10.0-r1*
* *network-bridge 1.0.2-r1 --> 2.0.0-r1*
* *om-gravity-compensation-controller 4.0.7-r1 --> 4.0.8-r1*
* *om-joint-trajectory-command-broadcaster 4.0.7-r1 --> 4.0.8-r1*
* *om-spring-actuator-controller 4.0.7-r1 --> 4.0.8-r1*
* *open-manipulator 4.0.7-r1 --> 4.0.8-r1*
* *open-manipulator-bringup 4.0.7-r1 --> 4.0.8-r1*
* *open-manipulator-collision 4.0.7-r1 --> 4.0.8-r1*
* *open-manipulator-description 4.0.7-r1 --> 4.0.8-r1*
* *open-manipulator-gui 4.0.7-r1 --> 4.0.8-r1*
* *open-manipulator-moveit-config 4.0.7-r1 --> 4.0.8-r1*
* *open-manipulator-playground 4.0.7-r1 --> 4.0.8-r1*
* *open-manipulator-teleop 4.0.7-r1 --> 4.0.8-r1*
* *rclcpp 28.1.11-r1 --> 28.1.12-r1*
* *rclcpp-action 28.1.11-r1 --> 28.1.12-r1*
* *rclcpp-components 28.1.11-r1 --> 28.1.12-r1*
* *rclcpp-lifecycle 28.1.11-r1 --> 28.1.12-r1*
* *realtime-tools 3.7.0-r1 --> 3.8.0-r1*
* *rmw-zenoh-cpp 0.2.6-r1 --> 0.2.7-r1*
* *ros2action 0.32.5-r1 --> 0.32.6-r1*
* *ros2cli 0.32.5-r1 --> 0.32.6-r1*
* *ros2cli-test-interfaces 0.32.5-r1 --> 0.32.6-r1*
* *ros2component 0.32.5-r1 --> 0.32.6-r1*
* *ros2doctor 0.32.5-r1 --> 0.32.6-r1*
* *ros2interface 0.32.5-r1 --> 0.32.6-r1*
* *ros2lifecycle 0.32.5-r1 --> 0.32.6-r1*
* *ros2lifecycle-test-fixtures 0.32.5-r1 --> 0.32.6-r1*
* *ros2multicast 0.32.5-r1 --> 0.32.6-r1*
* *ros2node 0.32.5-r1 --> 0.32.6-r1*
* *ros2param 0.32.5-r1 --> 0.32.6-r1*
* *ros2pkg 0.32.5-r1 --> 0.32.6-r1*
* *ros2run 0.32.5-r1 --> 0.32.6-r1*
* *ros2service 0.32.5-r1 --> 0.32.6-r1*
* *ros2topic 0.32.5-r1 --> 0.32.6-r1*
* *rosidlcpp 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-generator-c 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-generator-core 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-generator-cpp 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-generator-py 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-generator-type-description 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-parser 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-typesupport-c 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-typesupport-cpp 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-typesupport-fastrtps-c 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-typesupport-fastrtps-cpp 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-typesupport-introspection-c 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-typesupport-introspection-cpp 0.3.0-r1 --> 0.4.0-r1*
* *rtsp-image-transport 2.0.1-r1*
* *tf2-web-republisher 1.0.0-r1*
* *tf2-web-republisher-interfaces 1.0.0-r1*
* *theora-image-transport 4.0.5-r1 --> 4.0.6-r1*
* *turtlebot4-description 2.1.0-r1 --> 2.1.1-r1*
* *turtlebot4-msgs 2.1.0-r1 --> 2.1.1-r1*
* *turtlebot4-navigation 2.1.0-r1 --> 2.1.1-r1*
* *turtlebot4-node 2.1.0-r1 --> 2.1.1-r1*
* *zenoh-cpp-vendor 0.2.6-r1 --> 0.2.7-r1*
* *zenoh-security-tools 0.2.6-r1 --> 0.2.7-r1*
* *zstd-image-transport 4.0.5-r1 --> 4.0.6-r1*

Kilted Changes:
---------------
* *catch-ros2 0.2.2-r1 --> 0.2.3-r1*
* *chomp-motion-planner 2.14.0-r1 --> 2.14.1-r1*
* *compressed-depth-image-transport 5.1.0-r1 --> 5.1.1-r1*
* *compressed-image-transport 5.1.0-r1 --> 5.1.1-r1*
* *depthai 3.0.4-r1 --> 3.0.5-r1*
* *dynamixel-hardware-interface 1.4.13-r1 --> 1.4.14-r1*
* *image-transport-plugins 5.1.0-r1 --> 5.1.1-r1*
* *launch 3.8.2-r1 --> 3.8.3-r1*
* *launch-pytest 3.8.2-r1 --> 3.8.3-r1*
* *launch-testing 3.8.2-r1 --> 3.8.3-r1*
* *launch-testing-ament-cmake 3.8.2-r1 --> 3.8.3-r1*
* *launch-xml 3.8.2-r1 --> 3.8.3-r1*
* *launch-yaml 3.8.2-r1 --> 3.8.3-r1*
* *libmavconn 2.10.1-r1 --> 2.11.0-r1*
* *mavlink 2025.6.6-r1 --> 2025.9.9-r1*
* *mavros 2.10.1-r1 --> 2.11.0-r1*
* *mavros-extras 2.10.1-r1 --> 2.11.0-r1*
* *mavros-msgs 2.10.1-r1 --> 2.11.0-r1*
* *mola-common 0.5.0-r1 --> 0.5.1-r1*
* *mola-imu-preintegration 1.9.0-r1 --> 1.10.0-r1*
* *mola-state-estimation 1.9.0-r1 --> 1.10.0-r1*
* *mola-state-estimation-simple 1.9.0-r1 --> 1.10.0-r1*
* *mola-state-estimation-smoother 1.9.0-r1 --> 1.10.0-r1*
* *moveit 2.14.0-r1 --> 2.14.1-r1*
* *moveit-common 2.14.0-r1 --> 2.14.1-r1*
* *moveit-configs-utils 2.14.0-r1 --> 2.14.1-r1*
* *moveit-core 2.14.0-r1 --> 2.14.1-r1*
* *moveit-hybrid-planning 2.14.0-r1 --> 2.14.1-r1*
* *moveit-kinematics 2.14.0-r1 --> 2.14.1-r1*
* *moveit-planners 2.14.0-r1 --> 2.14.1-r1*
* *moveit-planners-chomp 2.14.0-r1 --> 2.14.1-r1*
* *moveit-planners-ompl 2.14.0-r1 --> 2.14.1-r1*
* *moveit-planners-stomp 2.14.0-r1 --> 2.14.1-r1*
* *moveit-plugins 2.14.0-r1 --> 2.14.1-r1*
* *moveit-py 2.14.0-r1 --> 2.14.1-r1*
* *moveit-resources-prbt-ikfast-manipulator-plugin 2.14.0-r1 --> 2.14.1-r1*
* *moveit-resources-prbt-moveit-config 2.14.0-r1 --> 2.14.1-r1*
* *moveit-resources-prbt-pg70-support 2.14.0-r1 --> 2.14.1-r1*
* *moveit-resources-prbt-support 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros-benchmarks 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros-control-interface 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros-move-group 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros-occupancy-map-monitor 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros-perception 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros-planning 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros-planning-interface 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros-robot-interaction 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros-tests 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros-trajectory-cache 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros-visualization 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros-warehouse 2.14.0-r1 --> 2.14.1-r1*
* *moveit-runtime 2.14.0-r1 --> 2.14.1-r1*
* *moveit-servo 2.14.0-r1 --> 2.14.1-r1*
* *moveit-setup-app-plugins 2.14.0-r1 --> 2.14.1-r1*
* *moveit-setup-assistant 2.14.0-r1 --> 2.14.1-r1*
* *moveit-setup-controllers 2.14.0-r1 --> 2.14.1-r1*
* *moveit-setup-core-plugins 2.14.0-r1 --> 2.14.1-r1*
* *moveit-setup-framework 2.14.0-r1 --> 2.14.1-r1*
* *moveit-setup-srdf-plugins 2.14.0-r1 --> 2.14.1-r1*
* *moveit-simple-controller-manager 2.14.0-r1 --> 2.14.1-r1*
* *network-bridge 2.0.0-r1*
* *ntpd-driver 2.2.0-r4 --> 2.3.0-r1*
* *om-gravity-compensation-controller 4.0.7-r1 --> 4.0.8-r1*
* *om-joint-trajectory-command-broadcaster 4.0.7-r1 --> 4.0.8-r1*
* *om-spring-actuator-controller 4.0.7-r1 --> 4.0.8-r1*
* *open-manipulator 4.0.7-r1 --> 4.0.8-r1*
* *open-manipulator-bringup 4.0.7-r1 --> 4.0.8-r1*
* *open-manipulator-collision 4.0.7-r1 --> 4.0.8-r1*
* *open-manipulator-description 4.0.7-r1 --> 4.0.8-r1*
* *open-manipulator-gui 4.0.7-r1 --> 4.0.8-r1*
* *open-manipulator-moveit-config 4.0.7-r1 --> 4.0.8-r1*
* *open-manipulator-playground 4.0.7-r1 --> 4.0.8-r1*
* *open-manipulator-teleop 4.0.7-r1 --> 4.0.8-r1*
* *pilz-industrial-motion-planner 2.14.0-r1 --> 2.14.1-r1*
* *pilz-industrial-motion-planner-testutils 2.14.0-r1 --> 2.14.1-r1*
* *rclcpp 29.5.2-r1 --> 29.5.3-r1*
* *rclcpp-action 29.5.2-r1 --> 29.5.3-r1*
* *rclcpp-components 29.5.2-r1 --> 29.5.3-r1*
* *rclcpp-lifecycle 29.5.2-r1 --> 29.5.3-r1*
* *realtime-tools 4.4.0-r1 --> 4.5.0-r1*
* *rmw-zenoh-cpp 0.6.3-r1 --> 0.6.4-r1*
* *ros2action 0.38.0-r1 --> 0.38.1-r1*
* *ros2cli 0.38.0-r1 --> 0.38.1-r1*
* *ros2cli-test-interfaces 0.38.0-r1 --> 0.38.1-r1*
* *ros2component 0.38.0-r1 --> 0.38.1-r1*
* *ros2doctor 0.38.0-r1 --> 0.38.1-r1*
* *ros2interface 0.38.0-r1 --> 0.38.1-r1*
* *ros2lifecycle 0.38.0-r1 --> 0.38.1-r1*
* *ros2lifecycle-test-fixtures 0.38.0-r1 --> 0.38.1-r1*
* *ros2multicast 0.38.0-r1 --> 0.38.1-r1*
* *ros2node 0.38.0-r1 --> 0.38.1-r1*
* *ros2param 0.38.0-r1 --> 0.38.1-r1*
* *ros2pkg 0.38.0-r1 --> 0.38.1-r1*
* *ros2run 0.38.0-r1 --> 0.38.1-r1*
* *ros2service 0.38.0-r1 --> 0.38.1-r1*
* *ros2topic 0.38.0-r1 --> 0.38.1-r1*
* *rosidlcpp 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-generator-c 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-generator-core 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-generator-cpp 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-generator-py 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-generator-type-description 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-parser 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-typesupport-c 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-typesupport-cpp 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-typesupport-fastrtps-c 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-typesupport-fastrtps-cpp 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-typesupport-introspection-c 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-typesupport-introspection-cpp 0.3.0-r1 --> 0.4.0-r1*
* *tf2-web-republisher 1.0.0-r1*
* *tf2-web-republisher-interfaces 1.0.0-r1*
* *theora-image-transport 5.1.0-r1 --> 5.1.1-r1*
* *zenoh-cpp-vendor 0.6.3-r1 --> 0.6.4-r1*
* *zenoh-security-tools 0.6.3-r1 --> 0.6.4-r1*
* *zstd-image-transport 5.1.0-r1 --> 5.1.1-r1*

Rolling Changes:
----------------
* *chomp-motion-planner 2.14.0-r1 --> 2.14.1-r1*
* *compressed-depth-image-transport 6.2.0-r1 --> 6.2.1-r1*
* *compressed-image-transport 6.2.0-r1 --> 6.2.1-r1*
* *dynamixel-hardware-interface 1.4.13-r1 --> 1.4.14-r1*
* *gz-cmake-vendor 0.3.1-r1 --> 0.4.0-r1*
* *gz-common-vendor 0.2.4-r1 --> 0.3.0-r1*
* *gz-fuel-tools-vendor 0.2.2-r1 --> 0.3.0-r1*
* *gz-launch-vendor 0.2.1-r1 --> 0.3.0-r1*
* *gz-math-vendor 0.3.1-r1 --> 0.4.0-r1*
* *gz-msgs-vendor 0.2.3-r1 --> 0.3.0-r1*
* *gz-physics-vendor 0.3.0-r1 --> 0.4.0-r1*
* *gz-plugin-vendor 0.2.2-r1 --> 0.3.0-r1*
* *gz-rendering-vendor 0.3.0-r1 --> 0.4.0-r1*
* *gz-sensors-vendor 0.2.2-r1 --> 0.3.0-r1*
* *gz-tools-vendor 0.2.0-r1 --> 0.2.1-r1*
* *gz-transport-vendor 0.2.2-r1 --> 0.3.0-r1*
* *gz-utils-vendor 0.3.0-r1 --> 0.4.0-r2*
* *image-transport-plugins 6.2.0-r1 --> 6.2.1-r1*
* *libmavconn 2.10.1-r1 --> 2.11.0-r1*
* *mavlink 2025.6.6-r1 --> 2025.9.9-r1*
* *mavros 2.10.1-r1 --> 2.11.0-r1*
* *mavros-extras 2.10.1-r1 --> 2.11.0-r1*
* *mavros-msgs 2.10.1-r1 --> 2.11.0-r1*
* *mola-common 0.5.0-r1 --> 0.5.1-r2*
* *mola-imu-preintegration 1.9.0-r1 --> 1.10.0-r1*
* *mola-state-estimation 1.9.0-r1 --> 1.10.0-r1*
* *mola-state-estimation-simple 1.9.0-r1 --> 1.10.0-r1*
* *mola-state-estimation-smoother 1.9.0-r1 --> 1.10.0-r1*
* *moveit 2.14.0-r1 --> 2.14.1-r1*
* *moveit-common 2.14.0-r1 --> 2.14.1-r1*
* *moveit-configs-utils 2.14.0-r1 --> 2.14.1-r1*
* *moveit-core 2.14.0-r1 --> 2.14.1-r1*
* *moveit-hybrid-planning 2.14.0-r1 --> 2.14.1-r1*
* *moveit-kinematics 2.14.0-r1 --> 2.14.1-r1*
* *moveit-planners 2.14.0-r1 --> 2.14.1-r1*
* *moveit-planners-chomp 2.14.0-r1 --> 2.14.1-r1*
* *moveit-planners-ompl 2.14.0-r1 --> 2.14.1-r1*
* *moveit-planners-stomp 2.14.0-r1 --> 2.14.1-r1*
* *moveit-plugins 2.14.0-r1 --> 2.14.1-r1*
* *moveit-py 2.14.0-r1 --> 2.14.1-r1*
* *moveit-resources-prbt-ikfast-manipulator-plugin 2.14.0-r1 --> 2.14.1-r1*
* *moveit-resources-prbt-moveit-config 2.14.0-r1 --> 2.14.1-r1*
* *moveit-resources-prbt-pg70-support 2.14.0-r1 --> 2.14.1-r1*
* *moveit-resources-prbt-support 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros-benchmarks 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros-control-interface 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros-move-group 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros-occupancy-map-monitor 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros-perception 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros-planning 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros-planning-interface 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros-robot-interaction 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros-tests 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros-trajectory-cache 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros-visualization 2.14.0-r1 --> 2.14.1-r1*
* *moveit-ros-warehouse 2.14.0-r1 --> 2.14.1-r1*
* *moveit-runtime 2.14.0-r1 --> 2.14.1-r1*
* *moveit-servo 2.14.0-r1 --> 2.14.1-r1*
* *moveit-setup-app-plugins 2.14.0-r1 --> 2.14.1-r1*
* *moveit-setup-assistant 2.14.0-r1 --> 2.14.1-r1*
* *moveit-setup-controllers 2.14.0-r1 --> 2.14.1-r1*
* *moveit-setup-core-plugins 2.14.0-r1 --> 2.14.1-r1*
* *moveit-setup-framework 2.14.0-r1 --> 2.14.1-r1*
* *moveit-setup-srdf-plugins 2.14.0-r1 --> 2.14.1-r1*
* *moveit-simple-controller-manager 2.14.0-r1 --> 2.14.1-r1*
* *network-bridge 2.0.0-r1*
* *ntpd-driver 2.2.0-r3 --> 2.3.0-r1*
* *pilz-industrial-motion-planner 2.14.0-r1 --> 2.14.1-r1*
* *pilz-industrial-motion-planner-testutils 2.14.0-r1 --> 2.14.1-r1*
* *pointcloud-to-laserscan 2.0.2-r2 --> 2.1.0-r1*
* *rclcpp 30.1.0-r1 --> 30.1.1-r1*
* *rclcpp-action 30.1.0-r1 --> 30.1.1-r1*
* *rclcpp-components 30.1.0-r1 --> 30.1.1-r1*
* *rclcpp-lifecycle 30.1.0-r1 --> 30.1.1-r1*
* *realtime-tools 4.4.0-r1 --> 4.5.0-r1*
* *resource-retriever 3.8.2-r1 --> 3.9.0-r1*
* *rmw-zenoh-cpp 0.9.0-r1 --> 0.9.1-r1*
* *ros2action 0.40.0-r1 --> 0.40.1-r1*
* *ros2cli 0.40.0-r1 --> 0.40.1-r1*
* *ros2cli-test-interfaces 0.40.0-r1 --> 0.40.1-r1*
* *ros2component 0.40.0-r1 --> 0.40.1-r1*
* *ros2doctor 0.40.0-r1 --> 0.40.1-r1*
* *ros2interface 0.40.0-r1 --> 0.40.1-r1*
* *ros2lifecycle 0.40.0-r1 --> 0.40.1-r1*
* *ros2lifecycle-test-fixtures 0.40.0-r1 --> 0.40.1-r1*
* *ros2multicast 0.40.0-r1 --> 0.40.1-r1*
* *ros2node 0.40.0-r1 --> 0.40.1-r1*
* *ros2param 0.40.0-r1 --> 0.40.1-r1*
* *ros2pkg 0.40.0-r1 --> 0.40.1-r1*
* *ros2run 0.40.0-r1 --> 0.40.1-r1*
* *ros2service 0.40.0-r1 --> 0.40.1-r1*
* *ros2topic 0.40.0-r1 --> 0.40.1-r1*
* *rosidlcpp 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-generator-c 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-generator-core 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-generator-cpp 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-generator-py 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-generator-type-description 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-parser 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-typesupport-c 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-typesupport-cpp 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-typesupport-fastrtps-c 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-typesupport-fastrtps-cpp 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-typesupport-introspection-c 0.3.0-r1 --> 0.4.0-r1*
* *rosidlcpp-typesupport-introspection-cpp 0.3.0-r1 --> 0.4.0-r1*
* *rtsp-image-transport 2.0.1-r1*
* *sdformat-vendor 0.2.5-r1 --> 0.3.0-r1*
* *tf2-web-republisher 1.0.0-r1*
* *tf2-web-republisher-interfaces 1.0.0-r1*
* *theora-image-transport 6.2.0-r1 --> 6.2.1-r1*
* *zenoh-cpp-vendor 0.9.0-r1 --> 0.9.1-r1*
* *zenoh-security-tools 0.9.0-r1 --> 0.9.1-r1*
* *zstd-image-transport 6.2.0-r1 --> 6.2.1-r1*


Missing Dependencies:
=====================
 * [ ] action_tutorials_interfaces
 * [ ] actionlib_msgs
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gripper_controllers
 * [ ] gurumdds-3.0
 * [ ] gurumdds-3.2
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] libcurl_vendor
 * [ ] libopen3d-dev
 * [ ] libqt6svg6
 * [ ] libserial-dev
 * [ ] nanobind-dev
 * [ ] pybind11-json-dev
 * [ ] pybind11_json_vendor
 * [ ] python-is-python3
 * [ ] python3-jsonpickle
 * [ ] python3-pymap3d
 * [ ] python3-pytorch-pip
 * [ ] python3-torch-geometric-pip
 * [ ] python3-typer
 * [ ] python3-types-pyyaml
 * [ ] qml6-module-qt-labs-folderlistmodel
 * [ ] qml6-module-qt-labs-platform
 * [ ] qml6-module-qt-labs-settings
 * [ ] qml6-module-qt5compat-graphicaleffects
 * [ ] qml6-module-qtcharts
 * [ ] qml6-module-qtcore
 * [ ] qml6-module-qtpositioning
 * [ ] qml6-module-qtqml
 * [ ] qml6-module-qtqml-models
 * [ ] qml6-module-qtqml-workerscript
 * [ ] qml6-module-qtquick-controls
 * [ ] qml6-module-qtquick-dialogs
 * [ ] qml6-module-qtquick-layouts
 * [ ] qml6-module-qtquick-templates
 * [ ] qml6-module-qtquick-window
 * [ ] qt6-5compat-dev
 * [ ] qt6-base-private-dev
 * [ ] qt6-declarative-private-dev
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo