### PR TITLE
rosdistro sync, Fri Sep 19 13:31:36 2025

### DIFF
--- a/distros/humble/ackermann-steering-controller/default.nix
+++ b/distros/humble/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-ackermann-steering-controller";
-  version = "2.49.1-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.49.1-1.tar.gz";
-    name = "2.49.1-1.tar.gz";
-    sha256 = "da52155275bb8089de01748b4166e3e104cc858efabcc6496f70f4754097bd41";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "7b14a5ec17a6777f002c4803fa49dd663a0b1c23d46cb94cf93e3472b973e63b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/adi-imu/default.nix
+++ b/distros/humble/adi-imu/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-copyright, ament-lint-auto, ament-pep257, builtin-interfaces, geometry-msgs, libiio, rclcpp, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-adi-imu";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/adi_imu-release/archive/release/humble/adi_imu/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "aded4759ba5fb51d90d2f107b9aadb8e70ebcfb3d88a4868f586873d3e7d2e84";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-xmllint ament-copyright ament-lint-auto ament-pep257 ];
+  propagatedBuildInputs = [ ament-cmake builtin-interfaces geometry-msgs libiio rclcpp rosidl-default-runtime sensor-msgs std-msgs ];
+
+  meta = {
+    description = "Publisher for ADI IMUs";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/admittance-controller/default.nix
+++ b/distros/humble/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-admittance-controller";
-  version = "2.49.1-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.49.1-1.tar.gz";
-    name = "2.49.1-1.tar.gz";
-    sha256 = "d3353b6803e944d9ba2d34351986eebb10123ce0a635c994613841d343dfa40e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "4be0e4ca1312af1ce43c41b4b394dd84fecdbfe7f2640028c8fb03487448100f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/bicycle-steering-controller/default.nix
+++ b/distros/humble/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-bicycle-steering-controller";
-  version = "2.49.1-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.49.1-1.tar.gz";
-    name = "2.49.1-1.tar.gz";
-    sha256 = "cdbdb6f8853b2de6067c69c5703a96ea22032d1e2c7de21b39038ca5321bdbf1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "a7df72aab3224510a7894fc4e059031d0891c019000d344292d09ef73da8b513";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-interface/default.nix
+++ b/distros/humble/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, geometry-msgs, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-interface";
-  version = "2.51.0-r1";
+  version = "2.52.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.51.0-1.tar.gz";
-    name = "2.51.0-1.tar.gz";
-    sha256 = "95a734a18d5ec620f398f2335c6499791fc49c3c0807e60c4dbef520e7b830d0";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.52.0-1.tar.gz";
+    name = "2.52.0-1.tar.gz";
+    sha256 = "7e666ff231bee3af3dfa113fdcddfba5be1da3914283fd82ffd96056967aa3f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager-msgs/default.nix
+++ b/distros/humble/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-controller-manager-msgs";
-  version = "2.51.0-r1";
+  version = "2.52.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.51.0-1.tar.gz";
-    name = "2.51.0-1.tar.gz";
-    sha256 = "c3c01faa8488a8404c6d3ca464b1bc4e8da442393d3adbb14990e930d915dc99";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.52.0-1.tar.gz";
+    name = "2.52.0-1.tar.gz";
+    sha256 = "18d4a3ea48c0f4c0c71d19362f81acbe6622dfd1500010dad35b2196881ee7c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager/default.nix
+++ b/distros/humble/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, hardware-interface, hardware-interface-testing, launch, launch-ros, launch-testing, launch-testing-ros, pluginlib, python3Packages, rclcpp, rclpy, rcpputils, realtime-tools, robot-state-publisher, ros2-control-test-assets, ros2param, ros2run, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-manager";
-  version = "2.51.0-r1";
+  version = "2.52.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.51.0-1.tar.gz";
-    name = "2.51.0-1.tar.gz";
-    sha256 = "d19f181425d502a862e473aa1c6052b7c0f063db0339fb760d2918195611d89e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.52.0-1.tar.gz";
+    name = "2.52.0-1.tar.gz";
+    sha256 = "8eabefdbc69ee8fcfe7a6cc4da62759ab599a8a7ca1f1457424487520a55d6ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diff-drive-controller/default.nix
+++ b/distros/humble/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-diff-drive-controller";
-  version = "2.49.1-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.49.1-1.tar.gz";
-    name = "2.49.1-1.tar.gz";
-    sha256 = "94c3a2fe320eea8305739773a0ac421e58d331ae95d97a24063770903f1073b7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "0843d264630f24390ea40e6ec7ec5b4816fb43bcd0d09426ac6f1128dac9f5e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/effort-controllers/default.nix
+++ b/distros/humble/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-effort-controllers";
-  version = "2.49.1-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.49.1-1.tar.gz";
-    name = "2.49.1-1.tar.gz";
-    sha256 = "09210078bffe7fc163ea71c1d29bb0327b05a017158c5f5c89cefde02b5dfffb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "31f646b22ac8dcda7a1bb02626a375727f8ed2816189cfbccc62587ea6294d06";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/force-torque-sensor-broadcaster/default.nix
+++ b/distros/humble/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-force-torque-sensor-broadcaster";
-  version = "2.49.1-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.49.1-1.tar.gz";
-    name = "2.49.1-1.tar.gz";
-    sha256 = "3662c1265a222f5f5f55755296669c26f528d67e84749c7144e548090d4445a4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "0bfe35acec4fa614d7263a9ad2f5cb31d6933fe1bde083c005e78ed0fbb747d9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/forward-command-controller/default.nix
+++ b/distros/humble/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-forward-command-controller";
-  version = "2.49.1-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.49.1-1.tar.gz";
-    name = "2.49.1-1.tar.gz";
-    sha256 = "f7a32c45696ba751a80142f17ef03bc08283385cf79c663cc8c5c2882713a94f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "2b62323c4c4ec37de88703bfe0a25d98f8c2fa2b78632ce46bff5b2e0b3928cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/franka-inria-inverse-dynamics-solver/default.nix
+++ b/distros/humble/franka-inria-inverse-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, franka-description, inverse-dynamics-solver, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-franka-inria-inverse-dynamics-solver";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/inverse_dynamics_solver-release/archive/release/humble/franka_inria_inverse_dynamics_solver/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "bf1d8f02f6fdc197a998c16216a45f2c3365adb603d206ea12274c1152a16772";
+    url = "https://github.com/ros2-gbp/inverse_dynamics_solver-release/archive/release/humble/franka_inria_inverse_dynamics_solver/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "4bd4fc56f7ea2566e7bf90f3e0132d4bb4d13603866d5b309e85cb18b98c2b06";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -30,6 +30,8 @@ self: super: {
 
  adi-iio = self.callPackage ./adi-iio {};
 
+ adi-imu = self.callPackage ./adi-imu {};
+
  adi-tmcl = self.callPackage ./adi-tmcl {};
 
  admittance-controller = self.callPackage ./admittance-controller {};
@@ -1709,6 +1711,8 @@ self: super: {
  leo-description = self.callPackage ./leo-description {};
 
  leo-desktop = self.callPackage ./leo-desktop {};
+
+ leo-filters = self.callPackage ./leo-filters {};
 
  leo-fw = self.callPackage ./leo-fw {};
 

--- a/distros/humble/gpio-controllers/default.nix
+++ b/distros/humble/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gpio-controllers";
-  version = "2.49.1-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gpio_controllers/2.49.1-1.tar.gz";
-    name = "2.49.1-1.tar.gz";
-    sha256 = "8fd12678b20797d9acdacf87617ac5e679e23707187c2cc21f014d8361f9f153";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gpio_controllers/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "d7192a272bedf5f60b690dbd356025587204bf301d0fb663bb532b0d768d6116";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gripper-controllers/default.nix
+++ b/distros/humble/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gripper-controllers";
-  version = "2.49.1-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.49.1-1.tar.gz";
-    name = "2.49.1-1.tar.gz";
-    sha256 = "9e9b1129e01962757eed7ce418660ccf37b0069f93302b42c8f58ab05bb1bbd2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "d99da0bd05b71f20069eb293b9cd48fe2ed97d1d5f0349b6b069492da3da73fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hardware-interface-testing/default.nix
+++ b/distros/humble/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-hardware-interface-testing";
-  version = "2.51.0-r1";
+  version = "2.52.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface_testing/2.51.0-1.tar.gz";
-    name = "2.51.0-1.tar.gz";
-    sha256 = "aaca7a20390db9dec804b0b80f189f8aa33dd80122f61db649a77404e5718108";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface_testing/2.52.0-1.tar.gz";
+    name = "2.52.0-1.tar.gz";
+    sha256 = "5507915fbc85827981ab9457bbb568dcb6303f4f1f792ef5137862f59dba1768";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hardware-interface/default.nix
+++ b/distros/humble/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-humble-hardware-interface";
-  version = "2.51.0-r1";
+  version = "2.52.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.51.0-1.tar.gz";
-    name = "2.51.0-1.tar.gz";
-    sha256 = "d1d9e8029ff609b4e595179cbd308c942fb4215480996d6277566d047d221cc5";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.52.0-1.tar.gz";
+    name = "2.52.0-1.tar.gz";
+    sha256 = "d4011a4846fdd6d7ab6724d1242da278a8c0d726b332e0544c898630a4c667ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/imu-sensor-broadcaster/default.nix
+++ b/distros/humble/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-imu-sensor-broadcaster";
-  version = "2.49.1-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.49.1-1.tar.gz";
-    name = "2.49.1-1.tar.gz";
-    sha256 = "a854ca5a053ef7ef244fe1126148ac8d6116e76204ad164752f0f5b9caf0fce6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "f1ba70aff419080b9edcaddc8bd7091943927581d9b1ebb87a9cd60376d3bea8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/inverse-dynamics-solver/default.nix
+++ b/distros/humble/inverse-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, pluginlib, python, python3Packages, rclcpp, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, sensor-msgs, urdf }:
 buildRosPackage {
   pname = "ros-humble-inverse-dynamics-solver";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/inverse_dynamics_solver-release/archive/release/humble/inverse_dynamics_solver/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "d35dc419c02fe58c9fdfe3b1ef7838cde9132dc884ed369340f8eb63db8a97e0";
+    url = "https://github.com/ros2-gbp/inverse_dynamics_solver-release/archive/release/humble/inverse_dynamics_solver/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "5fe281d173755efabe5c5c1601fefdf1aa6a00b9c698b46766f676e0a07d4f55";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-limits/default.nix
+++ b/distros/humble/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gtest, launch-ros, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle, urdf }:
 buildRosPackage {
   pname = "ros-humble-joint-limits";
-  version = "2.51.0-r1";
+  version = "2.52.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.51.0-1.tar.gz";
-    name = "2.51.0-1.tar.gz";
-    sha256 = "09cd6684672285bbe0defc342c9bae0a65805e6fd2a93aa6314223b909d53e09";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.52.0-1.tar.gz";
+    name = "2.52.0-1.tar.gz";
+    sha256 = "5523224d17ae3e6195bebe86314ee144908ce5960fc3f89ef1de841472057671";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-state-broadcaster/default.nix
+++ b/distros/humble/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-state-broadcaster";
-  version = "2.49.1-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.49.1-1.tar.gz";
-    name = "2.49.1-1.tar.gz";
-    sha256 = "8f3f7e8459608bfcdff1aa81ed7248f80f2f2f94b24eb754328ff6bfef3c901d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "e21916d81b8d33f7fbab4fe031ac748ded72b2241b05804bd4febaf1fcef0a64";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-trajectory-controller/default.nix
+++ b/distros/humble/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-trajectory-controller";
-  version = "2.49.1-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.49.1-1.tar.gz";
-    name = "2.49.1-1.tar.gz";
-    sha256 = "28b14255d3b1cf616433fc6b7395bf8b98d3416bff94d35a77980cdec01c2f98";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "f93ea2a700d25f68882ed48864a7867819964755acc1de91e8a0e192a95aa89b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kdl-inverse-dynamics-solver/default.nix
+++ b/distros/humble/kdl-inverse-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, franka-description, inverse-dynamics-solver, kdl-parser, pluginlib, rclcpp, ros-testing, ur-description }:
 buildRosPackage {
   pname = "ros-humble-kdl-inverse-dynamics-solver";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/inverse_dynamics_solver-release/archive/release/humble/kdl_inverse_dynamics_solver/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "fe7d6ecd27be66136c80baab8012c19e009b10d12e3f5a792068a6eda770b4cf";
+    url = "https://github.com/ros2-gbp/inverse_dynamics_solver-release/archive/release/humble/kdl_inverse_dynamics_solver/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "2798054c10a31115557135e81085370af24329c52f84f5b33ba395aac43c02da";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/launch-ros/default.nix
+++ b/distros/humble/launch-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, composition-interfaces, launch, lifecycle-msgs, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-launch-ros";
-  version = "0.19.10-r1";
+  version = "0.19.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/launch_ros/0.19.10-1.tar.gz";
-    name = "0.19.10-1.tar.gz";
-    sha256 = "e109800f1144255580840191a99c92adbcb655f762a72d4d747513efec62e34d";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/launch_ros/0.19.12-1.tar.gz";
+    name = "0.19.12-1.tar.gz";
+    sha256 = "b077b19b1079caf44bc51f829d59b5fb75eb9afc8fa60d324d02e2da5864b8b7";
   };
 
   buildType = "ament_python";

--- a/distros/humble/launch-testing-ros/default.nix
+++ b/distros/humble/launch-testing-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, launch-testing, python3Packages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-launch-testing-ros";
-  version = "0.19.10-r1";
+  version = "0.19.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/launch_testing_ros/0.19.10-1.tar.gz";
-    name = "0.19.10-1.tar.gz";
-    sha256 = "0ec1a6b4bf6ff53f6b2613bafa046010a9484ed7f65105cbef9c2c3707566c31";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/launch_testing_ros/0.19.12-1.tar.gz";
+    name = "0.19.12-1.tar.gz";
+    sha256 = "e3d2f6c14097f9859b243f29249ac931940323d5018ec4b23ffcb1ca2ae6bcc6";
   };
 
   buildType = "ament_python";

