### PR TITLE
rolling: Fix gz-{senzor,transport}-vendor patching

### DIFF
--- a/distros/rolling/gz-sensors-vendor/vendored-source.json
+++ b/distros/rolling/gz-sensors-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_sensors_vendor": {
     "url": "https://github.com/gazebosim/gz-sensors.git",
-    "rev": "gz-sensors9_9.1.0",
-    "hash": "sha256-dMqJqp5229r/mKjBzUJD/tEbsYZANAFNycHYc7CIkz8="
+    "rev": "gz-sensors10_10.0.0-pre1",
+    "hash": "sha256-xPpi0FQ0BaJU7MC+mx1KqVwp5cvdB1fEn+nKdoqJERE="
   }
 }

--- a/distros/rolling/gz-transport-vendor/vendored-source.json
+++ b/distros/rolling/gz-transport-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_transport_vendor": {
     "url": "https://github.com/gazebosim/gz-transport.git",
-    "rev": "gz-transport14_14.1.0",
-    "hash": "sha256-45jD5lwNDJRJw8TKxCVBifKJYZ+NZcygSJozrynbs9g="
+    "rev": "gz-transport15_15.0.0-pre1",
+    "hash": "sha256-1aunwBt20R9MfvMCfzokGnltmXSUOtqJQakDS9vvhnw="
   }
 }

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -81,7 +81,7 @@ in {
 
   gz-rendering-vendor = lib.patchAmentVendorGit rosSuper.gz-rendering-vendor { };
 
-  gz-sensors-vendor = lib.patchGzAmentVendorGit rosSuper.gz-sensors-vendor { };
+  gz-sensors-vendor = lib.patchAmentVendorGit rosSuper.gz-sensors-vendor { };
 
   gz-sim-vendor = lib.patchGzAmentVendorGit rosSuper.gz-sim-vendor { };
 
@@ -107,7 +107,7 @@ in {
     '';
   });
 
-  gz-transport-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-transport-vendor { }).overrideAttrs({
+  gz-transport-vendor = (lib.patchAmentVendorGit rosSuper.gz-transport-vendor { }).overrideAttrs({
     buildInputs ? [], ...
   }: {
     buildInputs = buildInputs ++ [ self.libsodium ];


### PR DESCRIPTION
The remaining gz-*-packages require new `rosdep` entries, and will be changes later.