### PR TITLE
rcutils: Resolve patch conflicts for rolling

### DIFF
--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -229,6 +229,19 @@ in with lib; {
     ];
   });
 
+  rcutils = rosSuper.rcutils.overrideAttrs ({
+    patches ? [], ...
+  }: {
+    patches = patches ++ [
+      # Fix linking to libatomic
+      # https://github.com/ros2/rcutils/pull/384
+      (self.fetchpatch {
+        url = "https://github.com/ros2/rcutils/commit/05e7336b2160739915be0e2c4a81710806fd2f9c.patch";
+        hash = "sha256-EiO1AJnhvOk81TzFMP4E8NhB+9ymef2oA7l26FZFb1M=";
+      })
+    ];
+  });
+
   rosidl-generator-py = rosSuper.rosidl-generator-py.overrideAttrs ({
     postPatch ? "", ...
   }: let

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -204,6 +204,19 @@ in {
     ];
   });
 
+  rcutils = rosSuper.rcutils.overrideAttrs ({
+    patches ? [], ...
+  }: {
+    patches = patches ++ [
+      # Fix linking to libatomic
+      # https://github.com/ros2/rcutils/pull/384
+      (self.fetchpatch {
+        url = "https://github.com/ros2/rcutils/commit/05e7336b2160739915be0e2c4a81710806fd2f9c.patch";
+        hash = "sha256-EiO1AJnhvOk81TzFMP4E8NhB+9ymef2oA7l26FZFb1M=";
+      })
+    ];
+  });
+
   rviz-ogre-vendor = lib.patchAmentVendorGit rosSuper.rviz-ogre-vendor {
     tarSourceArgs.hook = let
       version = "1.79";

--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -175,6 +175,19 @@ in {
     fetchgitArgs.hash = "sha256-b02OFUx0BxUA6HN6IaacSg1t3RP4o7NND7X0U635W8U=";
   };
 
+  rcutils = rosSuper.rcutils.overrideAttrs ({
+    patches ? [], ...
+  }: {
+    patches = patches ++ [
+      # Fix linking to libatomic
+      # https://github.com/ros2/rcutils/pull/384
+      (self.fetchpatch {
+        url = "https://github.com/ros2/rcutils/commit/05e7336b2160739915be0e2c4a81710806fd2f9c.patch";
+        hash = "sha256-EiO1AJnhvOk81TzFMP4E8NhB+9ymef2oA7l26FZFb1M=";
+      })
+    ];
+  });
+
   rviz-ogre-vendor = lib.patchAmentVendorGit rosSuper.rviz-ogre-vendor {
     tarSourceArgs.hook = let
       version = "1.79";

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -175,6 +175,20 @@ in {
     fetchgitArgs.hash = "sha256-b02OFUx0BxUA6HN6IaacSg1t3RP4o7NND7X0U635W8U=";
   };
 
+  rcutils = rosSuper.rcutils.overrideAttrs ({
+    patches ? [], ...
+  }: {
+    patches = [ # override the patch from ros2-overlay.nix!
+      # Fix linking to libatomic
+      # https://github.com/ros2/rcutils/pull/384
+      (self.fetchpatch {
+        # Version #384 rebased to rolling
+        url = "https://github.com/ros2/rcutils/commit/acdcf805dfd8d3cf77f269ef280077d4226e6e4e.patch";
+        hash = "sha256-RWEgleC72d8qZKeLGQ2XKx6js83MgTvcb1PJ28shrsk=";
+      })
+    ];
+  });
+
   rviz-ogre-vendor = lib.patchAmentVendorGit rosSuper.rviz-ogre-vendor {
     tarSourceArgs.hook = let
       version = "1.79";

--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -235,19 +235,6 @@ rosSelf: rosSuper: with rosSelf.lib; {
     outputs = [ "out" "dev" ];
   });
 
-  rcutils = rosSuper.rcutils.overrideAttrs ({
-    patches ? [], ...
-  }: {
-    patches = patches ++ [
-      # Fix linking to libatomic
-      # https://github.com/ros2/rcutils/pull/384
-      (self.fetchpatch {
-        url = "https://github.com/ros2/rcutils/commit/05e7336b2160739915be0e2c4a81710806fd2f9c.patch";
-        hash = "sha256-EiO1AJnhvOk81TzFMP4E8NhB+9ymef2oA7l26FZFb1M=";
-      })
-    ];
-  });
-
   rig-reconfigure = patchExternalProjectGit rosSuper.rig-reconfigure {
     url = "https://github.com/ocornut/imgui.git";
     rev = "v1.89.8-docking";


### PR DESCRIPTION
For rolling, the patch needs to be updated. Therefore, we move patching from `ros2-overlay.nix` to distro-specific `overrides.nix` and change it for rolling.

@lopsided98 Do you remember how to test whether the patch is still needed (see https://github.com/ros2/rcutils/pull/384#issuecomment-1254333151)? I tried to compile and cross-compile some packages that depend on `rcutils` and and all builds both with and without the patch. Also running the natively compiled packages seems to work even without the patch. By looking and the patch, I'd say the change still makes sense, but I don't know how to demonstrate that. Compared to your comment, I tried to cross-compile to aarch64 but you wrote about armv6 (which seems currently broken).