--- a/distros/humble/leo-bringup/default.nix
+++ b/distros/humble/leo-bringup/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, image-proc, leo-description, leo-fw, robot-state-publisher, rosapi, rosbridge-server, sensor-msgs, v4l2-camera, web-video-server, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-index-python, ament-lint-auto, geometry-msgs, image-proc, launch, launch-ros, leo-description, leo-filters, leo-fw, robot-state-publisher, rosapi, rosbridge-server, sensor-msgs, web-video-server, xacro }:
 buildRosPackage {
   pname = "ros-humble-leo-bringup";
-  version = "1.5.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/humble/leo_bringup/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "bd791fd55901b77fdd6a21a24e8dc37df67f3495ab16f2448aac2541b1c37dc7";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/humble/leo_bringup/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "da20079ee2fdc0f39b79e146c8b3a5e4a8603b7c09ea5cd27c206324133d50cd";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ geometry-msgs image-proc leo-description leo-fw robot-state-publisher rosapi rosbridge-server sensor-msgs v4l2-camera web-video-server xacro ];
+  checkInputs = [ ament-cmake-black ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ ament-index-python geometry-msgs image-proc launch launch-ros leo-description leo-filters leo-fw robot-state-publisher rosapi rosbridge-server sensor-msgs web-video-server xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/leo-filters/default.nix
+++ b/distros/humble/leo-filters/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, generate-parameter-library, geometry-msgs, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, std-srvs, tf2, tf2-ros, yaml-cpp }:
+buildRosPackage {
+  pname = "ros-humble-leo-filters";
+  version = "1.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/humble/leo_filters/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "668b9b546e6c1550c6c65b3b62933be284e3988c0417894c4e98dd64366b12a7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ generate-parameter-library geometry-msgs nav-msgs rclcpp rclcpp-components sensor-msgs std-srvs tf2 tf2-ros yaml-cpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Nodes for filtering and processing imu and wheel odom messages.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/leo-fw/default.nix
+++ b/distros/humble/leo-fw/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-python, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-python, ament-lint-auto, geometry-msgs, leo-msgs, nav-msgs, python3Packages, rclcpp, rclcpp-components, rclpy, ros2cli, sensor-msgs, std-msgs, std-srvs, yaml-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-pep257, ament-cmake-python, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-python, ament-lint-auto, geometry-msgs, leo-msgs, nav-msgs, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, ros2cli, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-leo-fw";
-  version = "1.5.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/humble/leo_fw/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "f1bb02044b35653579c3454843051f9dd7acfdf8c1f428855aeebaf8a682c046";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/humble/leo_fw/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "3ab405b5f4d514de64bbea8bcc8652afcadcbbe21f91e314d2a48bb4c8e9a4cd";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-python yaml-cpp ];
-  checkInputs = [ ament-cmake-black ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-mypy ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ ament-index-python geometry-msgs leo-msgs nav-msgs python3Packages.dbus-python python3Packages.numpy python3Packages.pyyaml python3Packages.whichcraft rclcpp rclcpp-components rclpy ros2cli sensor-msgs std-msgs std-srvs ];
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-black ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-mypy ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ ament-index-python geometry-msgs leo-msgs nav-msgs python3Packages.dbus-python python3Packages.pyyaml python3Packages.whichcraft rcl-interfaces rclcpp rclcpp-components rclpy ros2cli sensor-msgs std-msgs std-srvs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/humble/leo-robot/default.nix
+++ b/distros/humble/leo-robot/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, leo, leo-bringup, leo-fw }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, leo, leo-bringup, leo-filters, leo-fw }:
 buildRosPackage {
   pname = "ros-humble-leo-robot";
-  version = "1.5.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/humble/leo_robot/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "37e655e3763f61f1fc4861f2ae0ac755a10770846f96fea2e44201357c6577ca";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/humble/leo_robot/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "43bfee69aeeab368390ebc0052e51047455975b0b8defdbe2d225d387999248a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ leo leo-bringup leo-fw ];
+  propagatedBuildInputs = [ leo leo-bringup leo-filters leo-fw ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/libmavconn/default.nix
+++ b/distros/humble/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-libmavconn";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/libmavconn/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "5e5273da2f8e57fda3ce0f8e0ca9636e23d803d1d26f8bcea8a59fb51aa557f5";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/libmavconn/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "518cc91f739331fb0e4c8850052d3a18087bbcbd5756588d7a0e6e010da1acc3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mavros-extras/default.nix
+++ b/distros/humble/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-mavros-extras";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros_extras/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "753438921360ae4ea707c02ef11ed2a3695e057ac0a311fcbf50c0f35dd9f6f6";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros_extras/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "9ff4871f1094113742b127e994da986eca8c9416de4d42fd28ef95b1ed8e01c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mavros-msgs/default.nix
+++ b/distros/humble/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-mavros-msgs";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros_msgs/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "e44ce041147be3ad10ccfac0e6657819340995b3208fae5f9e5a7a7135b9d78f";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros_msgs/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "17a53832c3c14e9b1f62b659f3dd4f2806c371162f3a743dc3f08b93331b75c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mavros/default.nix
+++ b/distros/humble/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-mavros";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "57fc8d066c0f3cd9145cead3c0054cd22cd1dc603ba77695d6047b7457621466";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "9b522575482cc0f72c78b4c4968d880cbd2546d2b7f7d55719a7c153b77c178a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mecanum-drive-controller/default.nix
+++ b/distros/humble/mecanum-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-mecanum-drive-controller";
-  version = "2.49.1-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/mecanum_drive_controller/2.49.1-1.tar.gz";
-    name = "2.49.1-1.tar.gz";
-    sha256 = "cb70f91b8891b543fe409ea8c8cb5fe7d229ece490263f103b048139e6fb3af4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/mecanum_drive_controller/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "fcf5ece6007f4c1402b7a441545c9b587a1f31c7d2e20609824330a79dbe730d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pid-controller/default.nix
+++ b/distros/humble/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-pid-controller";
-  version = "2.49.1-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pid_controller/2.49.1-1.tar.gz";
-    name = "2.49.1-1.tar.gz";
-    sha256 = "3431cfd3d906069521ecc52a6cffe3a9ac2e1f3b2e539953f37df0f8e45713bb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pid_controller/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "802de74c647ba7264dfa6aba14966ad526d4e999f0b730c27febfe0910b9775a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pose-broadcaster/default.nix
+++ b/distros/humble/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-pose-broadcaster";
-  version = "2.49.1-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pose_broadcaster/2.49.1-1.tar.gz";
-    name = "2.49.1-1.tar.gz";
-    sha256 = "1bfb1c92c96b0886d90ade134fa906bdbaf6a9cc1ae9692ef78d2f94ab1e628c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pose_broadcaster/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "be57d3abf518b9566288bef9022f6850595da392c1a925a8cc1b4a9648c70a6a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/position-controllers/default.nix
+++ b/distros/humble/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-position-controllers";
-  version = "2.49.1-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.49.1-1.tar.gz";
-    name = "2.49.1-1.tar.gz";
-    sha256 = "81fb8b3ba1ff4f15e92a98729b14f93b89c5e54f50cd3772dfb620444b65fcfb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "42759038d3aa0d00f5aca5708ea5b3e643f223810eaaf605c3c90b861aa8a5c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/range-sensor-broadcaster/default.nix
+++ b/distros/humble/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-range-sensor-broadcaster";
-  version = "2.49.1-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/range_sensor_broadcaster/2.49.1-1.tar.gz";
-    name = "2.49.1-1.tar.gz";
-    sha256 = "5ccb4819830989245897c38e81cf05c9b64926bc89a7e51f980ccaf8ccaef0ff";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/range_sensor_broadcaster/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "4d0602b663538a08be99c0517d158c2a4b7f802f3be2cb0e506d78b0d8d2ee17";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control-test-assets/default.nix
+++ b/distros/humble/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-ros2-control-test-assets";
-  version = "2.51.0-r1";
+  version = "2.52.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.51.0-1.tar.gz";
-    name = "2.51.0-1.tar.gz";
-    sha256 = "6b871d467a3c3aa77488248349ec17410624efc6accd6b89b831ba8ea281196b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.52.0-1.tar.gz";
+    name = "2.52.0-1.tar.gz";
+    sha256 = "b84046f9e909dbf3e8c8e652a947487f1364a6227141f3ddd8101208ac8d3446";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control/default.nix
+++ b/distros/humble/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-humble-ros2-control";
-  version = "2.51.0-r1";
+  version = "2.52.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.51.0-1.tar.gz";
-    name = "2.51.0-1.tar.gz";
-    sha256 = "f4a033ce9408a1d5d61090db375bb19f05575e1cea97324db08ec311ad57ce63";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.52.0-1.tar.gz";
+    name = "2.52.0-1.tar.gz";
+    sha256 = "3b0ffdc121b0799eb0a9025f5538616d3698bf5fc0892857bfc2af672a5cf2bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-controllers-test-nodes/default.nix
+++ b/distros/humble/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers-test-nodes";
-  version = "2.49.1-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.49.1-1.tar.gz";
-    name = "2.49.1-1.tar.gz";
-    sha256 = "48b10630f864d1437fe5673f95cfe18c4e1be230d07bd04694187c1b3e2e31a2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "ba4a9da2e5ff15e40c2091ee0bb0892a8cc0dd97dced6acf0055f2e078251d3d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2-controllers/default.nix
+++ b/distros/humble/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gripper-controllers, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers";
-  version = "2.49.1-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.49.1-1.tar.gz";
-    name = "2.49.1-1.tar.gz";
-    sha256 = "f82520c540784e9716bce62576383e80e5632ecea3d884505e7ab12a4bea4307";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "551f110f43091d034b7473b875f6ca5fd7dcbaa833ac37b5d0327b9c1bc72bc0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2controlcli/default.nix
+++ b/distros/humble/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-humble-ros2controlcli";
-  version = "2.51.0-r1";
+  version = "2.52.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.51.0-1.tar.gz";
-    name = "2.51.0-1.tar.gz";
-    sha256 = "1d4adefb534bdbd3f49ef0c850d542f7c18591b76d35bad22418b108cf4fd38e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.52.0-1.tar.gz";
+    name = "2.52.0-1.tar.gz";
+    sha256 = "a2365aef41dd9297aad4a5fb897a23b7fd4842881def7fa4e28eef9038c51950";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2launch/default.nix
+++ b/distros/humble/ros2launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, launch-xml, launch-yaml, python3Packages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-humble-ros2launch";
-  version = "0.19.10-r1";
+  version = "0.19.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/ros2launch/0.19.10-1.tar.gz";
-    name = "0.19.10-1.tar.gz";
-    sha256 = "2fae8fa15cd9d6d4e8bc6080d3aa7e429be94ccfd794737930c19a0a98f7bb97";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/ros2launch/0.19.12-1.tar.gz";
+    name = "0.19.12-1.tar.gz";
+    sha256 = "e461d479a4ed11828edc502cc5cf49e6aa889e09d990f9f30c5857cdfd052250";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-controller-manager/default.nix
+++ b/distros/humble/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-humble-rqt-controller-manager";
-  version = "2.51.0-r1";
+  version = "2.52.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.51.0-1.tar.gz";
-    name = "2.51.0-1.tar.gz";
-    sha256 = "8a5eb61012aaf854842d345b35034a4e34e8d745f6f7ae61385040d56edf17c2";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.52.0-1.tar.gz";
+    name = "2.52.0-1.tar.gz";
+    sha256 = "38d8933d0f16869c8e94a76fb2e8a01d31c15a4f0a6964b10b669626176cb446";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-dotgraph/default.nix
+++ b/distros/humble/rqt-dotgraph/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, python-qt-binding, python3Packages, qt-dotgraph, qt-gui-py-common, rqt-graph, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rqt-dotgraph";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_dotgraph-release/archive/release/humble/rqt_dotgraph/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "58a523b37cde25d21bca56dda953db0ca1e70bb729103bbfac7a00b631340594";
+    url = "https://github.com/ros2-gbp/rqt_dotgraph-release/archive/release/humble/rqt_dotgraph/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "1a3169c81e5fc9632692b190ad82f63ed49d3e96140cd7e87cf7fb535d492b89";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
-  propagatedBuildInputs = [ ament-index-python python-qt-binding python3Packages.pyqt5 python3Packages.pyside2 qt-dotgraph qt-gui-py-common rqt-graph rqt-gui rqt-gui-py std-msgs ];
+  propagatedBuildInputs = [ ament-index-python python-qt-binding python3Packages.pyqt5 qt-dotgraph qt-gui-py-common rqt-graph rqt-gui rqt-gui-py std-msgs ];
 
   meta = {
     description = "rqt GUI plugin to visualize dot graphs.";

--- a/distros/humble/rqt-joint-trajectory-controller/default.nix
+++ b/distros/humble/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-rqt-joint-trajectory-controller";
-  version = "2.49.1-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.49.1-1.tar.gz";
-    name = "2.49.1-1.tar.gz";
-    sha256 = "1f92085d50b75e1cd8b46daaea9bb3ced01b4b4b395f2c255f42f71f777329e3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "bf7d445d109e31d007d3429c81813756beab0c2d80c92c2363efc934d139bcf4";
   };
 
   buildType = "ament_python";

--- a/distros/humble/steering-controllers-library/default.nix
+++ b/distros/humble/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-steering-controllers-library";
-  version = "2.49.1-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.49.1-1.tar.gz";
-    name = "2.49.1-1.tar.gz";
-    sha256 = "f928c7bc07fe4196c96c334f85a2adddddce2f237db7c89ad4d45f74b5933436";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "44e7d83f093852036fb185bc8ae9489029be8bd9444d547171327db2354b9598";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/transmission-interface/default.nix
+++ b/distros/humble/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-transmission-interface";
-  version = "2.51.0-r1";
+  version = "2.52.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.51.0-1.tar.gz";
-    name = "2.51.0-1.tar.gz";
-    sha256 = "980ff02d1238e0700e0e9f9ce53349c34403909c5730361feb0fb61e88146132";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.52.0-1.tar.gz";
+    name = "2.52.0-1.tar.gz";
+    sha256 = "6ae18aebff9119498c9b4cb26e41048a54be85c28a8d2ff4a48c20f1be2072e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-controller/default.nix
+++ b/distros/humble/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-tricycle-controller";
-  version = "2.49.1-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.49.1-1.tar.gz";
-    name = "2.49.1-1.tar.gz";
-    sha256 = "2ceb2d6a4d107e8da6cdeebbc5652e694bb5ba49b9a86f94bb9b5dda636bc028";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "34d879fad240081180f283d6ecfeab22bb21b619e9eea4bfa2d8a39e6f03983a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-steering-controller/default.nix
+++ b/distros/humble/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-tricycle-steering-controller";
-  version = "2.49.1-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.49.1-1.tar.gz";
-    name = "2.49.1-1.tar.gz";
-    sha256 = "85a5b1241752b52312049ec4598230f1bea3ff08a4e25fb1013ce91b8284f5f2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "8e4ee6d462e61fecafa3261725205e36215668ff5b87894e022db33a9988ee6e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-client-library/default.nix
+++ b/distros/humble/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-humble-ur-client-library";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/humble/ur_client_library/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "eab702c5a315762d9565f4370f9d10edb0dfa951f5f97e85c3b3d17762fb5b20";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/humble/ur_client_library/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "5fea54df11b2505311f53b86087cde6b91b483c3b10e9a71784d14be0ff16123";
   };
 
   buildType = "cmake";

--- a/distros/humble/ur-description/default.nix
+++ b/distros/humble/ur-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, joint-state-publisher-gui, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, robot-state-publisher, rviz2, urdf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-description";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/humble/ur_description/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "dec77aa77ad4ed9e385ba68024a3d750ad4c343ff96536c7343aa8b5a0f13458";
+    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/humble/ur_description/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "fbb051d92b76df0b4b62706b83bb6ac7e2e5f5edeb65704a718ab27e243c1730";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur10-inverse-dynamics-solver/default.nix
+++ b/distros/humble/ur10-inverse-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, inverse-dynamics-solver, pluginlib, rclcpp, ros-testing, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, trajectory-msgs, ur-description }:
 buildRosPackage {
   pname = "ros-humble-ur10-inverse-dynamics-solver";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/inverse_dynamics_solver-release/archive/release/humble/ur10_inverse_dynamics_solver/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "aded82e150985e150d07b062f2529e77e57c43679146f28bd4313169f8fd26a8";
+    url = "https://github.com/ros2-gbp/inverse_dynamics_solver-release/archive/release/humble/ur10_inverse_dynamics_solver/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "314bb0d89daffaaf4e1ccc4d0b331099f983a83359e436efa5f2ba3652841210";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/velocity-controllers/default.nix
+++ b/distros/humble/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-velocity-controllers";
-  version = "2.49.1-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.49.1-1.tar.gz";
-    name = "2.49.1-1.tar.gz";
-    sha256 = "adaba4e4719e5742ee7b3b3b9009b93ff4e6dd2e5c02ef4921648904c48f9867";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "30997427ead08bd412bdbc782ffb306d74d8f1fd258959d6061b52021e56a5e8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ackermann-nlmpc-msgs/default.nix
+++ b/distros/jazzy/ackermann-nlmpc-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-ackermann-nlmpc-msgs";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ackmerann_nlmpc-release/archive/release/jazzy/ackermann_nlmpc_msgs/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "722b38ae5d92abd12a856b239dc36b4c88c3e70ba270a957f177c15bdfe1e786";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "Message definitions for ackermann_nlmpc";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/jazzy/ackermann-nlmpc/default.nix
+++ b/distros/jazzy/ackermann-nlmpc/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ackermann-msgs, ackermann-nlmpc-msgs, ament-pep257, geometry-msgs, nav-msgs, python3Packages, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-ackermann-nlmpc";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ackmerann_nlmpc-release/archive/release/jazzy/ackermann_nlmpc/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "b1baf73beff7d280f8b3299d1a153dd85ab9a8b2de8b498cfda8c7863b91b4c1";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-pep257 python3Packages.pytest ];
+  propagatedBuildInputs = [ ackermann-msgs ackermann-nlmpc-msgs geometry-msgs nav-msgs std-msgs ];
+
+  meta = {
+    description = "Lightweight non-linear MPC controller for autonomous driving in 2D environments";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/jazzy/ackermann-steering-controller/default.nix
+++ b/distros/jazzy/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-ackermann-steering-controller";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ackermann_steering_controller/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "fc8bd0f5afbb968e37e38a5cd418617e860e3d47fcb36aa8e29496fab965381c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ackermann_steering_controller/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "8b297ef13b7b60c6d464ee9e4b61edad9ff1d14cc2ca777b37241c300ebd64cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/admittance-controller/default.nix
+++ b/distros/jazzy/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-admittance-controller";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/admittance_controller/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "e19b02b413200ba7b97b32489783209ba35f7c113a9df1a36cb36a6d8bbe913b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/admittance_controller/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "de2f0029b07596529cff22bf61748d698fb8512d2bd5f0ffe0e061f6bc543002";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/bicycle-steering-controller/default.nix
+++ b/distros/jazzy/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-bicycle-steering-controller";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/bicycle_steering_controller/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "2c08d23a3caa77d6d356ec346eb15cce7dfaaf2c22ff9de2278c79f0b8d0b05e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/bicycle_steering_controller/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "c41d8ff0966379ed65dd25d9e89ad968e891773b983da1cc124037add4c1beb5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/chained-filter-controller/default.nix
+++ b/distros/jazzy/chained-filter-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, filters, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-chained-filter-controller";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/chained_filter_controller/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "c8eda3292f14c19028a1714c42044507499fca64a03ad0ff6ed86ee13963553d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/chained_filter_controller/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "0a311e509960a314a7ff8be78310c08150901e9b75ae7f5f5a84191cd8959fb9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-bt-joy/default.nix
+++ b/distros/jazzy/clearpath-bt-joy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, bluez, joy-linux, python3Packages, twist-mux }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-bt-joy";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bt_joy/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "01e4581cfcbf15a7291e0b554317c7caca5b90f20bebd0fa8708b9586e75bdf0";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bt_joy/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "3daa84559c9402e9db7fe9d4bf57695b394f4e0ee9c6b222f12efe2a794af7f0";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/clearpath-common/default.nix
+++ b/distros/jazzy/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-common";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_common/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "6ceb5b05b36ec96ee2b59c2c52849bb84fb92e6870d99858e0fd3ec58ac57c26";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_common/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "1e317d31774c0f4f51fa2dc4da486ad4a4ddd5374463e5badff7ba4d57015d62";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-config/default.nix
+++ b/distros/jazzy/clearpath-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-config";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/jazzy/clearpath_config/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "81640466e07f5d28bec074ce2dca33a69552fcf1256198de99b2e93b5b940106";
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/jazzy/clearpath_config/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "e41adaf67706a9a5214774d247c35d2804ec0575b153cb4567caacfdf53789d7";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/clearpath-control/default.nix
+++ b/distros/jazzy/clearpath-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-bt-joy, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, mecanum-drive-controller, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-control";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_control/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "dee7064ae16cc0ce5f0e7741ce5dc216a6f7a1740bc580344d4f4f17d5fc4fbe";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_control/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "3c3ab3d46a67b7b436349aa3c48d069c435216d638306f3ef737693c5151d322";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-customization/default.nix
+++ b/distros/jazzy/clearpath-customization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-customization";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_customization/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "91a1033aac648962f06ce390d851e46d3bc658dc9f51e2596dc427d65d7b8444";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_customization/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "cdca857d9ac8ce162e3bc8a8730c5af558947aabc491b6455562ec6d7143a0ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-description/default.nix
+++ b/distros/jazzy/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-description";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_description/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "ab5c1797b93e0bb3759880e335dab8197ec71b2dfed195bdbafafdb0e524a7c1";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_description/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "e095d82d6677974751b315f0bb069718e2523caee320a92ade3eb23049fe87ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-diagnostics/default.nix
+++ b/distros/jazzy/clearpath-diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-platform-msgs, diagnostic-aggregator, diagnostic-updater, foxglove-bridge, rclcpp, ros2launch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-diagnostics";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_diagnostics/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "718847deda919dade5053bd67f60fd52e6acf60c41fabfa3a1455544506441a9";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_diagnostics/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "463137de0a029e1b1b08c3e4c50c19304b9123ca0aeec9a346449d3b586d87c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-generator-common/default.nix
+++ b/distros/jazzy/clearpath-generator-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-diagnostics, clearpath-manipulators, moveit-setup-srdf-plugins }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-generator-common";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_generator_common/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "53843e72579feaa0336a8d6553b34d886c64cf42a90877fde3afff1964542d20";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_generator_common/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "d2af370bc3b79c66831a7e6c417cbafa0055fbbe3d5c447fae813a8de4e07bd7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-manipulators-description/default.nix
+++ b/distros/jazzy/clearpath-manipulators-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ewellix-description, robot-state-publisher, robotiq-description, ur-description, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-manipulators-description";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators_description/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "2582fd238fd28c164fb75694ac847354b657bbdb851270eb2f02ad8a7bba04f4";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators_description/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "e68a71afcae67e1e922bc516848c2afb64de7f4a1fb5f9fb6f1f0a179afbea46";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-manipulators/default.nix
+++ b/distros/jazzy/clearpath-manipulators/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, gripper-controllers, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-warehouse, moveit-setup-srdf-plugins, moveit-simple-controller-manager, position-controllers, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-manipulators";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "acae321889aefb2141d66e0acc9d3ada077dbf14587622819023da26ef9fb3e3";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "7ae49bb058f5a9ed8ad141f2cdeac44621af04bcadbec1e5940ea84078593175";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-mounts-description/default.nix
+++ b/distros/jazzy/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-mounts-description";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_mounts_description/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "4c0777e04e29325a354bd66cf0709438f3048b9d5f6a192fce755ad11934b894";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_mounts_description/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "bce13127e789aa14ff8c89a1e6d484b3709472c95bb27b7d53f365d87f5e1730";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-platform-description/default.nix
+++ b/distros/jazzy/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-platform-description";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_platform_description/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "6c3301081ad5fb19b0181546fdaf56024b51d42729e83cc29d1912f4190b147a";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_platform_description/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "8324642752f18f1e81df63ece8723ed464ebc78923a2d1f91da296fa31c83cce";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-sensors-description/default.nix
+++ b/distros/jazzy/clearpath-sensors-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, axis-description, microstrain-inertial-description, realsense2-description, velodyne-description }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-sensors-description";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_sensors_description/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "6fe632f1a457074e80fedf3ded3b9bb4c58994769deda0228408410fb9926b2c";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_sensors_description/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "02310927686696e4ba67f52d6a2fa8bbc5ba100816123b7fd10e3f2b643d4af9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/controller-interface/default.nix
+++ b/distros/jazzy/controller-interface/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, fmt, geometry-msgs, hardware-interface, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, fmt, geometry-msgs, hardware-interface, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-controller-interface";
-  version = "4.36.0-r1";
+  version = "4.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_interface/4.36.0-1.tar.gz";
-    name = "4.36.0-1.tar.gz";
-    sha256 = "e24646be50b8d25f335a0a011abd6ccf9c4d38e1f926e0801d06fc37594ab3a3";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_interface/4.37.0-1.tar.gz";
+    name = "4.37.0-1.tar.gz";
+    sha256 = "b691cb647934674a9f77fdf6d47d10af08d3929b72fa5442e9b14cbb0763f0d4";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-gen-version-h fmt ros2-control-cmake sensor-msgs ];
-  checkInputs = [ ament-cmake-gmock geometry-msgs ];
+  buildInputs = [ ament-cmake ament-cmake-gen-version-h fmt ros2-control-cmake ];
+  checkInputs = [ ament-cmake-gmock geometry-msgs sensor-msgs std-msgs ];
   propagatedBuildInputs = [ hardware-interface rclcpp-lifecycle realtime-tools ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ];
 

