### PR TITLE
zenoh_cpp_vendor

### DIFF
--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -311,31 +311,54 @@ in with lib; {
     ];
   });
 
-  zenoh-cpp-vendor = (lib.patchAmentVendorGit rosSuper.zenoh-cpp-vendor { }).overrideAttrs({
-    nativeBuildInputs ? [], postPatch ? "", ...
+  zenoh-cpp-vendor = (lib.patchAmentVendorGit rosSuper.zenoh-cpp-vendor {}).overrideAttrs(finalAttrs: {
+    nativeBuildInputs ? [], postPatch ? "", passthru ? {}, ...
   }: let
-      vendoredSourceJson = "${dirOf rosSuper.zenoh-cpp-vendor.meta.position}/vendored-source.json";
-      sourceInfos = builtins.fromJSON (builtins.readFile vendoredSourceJson);
-      zenoh-c-source = self.fetchFromGitHub {
-        owner = "eclipse-zenoh";
-        repo = "zenoh-c";
-        rev = sourceInfos.zenoh_c_vendor.rev;
-        hash = sourceInfos.zenoh_c_vendor.hash;
-      };
-    in {
+    outputHashes = {
+      "zenoh-1.5.1" = "sha256-EeigSU9l7LCnSkm4/jP0WcdO3Hw9m91zUh8jzVXYhKw=";
+    };
+    zenoh-c-source = finalAttrs.passthru.amentVendorSrcs.zenoh_c_vendor;
+  in {
     postPatch = postPatch + ''
-      ln -s ${zenoh-c-source.outPath}/Cargo.lock Cargo.lock
+      ln -s ${zenoh-c-source}/Cargo.lock Cargo.lock
     '';
     nativeBuildInputs = nativeBuildInputs ++ [
       self.rustPlatform.cargoSetupHook
-      self.cargo
       self.rustc
     ];
     cargoDeps = self.rustPlatform.importCargoLock {
-      lockFile = "${zenoh-c-source.outPath}/Cargo.lock";
-      outputHashes = {
-        "zenoh-1.4.0" = "sha256-eMrsoeToI8vsRLduRgSFh/yoGt/hHcCAqCGNE6ml9uw=";
-      };
+      lockFile = "${zenoh-c-source}/Cargo.lock";
+      inherit outputHashes;
     };
+
+    # Patch the build.rs script to be able to build internal
+    # opaque-types crate without network access.
+    passthru = lib.recursiveUpdate passthru {
+      amentVendorSrcs.zenoh_c_vendor = let
+        src = passthru.amentVendorSrcs.zenoh_c_vendor;
+      in
+        self.applyPatches {
+          inherit src;
+          name = src.rev;
+          patches = [ ./zenoh-cpp-vendor/zenoh-c.patch ];
+        };
+    };
+
+    # Prepare vendored dependencies for internal opaque-types crate.
+    # Execute in subshell to not change variables set by the normal
+    # cargoSetupPostUnpackHook.
+    preBuild = ''
+      (
+        mkdir nix-zenoh-opaque-types
+        cd nix-zenoh-opaque-types
+        cargoDeps=${self.rustPlatform.importCargoLock {
+          lockFile = "${zenoh-c-source}/build-resources/opaque-types/Cargo.lock";
+          inherit outputHashes;
+        }}
+        cargoSetupPostUnpackHook
+      )
+      # Export information for use by our patched build.rs script.
+      export NIX_ZENOH_OPAQUE_TYPES_CARGO_CONFIG=$PWD/nix-zenoh-opaque-types/.cargo/config.toml
+    '';
   });
 }

--- a/distros/humble/zenoh-cpp-vendor/vendored-source.json
+++ b/distros/humble/zenoh-cpp-vendor/vendored-source.json
@@ -1,0 +1,12 @@
+{
+  "zenoh_c_vendor": {
+    "url": "https://github.com/eclipse-zenoh/zenoh-c.git",
+    "rev": "8f9ce70e4c4b55d150632730fd4c48abffbde765",
+    "hash": "sha256-kbDIatj4GFhUyDo9yCc6FzPYszHE+Vd79w4r452p77Y="
+  },
+  "zenoh_cpp_vendor": {
+    "url": "https://github.com/eclipse-zenoh/zenoh-cpp",
+    "rev": "05533d20db70ffc1d53a0e07f39caa999e82febd",
+    "hash": "sha256-lEicWShyKo5NSFyDeMqItZIweY3syXKF629x7woSQ0o="
+  }
+}

--- a/distros/humble/zenoh-cpp-vendor/zenoh-c.patch
+++ b/distros/humble/zenoh-cpp-vendor/zenoh-c.patch
@@ -1,0 +1,25 @@
+diff --git a/buildrs/opaque_types_generator.rs b/buildrs/opaque_types_generator.rs
+index c1d0bdd3..2d190518 100644
+--- a/buildrs/opaque_types_generator.rs
++++ b/buildrs/opaque_types_generator.rs
+@@ -14,7 +14,10 @@ pub fn generate_opaque_types() {
+     let data_in = std::fs::read_to_string(path_in).unwrap();
+ 
+     // Check for cargo-level errors (dependency resolution, manifest parsing, etc.)
+-    if data_in.contains("error: failed to") || data_in.contains("Caused by:") {
++    if data_in.contains("error: failed to")
++        || data_in.contains("error: no matching package named")
++        || data_in.contains("Caused by:")
++    {
+         panic!(
+             "Failed to generate opaque types due to cargo error:\n\nCommand executed:\n\n{command}\n\nCargo output:\n\n{data_in}"
+         );
+@@ -127,6 +130,8 @@ fn produce_opaque_types_data() -> (String, PathBuf) {
+         .arg("build")
+         .args(feature_args)
+         .args(linker_args)
++        .arg("--config")
++        .arg(std::env::var("NIX_ZENOH_OPAQUE_TYPES_CARGO_CONFIG").unwrap())
+         .arg("--target")
+         .arg(target)
+         .arg("--manifest-path")

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -275,31 +275,54 @@ in {
     ];
   });
 
-  zenoh-cpp-vendor = (lib.patchAmentVendorGit rosSuper.zenoh-cpp-vendor { }).overrideAttrs({
-    nativeBuildInputs ? [], postPatch ? "", ...
+  zenoh-cpp-vendor = (lib.patchAmentVendorGit rosSuper.zenoh-cpp-vendor {}).overrideAttrs(finalAttrs: {
+    nativeBuildInputs ? [], postPatch ? "", passthru ? {}, ...
   }: let
-      vendoredSourceJson = "${dirOf rosSuper.zenoh-cpp-vendor.meta.position}/vendored-source.json";
-      sourceInfos = builtins.fromJSON (builtins.readFile vendoredSourceJson);
-      zenoh-c-source = self.fetchFromGitHub {
-        owner = "eclipse-zenoh";
-        repo = "zenoh-c";
-        rev = sourceInfos.zenoh_c_vendor.rev;
-        hash = sourceInfos.zenoh_c_vendor.hash;
-      };
-    in {
+    outputHashes = {
+      "zenoh-1.5.1" = "sha256-EeigSU9l7LCnSkm4/jP0WcdO3Hw9m91zUh8jzVXYhKw=";
+    };
+    zenoh-c-source = finalAttrs.passthru.amentVendorSrcs.zenoh_c_vendor;
+  in {
     postPatch = postPatch + ''
       ln -s ${zenoh-c-source}/Cargo.lock Cargo.lock
     '';
     nativeBuildInputs = nativeBuildInputs ++ [
       self.rustPlatform.cargoSetupHook
-      self.cargo
       self.rustc
     ];
     cargoDeps = self.rustPlatform.importCargoLock {
       lockFile = "${zenoh-c-source}/Cargo.lock";
-      outputHashes = {
-        "zenoh-1.5.0" = "sha256-hOvA6fpmToaF4qaDsL+wzvWSYRrkT8emIw/EdtCz9yE=";
-      };
+      inherit outputHashes;
     };
+
+    # Patch the build.rs script to be able to build internal
+    # opaque-types crate without network access.
+    passthru = lib.recursiveUpdate passthru {
+      amentVendorSrcs.zenoh_c_vendor = let
+        src = passthru.amentVendorSrcs.zenoh_c_vendor;
+      in
+        self.applyPatches {
+          inherit src;
+          name = src.rev;
+          patches = [ ./zenoh-cpp-vendor/zenoh-c.patch ];
+        };
+    };
+
+    # Prepare vendored dependencies for internal opaque-types crate.
+    # Execute in subshell to not change variables set by the normal
+    # cargoSetupPostUnpackHook.
+    preBuild = ''
+      (
+        mkdir nix-zenoh-opaque-types
+        cd nix-zenoh-opaque-types
+        cargoDeps=${self.rustPlatform.importCargoLock {
+          lockFile = "${zenoh-c-source}/build-resources/opaque-types/Cargo.lock";
+          inherit outputHashes;
+        }}
+        cargoSetupPostUnpackHook
+      )
+      # Export information for use by our patched build.rs script.
+      export NIX_ZENOH_OPAQUE_TYPES_CARGO_CONFIG=$PWD/nix-zenoh-opaque-types/.cargo/config.toml
+    '';
   });
 }

--- a/distros/jazzy/zenoh-cpp-vendor/zenoh-c.patch
+++ b/distros/jazzy/zenoh-cpp-vendor/zenoh-c.patch
@@ -1,0 +1,25 @@
+diff --git a/buildrs/opaque_types_generator.rs b/buildrs/opaque_types_generator.rs
+index c1d0bdd3..2d190518 100644
+--- a/buildrs/opaque_types_generator.rs
++++ b/buildrs/opaque_types_generator.rs
+@@ -14,7 +14,10 @@ pub fn generate_opaque_types() {
+     let data_in = std::fs::read_to_string(path_in).unwrap();
+ 
+     // Check for cargo-level errors (dependency resolution, manifest parsing, etc.)
+-    if data_in.contains("error: failed to") || data_in.contains("Caused by:") {
++    if data_in.contains("error: failed to")
++        || data_in.contains("error: no matching package named")
++        || data_in.contains("Caused by:")
++    {
+         panic!(
+             "Failed to generate opaque types due to cargo error:\n\nCommand executed:\n\n{command}\n\nCargo output:\n\n{data_in}"
+         );
+@@ -127,6 +130,8 @@ fn produce_opaque_types_data() -> (String, PathBuf) {
+         .arg("build")
+         .args(feature_args)
+         .args(linker_args)
++        .arg("--config")
++        .arg(std::env::var("NIX_ZENOH_OPAQUE_TYPES_CARGO_CONFIG").unwrap())
+         .arg("--target")
+         .arg(target)
+         .arg("--manifest-path")

--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -234,31 +234,54 @@ in {
     ];
   });
 
-  zenoh-cpp-vendor = (lib.patchAmentVendorGit rosSuper.zenoh-cpp-vendor { }).overrideAttrs({
-    nativeBuildInputs ? [], postPatch ? "", ...
+  zenoh-cpp-vendor = (lib.patchAmentVendorGit rosSuper.zenoh-cpp-vendor {}).overrideAttrs(finalAttrs: {
+    nativeBuildInputs ? [], postPatch ? "", passthru ? {}, ...
   }: let
-    vendoredSourceJson = "${dirOf rosSuper.zenoh-cpp-vendor.meta.position}/vendored-source.json";
-    sourceInfos = builtins.fromJSON (builtins.readFile vendoredSourceJson);
-    zenoh-c-source = self.fetchFromGitHub {
-      owner = "eclipse-zenoh";
-      repo = "zenoh-c";
-      rev = sourceInfos.zenoh_c_vendor.rev;
-      hash = sourceInfos.zenoh_c_vendor.hash;
+    outputHashes = {
+      "zenoh-1.5.1" = "sha256-EeigSU9l7LCnSkm4/jP0WcdO3Hw9m91zUh8jzVXYhKw=";
     };
+    zenoh-c-source = finalAttrs.passthru.amentVendorSrcs.zenoh_c_vendor;
   in {
     postPatch = postPatch + ''
       ln -s ${zenoh-c-source}/Cargo.lock Cargo.lock
     '';
     nativeBuildInputs = nativeBuildInputs ++ [
       self.rustPlatform.cargoSetupHook
-      self.cargo
       self.rustc
     ];
     cargoDeps = self.rustPlatform.importCargoLock {
       lockFile = "${zenoh-c-source}/Cargo.lock";
-      outputHashes = {
-        "zenoh-1.5.1" = "sha256-EeigSU9l7LCnSkm4/jP0WcdO3Hw9m91zUh8jzVXYhKw=";
-      };
+      inherit outputHashes;
     };
+
+    # Patch the build.rs script to be able to build internal
+    # opaque-types crate without network access.
+    passthru = lib.recursiveUpdate passthru {
+      amentVendorSrcs.zenoh_c_vendor = let
+        src = passthru.amentVendorSrcs.zenoh_c_vendor;
+      in
+        self.applyPatches {
+          inherit src;
+          name = src.rev;
+          patches = [ ./zenoh-cpp-vendor/zenoh-c.patch ];
+        };
+    };
+
+    # Prepare vendored dependencies for internal opaque-types crate.
+    # Execute in subshell to not change variables set by the normal
+    # cargoSetupPostUnpackHook.
+    preBuild = ''
+      (
+        mkdir nix-zenoh-opaque-types
+        cd nix-zenoh-opaque-types
+        cargoDeps=${self.rustPlatform.importCargoLock {
+          lockFile = "${zenoh-c-source}/build-resources/opaque-types/Cargo.lock";
+          inherit outputHashes;
+        }}
+        cargoSetupPostUnpackHook
+      )
+      # Export information for use by our patched build.rs script.
+      export NIX_ZENOH_OPAQUE_TYPES_CARGO_CONFIG=$PWD/nix-zenoh-opaque-types/.cargo/config.toml
+    '';
   });
 }

--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -233,4 +233,32 @@ in {
       })
     ];
   });
+
+  zenoh-cpp-vendor = (lib.patchAmentVendorGit rosSuper.zenoh-cpp-vendor { }).overrideAttrs({
+    nativeBuildInputs ? [], postPatch ? "", ...
+  }: let
+    vendoredSourceJson = "${dirOf rosSuper.zenoh-cpp-vendor.meta.position}/vendored-source.json";
+    sourceInfos = builtins.fromJSON (builtins.readFile vendoredSourceJson);
+    zenoh-c-source = self.fetchFromGitHub {
+      owner = "eclipse-zenoh";
+      repo = "zenoh-c";
+      rev = sourceInfos.zenoh_c_vendor.rev;
+      hash = sourceInfos.zenoh_c_vendor.hash;
+    };
+  in {
+    postPatch = postPatch + ''
+      ln -s ${zenoh-c-source}/Cargo.lock Cargo.lock
+    '';
+    nativeBuildInputs = nativeBuildInputs ++ [
+      self.rustPlatform.cargoSetupHook
+      self.cargo
+      self.rustc
+    ];
+    cargoDeps = self.rustPlatform.importCargoLock {
+      lockFile = "${zenoh-c-source}/Cargo.lock";
+      outputHashes = {
+        "zenoh-1.5.1" = "sha256-EeigSU9l7LCnSkm4/jP0WcdO3Hw9m91zUh8jzVXYhKw=";
+      };
+    };
+  });
 }

--- a/distros/kilted/zenoh-cpp-vendor/vendored-source.json
+++ b/distros/kilted/zenoh-cpp-vendor/vendored-source.json
@@ -1,0 +1,12 @@
+{
+  "zenoh_c_vendor": {
+    "url": "https://github.com/eclipse-zenoh/zenoh-c.git",
+    "rev": "8f9ce70e4c4b55d150632730fd4c48abffbde765",
+    "hash": "sha256-kbDIatj4GFhUyDo9yCc6FzPYszHE+Vd79w4r452p77Y="
+  },
+  "zenoh_cpp_vendor": {
+    "url": "https://github.com/eclipse-zenoh/zenoh-cpp",
+    "rev": "05533d20db70ffc1d53a0e07f39caa999e82febd",
+    "hash": "sha256-lEicWShyKo5NSFyDeMqItZIweY3syXKF629x7woSQ0o="
+  }
+}

--- a/distros/kilted/zenoh-cpp-vendor/zenoh-c.patch
+++ b/distros/kilted/zenoh-cpp-vendor/zenoh-c.patch
@@ -1,0 +1,25 @@
+diff --git a/buildrs/opaque_types_generator.rs b/buildrs/opaque_types_generator.rs
+index c1d0bdd3..2d190518 100644
+--- a/buildrs/opaque_types_generator.rs
++++ b/buildrs/opaque_types_generator.rs
+@@ -14,7 +14,10 @@ pub fn generate_opaque_types() {
+     let data_in = std::fs::read_to_string(path_in).unwrap();
+ 
+     // Check for cargo-level errors (dependency resolution, manifest parsing, etc.)
+-    if data_in.contains("error: failed to") || data_in.contains("Caused by:") {
++    if data_in.contains("error: failed to")
++        || data_in.contains("error: no matching package named")
++        || data_in.contains("Caused by:")
++    {
+         panic!(
+             "Failed to generate opaque types due to cargo error:\n\nCommand executed:\n\n{command}\n\nCargo output:\n\n{data_in}"
+         );
+@@ -127,6 +130,8 @@ fn produce_opaque_types_data() -> (String, PathBuf) {
+         .arg("build")
+         .args(feature_args)
+         .args(linker_args)
++        .arg("--config")
++        .arg(std::env::var("NIX_ZENOH_OPAQUE_TYPES_CARGO_CONFIG").unwrap())
+         .arg("--target")
+         .arg(target)
+         .arg("--manifest-path")

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -233,4 +233,32 @@ in {
       })
     ];
   });
+
+  zenoh-cpp-vendor = (lib.patchAmentVendorGit rosSuper.zenoh-cpp-vendor { }).overrideAttrs({
+    nativeBuildInputs ? [], postPatch ? "", ...
+  }: let
+      vendoredSourceJson = "${dirOf rosSuper.zenoh-cpp-vendor.meta.position}/vendored-source.json";
+      sourceInfos = builtins.fromJSON (builtins.readFile vendoredSourceJson);
+      zenoh-c-source = self.fetchFromGitHub {
+        owner = "eclipse-zenoh";
+        repo = "zenoh-c";
+        rev = sourceInfos.zenoh_c_vendor.rev;
+        hash = sourceInfos.zenoh_c_vendor.hash;
+      };
+    in {
+    postPatch = postPatch + ''
+      ln -s ${zenoh-c-source.outPath}/Cargo.lock Cargo.lock
+    '';
+    nativeBuildInputs = nativeBuildInputs ++ [
+      self.rustPlatform.cargoSetupHook
+      self.cargo
+      self.rustc
+    ];
+    cargoDeps = self.rustPlatform.importCargoLock {
+      lockFile = "${zenoh-c-source.outPath}/Cargo.lock";
+      outputHashes = {
+        "zenoh-1.3.1" = "sha256-MGYtIXdFCJLJk8YVj7ColCnRHSqyP2VFfwy08GTEgDw=";
+      };
+    };
+  });
 }

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -234,31 +234,54 @@ in {
     ];
   });
 
-  zenoh-cpp-vendor = (lib.patchAmentVendorGit rosSuper.zenoh-cpp-vendor { }).overrideAttrs({
-    nativeBuildInputs ? [], postPatch ? "", ...
+  zenoh-cpp-vendor = (lib.patchAmentVendorGit rosSuper.zenoh-cpp-vendor {}).overrideAttrs(finalAttrs: {
+    nativeBuildInputs ? [], postPatch ? "", passthru ? {}, ...
   }: let
-      vendoredSourceJson = "${dirOf rosSuper.zenoh-cpp-vendor.meta.position}/vendored-source.json";
-      sourceInfos = builtins.fromJSON (builtins.readFile vendoredSourceJson);
-      zenoh-c-source = self.fetchFromGitHub {
-        owner = "eclipse-zenoh";
-        repo = "zenoh-c";
-        rev = sourceInfos.zenoh_c_vendor.rev;
-        hash = sourceInfos.zenoh_c_vendor.hash;
-      };
-    in {
+    outputHashes = {
+      "zenoh-1.5.1" = "sha256-EeigSU9l7LCnSkm4/jP0WcdO3Hw9m91zUh8jzVXYhKw=";
+    };
+    zenoh-c-source = finalAttrs.passthru.amentVendorSrcs.zenoh_c_vendor;
+  in {
     postPatch = postPatch + ''
-      ln -s ${zenoh-c-source.outPath}/Cargo.lock Cargo.lock
+      ln -s ${zenoh-c-source}/Cargo.lock Cargo.lock
     '';
     nativeBuildInputs = nativeBuildInputs ++ [
       self.rustPlatform.cargoSetupHook
-      self.cargo
       self.rustc
     ];
     cargoDeps = self.rustPlatform.importCargoLock {
-      lockFile = "${zenoh-c-source.outPath}/Cargo.lock";
-      outputHashes = {
-        "zenoh-1.3.1" = "sha256-MGYtIXdFCJLJk8YVj7ColCnRHSqyP2VFfwy08GTEgDw=";
-      };
+      lockFile = "${zenoh-c-source}/Cargo.lock";
+      inherit outputHashes;
     };
+
+    # Patch the build.rs script to be able to build internal
+    # opaque-types crate without network access.
+    passthru = lib.recursiveUpdate passthru {
+      amentVendorSrcs.zenoh_c_vendor = let
+        src = passthru.amentVendorSrcs.zenoh_c_vendor;
+      in
+        self.applyPatches {
+          inherit src;
+          name = src.rev;
+          patches = [ ./zenoh-cpp-vendor/zenoh-c.patch ];
+        };
+    };
+
+    # Prepare vendored dependencies for internal opaque-types crate.
+    # Execute in subshell to not change variables set by the normal
+    # cargoSetupPostUnpackHook.
+    preBuild = ''
+      (
+        mkdir nix-zenoh-opaque-types
+        cd nix-zenoh-opaque-types
+        cargoDeps=${self.rustPlatform.importCargoLock {
+          lockFile = "${zenoh-c-source}/build-resources/opaque-types/Cargo.lock";
+          inherit outputHashes;
+        }}
+        cargoSetupPostUnpackHook
+      )
+      # Export information for use by our patched build.rs script.
+      export NIX_ZENOH_OPAQUE_TYPES_CARGO_CONFIG=$PWD/nix-zenoh-opaque-types/.cargo/config.toml
+    '';
   });
 }

--- a/distros/rolling/zenoh-cpp-vendor/vendored-source.json
+++ b/distros/rolling/zenoh-cpp-vendor/vendored-source.json
@@ -1,0 +1,12 @@
+{
+  "zenoh_c_vendor": {
+    "url": "https://github.com/eclipse-zenoh/zenoh-c.git",
+    "rev": "ffa4bddc947f7ed6c0e3b4546205dd1b73e7df81",
+    "hash": "sha256-6l9cjo3FMmcOI8ZdApflv2OPD9/zqPX4hTrUJlo4A58="
+  },
+  "zenoh_cpp_vendor": {
+    "url": "https://github.com/eclipse-zenoh/zenoh-cpp",
+    "rev": "868fdad0e7418e8f8cb96e94c89a3aed05905e63",
+    "hash": "sha256-PdBErEpHdjQvYWPFldOvjhLWwBj/k/gpJrmmtsj32s0="
+  }
+}

--- a/distros/rolling/zenoh-cpp-vendor/vendored-source.json
+++ b/distros/rolling/zenoh-cpp-vendor/vendored-source.json
@@ -1,12 +1,12 @@
 {
   "zenoh_c_vendor": {
     "url": "https://github.com/eclipse-zenoh/zenoh-c.git",
-    "rev": "ffa4bddc947f7ed6c0e3b4546205dd1b73e7df81",
-    "hash": "sha256-6l9cjo3FMmcOI8ZdApflv2OPD9/zqPX4hTrUJlo4A58="
+    "rev": "8f9ce70e4c4b55d150632730fd4c48abffbde765",
+    "hash": "sha256-kbDIatj4GFhUyDo9yCc6FzPYszHE+Vd79w4r452p77Y="
   },
   "zenoh_cpp_vendor": {
     "url": "https://github.com/eclipse-zenoh/zenoh-cpp",
-    "rev": "868fdad0e7418e8f8cb96e94c89a3aed05905e63",
-    "hash": "sha256-PdBErEpHdjQvYWPFldOvjhLWwBj/k/gpJrmmtsj32s0="
+    "rev": "05533d20db70ffc1d53a0e07f39caa999e82febd",
+    "hash": "sha256-lEicWShyKo5NSFyDeMqItZIweY3syXKF629x7woSQ0o="
   }
 }

--- a/distros/rolling/zenoh-cpp-vendor/zenoh-c.patch
+++ b/distros/rolling/zenoh-cpp-vendor/zenoh-c.patch
@@ -1,0 +1,25 @@
+diff --git a/buildrs/opaque_types_generator.rs b/buildrs/opaque_types_generator.rs
+index c1d0bdd3..2d190518 100644
+--- a/buildrs/opaque_types_generator.rs
++++ b/buildrs/opaque_types_generator.rs
+@@ -14,7 +14,10 @@ pub fn generate_opaque_types() {
+     let data_in = std::fs::read_to_string(path_in).unwrap();
+ 
+     // Check for cargo-level errors (dependency resolution, manifest parsing, etc.)
+-    if data_in.contains("error: failed to") || data_in.contains("Caused by:") {
++    if data_in.contains("error: failed to")
++        || data_in.contains("error: no matching package named")
++        || data_in.contains("Caused by:")
++    {
+         panic!(
+             "Failed to generate opaque types due to cargo error:\n\nCommand executed:\n\n{command}\n\nCargo output:\n\n{data_in}"
+         );
+@@ -127,6 +130,8 @@ fn produce_opaque_types_data() -> (String, PathBuf) {
+         .arg("build")
+         .args(feature_args)
+         .args(linker_args)
++        .arg("--config")
++        .arg(std::env::var("NIX_ZENOH_OPAQUE_TYPES_CARGO_CONFIG").unwrap())
+         .arg("--target")
+         .arg(target)
+         .arg("--manifest-path")


### PR DESCRIPTION
This is a set of commits, which finally fixes build of `zenoh_cpp_vendor`. This is important, because many `kilted` packages depend on it.

This took inspiration from #558, cleaned up few things  and added changes required for the current Zenoh version.