### PR TITLE
zenoh-cpp-vendor: Prepare for cross-compilation

### DIFF
--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -289,12 +289,13 @@ in {
   });
 
   zenoh-cpp-vendor = (lib.patchAmentVendorGit rosSuper.zenoh-cpp-vendor {}).overrideAttrs(finalAttrs: {
-    nativeBuildInputs ? [], postPatch ? "", passthru ? {}, ...
+    nativeBuildInputs ? [], postPatch ? "", passthru ? {}, cmakeFlags ? "", ...
   }: let
     outputHashes = {
       "zenoh-1.5.1" = "sha256-EeigSU9l7LCnSkm4/jP0WcdO3Hw9m91zUh8jzVXYhKw=";
     };
     zenoh-c-source = finalAttrs.passthru.amentVendorSrcs.zenoh_c_vendor;
+    inherit (self.stdenv) buildPlatform hostPlatform;
   in {
     postPatch = postPatch + ''
       ln -s ${zenoh-c-source}/Cargo.lock Cargo.lock
@@ -307,7 +308,9 @@ in {
       lockFile = "${zenoh-c-source}/Cargo.lock";
       inherit outputHashes;
     };
-
+    cmakeFlags = cmakeFlags ++
+      lib.optionals (buildPlatform != hostPlatform)
+        [ "-DZENOHC_CUSTOM_TARGET=${hostPlatform.config}" ];
     # Patch the build.rs script to be able to build internal
     # opaque-types crate without network access.
     passthru = lib.recursiveUpdate passthru {

--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -248,12 +248,13 @@ in {
   });
 
   zenoh-cpp-vendor = (lib.patchAmentVendorGit rosSuper.zenoh-cpp-vendor {}).overrideAttrs(finalAttrs: {
-    nativeBuildInputs ? [], postPatch ? "", passthru ? {}, ...
+    nativeBuildInputs ? [], postPatch ? "", passthru ? {}, cmakeFlags ? "", ...
   }: let
     outputHashes = {
       "zenoh-1.5.1" = "sha256-EeigSU9l7LCnSkm4/jP0WcdO3Hw9m91zUh8jzVXYhKw=";
     };
     zenoh-c-source = finalAttrs.passthru.amentVendorSrcs.zenoh_c_vendor;
+    inherit (self.stdenv) buildPlatform hostPlatform;
   in {
     postPatch = postPatch + ''
       ln -s ${zenoh-c-source}/Cargo.lock Cargo.lock
@@ -266,7 +267,9 @@ in {
       lockFile = "${zenoh-c-source}/Cargo.lock";
       inherit outputHashes;
     };
-
+    cmakeFlags = cmakeFlags ++
+      lib.optionals (buildPlatform != hostPlatform)
+        [ "-DZENOHC_CUSTOM_TARGET=${hostPlatform.config}" ];
     # Patch the build.rs script to be able to build internal
     # opaque-types crate without network access.
     passthru = lib.recursiveUpdate passthru {

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -249,12 +249,13 @@ in {
   });
 
   zenoh-cpp-vendor = (lib.patchAmentVendorGit rosSuper.zenoh-cpp-vendor {}).overrideAttrs(finalAttrs: {
-    nativeBuildInputs ? [], postPatch ? "", passthru ? {}, ...
+    nativeBuildInputs ? [], postPatch ? "", passthru ? {}, cmakeFlags ? "", ...
   }: let
     outputHashes = {
       "zenoh-1.5.1" = "sha256-EeigSU9l7LCnSkm4/jP0WcdO3Hw9m91zUh8jzVXYhKw=";
     };
     zenoh-c-source = finalAttrs.passthru.amentVendorSrcs.zenoh_c_vendor;
+    inherit (self.stdenv) buildPlatform hostPlatform;
   in {
     postPatch = postPatch + ''
       ln -s ${zenoh-c-source}/Cargo.lock Cargo.lock
@@ -267,7 +268,9 @@ in {
       lockFile = "${zenoh-c-source}/Cargo.lock";
       inherit outputHashes;
     };
-
+    cmakeFlags = cmakeFlags ++
+      lib.optionals (buildPlatform != hostPlatform)
+        [ "-DZENOHC_CUSTOM_TARGET=${hostPlatform.config}" ];
     # Patch the build.rs script to be able to build internal
     # opaque-types crate without network access.
     passthru = lib.recursiveUpdate passthru {


### PR DESCRIPTION
Without this change, it is not possible to cross-compile zenoh-cpp-vendor. However, as of now, cross-compiling doesn't work even with this commit, because our nixpkgs version is too old and does not include https://github.com/NixOS/nixpkgs/commit/112d13c5c7c83593972e786cfa9f6fcef06bdfd9c. So this change is just to be ready for cross-compilation support it after we move to nixpkgs which includes the mentioned commit.

@kjeremy Are you able to test this? I was not able to find a nixpkgs commit, which includes the mentioned fix and doesn't cause breakage in cross-compilation of other needed packages.