--- a/distros/jazzy/controller-manager-msgs/default.nix
+++ b/distros/jazzy/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-controller-manager-msgs";
-  version = "4.36.0-r1";
+  version = "4.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager_msgs/4.36.0-1.tar.gz";
-    name = "4.36.0-1.tar.gz";
-    sha256 = "8ed2571fbee3e47a6e545f51f97c5632dad26328e75c055e44355ee9ad6cd9af";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager_msgs/4.37.0-1.tar.gz";
+    name = "4.37.0-1.tar.gz";
+    sha256 = "116bdd0566330d08ca6e67e68806d63a8e27b6d51591b9044d348c70a4a64806";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/controller-manager/default.nix
+++ b/distros/jazzy/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, example-interfaces, fmt, generate-parameter-library, hardware-interface, hardware-interface-testing, launch, launch-ros, launch-testing, launch-testing-ros, libstatistics-collector, pluginlib, python3Packages, rclcpp, rclpy, rcpputils, realtime-tools, robot-state-publisher, ros2-control-cmake, ros2-control-test-assets, ros2param, ros2run, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-controller-manager";
-  version = "4.36.0-r1";
+  version = "4.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager/4.36.0-1.tar.gz";
-    name = "4.36.0-1.tar.gz";
-    sha256 = "757f2c1cf032646c24fab2ab3ffb5bd45729cdb74616f3c758cae412eaead60f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager/4.37.0-1.tar.gz";
+    name = "4.37.0-1.tar.gz";
+    sha256 = "fe742085ad1c6528d268a828b2c8616be25743a98ebaca7539af7d2664311ca7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/diff-drive-controller/default.nix
+++ b/distros/jazzy/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-diff-drive-controller";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/diff_drive_controller/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "156a89e2475381d3dbd14cd6869cc2b8cf0c55ad7408c378732cef36f9320326";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/diff_drive_controller/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "1d141150eddcfec19da3be1106a797e6e09065c07a2481d9cdf59b8d1fb7ba2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/effort-controllers/default.nix
+++ b/distros/jazzy/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-effort-controllers";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/effort_controllers/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "10ad9e4b6cf3168b0e2921a67a7a1c587d8c3390e56c994f1e8c6545a8d81639";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/effort_controllers/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "0875a785b55d1fa9ffe9b6f766dd11c787314b053ebb6f220ec37bb3c0adade7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/force-torque-sensor-broadcaster/default.nix
+++ b/distros/jazzy/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-force-torque-sensor-broadcaster";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/force_torque_sensor_broadcaster/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "ff5ee41ab1a629c75fddab3b6f4d7f11749297d175507464b3082a731274f6fd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/force_torque_sensor_broadcaster/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "2a39295f4d75a0298df382529548252f0d4ed1e9e8b3250fa70c5d7cd85a057e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/forward-command-controller/default.nix
+++ b/distros/jazzy/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-forward-command-controller";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/forward_command_controller/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "4cdde3c977aad28b545f0a8652531a4ea92d7119c215ed846b34c0acc188ba07";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/forward_command_controller/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "829b258c9bd58f106bbb331e3392be5396c6b84b67f575c0c1eefbc652da32ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/franka-inria-inverse-dynamics-solver/default.nix
+++ b/distros/jazzy/franka-inria-inverse-dynamics-solver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, eigen, inverse-dynamics-solver, pluginlib }:
+buildRosPackage {
+  pname = "ros-jazzy-franka-inria-inverse-dynamics-solver";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/inverse_dynamics_solver-release/archive/release/jazzy/franka_inria_inverse_dynamics_solver/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "cbeb0172fe8ffa00b93bab00e38afbde697a8047545dc08ebd866fb1acf8960f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ eigen inverse-dynamics-solver pluginlib ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A C++ library implementing the inverse dynamics solver for the Franka Emika Panda (FER) real robot.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -8,6 +8,10 @@ self: super: {
 
  ackermann-msgs = self.callPackage ./ackermann-msgs {};
 
+ ackermann-nlmpc = self.callPackage ./ackermann-nlmpc {};
+
+ ackermann-nlmpc-msgs = self.callPackage ./ackermann-nlmpc-msgs {};
+
  ackermann-steering-controller = self.callPackage ./ackermann-steering-controller {};
 
  action-msgs = self.callPackage ./action-msgs {};
@@ -1000,6 +1004,8 @@ self: super: {
 
  foxglove-msgs = self.callPackage ./foxglove-msgs {};
 
+ franka-inria-inverse-dynamics-solver = self.callPackage ./franka-inria-inverse-dynamics-solver {};
+
  fuse = self.callPackage ./fuse {};
 
  fuse-constraints = self.callPackage ./fuse-constraints {};
@@ -1238,6 +1244,8 @@ self: super: {
 
  intra-process-demo = self.callPackage ./intra-process-demo {};
 
+ inverse-dynamics-solver = self.callPackage ./inverse-dynamics-solver {};
+
  io-context = self.callPackage ./io-context {};
 
  irobot-create-common-bringup = self.callPackage ./irobot-create-common-bringup {};
@@ -1283,6 +1291,8 @@ self: super: {
  joy-tester = self.callPackage ./joy-tester {};
 
  kartech-linear-actuator-msgs = self.callPackage ./kartech-linear-actuator-msgs {};
+
+ kdl-inverse-dynamics-solver = self.callPackage ./kdl-inverse-dynamics-solver {};
 
  kdl-parser = self.callPackage ./kdl-parser {};
 
@@ -3275,6 +3285,8 @@ self: super: {
  unique-identifier-msgs = self.callPackage ./unique-identifier-msgs {};
 
  ur = self.callPackage ./ur {};
+
+ ur10-inverse-dynamics-solver = self.callPackage ./ur10-inverse-dynamics-solver {};
 
  ur-calibration = self.callPackage ./ur-calibration {};
 

--- a/distros/jazzy/gpio-controllers/default.nix
+++ b/distros/jazzy/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-gpio-controllers";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gpio_controllers/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "66b701242bc86eba75ac5856a6d33b6ad7fdd57cee48c8318a4fa6fd6a8fbaf5";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gpio_controllers/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "230985172ff50950edaf89bcd8c44df458687b5e26e6a485bd98ccc455a8968f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gps-sensor-broadcaster/default.nix
+++ b/distros/jazzy/gps-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-gps-sensor-broadcaster";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gps_sensor_broadcaster/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "0bcccdd98449a993c581a4470ffcac330ec0bee2278fde1da392c950d1ece75a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gps_sensor_broadcaster/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "dafb281dae81408b0bc5715ab6eac8d1f2cc26fd0b692647ce096e8523b3b317";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gripper-controllers/default.nix
+++ b/distros/jazzy/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-gripper-controllers";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gripper_controllers/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "075f399636f355b566627a8732cf8a5a8113593219ea9ba33ef26b173a20fe0b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gripper_controllers/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "62cd72e9deb1d01898d69e4d592e34f5aa860ca9fe751f9d09dd6e642e3d1f9f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/hardware-interface-testing/default.nix
+++ b/distros/jazzy/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, fmt, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-hardware-interface-testing";
-  version = "4.36.0-r1";
+  version = "4.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface_testing/4.36.0-1.tar.gz";
-    name = "4.36.0-1.tar.gz";
-    sha256 = "34514044b3d3ab23c2bba55afe0db866a8eb2abf38c30c8b4af28638cae6893e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface_testing/4.37.0-1.tar.gz";
+    name = "4.37.0-1.tar.gz";
+    sha256 = "4f20b196db51e63e8e49db265c40c75ba376d5a67e3ea2b027299bfa3c25b26a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/hardware-interface/default.nix
+++ b/distros/jazzy/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, control-msgs, fmt, joint-limits, lifecycle-msgs, pal-statistics, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sdformat-urdf, tinyxml2-vendor, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-hardware-interface";
-  version = "4.36.0-r1";
+  version = "4.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface/4.36.0-1.tar.gz";
-    name = "4.36.0-1.tar.gz";
-    sha256 = "f152c6ac8833f9f2de5016745715caebab18f3ed6d29fe1e7c62f47f7e175d0f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface/4.37.0-1.tar.gz";
+    name = "4.37.0-1.tar.gz";
+    sha256 = "7e277a356ee84c43c4d40aca0f99fb68ec4b488dd7f8775bffa11439a5752822";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/imu-sensor-broadcaster/default.nix
+++ b/distros/jazzy/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-imu-sensor-broadcaster";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/imu_sensor_broadcaster/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "9d3ddf4b1ce783b1eb8c6665e7af403c239bc740b37b35d7e5b00f53b87686d8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/imu_sensor_broadcaster/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "4ad6df9c47280d86dfffb5954260ccc3555e4b55e2b5b12d2ebe7299eefedb79";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/inverse-dynamics-solver/default.nix
+++ b/distros/jazzy/inverse-dynamics-solver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, eigen, pluginlib, python, python3Packages, rclcpp, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, sensor-msgs, urdf }:
+buildRosPackage {
+  pname = "ros-jazzy-inverse-dynamics-solver";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/inverse_dynamics_solver-release/archive/release/jazzy/inverse_dynamics_solver/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "a183a4b8da62490cf7b3ecf3bca9205e02c8a726136ae74aa293c2fb4fc1641f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ eigen pluginlib python python3Packages.matplotlib python3Packages.numpy python3Packages.tabulate rclcpp rosbag2-cpp rosbag2-storage rosbag2-storage-default-plugins sensor-msgs urdf ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A library implementing an inverse dynamics solver for serial manipulators.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/joint-limits/default.nix
+++ b/distros/jazzy/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, fmt, generate-parameter-library, launch-ros, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-limits";
-  version = "4.36.0-r1";
+  version = "4.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/joint_limits/4.36.0-1.tar.gz";
-    name = "4.36.0-1.tar.gz";
-    sha256 = "d96e33561b8db47392f203409b8c6b298afec8921942e4c7af2aa75f42536263";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/joint_limits/4.37.0-1.tar.gz";
+    name = "4.37.0-1.tar.gz";
+    sha256 = "f5a2690be15415c0df23d4395c898873bb49a9122dd7d226b4e4f8198cf56ed0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-state-broadcaster/default.nix
+++ b/distros/jazzy/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-state-broadcaster";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_state_broadcaster/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "f409970ade8be5b091185ae9c90bdc959e19d0b22e34d204694822e4531e9032";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_state_broadcaster/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "79982b843c0570bb1b32e1f916af782a843c24dadbaf35a05f8e8efe4e73f67c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-trajectory-controller/default.nix
+++ b/distros/jazzy/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-trajectory-controller";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_trajectory_controller/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "443c37dc1a41eadc4abc95f04db3b124db3bc7cdd591e0121e3a51f222399f63";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_trajectory_controller/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "5ced983daaa725c5d9939593377c57415bb02b1d16d0134e7b026ce000809933";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/kdl-inverse-dynamics-solver/default.nix
+++ b/distros/jazzy/kdl-inverse-dynamics-solver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, inverse-dynamics-solver, kdl-parser, pluginlib, rclcpp, ros-testing, ur-description }:
+buildRosPackage {
+  pname = "ros-jazzy-kdl-inverse-dynamics-solver";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/inverse_dynamics_solver-release/archive/release/jazzy/kdl_inverse_dynamics_solver/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "121e1c200783d5df11d10e614bd39ecf73c89581c82ffeda194620049aeec1f5";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common rclcpp ros-testing ];
+  propagatedBuildInputs = [ inverse-dynamics-solver kdl-parser pluginlib ur-description ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A KDL-based library implementing an inverse dynamics solver for simulated robots.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/launch-ros/default.nix
+++ b/distros/jazzy/launch-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, composition-interfaces, launch, lifecycle-msgs, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-launch-ros";
-  version = "0.26.8-r1";
+  version = "0.26.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/jazzy/launch_ros/0.26.8-1.tar.gz";
-    name = "0.26.8-1.tar.gz";
-    sha256 = "5b9209f69efc1cbf5c2d531c008e22e499391a89a259d4cef8250e30be656785";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/jazzy/launch_ros/0.26.9-1.tar.gz";
+    name = "0.26.9-1.tar.gz";
+    sha256 = "bf87b3b0557ea520e911650bbc40b162b3abac55ad755b68166bc8f028d11584";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/launch-testing-ros/default.nix
+++ b/distros/jazzy/launch-testing-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch-ros, launch-testing, python3Packages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-launch-testing-ros";
-  version = "0.26.8-r1";
+  version = "0.26.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/jazzy/launch_testing_ros/0.26.8-1.tar.gz";
-    name = "0.26.8-1.tar.gz";
-    sha256 = "894f31c677d7d9e9d24bb4097668a44b8cf9886d0208fde696d96a40f4207cad";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/jazzy/launch_testing_ros/0.26.9-1.tar.gz";
+    name = "0.26.9-1.tar.gz";
+    sha256 = "1055b642106dd9dc357787f05a169b02fd0bb042cc54fa15b7a7177791507dac";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/libmavconn/default.nix
+++ b/distros/jazzy/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-libmavconn";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/libmavconn/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "e1430d92de7c1c9fcb0b206f5d86f15458ff2bbc441149f1be9ca4aa092994c2";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/libmavconn/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "5cd7b39c362ec8b73ef65a571ce6574e5e88de92cb386c3d07864cc962ad3a8a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mavros-extras/default.nix
+++ b/distros/jazzy/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-mavros-extras";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros_extras/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "6a2c2400b7b719f4f8dd507881f3fcc1911517330727183d8c277abf31ac9ef9";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros_extras/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "0aeba59d1674af92d0398e7576c94ef08cc3c57adef75ee0e2544f7c26fb3a2b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mavros-msgs/default.nix
+++ b/distros/jazzy/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mavros-msgs";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros_msgs/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "afa70de23081110982b62d8359d057b24991760a19733e5c54f46a583f5d5696";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros_msgs/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "c81d80a1a28c6a6d1b1aedacc752853ea3f77295dfde91aae78b33a17ad25044";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mavros/default.nix
+++ b/distros/jazzy/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mavros";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "21e87d39c915f83f6a8d8d8bf12a2a2592704a7cdf4d25fdf5e3710948f571f3";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "207ea689e9571808ef501ae0d17df62c41ccf17313bcd7217613378a1345773b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mecanum-drive-controller/default.nix
+++ b/distros/jazzy/mecanum-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mecanum-drive-controller";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/mecanum_drive_controller/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "c5dcca95473fafa9e4defa8a7ba34ce6742c7e213ba6d6f7c745496a5bc599f8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/mecanum_drive_controller/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "2177cad398141d327169dd62320859552970bc194efc38276d02c92303172f91";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/omni-wheel-drive-controller/default.nix
+++ b/distros/jazzy/omni-wheel-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, eigen, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-omni-wheel-drive-controller";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/omni_wheel_drive_controller/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "9ed82e066e33a33a99092a266adc78662d360e914186d6cc061def636c0ef7b4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/omni_wheel_drive_controller/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "9ce35f7f38be594e44151f8fb4520515d61597f2360ba688a8f55296c66c5943";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/parallel-gripper-controller/default.nix
+++ b/distros/jazzy/parallel-gripper-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-parallel-gripper-controller";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/parallel_gripper_controller/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "0940cbdc84d732801d6500f7b58c86abc4e8e21364473ed095f80cffada9a1e4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/parallel_gripper_controller/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "11e512ebc79039c4046c6396d88d0acaf1a3bf4f71ce88612d5b4353852e0786";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pid-controller/default.nix
+++ b/distros/jazzy/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-pid-controller";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pid_controller/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "d9ec6572a30583138b7ebdd85afda107f3c8b886d955d0dab30866f417eadc18";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pid_controller/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "7e6eeb016262e008ecb8016917ed9c1756f7708952af3b274300123dbebcd089";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pose-broadcaster/default.nix
+++ b/distros/jazzy/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-pose-broadcaster";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pose_broadcaster/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "6d8452f173eec93db9874eb43f36a33a73733baf1c65bd7c31a430ae2fc89d42";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pose_broadcaster/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "cda0f56ffeedc52589fab27d9d788a49466e4ae0dc71302fb7bf7b11855028c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/position-controllers/default.nix
+++ b/distros/jazzy/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-position-controllers";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/position_controllers/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "5c8b85d48f427446bab7908e216d57b8442702940b554253068206e5ccea17de";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/position_controllers/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "f47a3734c3db5da8392bd5b050519aac5a201a6cefc4ab90df40efcdf07dba80";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/range-sensor-broadcaster/default.nix
+++ b/distros/jazzy/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-range-sensor-broadcaster";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/range_sensor_broadcaster/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "107aa125eb3ff85532243363a11cb1c0ac44171354ff3a29e955e4e1367364fb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/range_sensor_broadcaster/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "4e651df65a07bc18608fee2548cb456049e695a3c64c4109c5a424630007f4c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-control-test-assets/default.nix
+++ b/distros/jazzy/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-control-test-assets";
-  version = "4.36.0-r1";
+  version = "4.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control_test_assets/4.36.0-1.tar.gz";
-    name = "4.36.0-1.tar.gz";
-    sha256 = "07209cbf8129cec87419cba2f8a9ad3247dd49ce8dc2704cafc32579c7143558";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control_test_assets/4.37.0-1.tar.gz";
+    name = "4.37.0-1.tar.gz";
+    sha256 = "69464d02175c8fadb055e28d63a7e81548918a13c1c9e2ada3fb16fd83f4067c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-control/default.nix
+++ b/distros/jazzy/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-control";
-  version = "4.36.0-r1";
+  version = "4.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control/4.36.0-1.tar.gz";
-    name = "4.36.0-1.tar.gz";
-    sha256 = "7b10328ad3081b675e33eb3dce9ca3f7b837c95d822c06e9a7feebb50b2ab8d2";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control/4.37.0-1.tar.gz";
+    name = "4.37.0-1.tar.gz";
+    sha256 = "a31905d71e593f06851ecdbfc9d2fdcb81d43efb6fa5a7581d5247a42e0c7115";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-controllers-test-nodes/default.nix
+++ b/distros/jazzy/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-controllers-test-nodes";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers_test_nodes/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "d8e4724f8b2efd3b67d58b42935916016705e8eaba0f1c7c1e441d6e416240f8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers_test_nodes/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "b87f28744c4ac43e121c8aa01d5f7230e79452d3c40bcb016dedfb4e39207eb2";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2-controllers/default.nix
+++ b/distros/jazzy/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, chained-filter-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gps-sensor-broadcaster, gripper-controllers, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, omni-wheel-drive-controller, parallel-gripper-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-controllers";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "31c1f05683ed50a3738ed54c2daadf84ea35c0d7faa06162f6388b197ff44594";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "c03c59bbf174b40e4aaebdeb00897cf9c4f5c5f675a6f904b477a38fc0d26794";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2controlcli/default.nix
+++ b/distros/jazzy/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-jazzy-ros2controlcli";
-  version = "4.36.0-r1";
+  version = "4.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2controlcli/4.36.0-1.tar.gz";
-    name = "4.36.0-1.tar.gz";
-    sha256 = "1caa080556e308eff4b5e904c28aee106c94900d9940645479ed6aaf8583cc1e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2controlcli/4.37.0-1.tar.gz";
+    name = "4.37.0-1.tar.gz";
+    sha256 = "7d13c753c80abbda856f11c9e33ddbed7106be87053fccdeabec530078ac448b";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2launch/default.nix
+++ b/distros/jazzy/ros2launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, launch-xml, launch-yaml, python3Packages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-jazzy-ros2launch";
-  version = "0.26.8-r1";
+  version = "0.26.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/jazzy/ros2launch/0.26.8-1.tar.gz";
-    name = "0.26.8-1.tar.gz";
-    sha256 = "544256e9e435e4eea86b2d717ba1025f24b83ed613c78677d2e6ca74a71ec6f4";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/jazzy/ros2launch/0.26.9-1.tar.gz";
+    name = "0.26.9-1.tar.gz";
+    sha256 = "063a9f7e165598dfbfdc77a4d1747b8292fbaf3b51f7d59ce14212766300b15d";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rqt-controller-manager/default.nix
+++ b/distros/jazzy/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-jazzy-rqt-controller-manager";
-  version = "4.36.0-r1";
+  version = "4.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/rqt_controller_manager/4.36.0-1.tar.gz";
-    name = "4.36.0-1.tar.gz";
-    sha256 = "0bb3f16a18c3d8445196be52ebd3f0c548dc42fa4f201bd927de949bb6c7671f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/rqt_controller_manager/4.37.0-1.tar.gz";
+    name = "4.37.0-1.tar.gz";
+    sha256 = "c70f6f95e4db743a178e7d6096849ec16c1bc28fcbc1ad563ae2a1367a75e309";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rqt-dotgraph/default.nix
+++ b/distros/jazzy/rqt-dotgraph/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, python-qt-binding, python3Packages, qt-dotgraph, qt-gui-py-common, rqt-graph, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rqt-dotgraph";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_dotgraph-release/archive/release/jazzy/rqt_dotgraph/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "5901f474368ad2767cffcccd7b31d9f11adc7906461ef8c0ea7be7c4c2f4f193";
+    url = "https://github.com/ros2-gbp/rqt_dotgraph-release/archive/release/jazzy/rqt_dotgraph/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "9172f6d81e02c5357265d5bcb0b36b0e4a07249167c2eeefa0250fc7c1112f5c";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
-  propagatedBuildInputs = [ ament-index-python python-qt-binding python3Packages.pyqt5 python3Packages.pyside2 qt-dotgraph qt-gui-py-common rqt-graph rqt-gui rqt-gui-py std-msgs ];
+  propagatedBuildInputs = [ ament-index-python python-qt-binding python3Packages.pyqt5 qt-dotgraph qt-gui-py-common rqt-graph rqt-gui rqt-gui-py std-msgs ];
 
   meta = {
     description = "rqt GUI plugin to visualize dot graphs.";

--- a/distros/jazzy/rqt-joint-trajectory-controller/default.nix
+++ b/distros/jazzy/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rqt-joint-trajectory-controller";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/rqt_joint_trajectory_controller/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "ff00aee0433e9363c36c7c86f7a457934e64959025e072490f21ce511ca08ccd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/rqt_joint_trajectory_controller/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "9b2034967bfab4f9d23669f082b2f7cf734bbac119494ebd43ee69ca6cf25245";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/simulation-interfaces/default.nix
+++ b/distros/jazzy/simulation-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-simulation-interfaces";
-  version = "1.0.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/simulation_interfaces-release/archive/release/jazzy/simulation_interfaces/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "34db491f3b074292b174531f066a1dc6a479f6b3b27fdd4396b19c1505a64979";
+    url = "https://github.com/ros2-gbp/simulation_interfaces-release/archive/release/jazzy/simulation_interfaces/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "69012b76ad19b2d8eaa9b4c640073a34e2fd4f62db756c9145acb342233f6315";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/steering-controllers-library/default.nix
+++ b/distros/jazzy/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-steering-controllers-library";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/steering_controllers_library/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "76eabeae7e72f19a5d9fb16ff244c11b6b2f19f901c087b7a99c9d866be35c81";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/steering_controllers_library/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "64b6dce6d418c1a3f42f423b1b3386d9210f4bea046db6f9a233ca7165b6b990";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/transmission-interface/default.nix
+++ b/distros/jazzy/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, fmt, hardware-interface, pluginlib, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-transmission-interface";
-  version = "4.36.0-r1";
+  version = "4.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/transmission_interface/4.36.0-1.tar.gz";
-    name = "4.36.0-1.tar.gz";
-    sha256 = "a879bc9d3f3e1ebbe75ececf744c708a0cb55cd01d744cafcafd17234d5bdbcd";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/transmission_interface/4.37.0-1.tar.gz";
+    name = "4.37.0-1.tar.gz";
+    sha256 = "31a59ee4ddb0d999d58a598502a63fa3d497970b52eae59e6439aa7317f238af";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tricycle-controller/default.nix
+++ b/distros/jazzy/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-tricycle-controller";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_controller/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "7051412c842f0cf15e58dae5991a38e1be2dd9a21f5f191b88a41ddee55d72dc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_controller/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "decbabf21b84524a92a3b53c9282e9d52988e012be454d9a2c3046c6c64d555d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tricycle-steering-controller/default.nix
+++ b/distros/jazzy/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-tricycle-steering-controller";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_steering_controller/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "00aa4e86d79a934f01f616dc044fabb96eca0a427d16ca6ff2c1e0a4a91d82ce";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_steering_controller/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "60b26de110376466ff7d77ff2e6a29cd2dbbee8e3f4210929696cb508fafb150";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-calibration/default.nix
+++ b/distros/jazzy/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-ur-calibration";
-  version = "3.3.3-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_calibration/3.3.3-1.tar.gz";
-    name = "3.3.3-1.tar.gz";
-    sha256 = "1fe5d7eb500d61391268df0703fe5eed1c136cdbd3e60439eaf289dcc062e4d9";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_calibration/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "5de153cc1f9531edaa4c7c68cd956b7f27a62c2fee6705136aeb5ad5be1627ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-client-library/default.nix
+++ b/distros/jazzy/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-jazzy-ur-client-library";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/jazzy/ur_client_library/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "b190cae2fdb9338540e578cd2640f0527fa8bec904915978b0598cafd3cf5fb5";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/jazzy/ur_client_library/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "88f9cad8c74faeb955024968b889f0b4bdfba792796c2709cb83787e143e1d17";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/ur-controllers/default.nix
+++ b/distros/jazzy/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, angles, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, trajectory-msgs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ur-controllers";
-  version = "3.3.3-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_controllers/3.3.3-1.tar.gz";
-    name = "3.3.3-1.tar.gz";
-    sha256 = "fd914f6aaa0090edd4b9e1e6f8465f58ab754bca419d07fd111efb9de575067a";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_controllers/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "84a62263bc37c617d2f37e7a594243c96bc6b5d4460641d608971755ce32e85b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-dashboard-msgs/default.nix
+++ b/distros/jazzy/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-ur-dashboard-msgs";
-  version = "3.3.3-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_dashboard_msgs/3.3.3-1.tar.gz";
-    name = "3.3.3-1.tar.gz";
-    sha256 = "a14c138b387d78ac37e4ff45b68f20424c768411d124091823dc7e9da62b3f8d";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_dashboard_msgs/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "392ff4aafef1688dcc7b97fe76f39a8c6f300c652f01f3127038b8f127964f1c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-description/default.nix
+++ b/distros/jazzy/ur-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, joint-state-publisher-gui, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, robot-state-publisher, rviz2, urdf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-ur-description";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/jazzy/ur_description/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "b77eaba50ccd30d012e239b23a5aced23ff1d45d2493cb8384263b1099042102";
+    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/jazzy/ur_description/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "7ff40b58a309a600280814df8751af6f7c4209d4dbe4226f310a8da5914ff8e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-moveit-config/default.nix
+++ b/distros/jazzy/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, ur-description, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-ur-moveit-config";
-  version = "3.3.3-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_moveit_config/3.3.3-1.tar.gz";
-    name = "3.3.3-1.tar.gz";
-    sha256 = "2beb5af0231f16e6ba3a590c0d1205d77bdc5199b970bf722dffc37a54bbccde";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_moveit_config/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "a096c1dcaba2dec3d827fc7564378620c369e5e19ce99bce9ccf646962d99c85";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-robot-driver/default.nix
+++ b/distros/jazzy/ur-robot-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, backward-ros, controller-manager, controller-manager-msgs, force-torque-sensor-broadcaster, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, pluginlib, pose-broadcaster, position-controllers, rclcpp, rclcpp-lifecycle, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, socat, std-msgs, std-srvs, tf2-geometry-msgs, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-ur-robot-driver";
-  version = "3.3.3-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_robot_driver/3.3.3-1.tar.gz";
-    name = "3.3.3-1.tar.gz";
-    sha256 = "559616f421231b0336cb0899930aa7f44b742fca0fdd5925ac50eeb48805c067";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_robot_driver/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "ac37340cacdd794d5664a9e49d002aba2411c329154471a9a11bd86794afa3c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur/default.nix
+++ b/distros/jazzy/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-jazzy-ur";
-  version = "3.3.3-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur/3.3.3-1.tar.gz";
-    name = "3.3.3-1.tar.gz";
-    sha256 = "c4b9d72cd325ffea81bf062607d7a3c04f89306df1bb0fe0932a9c71c549ea3b";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "6b0b7e11dbe0a16c7bc9794288b1c8c5f247b76a12d77e12a82c3d8289405350";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur10-inverse-dynamics-solver/default.nix
+++ b/distros/jazzy/ur10-inverse-dynamics-solver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, inverse-dynamics-solver, pluginlib, rclcpp, ros-testing, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, trajectory-msgs, ur-description }:
+buildRosPackage {
+  pname = "ros-jazzy-ur10-inverse-dynamics-solver";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/inverse_dynamics_solver-release/archive/release/jazzy/ur10_inverse_dynamics_solver/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "529d8dfd1c22b4af0583ffad4305d11154a26365c78a7151a5d7d846cad3439d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common rclcpp ros-testing rosbag2-cpp rosbag2-storage rosbag2-storage-default-plugins trajectory-msgs ];
+  propagatedBuildInputs = [ inverse-dynamics-solver pluginlib ur-description ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A C++ library implementing the inverse dynamics solver for the UR10 real robot.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/velocity-controllers/default.nix
+++ b/distros/jazzy/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-velocity-controllers";
-  version = "4.31.0-r1";
+  version = "4.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/velocity_controllers/4.31.0-1.tar.gz";
-    name = "4.31.0-1.tar.gz";
-    sha256 = "7f8ca48a2314a09c872b5f74aa6afb043183f7572b13a0da0ca4de9054000893";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/velocity_controllers/4.32.0-1.tar.gz";
+    name = "4.32.0-1.tar.gz";
+    sha256 = "940728affe0b8220762ddbe0d200d1635cdb788ea8e227c31cc891d5935d2566";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ackermann-nlmpc-msgs/default.nix
+++ b/distros/kilted/ackermann-nlmpc-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-ackermann-nlmpc-msgs";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ackmerann_nlmpc-release/archive/release/kilted/ackermann_nlmpc_msgs/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "a9286c9b1a35d38524a20225f21e0aedadbd7f5c8b7349475a8302b6c6472868";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "Message definitions for ackermann_nlmpc";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/kilted/ackermann-nlmpc/default.nix
+++ b/distros/kilted/ackermann-nlmpc/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ackermann-msgs, ackermann-nlmpc-msgs, ament-pep257, geometry-msgs, nav-msgs, python3Packages, std-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-ackermann-nlmpc";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ackmerann_nlmpc-release/archive/release/kilted/ackermann_nlmpc/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "5db78777717bd64c88d4217c960b54acff12cf162336be55939c375b5cc491a1";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-pep257 python3Packages.pytest ];
+  propagatedBuildInputs = [ ackermann-msgs ackermann-nlmpc-msgs geometry-msgs nav-msgs std-msgs ];
+
+  meta = {
+    description = "Lightweight non-linear MPC controller for autonomous driving in 2D environments";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/kilted/ackermann-steering-controller/default.nix
+++ b/distros/kilted/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-kilted-ackermann-steering-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/ackermann_steering_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "11e3a3d173e806f844032c3364ccd08fbc607ac667f0c67d5048fde4f211a3c7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/ackermann_steering_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "e4e53801736a80dcd6aaa36889f487213c118031f6853ba3e5258c9ca2321734";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/admittance-controller/default.nix
+++ b/distros/kilted/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kilted-admittance-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/admittance_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "4bc3f9013424b35d2a27d588479bf379e65e0072ce570a91dd768575dc536dfa";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/admittance_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "5f593f9ad6a7e3ce8b256d3a65235a7f1e8a418a446006c4e69d69c0371305fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/bicycle-steering-controller/default.nix
+++ b/distros/kilted/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-kilted-bicycle-steering-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/bicycle_steering_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "9738b27acd51d1014715e7d55f5bb7a3773f7f2a5adc477e851dc737852ddcdd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/bicycle_steering_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "18656390880042f80fee735c752715296f32b8560a12d9a2a1897a68fd72f7cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/chained-filter-controller/default.nix
+++ b/distros/kilted/chained-filter-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, filters, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-chained-filter-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/chained_filter_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "6217c22b1a8399371e64f97af4b959d349cf4e28e7acf517b03537d511e0541b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/chained_filter_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "dafde3ba34678d2565a4572763831705e00fc2cf987b089347e8fb86e8873397";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/diff-drive-controller/default.nix
+++ b/distros/kilted/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-kilted-diff-drive-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/diff_drive_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "79f7ace1da42e7d2626d0e3ce44b230788de48d620f8d6c3be0daf0fffdc8b51";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/diff_drive_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "8d71d7ce06fe1f341eb0b9569c3ca0f19ccf3bdb18ddab17318b6e5451758be3";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/effort-controllers/default.nix
+++ b/distros/kilted/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-effort-controllers";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/effort_controllers/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "7ef65bc834c6345f23f66c3f17fb46917390c7c0dedd6cc3f05203fd1b4fe11b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/effort_controllers/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "c0ad9f92eb2edc376d91b8147925a812b257c863911ec75f6b090ecfc70ae8b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/force-torque-sensor-broadcaster/default.nix
+++ b/distros/kilted/force-torque-sensor-broadcaster/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-force-torque-sensor-broadcaster";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/force_torque_sensor_broadcaster/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "c3ec262fe87f867c8bc8d6ba1c6c66f5da70ccd2670679dde0d14a386f108a9b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/force_torque_sensor_broadcaster/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "868516e1dfc6d6fe89f302259b2413e9f760bf8144f31ecf0125397f7c5d4b33";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
-  propagatedBuildInputs = [ backward-ros controller-interface generate-parameter-library geometry-msgs hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools ];
+  propagatedBuildInputs = [ backward-ros controller-interface filters generate-parameter-library geometry-msgs hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/forward-command-controller/default.nix
+++ b/distros/kilted/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-forward-command-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/forward_command_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "83fa35afce34e575a7996ee0d9e9f9e8d5edc6d7ed3349d807b36c32045294ec";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/forward_command_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "57453a4ac3a0075f2a9b623216e283bb9744ab5d9200350ddcad72cddfe7f8af";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/generated.nix
+++ b/distros/kilted/generated.nix
@@ -8,6 +8,10 @@ self: super: {
 
  ackermann-msgs = self.callPackage ./ackermann-msgs {};
 
+ ackermann-nlmpc = self.callPackage ./ackermann-nlmpc {};
+
+ ackermann-nlmpc-msgs = self.callPackage ./ackermann-nlmpc-msgs {};
+
  ackermann-steering-controller = self.callPackage ./ackermann-steering-controller {};
 
  action-msgs = self.callPackage ./action-msgs {};
@@ -870,6 +874,36 @@ self: super: {
 
  grbl-ros = self.callPackage ./grbl-ros {};
 
+ grid-map = self.callPackage ./grid-map {};
+
+ grid-map-cmake-helpers = self.callPackage ./grid-map-cmake-helpers {};
+
+ grid-map-core = self.callPackage ./grid-map-core {};
+
+ grid-map-costmap-2d = self.callPackage ./grid-map-costmap-2d {};
+
+ grid-map-cv = self.callPackage ./grid-map-cv {};
+
+ grid-map-demos = self.callPackage ./grid-map-demos {};
+
+ grid-map-filters = self.callPackage ./grid-map-filters {};
+
+ grid-map-loader = self.callPackage ./grid-map-loader {};
+
+ grid-map-msgs = self.callPackage ./grid-map-msgs {};
+
+ grid-map-octomap = self.callPackage ./grid-map-octomap {};
+
+ grid-map-pcl = self.callPackage ./grid-map-pcl {};
+
+ grid-map-ros = self.callPackage ./grid-map-ros {};
+
+ grid-map-rviz-plugin = self.callPackage ./grid-map-rviz-plugin {};
+
+ grid-map-sdf = self.callPackage ./grid-map-sdf {};
+
+ grid-map-visualization = self.callPackage ./grid-map-visualization {};
+
  gscam = self.callPackage ./gscam {};
 
  gtest-vendor = self.callPackage ./gtest-vendor {};
@@ -1561,6 +1595,8 @@ self: super: {
  nav-msgs = self.callPackage ./nav-msgs {};
 
  navigation2 = self.callPackage ./navigation2 {};
+
+ neo-nav2-bringup = self.callPackage ./neo-nav2-bringup {};
 
  neobotix-usboard-msgs = self.callPackage ./neobotix-usboard-msgs {};
 

--- a/distros/kilted/gpio-controllers/default.nix
+++ b/distros/kilted/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-gpio-controllers";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/gpio_controllers/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "387953d4a1951dc542e0da47697070c363a5c18b99e84320ffca1949e591989a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/gpio_controllers/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "914115a04c68ba797e4c7e8c3b40526110828e3e7c61b89a66129147e9396c34";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/gps-sensor-broadcaster/default.nix
+++ b/distros/kilted/gps-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-gps-sensor-broadcaster";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/gps_sensor_broadcaster/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "279a9ed289dee483d396c22156a497217ba7f69b04341a0e3329796b0b906a07";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/gps_sensor_broadcaster/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "7b434a858a8beccbde45abe9a9ba8513d104661a21987d609877a761cd37db84";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/grid-map-cmake-helpers/default.nix
+++ b/distros/kilted/grid-map-cmake-helpers/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core }:
+buildRosPackage {
+  pname = "ros-kilted-grid-map-cmake-helpers";
+  version = "2.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/grid_map-release/archive/release/kilted/grid_map_cmake_helpers/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "cc61266b6febd96b6c9102e945f0132335ffdcb945dcc8ca0e562c6473bbeb43";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ ament-cmake-core ];
+  nativeBuildInputs = [ ament-cmake-core ];
+
+  meta = {
+    description = "CMake support functionality used throughout grid_map";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/grid-map-core/default.nix
+++ b/distros/kilted/grid-map-core/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, grid-map-cmake-helpers }:
+buildRosPackage {
+  pname = "ros-kilted-grid-map-core";
+  version = "2.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/grid_map-release/archive/release/kilted/grid_map_core/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "7245102114c1640e8de340077bfa885bae54f4fe30ed50867d4e6fcc1c3062ef";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake grid-map-cmake-helpers ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ eigen ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Universal grid map library to manage two-dimensional grid maps with multiple data layers.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/grid-map-costmap-2d/default.nix
+++ b/distros/kilted/grid-map-costmap-2d/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, grid-map-cmake-helpers, grid-map-core, nav2-costmap-2d, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-kilted-grid-map-costmap-2d";
+  version = "2.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/grid_map-release/archive/release/kilted/grid_map_costmap_2d/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "7d6aa8d3fd9a0a864e274192c834fc70002aa9aa5568a095da6d503e2663c295";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake grid-map-cmake-helpers ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs grid-map-core nav2-costmap-2d tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Interface for grid maps to the costmap_2d format.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/grid-map-cv/default.nix
+++ b/distros/kilted/grid-map-cv/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cv-bridge, filters, grid-map-cmake-helpers, grid-map-core, pluginlib, rclcpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-grid-map-cv";
+  version = "2.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/grid_map-release/archive/release/kilted/grid_map_cv/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "fe80e8f88d97af1c1d9318ea0ccb8e594ebf3b1151f8391abd5431dfb3dc4f58";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake grid-map-cmake-helpers ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge filters grid-map-core pluginlib rclcpp sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Conversions between grid maps and OpenCV images.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/grid-map-demos/default.nix
+++ b/distros/kilted/grid-map-demos/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, grid-map-cmake-helpers, grid-map-core, grid-map-cv, grid-map-filters, grid-map-loader, grid-map-msgs, grid-map-octomap, grid-map-ros, grid-map-rviz-plugin, grid-map-visualization, octomap-msgs, octomap-rviz-plugins, octomap-server, python3Packages, rclcpp, rclpy, rviz2, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-grid-map-demos";
+  version = "2.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/grid_map-release/archive/release/kilted/grid_map_demos/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "10dc3eb98ccd0688d9c2558b11de561063f4aff28dccf9d751fe778f06e221a0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake grid-map-cmake-helpers ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs grid-map-core grid-map-cv grid-map-filters grid-map-loader grid-map-msgs grid-map-octomap grid-map-ros grid-map-rviz-plugin grid-map-visualization octomap-msgs octomap-rviz-plugins octomap-server python3Packages.opencv4 rclcpp rclpy rviz2 sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Demo nodes to demonstrate the usage of the grid map library.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/grid-map-filters/default.nix
+++ b/distros/kilted/grid-map-filters/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, filters, grid-map-cmake-helpers, grid-map-core, grid-map-msgs, grid-map-ros, pluginlib, tbb_2021_11 }:
+buildRosPackage {
+  pname = "ros-kilted-grid-map-filters";
+  version = "2.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/grid_map-release/archive/release/kilted/grid_map_filters/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "5396d1000c40ec87e361002455ca0ecbae10354fe42ae15b8e4324e6ec4f0a3a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake grid-map-cmake-helpers ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ filters grid-map-core grid-map-msgs grid-map-ros pluginlib tbb_2021_11 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Processing grid maps as a sequence of ROS filters.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/grid-map-loader/default.nix
+++ b/distros/kilted/grid-map-loader/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, grid-map-cmake-helpers, grid-map-msgs, grid-map-ros }:
+buildRosPackage {
+  pname = "ros-kilted-grid-map-loader";
+  version = "2.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/grid_map-release/archive/release/kilted/grid_map_loader/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "aabb7aa0d7e6989c0d7c731c98d37fcdef77e44fbe38637148e760fa179be765";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake grid-map-cmake-helpers ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ grid-map-msgs grid-map-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Loading and publishing grid maps from bag files.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/grid-map-msgs/default.nix
+++ b/distros/kilted/grid-map-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, grid-map-cmake-helpers, rclcpp, rosidl-default-generators, std-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-grid-map-msgs";
+  version = "2.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/grid_map-release/archive/release/kilted/grid_map_msgs/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "297d5dc494f59feacfd6241b74a473081279211deaca8fd7f4b7f9f840e413a6";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake grid-map-cmake-helpers ];
+  propagatedBuildInputs = [ geometry-msgs rclcpp rosidl-default-generators std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Definition of the multi-layered grid map message type.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/grid-map-octomap/default.nix
+++ b/distros/kilted/grid-map-octomap/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, grid-map-cmake-helpers, grid-map-core, octomap }:
+buildRosPackage {
+  pname = "ros-kilted-grid-map-octomap";
+  version = "2.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/grid_map-release/archive/release/kilted/grid_map_octomap/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "6999119c4953a060e6cfe92a9ca046779781b34961bdc24cb64831c84656cbaf";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake grid-map-cmake-helpers ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ grid-map-core octomap ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Conversions between grid maps and OctoMap types.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/grid-map-pcl/default.nix
+++ b/distros/kilted/grid-map-pcl/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, grid-map-cmake-helpers, grid-map-core, grid-map-msgs, grid-map-ros, pcl, rclcpp, rcutils, yaml-cpp }:
+buildRosPackage {
+  pname = "ros-kilted-grid-map-pcl";
+  version = "2.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/grid_map-release/archive/release/kilted/grid_map_pcl/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "7c8ec64f244fedb77f57a443ba901c3a4b2f9ef90345b4621b44e183ff5f37be";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake grid-map-cmake-helpers ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ grid-map-core grid-map-msgs grid-map-ros pcl rclcpp rcutils yaml-cpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Conversions between grid maps and Point Cloud Library (PCL) types.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/grid-map-ros/default.nix
+++ b/distros/kilted/grid-map-ros/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, grid-map-cmake-helpers, grid-map-core, grid-map-cv, grid-map-msgs, nav-msgs, nav2-msgs, rclcpp, rcutils, rosbag2-cpp, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, tf2, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-grid-map-ros";
+  version = "2.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/grid_map-release/archive/release/kilted/grid_map_ros/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "faf6df7bcc328af20650bcd80ea513eab5a525c49e4275f4b63745dd3cfb7c17";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake grid-map-cmake-helpers ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common rosbag2-storage-default-plugins ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs grid-map-core grid-map-cv grid-map-msgs nav-msgs nav2-msgs rclcpp rcutils rosbag2-cpp sensor-msgs std-msgs tf2 visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS interface for the grid map library to manage two-dimensional grid maps with multiple data layers.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/grid-map-rviz-plugin/default.nix
+++ b/distros/kilted/grid-map-rviz-plugin/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, grid-map-cmake-helpers, grid-map-msgs, grid-map-ros, qt5, rclcpp, rviz-common, rviz-ogre-vendor, rviz-rendering }:
+buildRosPackage {
+  pname = "ros-kilted-grid-map-rviz-plugin";
+  version = "2.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/grid_map-release/archive/release/kilted/grid_map_rviz_plugin/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "ea68256a296837fa37f34ff1db70381d6ef129cbad7c7ebc1e2951ee909ab593";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake grid-map-cmake-helpers ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ grid-map-msgs grid-map-ros qt5.qtbase rclcpp rviz-common rviz-ogre-vendor rviz-rendering ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "RViz plugin for displaying grid map messages.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/grid-map-sdf/default.nix
+++ b/distros/kilted/grid-map-sdf/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, grid-map-cmake-helpers, grid-map-core, pcl }:
+buildRosPackage {
+  pname = "ros-kilted-grid-map-sdf";
+  version = "2.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/grid_map-release/archive/release/kilted/grid_map_sdf/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "abbb2de5c8a34dd661df45b9ab1894d6856c783941400f96418faae86cbe5a14";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake grid-map-cmake-helpers ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ grid-map-core pcl ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Generates signed distance fields from grid maps.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/grid-map-visualization/default.nix
+++ b/distros/kilted/grid-map-visualization/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, grid-map-cmake-helpers, grid-map-core, grid-map-msgs, grid-map-ros, nav-msgs, rclcpp, sensor-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-grid-map-visualization";
+  version = "2.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/grid_map-release/archive/release/kilted/grid_map_visualization/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "d801ac0a18b2e84ea69b70d2f860f29450178341dd7910713579dfbade304ba9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake grid-map-cmake-helpers ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ grid-map-core grid-map-msgs grid-map-ros nav-msgs rclcpp sensor-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Configurable tool to visualize grid maps in RViz.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/grid-map/default.nix
+++ b/distros/kilted/grid-map/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, grid-map-cmake-helpers, grid-map-core, grid-map-costmap-2d, grid-map-cv, grid-map-demos, grid-map-filters, grid-map-loader, grid-map-msgs, grid-map-octomap, grid-map-pcl, grid-map-ros, grid-map-rviz-plugin, grid-map-sdf, grid-map-visualization }:
+buildRosPackage {
+  pname = "ros-kilted-grid-map";
+  version = "2.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/grid_map-release/archive/release/kilted/grid_map/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "ac6dbb196ae12ad560635305aa2f3f3ecbdbc9e3c99f03c7c0949e6b1bff30b9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ grid-map-cmake-helpers grid-map-core grid-map-costmap-2d grid-map-cv grid-map-demos grid-map-filters grid-map-loader grid-map-msgs grid-map-octomap grid-map-pcl grid-map-ros grid-map-rviz-plugin grid-map-sdf grid-map-visualization ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Meta-package for the universal grid map library.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/gz-launch-vendor/vendored-source.json
+++ b/distros/kilted/gz-launch-vendor/vendored-source.json
@@ -1,0 +1,7 @@
+{
+  "gz_launch_vendor": {
+    "url": "https://github.com/gazebosim/gz-launch.git",
+    "rev": "gz-launch8_8.0.1",
+    "hash": "sha256-el+4sVBOmeBj8VJqKut8pIhVJeyEyodrt6titunbBF0="
+  }
+}

--- a/distros/kilted/gz-physics-vendor/vendored-source.json
+++ b/distros/kilted/gz-physics-vendor/vendored-source.json
@@ -1,0 +1,7 @@
+{
+  "gz_physics_vendor": {
+    "url": "https://github.com/gazebosim/gz-physics.git",
+    "rev": "gz-physics8_8.3.0",
+    "hash": "sha256-U02OIZ59IMxxbZeC8bjqmFKmfWTzDTc7F4YO5gsJdYg="
+  }
+}

--- a/distros/kilted/gz-sensors-vendor/vendored-source.json
+++ b/distros/kilted/gz-sensors-vendor/vendored-source.json
@@ -1,0 +1,7 @@
+{
+  "gz_sensors_vendor": {
+    "url": "https://github.com/gazebosim/gz-sensors.git",
+    "rev": "gz-sensors9_9.2.0",
+    "hash": "sha256-Vxl3xdmh8ybRbjDxNGt8qgQOP9ctAcYAoVwWeytAglc="
+  }
+}

--- a/distros/kilted/gz-sim-vendor/vendored-source.json
+++ b/distros/kilted/gz-sim-vendor/vendored-source.json
@@ -1,0 +1,7 @@
+{
+  "gz_sim_vendor": {
+    "url": "https://github.com/gazebosim/gz-sim.git",
+    "rev": "gz-sim9_9.1.0",
+    "hash": "sha256-niVXuqMvEhwCW2NcrEhIChh3DsD2M8ZTspDi+zF0kBc="
+  }
+}

--- a/distros/kilted/imu-sensor-broadcaster/default.nix
+++ b/distros/kilted/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, eigen, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-kilted-imu-sensor-broadcaster";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/imu_sensor_broadcaster/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "7988a1cd56a6fdebd52d73b4f464a4500539b7d3a0d1642fde4985e4eeee8fc2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/imu_sensor_broadcaster/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "8f9353599f7840385a16c7130d3ee62bf939db895d116ed1e6a61b5ffc8ab2d9";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/joint-state-broadcaster/default.nix
+++ b/distros/kilted/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, urdf }:
 buildRosPackage {
   pname = "ros-kilted-joint-state-broadcaster";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/joint_state_broadcaster/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "6323a31b0ddd8853b29141a8595cb6c2d6f2415260583f591cf60a8a6aab700f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/joint_state_broadcaster/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "465133745778ec6fcd55e7fbaa2fab65a7ce5a61aa7ac33a65f0056032ee1fb9";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/joint-trajectory-controller/default.nix
+++ b/distros/kilted/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-kilted-joint-trajectory-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/joint_trajectory_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "6f21ceab17528bb4454e94ed800839a48162be3d5d8b8a3a0213eaf4fe1d5614";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/joint_trajectory_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "60e11a0eddd1cb1306ae57efbb0a961271536cfaf79d9fad22bf3b4e7bb0d967";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/launch-ros/default.nix
+++ b/distros/kilted/launch-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, launch, lifecycle-msgs, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-kilted-launch-ros";
-  version = "0.28.2-r1";
+  version = "0.28.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/kilted/launch_ros/0.28.2-1.tar.gz";
-    name = "0.28.2-1.tar.gz";
-    sha256 = "6302d284d82afcde8ce0562ec284850184b19d4668a1f066c828c887f7ceed9d";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/kilted/launch_ros/0.28.3-1.tar.gz";
+    name = "0.28.3-1.tar.gz";
+    sha256 = "5bc6a1e023c4122859bffd433964fbde071bff72804466da2a1273bb357b5add";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/launch-testing-ros/default.nix
+++ b/distros/kilted/launch-testing-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch-ros, launch-testing, python3Packages, rclpy, rmw-test-fixture-implementation, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-launch-testing-ros";
-  version = "0.28.2-r1";
+  version = "0.28.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/kilted/launch_testing_ros/0.28.2-1.tar.gz";
-    name = "0.28.2-1.tar.gz";
-    sha256 = "7b2b62944248ad9f552456a596eefeb84d6551f032711d2423109588dd02b130";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/kilted/launch_testing_ros/0.28.3-1.tar.gz";
+    name = "0.28.3-1.tar.gz";
+    sha256 = "f246ad21902ddf557ae0661eab1ff5026fa7f2e9991df9cdcd8416da762a5c99";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/libmavconn/default.nix
+++ b/distros/kilted/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
 buildRosPackage {
   pname = "ros-kilted-libmavconn";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/libmavconn/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "05d77ac1ae102309341d98dc9013c22445bd1f8c7176f41124a22a4ea79d71ed";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/libmavconn/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "b392a413a77424a1417bddcdd623b7e010f6ced9143cb96af6760b837647b917";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mavros-extras/default.nix
+++ b/distros/kilted/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-kilted-mavros-extras";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/mavros_extras/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "86b668040b6c938a99ad3a2eb263bc426c0abcf6ec9aa0206c3b5a95c8df0fef";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/mavros_extras/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "56c75d6ec31aae88c0c0caf7ce55d68516e19c0d00c19da14e505ffe309ebc17";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mavros-msgs/default.nix
+++ b/distros/kilted/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mavros-msgs";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/mavros_msgs/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "7cfa8a9c7e598096053da02ef37483f4c3779c243af344440307feaeb1506cf6";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/mavros_msgs/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "6d24b0cda98379f3b617137abb2ac70ba76e66a8d749c19e12253e9004bde57c";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mavros/default.nix
+++ b/distros/kilted/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mavros";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/mavros/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "88caee5623a0f0b0335fee745790b7b05553ea740bcd6b6e6da03ddd63d325e9";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/mavros/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "4d31dcdf37533a9e60e6170e59683ae0f88b7378cee21039a51461d0bfc97e42";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mecanum-drive-controller/default.nix
+++ b/distros/kilted/mecanum-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mecanum-drive-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/mecanum_drive_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "8e2d7fbbbc1fa6a48207fef3c90fd06d6bea22132a350fc13cc47a1b1d81b6be";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/mecanum_drive_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "b6129304704d8ba37bcc7a00e77e2f2f85f7dcb1216526c605cb337d4888679d";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/motion-primitives-controllers/default.nix
+++ b/distros/kilted/motion-primitives-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-kilted-motion-primitives-controllers";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/motion_primitives_controllers/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "ccf4962372b41d7ea3df7eed24158ec1d114def5f903a147effc49ead2ec9974";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/motion_primitives_controllers/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "e470c6e3aa374d671d02da5682adfc49bd2731f4607d3084338f737262e0cf87";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/neo-nav2-bringup/default.nix
+++ b/distros/kilted/neo-nav2-bringup/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, nav2-common, navigation2, slam-toolbox }:
+buildRosPackage {
+  pname = "ros-kilted-neo-nav2-bringup";
+  version = "1.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/neo_nav2_bringup-release/archive/release/kilted/neo_nav2_bringup/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "3491e090478da02b5ea6a1c461999570bba1268c60f740d1330ccb4c545fab4a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ nav2-common navigation2 slam-toolbox ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS-2 navigation bringup packages for neobotix robots";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kilted/omni-wheel-drive-controller/default.nix
+++ b/distros/kilted/omni-wheel-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, eigen, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-kilted-omni-wheel-drive-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/omni_wheel_drive_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "9e2e3738de8289da080a5b7a6a21ede1f7b7ac355c75e28d45e7784672d481f0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/omni_wheel_drive_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "141e6ea108ff92f46c056103cadc19349cafb1512cc4e6213f4afefe6740af9a";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/parallel-gripper-controller/default.nix
+++ b/distros/kilted/parallel-gripper-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-parallel-gripper-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/parallel_gripper_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "8568cb97accb1445d7a2bfae44778133fc5123d0a72e9ec8496121d4f5873d1b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/parallel_gripper_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "d8cd547e5c32ed359b65b137ec26b8fb8dfb2d8b7be59cc9369c4cf7dbb1fe54";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/pid-controller/default.nix
+++ b/distros/kilted/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-kilted-pid-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/pid_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "ad37d0c6dccd3573d8f70d9bd59232fdd25f1656de6cac8abe80809dad3da0ec";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/pid_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "aa7033c4c23d3bc75761e2ce41465549b993094c4d061b616c25deadc680af6b";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/pose-broadcaster/default.nix
+++ b/distros/kilted/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-kilted-pose-broadcaster";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/pose_broadcaster/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "77ab3ab9994a1d8c97c56ada633cc80d78aff05e848270d842f2671b19dd1397";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/pose_broadcaster/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "0072da9fb92647d593679b7ff38bfd5dd086261d9ee42dcf6e838a0e46d64ac3";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/position-controllers/default.nix
+++ b/distros/kilted/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-position-controllers";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/position_controllers/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "9c044aee057c66601aa07fb041577dc597aeba8270a3d4c03f3b04406880206d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/position_controllers/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "35d2f7bbd8d6ec613c74e51e065a627a9d88ffcf68c885c834668cede1c711cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/range-sensor-broadcaster/default.nix
+++ b/distros/kilted/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-range-sensor-broadcaster";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/range_sensor_broadcaster/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "0b0d18dbaa23e1e9327b4cec48f2feb60b6145f5b602953ede3e4847ec70808e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/range_sensor_broadcaster/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "59c87cf1c4c6070d63b460473815a1759d71fbc1d3598fc4cafdd4b9583f27ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros2-controllers-test-nodes/default.nix
+++ b/distros/kilted/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ros2-controllers-test-nodes";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/ros2_controllers_test_nodes/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "77b7f491a4f0f5c440329fbefa633f8e5dd72aeaf24c37c59709a64e71e61d91";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/ros2_controllers_test_nodes/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "d88c060369f79a9057bd9b38b2ce9fcbfaef94c5f59fa16826845aac288a0921";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/ros2-controllers/default.nix
+++ b/distros/kilted/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, chained-filter-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gps-sensor-broadcaster, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, motion-primitives-controllers, omni-wheel-drive-controller, parallel-gripper-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-kilted-ros2-controllers";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/ros2_controllers/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "241e34a64a03bb2f98d0b7c73b414fa0f3ed30e2af0dfe4af8deb57afc3f8ba8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/ros2_controllers/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "997fdcb13c8f5326359587f107526ac3963a403f198121a035ff8489764079a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros2launch/default.nix
+++ b/distros/kilted/ros2launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-ros, launch-xml, launch-yaml, python3Packages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-kilted-ros2launch";
-  version = "0.28.2-r1";
+  version = "0.28.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/kilted/ros2launch/0.28.2-1.tar.gz";
-    name = "0.28.2-1.tar.gz";
-    sha256 = "a75ad2cf36b29c6ca479eee3ae4c732dee1e0da56faec5821995a109d8a4dc0a";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/kilted/ros2launch/0.28.3-1.tar.gz";
+    name = "0.28.3-1.tar.gz";
+    sha256 = "d22d3de627d0c8ec4f4c68443f0efe491dd91aaaab19ff0840100ac282b85bda";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/rqt-dotgraph/default.nix
+++ b/distros/kilted/rqt-dotgraph/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, python-qt-binding, python3Packages, qt-dotgraph, qt-gui-py-common, rqt-graph, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-rqt-dotgraph";
-  version = "0.0.4-r2";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_dotgraph-release/archive/release/kilted/rqt_dotgraph/0.0.4-2.tar.gz";
-    name = "0.0.4-2.tar.gz";
-    sha256 = "a5253d3e57ce6a3705acd57fa8bffe4c19c627bf7dd8256c1a91c388f69751cc";
+    url = "https://github.com/ros2-gbp/rqt_dotgraph-release/archive/release/kilted/rqt_dotgraph/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "230c3359dc764b64a5aba6f31da0efdd5ae420362c426722f96cd620c28653ca";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
-  propagatedBuildInputs = [ ament-index-python python-qt-binding python3Packages.pyqt5 python3Packages.pyside2 qt-dotgraph qt-gui-py-common rqt-graph rqt-gui rqt-gui-py std-msgs ];
+  propagatedBuildInputs = [ ament-index-python python-qt-binding python3Packages.pyqt5 qt-dotgraph qt-gui-py-common rqt-graph rqt-gui rqt-gui-py std-msgs ];
 
   meta = {
     description = "rqt GUI plugin to visualize dot graphs.";

--- a/distros/kilted/rqt-joint-trajectory-controller/default.nix
+++ b/distros/kilted/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kilted-rqt-joint-trajectory-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/rqt_joint_trajectory_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "58d192709aeda8c003b52e40de3451bde60083129213b9edf46868d7d9bb64b7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/rqt_joint_trajectory_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "b93922b386407d9250de5ee2d4113f4ea6acf89d039a6d109180c2293500debc";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/simulation-interfaces/default.nix
+++ b/distros/kilted/simulation-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-simulation-interfaces";
-  version = "1.0.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/simulation_interfaces-release/archive/release/kilted/simulation_interfaces/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "01e22d3b6c255ef6b08bf05a3145a8f9b79f638b2299f5c56ffb8c27084603f4";
+    url = "https://github.com/ros2-gbp/simulation_interfaces-release/archive/release/kilted/simulation_interfaces/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "bc4880966effa1f11ccb328e5393abfb3a160d456401a254ae813cee77dfc950";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/steering-controllers-library/default.nix
+++ b/distros/kilted/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-kilted-steering-controllers-library";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/steering_controllers_library/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "84d3a9a53e149ce273d25758016d9b0114db257b3ec1cc44e27d33255814f8ff";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/steering_controllers_library/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "19076466e46c3311665b2f2d060537221d17ce3e0a710b83dc42d514ec38f783";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/tricycle-controller/default.nix
+++ b/distros/kilted/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-kilted-tricycle-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/tricycle_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "b65db0c13082bb10083f859ef408a40e7a23b650a117882af784a4b0cbc67085";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/tricycle_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "ed547214aeecf8a5958deb6e25caf399ef7ca37e10e80b8f6d88a84be6172cc2";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/tricycle-steering-controller/default.nix
+++ b/distros/kilted/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-kilted-tricycle-steering-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/tricycle_steering_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "415ce6b304bf821601ce5cedd2b770bd072da84edeeecc2bd1fb85da7e76dab6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/tricycle_steering_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "2343f3444b0bae635bde6a7230ad98d197d522005199eeee643fca5d49f769a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ur-calibration/default.nix
+++ b/distros/kilted/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-kilted-ur-calibration";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/kilted/ur_calibration/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "78bdc98f7e0dfca634fbdc35ea824194132e6973bf5f2d5b4abb234bb6b2eb4a";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/kilted/ur_calibration/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "3b16df240350f3466666a907352204405247540a919a12ee4d373e1d8eb380cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ur-client-library/default.nix
+++ b/distros/kilted/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-kilted-ur-client-library";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/kilted/ur_client_library/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "26cb7f9a9191d14201d34aac2af62da9c1705e1ce1a7bca4d61114d10de4fb93";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/kilted/ur_client_library/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "ade5cb5dea04933e78ef94d35b7481d624e71fb4cc920db0cf79b47762e83668";
   };
 
   buildType = "cmake";

--- a/distros/kilted/ur-controllers/default.nix
+++ b/distros/kilted/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, angles, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, trajectory-msgs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ur-controllers";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/kilted/ur_controllers/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "73bc8ba6d933ecddea7ad6cbcf09c936b1a279ff7d889f3bacb09b2f195446a9";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/kilted/ur_controllers/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "a7a805bf849c44f8fb79c5db9e37689dc893a4e7dbc3d159fa9226b812248c19";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ur-dashboard-msgs/default.nix
+++ b/distros/kilted/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-kilted-ur-dashboard-msgs";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/kilted/ur_dashboard_msgs/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "2d26a253d82b4c42ed2a0607d711f0e1ab333191c95bc270a81ee83db4f10657";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/kilted/ur_dashboard_msgs/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "927fb0b1712ac3d2b7ce61d015ef0d512100715cdfcd1a85cf78a38bc46f958c";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ur-description/default.nix
+++ b/distros/kilted/ur-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, joint-state-publisher-gui, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, robot-state-publisher, rviz2, urdf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-kilted-ur-description";
-  version = "4.0.0-r1";
+  version = "4.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/kilted/ur_description/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "0c82e68786b641ef7a03c0d0e7b8aaf5d476b261e25021ba716a63a2ece5ac11";
+    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/kilted/ur_description/4.1.0-1.tar.gz";
+    name = "4.1.0-1.tar.gz";
+    sha256 = "8be8800a247ea3a38d70815e267f195907b09efb706f9bd4297530674e32c2c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ur-moveit-config/default.nix
+++ b/distros/kilted/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, ur-description, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-kilted-ur-moveit-config";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/kilted/ur_moveit_config/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "24e1ca8af789c9d4e594bd436ed86dea4df1e158a6c9a74975c579e23af29291";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/kilted/ur_moveit_config/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "0fb20c9dcf510e746b4957d21d6900215fc192ab55822b8db0335201fbba4c9a";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ur-robot-driver/default.nix
+++ b/distros/kilted/ur-robot-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, backward-ros, controller-manager, controller-manager-msgs, force-torque-sensor-broadcaster, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, pluginlib, pose-broadcaster, position-controllers, rclcpp, rclcpp-lifecycle, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, socat, std-msgs, std-srvs, tf2-geometry-msgs, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-kilted-ur-robot-driver";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/kilted/ur_robot_driver/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "24ca40095ea782ca6b3d08a588481fbec40afa993e4c852ab9bed4da11fa8269";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/kilted/ur_robot_driver/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "73b9c4b0f4d8d08caa7a03330c4ade5686377c7ade8b3b8642363c77ff4178cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ur/default.nix
+++ b/distros/kilted/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-kilted-ur";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/kilted/ur/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "2aea401b71f5080383abc970c4492c7338a4da5528c2386b85a575abd7175896";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/kilted/ur/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "25d12daebb7be3fb0b40a5b3638a03ac3e3745ba442e982309fab62dbf267715";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/velocity-controllers/default.nix
+++ b/distros/kilted/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-velocity-controllers";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/velocity_controllers/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "54b673414fbf9a37480583d86f71c7392cc660c6f9306680a4ab8f2bd17cf273";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/velocity_controllers/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "d911431fbfebdbf37f26d58d07cd95a95039b50abb4876b9742a2aef58f15d41";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ackermann-nlmpc-msgs/default.nix
+++ b/distros/rolling/ackermann-nlmpc-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-ackermann-nlmpc-msgs";
+  version = "1.0.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ackmerann_nlmpc-release/archive/release/rolling/ackermann_nlmpc_msgs/1.0.2-2.tar.gz";
+    name = "1.0.2-2.tar.gz";
+    sha256 = "f886d626cec027ebf4e12494ef4262fc2b84dfe668378b776d7c6a2f9a01fe55";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "Message definitions for ackermann_nlmpc";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/rolling/ackermann-nlmpc/default.nix
+++ b/distros/rolling/ackermann-nlmpc/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ackermann-msgs, ackermann-nlmpc-msgs, ament-pep257, geometry-msgs, nav-msgs, python3Packages, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-ackermann-nlmpc";
+  version = "1.0.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ackmerann_nlmpc-release/archive/release/rolling/ackermann_nlmpc/1.0.2-2.tar.gz";
+    name = "1.0.2-2.tar.gz";
+    sha256 = "95c85b949a5530798482f0e004ee4b4502eafafff1a9e86824ea1417840f9d1b";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-pep257 python3Packages.pytest ];
+  propagatedBuildInputs = [ ackermann-msgs ackermann-nlmpc-msgs geometry-msgs nav-msgs std-msgs ];
+
+  meta = {
+    description = "Lightweight non-linear MPC controller for autonomous driving in 2D environments";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/rolling/ackermann-steering-controller/default.nix
+++ b/distros/rolling/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-ackermann-steering-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "b7825c50dade14510c22ee34d609f28991f4910f5a43896274a61a618456ecdb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "0f89c16dfc9b720f337e306762abfaca0c048fdf0c8ee38fe1a37726c180ccb8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/admittance-controller/default.nix
+++ b/distros/rolling/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-admittance-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "a4865fc87b2d7918c73049cb573774cdefa5d57a4623aef60c73aba6903943a2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "c5ed98f460e2ffd9317587bbc1ce9b6646257a01dc6a53216caea7df93dff4cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/bicycle-steering-controller/default.nix
+++ b/distros/rolling/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-bicycle-steering-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "d12c27b9576460fadf5fae2781fce2d1be6db2aa8f8b5707c6db0a1310719274";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "31664d17ae44536d1f87a3b381934aef081c0e606d30f45ce492a73d1f099e3e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/camera-calibration/default.nix
+++ b/distros/rolling/camera-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, cv-bridge, image-geometry, message-filters, python3Packages, rclpy, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-camera-calibration";
-  version = "7.1.1-r1";
+  version = "7.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/camera_calibration/7.1.1-1.tar.gz";
-    name = "7.1.1-1.tar.gz";
-    sha256 = "2f065a9410c810b58b3244c759a9536a1d417079fc482080cd8b6f79f4892e2c";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/camera_calibration/7.1.2-1.tar.gz";
+    name = "7.1.2-1.tar.gz";
+    sha256 = "89854ae2f94746d2267fe605dd604bb4d1aa5e6f916196f7cb9f42f281a26dc3";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/chained-filter-controller/default.nix
+++ b/distros/rolling/chained-filter-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, filters, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-chained-filter-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/chained_filter_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "e3241bc0fe39e54505ab503da4691db39daf8269abadc188d2568588431232a9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/chained_filter_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "708b43f1fcfb68bdca3bc26952d1e3ef9025b56c727408a54a2a3bf66640ba5c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/depth-image-proc/default.nix
+++ b/distros/rolling/depth-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, image-geometry, image-proc, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, stereo-msgs, tf2, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-depth-image-proc";
-  version = "7.1.1-r1";
+  version = "7.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/depth_image_proc/7.1.1-1.tar.gz";
-    name = "7.1.1-1.tar.gz";
-    sha256 = "2a766084df5ed2079c6a01f3d09710258ecab038c253ff3fdf296b6de19bef04";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/depth_image_proc/7.1.2-1.tar.gz";
+    name = "7.1.2-1.tar.gz";
+    sha256 = "ef22cbced95210abde7084a3e9905fcd045e88b0d76a8263a86e0fde05fb8458";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/diff-drive-controller/default.nix
+++ b/distros/rolling/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diff-drive-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "29c101dc951072935440b1fcde0b0fb44a4b06d6a55030a962da44512b6c26bb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "a6aa7ebd44a9e250ba2377c483fd52a26904b84c7fe774f22c13111198706ca8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/effort-controllers/default.nix
+++ b/distros/rolling/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-effort-controllers";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "a6adcf37e45621d51b9b86348fe03d2f82bef6588dcbf52c52b44380d2928ded";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "0daa6dc0e265ec4786527bf41188b33e4bdc93cd9bc1f186ecb2d4c7046e2ed2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/force-torque-sensor-broadcaster/default.nix
+++ b/distros/rolling/force-torque-sensor-broadcaster/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-force-torque-sensor-broadcaster";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "8540b22a14d53ea8adb052bc691f1b3953f4ffc0f1cd72f06af603d0b3f8549a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "7ff4f90539a327ba548b7a770f67b369b0fb824e3de12507939a18a80a9c4d8a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
-  propagatedBuildInputs = [ backward-ros controller-interface generate-parameter-library geometry-msgs hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools ];
+  propagatedBuildInputs = [ backward-ros controller-interface filters generate-parameter-library geometry-msgs hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/forward-command-controller/default.nix
+++ b/distros/rolling/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-forward-command-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "f6d5c0b93cfbc561be15fc600fe02a7314b06dd7d617897ed5bf4b27a5964aec";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "d22b9e2eb13e6b777f2fd6dd29f355632d6f54c0caa9e8384ca90b0a887bb73d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -8,6 +8,10 @@ self: super: {
 
  ackermann-msgs = self.callPackage ./ackermann-msgs {};
 
+ ackermann-nlmpc = self.callPackage ./ackermann-nlmpc {};
+
+ ackermann-nlmpc-msgs = self.callPackage ./ackermann-nlmpc-msgs {};
+
  ackermann-steering-controller = self.callPackage ./ackermann-steering-controller {};
 
  action-msgs = self.callPackage ./action-msgs {};
@@ -1483,6 +1487,32 @@ self: super: {
  odom-to-tf-ros2 = self.callPackage ./odom-to-tf-ros2 {};
 
  odri-master-board-sdk = self.callPackage ./odri-master-board-sdk {};
+
+ off-highway-can = self.callPackage ./off-highway-can {};
+
+ off-highway-general-purpose-radar = self.callPackage ./off-highway-general-purpose-radar {};
+
+ off-highway-general-purpose-radar-msgs = self.callPackage ./off-highway-general-purpose-radar-msgs {};
+
+ off-highway-premium-radar = self.callPackage ./off-highway-premium-radar {};
+
+ off-highway-premium-radar-msgs = self.callPackage ./off-highway-premium-radar-msgs {};
+
+ off-highway-premium-radar-sample = self.callPackage ./off-highway-premium-radar-sample {};
+
+ off-highway-premium-radar-sample-msgs = self.callPackage ./off-highway-premium-radar-sample-msgs {};
+
+ off-highway-radar = self.callPackage ./off-highway-radar {};
+
+ off-highway-radar-msgs = self.callPackage ./off-highway-radar-msgs {};
+
+ off-highway-sensor-drivers = self.callPackage ./off-highway-sensor-drivers {};
+
+ off-highway-sensor-drivers-examples = self.callPackage ./off-highway-sensor-drivers-examples {};
+
+ off-highway-uss = self.callPackage ./off-highway-uss {};
+
+ off-highway-uss-msgs = self.callPackage ./off-highway-uss-msgs {};
 
  om-gravity-compensation-controller = self.callPackage ./om-gravity-compensation-controller {};
 

--- a/distros/rolling/gpio-controllers/default.nix
+++ b/distros/rolling/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-gpio-controllers";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gpio_controllers/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "5793c9a6f195ea1d8616ed2c9337d66fc17678117e3d0e1590bdcdde1c5c62d1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gpio_controllers/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "dacbcae4f7e848df9df8b74b5614a9815eb6696cfc749352bebd65258de13f0e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gps-sensor-broadcaster/default.nix
+++ b/distros/rolling/gps-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-gps-sensor-broadcaster";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gps_sensor_broadcaster/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "eaed8aca68ad5e5711cc9a975793c135a94cfee4efaa7a2d5cf23883ea176f89";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gps_sensor_broadcaster/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "87886e3fc1b9ecad1440c1c737b150550ef0f6f4f5d1be1884503dc9d5cca982";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-pipeline/default.nix
+++ b/distros/rolling/image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, camera-calibration, depth-image-proc, image-proc, image-publisher, image-rotate, image-view, stereo-image-proc }:
 buildRosPackage {
   pname = "ros-rolling-image-pipeline";
-  version = "7.1.1-r1";
+  version = "7.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_pipeline/7.1.1-1.tar.gz";
-    name = "7.1.1-1.tar.gz";
-    sha256 = "8428d050b963328d2eb7b7a71761953182bc8ab84d8bef287419c64daa2a7430";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_pipeline/7.1.2-1.tar.gz";
+    name = "7.1.2-1.tar.gz";
+    sha256 = "08e9cf0536917cb796918afab56f5b3d336e610a115f4b81d9a24ea1d27c664e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-proc/default.nix
+++ b/distros/rolling/image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, camera-calibration-parsers, cv-bridge, geometry-msgs, image-geometry, image-transport, opencv, rclcpp, rclcpp-components, rcutils, sensor-msgs, tf2, tf2-geometry-msgs, tracetools-image-pipeline }:
 buildRosPackage {
   pname = "ros-rolling-image-proc";
-  version = "7.1.1-r1";
+  version = "7.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_proc/7.1.1-1.tar.gz";
-    name = "7.1.1-1.tar.gz";
-    sha256 = "d971023f0c2eb93e37987b930526f4d851e75f12b61e21b43327ae465432dc23";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_proc/7.1.2-1.tar.gz";
+    name = "7.1.2-1.tar.gz";
+    sha256 = "e17f20b34aed2d44f62d3176f14973cc69811f7dd46a94e28853281d56e2221f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-publisher/default.nix
+++ b/distros/rolling/image-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, camera-info-manager, cv-bridge, image-transport, rcl-interfaces, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-rolling-image-publisher";
-  version = "7.1.1-r1";
+  version = "7.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_publisher/7.1.1-1.tar.gz";
-    name = "7.1.1-1.tar.gz";
-    sha256 = "83e3b59038b1ed092a18514d78a8f1b94bdd87cafcb6d8359c0099393faa8e35";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_publisher/7.1.2-1.tar.gz";
+    name = "7.1.2-1.tar.gz";
+    sha256 = "99f2af866dd39230516b1a1deb9a060bc5944d6232fb792888ec7f42bc6fd99f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-rotate/default.nix
+++ b/distros/rolling/image-rotate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, geometry-msgs, image-transport, opencv, rcl-interfaces, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-image-rotate";
-  version = "7.1.1-r1";
+  version = "7.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_rotate/7.1.1-1.tar.gz";
-    name = "7.1.1-1.tar.gz";
-    sha256 = "4d9a54efcd5d9e2268cd8a673c33faa8d36f84670bce5b315e84eac51cf2e6e4";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_rotate/7.1.2-1.tar.gz";
+    name = "7.1.2-1.tar.gz";
+    sha256 = "cdd9b04a1c4b56ee39fa6e922781f75d319559078fdccf0e05b7a13c2deee66f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-view/default.nix
+++ b/distros/rolling/image-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, camera-calibration-parsers, cv-bridge, image-transport, message-filters, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-srvs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-rolling-image-view";
-  version = "7.1.1-r1";
+  version = "7.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_view/7.1.1-1.tar.gz";
-    name = "7.1.1-1.tar.gz";
-    sha256 = "c29c65cd46f6538a025848779e478fb2d4d35b842b466385f742220ead32d9a9";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_view/7.1.2-1.tar.gz";
+    name = "7.1.2-1.tar.gz";
+    sha256 = "7098d1f1d7166421a3ecb79a2028c2437f4671416fa30b6cf3b645aa0573c265";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/imu-sensor-broadcaster/default.nix
+++ b/distros/rolling/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, eigen, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-imu-sensor-broadcaster";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "4f60140582e3f452c6f3af2e385a289dd2494f93858a6e721cef76a092f95e2a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "0e65611385b9de23d77ced3298e06daaad76c3230a45d3b8488e4b652ea27cab";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-state-broadcaster/default.nix
+++ b/distros/rolling/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-state-broadcaster";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "04b1805b4d7feb8883164b8cb671790bf49a657895a90f106fb39464728f60dd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "091ffc881586936dc7f5296a97c68f179671ae2bcfcf5a0f3ac3a134861b171e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-trajectory-controller/default.nix
+++ b/distros/rolling/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-trajectory-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "2e7d4d711a092f3c37bc8694fc98e3c27fd1198a67adaf574356abf8be42c640";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "bc1008a86a52d045700835f020852cf000c69692202aa15b2574ac4884145170";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/libmavconn/default.nix
+++ b/distros/rolling/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-libmavconn";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/libmavconn/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "111fd03bef4f51056871148c2cec439b9e8e93bd9b1e90a5c390c1cb80004a55";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/libmavconn/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "dd2e1cd60e3bb4efc8b5ab675321887ef9443e6d9d00b8ce7005e8dfd42629f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mavros-extras/default.nix
+++ b/distros/rolling/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-mavros-extras";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros_extras/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "cdbd2df1a55fdcdda870bf67cedb733e2129d7dd70f740b2867bdd0abb970594";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros_extras/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "a92f46e7243e6bbadb5afd73240eac091b278a9827e0f533e303761fbf49325f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mavros-msgs/default.nix
+++ b/distros/rolling/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mavros-msgs";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros_msgs/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "d3dac4de62c8b5fb0b93f7f18b58d4c4cb5d9236becc122fbc2d10ef8279b194";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros_msgs/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "f913e955fd02a1dda3b20a1d70b4dff9451e3d5656eabca90d9dc7779036918c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mavros/default.nix
+++ b/distros/rolling/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mavros";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "2b70af3c66e4d6adfe58e1a6d4ad145a4a13504abeade6de1a234c8c3232d724";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "ed518e594925dc16bda1d5dc5a90e263c7acb1478b1661cc57088bb0a3fd860b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mecanum-drive-controller/default.nix
+++ b/distros/rolling/mecanum-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mecanum-drive-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/mecanum_drive_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "ca75c306c39e71c0ac73fc5934cb028957c9036c26e7b4ccef880f69ca821b5e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/mecanum_drive_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "eb6ed344643c2b5ac450642122cbf8f905f3c05f28e62e031f8e6ed8a94c5d23";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/motion-primitives-controllers/default.nix
+++ b/distros/rolling/motion-primitives-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-motion-primitives-controllers";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/motion_primitives_controllers/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "4a2bb15ba2f38e3c41757ddfd9ff54dffd90ad1a3556615522d9aeacfb249bf7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/motion_primitives_controllers/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "6edbc234b433ee9d4a69e06f81f9f9b0b6afee19eae9863bd24bd962ca43df17";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/off-highway-can/default.nix
+++ b/distros/rolling/off-highway-can/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, can-msgs, diagnostic-updater, rclcpp, ros2-socketcan-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-off-highway-can";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/rolling/off_highway_can/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "7f0bc37fae4cad2032b8c761642ad5a2d9cf25b1a744bba18fd1ec1a51f8af83";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ can-msgs diagnostic-updater rclcpp ros2-socketcan-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The off_highway_can package";
+    license = with lib.licenses; [ "Apache-2.0,-MIT" ];
+  };
+}

--- a/distros/rolling/off-highway-general-purpose-radar-msgs/default.nix
+++ b/distros/rolling/off-highway-general-purpose-radar-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-off-highway-general-purpose-radar-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/rolling/off_highway_general_purpose_radar_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "8bdd210247149971d373964894a88e5dcc5ecf51596240e39920cbf38c29ef16";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "The off_highway_general_purpose_radar_msgs package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/off-highway-general-purpose-radar/default.nix
+++ b/distros/rolling/off-highway-general-purpose-radar/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, can-msgs, off-highway-can, off-highway-general-purpose-radar-msgs, pcl, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-off-highway-general-purpose-radar";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/rolling/off_highway_general_purpose_radar/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "312c5311f4dba7ada6efb276f145b90145373ba5dac51cf8785f11985b5b0760";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake pcl-conversions ];
+  checkInputs = [ ament-cmake-ros ament-lint-auto ament-lint-common pcl-ros ];
+  propagatedBuildInputs = [ can-msgs off-highway-can off-highway-general-purpose-radar-msgs pcl rclcpp rclcpp-components sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The off_highway_general_purpose_radar package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/off-highway-premium-radar-msgs/default.nix
+++ b/distros/rolling/off-highway-premium-radar-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-off-highway-premium-radar-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/rolling/off_highway_premium_radar_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "e65ed1a656cd2c296e2b045043a0422f6a15f2bc072c95d6097d2c475858e68b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The off_highway_premium_radar_msgs package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/off-highway-premium-radar-sample-msgs/default.nix
+++ b/distros/rolling/off-highway-premium-radar-sample-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-off-highway-premium-radar-sample-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/rolling/off_highway_premium_radar_sample_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "ba399424f86ebe4f3b86bc0229aedf19bf65af76359d7ab00fa634078c5c2171";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "The off_highway_premium_radar_sample_msgs package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/off-highway-premium-radar-sample/default.nix
+++ b/distros/rolling/off-highway-premium-radar-sample/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, asio, asio-cmake-module, diagnostic-updater, io-context, off-highway-premium-radar-sample-msgs, pcl, pcl-conversions, rclcpp, rclcpp-components, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-off-highway-premium-radar-sample";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/rolling/off_highway_premium_radar_sample/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "8455fcd1e4e4cb98d18d4551eb9442fe391fb5068e74cd5ca5e84d889c5d5d69";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake asio-cmake-module pcl-conversions ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ asio diagnostic-updater io-context off-highway-premium-radar-sample-msgs pcl rclcpp rclcpp-components sensor-msgs std-msgs tf2 tf2-geometry-msgs ];
+  nativeBuildInputs = [ ament-cmake asio-cmake-module ];
+
+  meta = {
+    description = "The off_highway_premium_radar_sample package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/off-highway-premium-radar/default.nix
+++ b/distros/rolling/off-highway-premium-radar/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, asio, asio-cmake-module, diagnostic-updater, io-context, off-highway-premium-radar-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-off-highway-premium-radar";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/rolling/off_highway_premium_radar/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "181219b17f4d22139a09e1c0cf013fe83c026f6514e907b6298a7ef35504251f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake asio-cmake-module ];
+  checkInputs = [ ament-cmake-ros ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ asio diagnostic-updater io-context off-highway-premium-radar-msgs rclcpp rclcpp-components sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake asio-cmake-module ];
+
+  meta = {
+    description = "The off_highway_premium_radar package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/off-highway-radar-msgs/default.nix
+++ b/distros/rolling/off-highway-radar-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-off-highway-radar-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/rolling/off_highway_radar_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "13f0ab8846d90754759548a2bda81268d3351b61018ffb2a42a197dfd98cee1f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "The off_highway_radar_msgs package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/off-highway-radar/default.nix
+++ b/distros/rolling/off-highway-radar/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, can-msgs, off-highway-can, off-highway-radar-msgs, pcl, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-off-highway-radar";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/rolling/off_highway_radar/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "115ac1bbe1bc8fb253c9b199871b746eb33e2a8ac35ef38f110fc452a14be356";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake pcl-conversions ];
+  checkInputs = [ ament-cmake-ros ament-lint-auto ament-lint-common pcl-ros ];
+  propagatedBuildInputs = [ can-msgs off-highway-can off-highway-radar-msgs pcl rclcpp rclcpp-components sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The off_highway_radar package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/off-highway-sensor-drivers-examples/default.nix
+++ b/distros/rolling/off-highway-sensor-drivers-examples/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, off-highway-premium-radar, off-highway-radar, rclcpp, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-rolling-off-highway-sensor-drivers-examples";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/rolling/off_highway_sensor_drivers_examples/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "675e09bdd3b14df44607be7dc71416d173fdc2279e00cc4109f39433914bf245";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs nav-msgs off-highway-premium-radar off-highway-radar rclcpp rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The off_highway_sensor_drivers_examples package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/off-highway-sensor-drivers/default.nix
+++ b/distros/rolling/off-highway-sensor-drivers/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, off-highway-can, off-highway-general-purpose-radar, off-highway-general-purpose-radar-msgs, off-highway-premium-radar, off-highway-premium-radar-msgs, off-highway-premium-radar-sample, off-highway-premium-radar-sample-msgs, off-highway-radar, off-highway-radar-msgs, off-highway-uss, off-highway-uss-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-off-highway-sensor-drivers";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/rolling/off_highway_sensor_drivers/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "2f2806719ffe53345f2f9aabc109c4612747cc378b14303625955f816af9d9fb";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ off-highway-can off-highway-general-purpose-radar off-highway-general-purpose-radar-msgs off-highway-premium-radar off-highway-premium-radar-msgs off-highway-premium-radar-sample off-highway-premium-radar-sample-msgs off-highway-radar off-highway-radar-msgs off-highway-uss off-highway-uss-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The off_highway_sensor_drivers package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/off-highway-uss-msgs/default.nix
+++ b/distros/rolling/off-highway-uss-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-off-highway-uss-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/rolling/off_highway_uss_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "29930955239cd0264c0eb7ebf018129510e9c6825b2b5d2762c29aab592a7b08";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "The off_highway_uss_msgs package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/off-highway-uss/default.nix
+++ b/distros/rolling/off-highway-uss/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, can-msgs, off-highway-can, off-highway-uss-msgs, pcl, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-off-highway-uss";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/rolling/off_highway_uss/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "5a00142888dc5e32bf14550e4860a9f4dff8d64e7c342fd04c54c8ec180b6ed0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake pcl-conversions ];
+  checkInputs = [ ament-cmake-ros ament-lint-auto ament-lint-common pcl-ros ];
+  propagatedBuildInputs = [ can-msgs off-highway-can off-highway-uss-msgs pcl rclcpp rclcpp-components sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The off_highway_uss package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/omni-wheel-drive-controller/default.nix
+++ b/distros/rolling/omni-wheel-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, eigen, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-omni-wheel-drive-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/omni_wheel_drive_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "117403ab178848a583afbbe0095d7fedfeefcbd345890de4249f78da85208c9e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/omni_wheel_drive_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "a021ec2d251e1fcda6d45824e16301d4d8ebe69f0ffbafa59851b53b7b263ba1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/parallel-gripper-controller/default.nix
+++ b/distros/rolling/parallel-gripper-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-parallel-gripper-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/parallel_gripper_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "dee9e836cd8ad97978cd0fffdb9cf359925a9e45c5f2ac28f5adae838e510560";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/parallel_gripper_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "d4f2309b7a126ff49c06e17848a618712f039a5b82f14a835edbd59d37d80304";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pid-controller/default.nix
+++ b/distros/rolling/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-pid-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pid_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "ba4278cb1a43f2514b457de6d1af060dd652d7d0b7a743259e90e924602b8b40";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pid_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "6885dec552855145303810a62e9b0f11b2ef15d67ba637d4b01fac42dd9101cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pose-broadcaster/default.nix
+++ b/distros/rolling/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-pose-broadcaster";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pose_broadcaster/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "17da4dcdac2ff336c44881ede7cc22a555f8ed8cf9236bb5068a76a6aa13bf2a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pose_broadcaster/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "ed05741b797c0dce24d26aca804ecd422774a924286ba1cba98d7110f23acbff";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/position-controllers/default.nix
+++ b/distros/rolling/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-position-controllers";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "bf9f7feac88dbd8930d1834c01d4b77c3af5236a7a39107e8fad818b3b42ce5b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "7f05a82f6b6847a5f77af987a4e54f39e351b0c6260103964159db0a6fba8b09";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/range-sensor-broadcaster/default.nix
+++ b/distros/rolling/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-range-sensor-broadcaster";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "710be05bdfbf86d0981201580ac766bead22d37d19bb7313ddfb5e5b798dc6a7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "38d62208df5dbb19506936765ec998f9cc3c39df2873eafb1d379b53ae44d2e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-controllers-test-nodes/default.nix
+++ b/distros/rolling/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers-test-nodes";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "11995d34ec220566ac670d59516f4b06cdd906977ad8dbf4ef13434a22b2b68f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "c0fcfaf020a0dd033095bce7565893aed44bfe674b9e3c540559f60d1983ee81";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2-controllers/default.nix
+++ b/distros/rolling/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, chained-filter-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gps-sensor-broadcaster, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, motion-primitives-controllers, omni-wheel-drive-controller, parallel-gripper-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "9ec5298980be616f2bfbfc7597f753724fa2d3a2c3fafa113dc15283ee844e4d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "5e5060bb00ac23b688d267d32554432a6aca918846beb579c8b03b4ce0bbb8f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-dotgraph/default.nix
+++ b/distros/rolling/rqt-dotgraph/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, python-qt-binding, python3Packages, qt-dotgraph, qt-gui-py-common, rqt-graph, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-dotgraph";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_dotgraph-release/archive/release/rolling/rqt_dotgraph/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "92fe5f98f00ec6e9ea898b53ec9ac06e93cf05d623baa58df92c457a6068923c";
+    url = "https://github.com/ros2-gbp/rqt_dotgraph-release/archive/release/rolling/rqt_dotgraph/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "f6852aea594652ec4692497b230f752a6996597fe5b530854e66e0a2ee97b5df";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
-  propagatedBuildInputs = [ ament-index-python python-qt-binding python3Packages.pyqt5 python3Packages.pyside2 qt-dotgraph qt-gui-py-common rqt-graph rqt-gui rqt-gui-py std-msgs ];
+  propagatedBuildInputs = [ ament-index-python python-qt-binding python3Packages.pyqt5 qt-dotgraph qt-gui-py-common rqt-graph rqt-gui rqt-gui-py std-msgs ];
 
   meta = {
     description = "rqt GUI plugin to visualize dot graphs.";

--- a/distros/rolling/rqt-joint-trajectory-controller/default.nix
+++ b/distros/rolling/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-joint-trajectory-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "3e1fc253e3dbc8c1af5af651d0af84bfdaa5865e2b2c264433db05a9f6c942f1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "ef8ebd1ad420e937420f58d763dc9c452bece5b28bb2ad5759de55cde880e835";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/steering-controllers-library/default.nix
+++ b/distros/rolling/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-steering-controllers-library";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "8f355c6a4435309e7143215369afb34910b24cef760a464fcd9b11277d37d556";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "f23a870071afe2d395f5f850013121bc80ae443c113b8c887bcf9152f452537f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/stereo-image-proc/default.nix
+++ b/distros/rolling/stereo-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-geometry, image-proc, image-transport, launch, launch-ros, launch-testing, launch-testing-ament-cmake, message-filters, python-cmake-module, python3Packages, rclcpp, rclcpp-components, rclpy, ros-testing, sensor-msgs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-rolling-stereo-image-proc";
-  version = "7.1.1-r1";
+  version = "7.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/stereo_image_proc/7.1.1-1.tar.gz";
-    name = "7.1.1-1.tar.gz";
-    sha256 = "356a16f2059ecf0c7e56613cba5e501d93475ecb46ef1565ae0224cc29f2d87b";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/stereo_image_proc/7.1.2-1.tar.gz";
+    name = "7.1.2-1.tar.gz";
+    sha256 = "0248f2fef0000f6fb034e98b49460967fa022c3438137df9ca05aa5f6b63ae5b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tracetools-image-pipeline/default.nix
+++ b/distros/rolling/tracetools-image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, pkg-config }:
 buildRosPackage {
   pname = "ros-rolling-tracetools-image-pipeline";
-  version = "7.1.1-r1";
+  version = "7.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/tracetools_image_pipeline/7.1.1-1.tar.gz";
-    name = "7.1.1-1.tar.gz";
-    sha256 = "1f43f25a60779a1b6943be10d2e8750e776cdbfb90f5fb7c778bca8643a67084";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/tracetools_image_pipeline/7.1.2-1.tar.gz";
+    name = "7.1.2-1.tar.gz";
+    sha256 = "d5e87ca6c9ecd5fb4e2878df401569e5d595be70f14f84c8f9362dcbacccdf7b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-controller/default.nix
+++ b/distros/rolling/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "c6253897a5f5d5f1b13cd8abc3095884c145e943d94f3cd50ec1b3ff4ce255f3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "17a4ab9c4402f66a0c1df5ce3cb76d6e14deaaf3ca37ccd3de587a6d017b18b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-steering-controller/default.nix
+++ b/distros/rolling/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-steering-controller";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "a6f79159635e655a026a8a558c9710f5da58b1dd8a7e22036b0749e30df6c4dc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "b1a7a0ba8cf61dd8e6b7762e8b6b7c289dc50cf1621a767d3b70a6dfe55a491a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-calibration/default.nix
+++ b/distros/rolling/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ur-calibration";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_calibration/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "bac6a98afffe5dcf86d12860fdf197475faf2937766f704e16b467ecd1f10e1f";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_calibration/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "621a5a62a1971f250922d2da04b3fc8bd3a6fdb986f8cfa422f5c270d88aa117";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-client-library/default.nix
+++ b/distros/rolling/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-rolling-ur-client-library";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/rolling/ur_client_library/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "79a87c2edb07535535b033d4076a4c1c88184d854259a8f06c204a3095ffc844";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/rolling/ur_client_library/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "a883cf0d60b6e72cea862640da6725cfceaf09dad8e3cebc9f766a1dd1de4c17";
   };
 
   buildType = "cmake";

--- a/distros/rolling/ur-controllers/default.nix
+++ b/distros/rolling/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, angles, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, trajectory-msgs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ur-controllers";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_controllers/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "693a2ca17453c98eb1c152421544e31d8e9aeb5e00925e7a56bdf8cbe68aa149";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_controllers/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "52d670c11f80f309d75db289d7f8af83a0e6a2ab636ebc8ab0ff6dd20c883950";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-dashboard-msgs/default.nix
+++ b/distros/rolling/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-ur-dashboard-msgs";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_dashboard_msgs/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "361e531f3bb0f65a8f149bf1179b0bcdd7a6d2377dd7060b1e15c70d85bfc644";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_dashboard_msgs/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "b791724f84e600416e1a5332c7befd91d473ceeb0ba43bffe55d58d8ff289b43";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-description/default.nix
+++ b/distros/rolling/ur-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, joint-state-publisher-gui, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, robot-state-publisher, rviz2, urdf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ur-description";
-  version = "4.0.0-r1";
+  version = "4.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/rolling/ur_description/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "11ac34fdef88bf1ec77949920c81793245cf46e610f0482142d71e11dc8bbf7c";
+    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/rolling/ur_description/4.1.0-1.tar.gz";
+    name = "4.1.0-1.tar.gz";
+    sha256 = "a91cd638cd5ad713747de3ab8adec3598f96462d2710ae306e92ec3de7540fd4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-moveit-config/default.nix
+++ b/distros/rolling/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, ur-description, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ur-moveit-config";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_moveit_config/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "c411e00b52b280f50263d6a9f3e5802fe6e3f67110ec1e5e6f346bcacadcf1b8";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_moveit_config/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "20ff46824e28e956eef2bcf8d16eaa1b5cd42432d7941d417dbceb429d271b73";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-robot-driver/default.nix
+++ b/distros/rolling/ur-robot-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, backward-ros, controller-manager, controller-manager-msgs, force-torque-sensor-broadcaster, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, pluginlib, pose-broadcaster, position-controllers, rclcpp, rclcpp-lifecycle, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, socat, std-msgs, std-srvs, tf2-geometry-msgs, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ur-robot-driver";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_robot_driver/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "281284062b48284c2a5172801d2b7f7de4cd3d6af5754859b454d009ed31d366";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_robot_driver/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "c380b0d7d59cf4e076736b2984e24d383d139a2b34b682bb7c0be653ce0900ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur/default.nix
+++ b/distros/rolling/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-rolling-ur";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "eb35ec211cb04c0ff8750563c130de75915b2cf17464f99d602d7da30094ba61";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "004ab5a2c173596b58cab4dab0a3fe5149dbd23b6c1919d7f33ec974705bef92";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/velocity-controllers/default.nix
+++ b/distros/rolling/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-velocity-controllers";
-  version = "5.6.1-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/5.6.1-1.tar.gz";
-    name = "5.6.1-1.tar.gz";
-    sha256 = "c80dc7929987eea7ce66e1c4bdf8956fb3bad9a5a8b1ea5e0f4bccc3014cc4f6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "01ffe96fccb9801d730d166cd96dc26f351baccd7d2f32dd29e843db29d25b60";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'kilted', 'rolling'] from nix-ros-overlay commit 9d0557032aadb65df065b1972a632572b57234b5.
This pull request was generated by running the following command:

```
superflore-gen-nix --dry-run --output-repository-path . --all --tar-archive-dir /home/runner/.ros/tar --upstream-branch develop
```

Changes:
========
Humble Changes:
---------------
* *ackermann-steering-controller 2.49.1-r1 --> 2.50.0-r1*
* *adi-imu 1.0.0-r1*
* *admittance-controller 2.49.1-r1 --> 2.50.0-r1*
* *bicycle-steering-controller 2.49.1-r1 --> 2.50.0-r1*
* *controller-interface 2.51.0-r1 --> 2.52.0-r1*
* *controller-manager 2.51.0-r1 --> 2.52.0-r1*
* *controller-manager-msgs 2.51.0-r1 --> 2.52.0-r1*
* *diff-drive-controller 2.49.1-r1 --> 2.50.0-r1*
* *effort-controllers 2.49.1-r1 --> 2.50.0-r1*
* *force-torque-sensor-broadcaster 2.49.1-r1 --> 2.50.0-r1*
* *forward-command-controller 2.49.1-r1 --> 2.50.0-r1*
* *franka-inria-inverse-dynamics-solver 1.0.1-r1 --> 1.0.2-r1*
* *gpio-controllers 2.49.1-r1 --> 2.50.0-r1*
* *gripper-controllers 2.49.1-r1 --> 2.50.0-r1*
* *hardware-interface 2.51.0-r1 --> 2.52.0-r1*
* *hardware-interface-testing 2.51.0-r1 --> 2.52.0-r1*
* *imu-sensor-broadcaster 2.49.1-r1 --> 2.50.0-r1*
* *inverse-dynamics-solver 1.0.1-r1 --> 1.0.2-r1*
* *joint-limits 2.51.0-r1 --> 2.52.0-r1*
* *joint-state-broadcaster 2.49.1-r1 --> 2.50.0-r1*
* *joint-trajectory-controller 2.49.1-r1 --> 2.50.0-r1*
* *kdl-inverse-dynamics-solver 1.0.1-r1 --> 1.0.2-r1*
* *launch-ros 0.19.10-r1 --> 0.19.12-r1*
* *launch-testing-ros 0.19.10-r1 --> 0.19.12-r1*
* *leo-bringup 1.5.0-r1 --> 1.6.0-r1*
* *leo-filters 1.6.0-r1*
* *leo-fw 1.5.0-r1 --> 1.6.0-r1*
* *leo-robot 1.5.0-r1 --> 1.6.0-r1*
* *libmavconn 2.11.0-r1 --> 2.12.0-r1*
* *mavros 2.11.0-r1 --> 2.12.0-r1*
* *mavros-extras 2.11.0-r1 --> 2.12.0-r1*
* *mavros-msgs 2.11.0-r1 --> 2.12.0-r1*
* *mecanum-drive-controller 2.49.1-r1 --> 2.50.0-r1*
* *pid-controller 2.49.1-r1 --> 2.50.0-r1*
* *pose-broadcaster 2.49.1-r1 --> 2.50.0-r1*
* *position-controllers 2.49.1-r1 --> 2.50.0-r1*
* *range-sensor-broadcaster 2.49.1-r1 --> 2.50.0-r1*
* *ros2-control 2.51.0-r1 --> 2.52.0-r1*
* *ros2-control-test-assets 2.51.0-r1 --> 2.52.0-r1*
* *ros2-controllers 2.49.1-r1 --> 2.50.0-r1*
* *ros2-controllers-test-nodes 2.49.1-r1 --> 2.50.0-r1*
* *ros2controlcli 2.51.0-r1 --> 2.52.0-r1*
* *ros2launch 0.19.10-r1 --> 0.19.12-r1*
* *rqt-controller-manager 2.51.0-r1 --> 2.52.0-r1*
* *rqt-dotgraph 0.0.4-r1 --> 0.0.5-r1*
* *rqt-joint-trajectory-controller 2.49.1-r1 --> 2.50.0-r1*
* *steering-controllers-library 2.49.1-r1 --> 2.50.0-r1*
* *transmission-interface 2.51.0-r1 --> 2.52.0-r1*
* *tricycle-controller 2.49.1-r1 --> 2.50.0-r1*
* *tricycle-steering-controller 2.49.1-r1 --> 2.50.0-r1*
* *ur-client-library 2.2.0-r1 --> 2.3.0-r1*
* *ur-description 2.6.0-r1 --> 2.7.0-r1*
* *ur10-inverse-dynamics-solver 1.0.1-r1 --> 1.0.2-r1*
* *velocity-controllers 2.49.1-r1 --> 2.50.0-r1*

Jazzy Changes:
--------------
* *ackermann-nlmpc 1.0.2-r1*
* *ackermann-nlmpc-msgs 1.0.2-r1*
* *ackermann-steering-controller 4.31.0-r1 --> 4.32.0-r1*
* *admittance-controller 4.31.0-r1 --> 4.32.0-r1*
* *bicycle-steering-controller 4.31.0-r1 --> 4.32.0-r1*
* *chained-filter-controller 4.31.0-r1 --> 4.32.0-r1*
* *clearpath-bt-joy 2.7.2-r1 --> 2.7.3-r1*
* *clearpath-common 2.7.2-r1 --> 2.7.3-r1*
* *clearpath-config 2.7.1-r1 --> 2.7.2-r1*
* *clearpath-control 2.7.2-r1 --> 2.7.3-r1*
* *clearpath-customization 2.7.2-r1 --> 2.7.3-r1*
* *clearpath-description 2.7.2-r1 --> 2.7.3-r1*
* *clearpath-diagnostics 2.7.2-r1 --> 2.7.3-r1*
* *clearpath-generator-common 2.7.2-r1 --> 2.7.3-r1*
* *clearpath-manipulators 2.7.2-r1 --> 2.7.3-r1*
* *clearpath-manipulators-description 2.7.2-r1 --> 2.7.3-r1*
* *clearpath-mounts-description 2.7.2-r1 --> 2.7.3-r1*
* *clearpath-platform-description 2.7.2-r1 --> 2.7.3-r1*
* *clearpath-sensors-description 2.7.2-r1 --> 2.7.3-r1*
* *controller-interface 4.36.0-r1 --> 4.37.0-r1*
* *controller-manager 4.36.0-r1 --> 4.37.0-r1*
* *controller-manager-msgs 4.36.0-r1 --> 4.37.0-r1*
* *diff-drive-controller 4.31.0-r1 --> 4.32.0-r1*
* *effort-controllers 4.31.0-r1 --> 4.32.0-r1*
* *force-torque-sensor-broadcaster 4.31.0-r1 --> 4.32.0-r1*
* *forward-command-controller 4.31.0-r1 --> 4.32.0-r1*
* *franka-inria-inverse-dynamics-solver 2.0.0-r1*
* *gpio-controllers 4.31.0-r1 --> 4.32.0-r1*
* *gps-sensor-broadcaster 4.31.0-r1 --> 4.32.0-r1*
* *gripper-controllers 4.31.0-r1 --> 4.32.0-r1*
* *hardware-interface 4.36.0-r1 --> 4.37.0-r1*
* *hardware-interface-testing 4.36.0-r1 --> 4.37.0-r1*
* *imu-sensor-broadcaster 4.31.0-r1 --> 4.32.0-r1*
* *inverse-dynamics-solver 2.0.0-r1*
* *joint-limits 4.36.0-r1 --> 4.37.0-r1*
* *joint-state-broadcaster 4.31.0-r1 --> 4.32.0-r1*
* *joint-trajectory-controller 4.31.0-r1 --> 4.32.0-r1*
* *kdl-inverse-dynamics-solver 2.0.0-r1*
* *launch-ros 0.26.8-r1 --> 0.26.9-r1*
* *launch-testing-ros 0.26.8-r1 --> 0.26.9-r1*
* *libmavconn 2.11.0-r1 --> 2.12.0-r1*
* *mavros 2.11.0-r1 --> 2.12.0-r1*
* *mavros-extras 2.11.0-r1 --> 2.12.0-r1*
* *mavros-msgs 2.11.0-r1 --> 2.12.0-r1*
* *mecanum-drive-controller 4.31.0-r1 --> 4.32.0-r1*
* *omni-wheel-drive-controller 4.31.0-r1 --> 4.32.0-r1*
* *parallel-gripper-controller 4.31.0-r1 --> 4.32.0-r1*
* *pid-controller 4.31.0-r1 --> 4.32.0-r1*
* *pose-broadcaster 4.31.0-r1 --> 4.32.0-r1*
* *position-controllers 4.31.0-r1 --> 4.32.0-r1*
* *range-sensor-broadcaster 4.31.0-r1 --> 4.32.0-r1*
* *ros2-control 4.36.0-r1 --> 4.37.0-r1*
* *ros2-control-test-assets 4.36.0-r1 --> 4.37.0-r1*
* *ros2-controllers 4.31.0-r1 --> 4.32.0-r1*
* *ros2-controllers-test-nodes 4.31.0-r1 --> 4.32.0-r1*
* *ros2controlcli 4.36.0-r1 --> 4.37.0-r1*
* *ros2launch 0.26.8-r1 --> 0.26.9-r1*
* *rqt-controller-manager 4.36.0-r1 --> 4.37.0-r1*
* *rqt-dotgraph 0.0.4-r1 --> 0.0.5-r1*
* *rqt-joint-trajectory-controller 4.31.0-r1 --> 4.32.0-r1*
* *simulation-interfaces 1.0.0-r1 --> 1.2.0-r1*
* *steering-controllers-library 4.31.0-r1 --> 4.32.0-r1*
* *transmission-interface 4.36.0-r1 --> 4.37.0-r1*
* *tricycle-controller 4.31.0-r1 --> 4.32.0-r1*
* *tricycle-steering-controller 4.31.0-r1 --> 4.32.0-r1*
* *ur 3.3.3-r1 --> 3.4.0-r1*
* *ur-calibration 3.3.3-r1 --> 3.4.0-r1*
* *ur-client-library 2.2.0-r1 --> 2.3.0-r1*
* *ur-controllers 3.3.3-r1 --> 3.4.0-r1*
* *ur-dashboard-msgs 3.3.3-r1 --> 3.4.0-r1*
* *ur-description 3.2.0-r1 --> 3.3.0-r1*
* *ur-moveit-config 3.3.3-r1 --> 3.4.0-r1*
* *ur-robot-driver 3.3.3-r1 --> 3.4.0-r1*
* *ur10-inverse-dynamics-solver 2.0.0-r1*
* *velocity-controllers 4.31.0-r1 --> 4.32.0-r1*

Kilted Changes:
---------------
* *ackermann-nlmpc 1.0.2-r1*
* *ackermann-nlmpc-msgs 1.0.2-r1*
* *ackermann-steering-controller 5.6.1-r1 --> 5.7.0-r1*
* *admittance-controller 5.6.1-r1 --> 5.7.0-r1*
* *bicycle-steering-controller 5.6.1-r1 --> 5.7.0-r1*
* *chained-filter-controller 5.6.1-r1 --> 5.7.0-r1*
* *diff-drive-controller 5.6.1-r1 --> 5.7.0-r1*
* *effort-controllers 5.6.1-r1 --> 5.7.0-r1*
* *force-torque-sensor-broadcaster 5.6.1-r1 --> 5.7.0-r1*
* *forward-command-controller 5.6.1-r1 --> 5.7.0-r1*
* *gpio-controllers 5.6.1-r1 --> 5.7.0-r1*
* *gps-sensor-broadcaster 5.6.1-r1 --> 5.7.0-r1*
* *grid-map 2.4.0-r1*
* *grid-map-cmake-helpers 2.4.0-r1*
* *grid-map-core 2.4.0-r1*
* *grid-map-costmap-2d 2.4.0-r1*
* *grid-map-cv 2.4.0-r1*
* *grid-map-demos 2.4.0-r1*
* *grid-map-filters 2.4.0-r1*
* *grid-map-loader 2.4.0-r1*
* *grid-map-msgs 2.4.0-r1*
* *grid-map-octomap 2.4.0-r1*
* *grid-map-pcl 2.4.0-r1*
* *grid-map-ros 2.4.0-r1*
* *grid-map-rviz-plugin 2.4.0-r1*
* *grid-map-sdf 2.4.0-r1*
* *grid-map-visualization 2.4.0-r1*
* *imu-sensor-broadcaster 5.6.1-r1 --> 5.7.0-r1*
* *joint-state-broadcaster 5.6.1-r1 --> 5.7.0-r1*
* *joint-trajectory-controller 5.6.1-r1 --> 5.7.0-r1*
* *launch-ros 0.28.2-r1 --> 0.28.3-r1*
* *launch-testing-ros 0.28.2-r1 --> 0.28.3-r1*
* *libmavconn 2.11.0-r1 --> 2.12.0-r1*
* *mavros 2.11.0-r1 --> 2.12.0-r1*
* *mavros-extras 2.11.0-r1 --> 2.12.0-r1*
* *mavros-msgs 2.11.0-r1 --> 2.12.0-r1*
* *mecanum-drive-controller 5.6.1-r1 --> 5.7.0-r1*
* *motion-primitives-controllers 5.6.1-r1 --> 5.7.0-r1*
* *neo-nav2-bringup 1.0.4-r1*
* *omni-wheel-drive-controller 5.6.1-r1 --> 5.7.0-r1*
* *parallel-gripper-controller 5.6.1-r1 --> 5.7.0-r1*
* *pid-controller 5.6.1-r1 --> 5.7.0-r1*
* *pose-broadcaster 5.6.1-r1 --> 5.7.0-r1*
* *position-controllers 5.6.1-r1 --> 5.7.0-r1*
* *range-sensor-broadcaster 5.6.1-r1 --> 5.7.0-r1*
* *ros2-controllers 5.6.1-r1 --> 5.7.0-r1*
* *ros2-controllers-test-nodes 5.6.1-r1 --> 5.7.0-r1*
* *ros2launch 0.28.2-r1 --> 0.28.3-r1*
* *rqt-dotgraph 0.0.4-r2 --> 0.0.5-r1*
* *rqt-joint-trajectory-controller 5.6.1-r1 --> 5.7.0-r1*
* *simulation-interfaces 1.0.0-r1 --> 1.3.0-r1*
* *steering-controllers-library 5.6.1-r1 --> 5.7.0-r1*
* *tricycle-controller 5.6.1-r1 --> 5.7.0-r1*
* *tricycle-steering-controller 5.6.1-r1 --> 5.7.0-r1*
* *ur 4.1.0-r1 --> 4.2.0-r1*
* *ur-calibration 4.1.0-r1 --> 4.2.0-r1*
* *ur-client-library 2.2.0-r1 --> 2.3.0-r1*
* *ur-controllers 4.1.0-r1 --> 4.2.0-r1*
* *ur-dashboard-msgs 4.1.0-r1 --> 4.2.0-r1*
* *ur-description 4.0.0-r1 --> 4.1.0-r1*
* *ur-moveit-config 4.1.0-r1 --> 4.2.0-r1*
* *ur-robot-driver 4.1.0-r1 --> 4.2.0-r1*
* *velocity-controllers 5.6.1-r1 --> 5.7.0-r1*

Rolling Changes:
----------------
* *ackermann-nlmpc 1.0.2-r2*
* *ackermann-nlmpc-msgs 1.0.2-r2*
* *ackermann-steering-controller 5.6.1-r1 --> 5.7.0-r1*
* *admittance-controller 5.6.1-r1 --> 5.7.0-r1*
* *bicycle-steering-controller 5.6.1-r1 --> 5.7.0-r1*
* *camera-calibration 7.1.1-r1 --> 7.1.2-r1*
* *chained-filter-controller 5.6.1-r1 --> 5.7.0-r1*
* *depth-image-proc 7.1.1-r1 --> 7.1.2-r1*
* *diff-drive-controller 5.6.1-r1 --> 5.7.0-r1*
* *effort-controllers 5.6.1-r1 --> 5.7.0-r1*
* *force-torque-sensor-broadcaster 5.6.1-r1 --> 5.7.0-r1*
* *forward-command-controller 5.6.1-r1 --> 5.7.0-r1*
* *gpio-controllers 5.6.1-r1 --> 5.7.0-r1*
* *gps-sensor-broadcaster 5.6.1-r1 --> 5.7.0-r1*
* *image-pipeline 7.1.1-r1 --> 7.1.2-r1*
* *image-proc 7.1.1-r1 --> 7.1.2-r1*
* *image-publisher 7.1.1-r1 --> 7.1.2-r1*
* *image-rotate 7.1.1-r1 --> 7.1.2-r1*
* *image-view 7.1.1-r1 --> 7.1.2-r1*
* *imu-sensor-broadcaster 5.6.1-r1 --> 5.7.0-r1*
* *joint-state-broadcaster 5.6.1-r1 --> 5.7.0-r1*
* *joint-trajectory-controller 5.6.1-r1 --> 5.7.0-r1*
* *libmavconn 2.11.0-r1 --> 2.12.0-r1*
* *mavros 2.11.0-r1 --> 2.12.0-r1*
* *mavros-extras 2.11.0-r1 --> 2.12.0-r1*
* *mavros-msgs 2.11.0-r1 --> 2.12.0-r1*
* *mecanum-drive-controller 5.6.1-r1 --> 5.7.0-r1*
* *motion-primitives-controllers 5.6.1-r1 --> 5.7.0-r1*
* *off-highway-can 1.0.0-r1*
* *off-highway-general-purpose-radar 1.0.0-r1*
* *off-highway-general-purpose-radar-msgs 1.0.0-r1*
* *off-highway-premium-radar 1.0.0-r1*
* *off-highway-premium-radar-msgs 1.0.0-r1*
* *off-highway-premium-radar-sample 1.0.0-r1*
* *off-highway-premium-radar-sample-msgs 1.0.0-r1*
* *off-highway-radar 1.0.0-r1*
* *off-highway-radar-msgs 1.0.0-r1*
* *off-highway-sensor-drivers 1.0.0-r1*
* *off-highway-sensor-drivers-examples 1.0.0-r1*
* *off-highway-uss 1.0.0-r1*
* *off-highway-uss-msgs 1.0.0-r1*
* *omni-wheel-drive-controller 5.6.1-r1 --> 5.7.0-r1*
* *parallel-gripper-controller 5.6.1-r1 --> 5.7.0-r1*
* *pid-controller 5.6.1-r1 --> 5.7.0-r1*
* *pose-broadcaster 5.6.1-r1 --> 5.7.0-r1*
* *position-controllers 5.6.1-r1 --> 5.7.0-r1*
* *range-sensor-broadcaster 5.6.1-r1 --> 5.7.0-r1*
* *ros2-controllers 5.6.1-r1 --> 5.7.0-r1*
* *ros2-controllers-test-nodes 5.6.1-r1 --> 5.7.0-r1*
* *rqt-dotgraph 0.0.4-r1 --> 0.0.5-r1*
* *rqt-joint-trajectory-controller 5.6.1-r1 --> 5.7.0-r1*
* *steering-controllers-library 5.6.1-r1 --> 5.7.0-r1*
* *stereo-image-proc 7.1.1-r1 --> 7.1.2-r1*
* *tracetools-image-pipeline 7.1.1-r1 --> 7.1.2-r1*
* *tricycle-controller 5.6.1-r1 --> 5.7.0-r1*
* *tricycle-steering-controller 5.6.1-r1 --> 5.7.0-r1*
* *ur 4.1.0-r1 --> 4.2.0-r1*
* *ur-calibration 4.1.0-r1 --> 4.2.0-r1*
* *ur-client-library 2.2.0-r1 --> 2.3.0-r1*
* *ur-controllers 4.1.0-r1 --> 4.2.0-r1*
* *ur-dashboard-msgs 4.1.0-r1 --> 4.2.0-r1*
* *ur-description 4.0.0-r1 --> 4.1.0-r1*
* *ur-moveit-config 4.1.0-r1 --> 4.2.0-r1*
* *ur-robot-driver 4.1.0-r1 --> 4.2.0-r1*
* *velocity-controllers 5.6.1-r1 --> 5.7.0-r1*


Missing Dependencies:
=====================
 * [ ] action_tutorials_interfaces
 * [ ] actionlib_msgs
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gripper_controllers
 * [ ] gurumdds-3.0
 * [ ] gurumdds-3.2
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] libcurl_vendor
 * [ ] libopen3d-dev
 * [ ] libqt6svg6
 * [ ] libserial-dev
 * [ ] nanobind-dev
 * [ ] pybind11-json-dev
 * [ ] pybind11_json_vendor
 * [ ] python-is-python3
 * [ ] python3-jsonpickle
 * [ ] python3-pymap3d
 * [ ] python3-pytorch-pip
 * [ ] python3-torch-geometric-pip
 * [ ] python3-typer
 * [ ] python3-types-pyyaml
 * [ ] qml6-module-qt-labs-folderlistmodel
 * [ ] qml6-module-qt-labs-platform
 * [ ] qml6-module-qt-labs-settings
 * [ ] qml6-module-qt5compat-graphicaleffects
 * [ ] qml6-module-qtcharts
 * [ ] qml6-module-qtcore
 * [ ] qml6-module-qtpositioning
 * [ ] qml6-module-qtqml
 * [ ] qml6-module-qtqml-models
 * [ ] qml6-module-qtqml-workerscript
 * [ ] qml6-module-qtquick-controls
 * [ ] qml6-module-qtquick-dialogs
 * [ ] qml6-module-qtquick-layouts
 * [ ] qml6-module-qtquick-templates
 * [ ] qml6-module-qtquick-window
 * [ ] qt6-5compat-dev
 * [ ] qt6-base-private-dev
 * [ ] qt6-declarative-private-dev
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo