### PR TITLE
rosdistro sync, Fri Sep 26 14:00:53 2025

### DIFF
--- a/distros/humble/action-tutorials-cpp/default.nix
+++ b/distros/humble/action-tutorials-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-action, rclcpp-components }:
 buildRosPackage {
   pname = "ros-humble-action-tutorials-cpp";
-  version = "0.20.5-r1";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/action_tutorials_cpp/0.20.5-1.tar.gz";
-    name = "0.20.5-1.tar.gz";
-    sha256 = "5b0e6640ad5ea37a4f24e58cab50945abcda6abd41e6cf5e1459bee7a7b46d76";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/action_tutorials_cpp/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "39bdde3fa495a799d174954f8755be61a84d7fb873189f2dfba7cecc0b003176";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/action-tutorials-interfaces/default.nix
+++ b/distros/humble/action-tutorials-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-action-tutorials-interfaces";
-  version = "0.20.5-r1";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/action_tutorials_interfaces/0.20.5-1.tar.gz";
-    name = "0.20.5-1.tar.gz";
-    sha256 = "d0206e68051e4b9ad215a8dc95242b9303f9a91ace9f57f974ebb59bb568b96d";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/action_tutorials_interfaces/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "abd046b407394180c0962432f5b2a6037383907c4cd9b795f174d1a916463fdb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/action-tutorials-py/default.nix
+++ b/distros/humble/action-tutorials-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-lint-auto, ament-lint-common, rclpy }:
 buildRosPackage {
   pname = "ros-humble-action-tutorials-py";
-  version = "0.20.5-r1";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/action_tutorials_py/0.20.5-1.tar.gz";
-    name = "0.20.5-1.tar.gz";
-    sha256 = "7a2dd8a9899f9a8760a64c8f30ccec84c0bd1b1d0cb2fd37205414f8901b48d8";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/action_tutorials_py/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "c3e2b99873ba9da867eef8da377a0fbe3937c8fcebd3d183d875d28431c31d19";
   };
 
   buildType = "ament_python";

--- a/distros/humble/bcr-arm-description/default.nix
+++ b/distros/humble/bcr-arm-description/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, urdf-tutorial }:
+buildRosPackage {
+  pname = "ros-humble-bcr-arm-description";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bcr_arm-release/archive/release/humble/bcr_arm_description/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "d371b9af5d886fc7ee576c7cf7bf79e7c1e6a6a0c5ac60bd6bbd0be7b88dbcd8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ urdf-tutorial ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "robot description files including urdf, meshes and launch files for the bcr arm";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/bcr-arm-moveit-config/default.nix
+++ b/distros/humble/bcr-arm-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, bcr-arm-description, controller-manager, joint-state-publisher, joint-state-publisher-gui, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, tf2-ros, topic-based-ros2-control, xacro }:
+buildRosPackage {
+  pname = "ros-humble-bcr-arm-moveit-config";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bcr_arm-release/archive/release/humble/bcr_arm_moveit_config/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "7aa0a3c78221673312bf67d1abea740edeaf9b81f1f731f9e98f4ba200ee2d17";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ bcr-arm-description controller-manager joint-state-publisher joint-state-publisher-gui moveit-configs-utils moveit-kinematics moveit-planners moveit-ros-move-group moveit-ros-visualization moveit-setup-assistant moveit-simple-controller-manager robot-state-publisher rviz-common rviz-default-plugins rviz2 tf2-ros topic-based-ros2-control xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "moveit configuration and launch files for motion planning with the bcr arm";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/bcr-arm-ros2/default.nix
+++ b/distros/humble/bcr-arm-ros2/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, bcr-arm-description, bcr-arm-gazebo, bcr-arm-moveit-config }:
+buildRosPackage {
+  pname = "ros-humble-bcr-arm-ros2";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bcr_arm-release/archive/release/humble/bcr_arm_ros2/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "ef616642fe29afe9b5b0d26e035cb7319c202f1edba92e002bea4bdec3b4e508";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ bcr-arm-description bcr-arm-gazebo bcr-arm-moveit-config ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "TODO: Package description (metapackage)";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/bcr-arm/default.nix
+++ b/distros/humble/bcr-arm/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bcr-arm-description, bcr-arm-gazebo, bcr-arm-moveit-config }:
+buildRosPackage {
+  pname = "ros-humble-bcr-arm";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bcr_arm-release/archive/release/humble/bcr_arm/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "34e5488b673fe448771254585b5a606d3c81ca6c6b8031b7945dc5d988977b9f";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ bcr-arm-description bcr-arm-gazebo bcr-arm-moveit-config ];
+
+  meta = {
+    description = "Metapackage for the BCR Arm robot stack";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/clearpath-common/default.nix
+++ b/distros/humble/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common }:
 buildRosPackage {
   pname = "ros-humble-clearpath-common";
-  version = "1.3.6-r1";
+  version = "1.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/1.3.6-1.tar.gz";
-    name = "1.3.6-1.tar.gz";
-    sha256 = "0004f5b21821c0ffbbd857af06552793a3005bd025d6d2d1a3ba870109804845";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/1.3.7-1.tar.gz";
+    name = "1.3.7-1.tar.gz";
+    sha256 = "59434755eea3defdfbadc18f1d325843778e19ff437de64b236ce19476ec27d0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-config/default.nix
+++ b/distros/humble/clearpath-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-clearpath-config";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "b4ecc5f1fbffa5301fc5b886b6bc652292f60154e825263bd752e26fe71cf9a1";
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "86fe97cdb02f454df5c35cb3a05bf5e5d30c008aa4ee5589a3c5b8a99faff020";
   };
 
   buildType = "ament_python";

--- a/distros/humble/clearpath-control/default.nix
+++ b/distros/humble/clearpath-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-mecanum-drive-controller, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-humble-clearpath-control";
-  version = "1.3.6-r1";
+  version = "1.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/1.3.6-1.tar.gz";
-    name = "1.3.6-1.tar.gz";
-    sha256 = "99fe788b82b513333b59b7fc8a2e7fea7629ea933a3715fc6a7c6c5357aef9b2";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/1.3.7-1.tar.gz";
+    name = "1.3.7-1.tar.gz";
+    sha256 = "02b49ab0a237068aa724442bf23660f389a0334348d5f0c30a671a5307886fe2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-customization/default.nix
+++ b/distros/humble/clearpath-customization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-clearpath-customization";
-  version = "1.3.6-r1";
+  version = "1.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_customization/1.3.6-1.tar.gz";
-    name = "1.3.6-1.tar.gz";
-    sha256 = "10324da35f843e9f2a049817c70d267e79ee00dc1db962f129e2e917d1fa8720";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_customization/1.3.7-1.tar.gz";
+    name = "1.3.7-1.tar.gz";
+    sha256 = "e41eda1d536ed08b1262b2e2b5acab001f1ec419d61ea393dabdffa77892af52";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-description/default.nix
+++ b/distros/humble/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-description";
-  version = "1.3.6-r1";
+  version = "1.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/1.3.6-1.tar.gz";
-    name = "1.3.6-1.tar.gz";
-    sha256 = "ce8f51f967b76968d002a36772487ab9f7570ee28dcd63e47d737eb6187d407d";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/1.3.7-1.tar.gz";
+    name = "1.3.7-1.tar.gz";
+    sha256 = "98a3299afb40c6f7ba83bb2fd3618e4452630d9c486dbef0afb238520ee155ce";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-generator-common/default.nix
+++ b/distros/humble/clearpath-generator-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-manipulators, moveit-setup-srdf-plugins }:
 buildRosPackage {
   pname = "ros-humble-clearpath-generator-common";
-  version = "1.3.6-r1";
+  version = "1.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/1.3.6-1.tar.gz";
-    name = "1.3.6-1.tar.gz";
-    sha256 = "0e97e713e5d7a8d4f7c78a097d89fe0c7d89b105377a5cf2625621c8a3c45fe9";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/1.3.7-1.tar.gz";
+    name = "1.3.7-1.tar.gz";
+    sha256 = "897b6c252ee1306e5c22594a26f6c386df5c3274761e94c7c9e25e7b4bf247fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-manipulators-description/default.nix
+++ b/distros/humble/clearpath-manipulators-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ewellix-description, franka-description, kortex-description, robot-state-publisher, robotiq-description, ur-description, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-manipulators-description";
-  version = "1.3.6-r1";
+  version = "1.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators_description/1.3.6-1.tar.gz";
-    name = "1.3.6-1.tar.gz";
-    sha256 = "6635265bc0417f03389ce5ab880c637eac8a283cf356dd4d863f6adffdb03e0a";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators_description/1.3.7-1.tar.gz";
+    name = "1.3.7-1.tar.gz";
+    sha256 = "080196d094ea56e744823596c837af4a338ff48b6fb8902ebfdfe0a58d81e3cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-manipulators/default.nix
+++ b/distros/humble/clearpath-manipulators/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, gripper-controllers, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-warehouse, moveit-simple-controller-manager, position-controllers, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-manipulators";
-  version = "1.3.6-r1";
+  version = "1.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators/1.3.6-1.tar.gz";
-    name = "1.3.6-1.tar.gz";
-    sha256 = "2d17373669b00596fd7848f47751742f7cb077d50c06ff2b7d2d02593a80b688";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators/1.3.7-1.tar.gz";
+    name = "1.3.7-1.tar.gz";
+    sha256 = "35bb4f5cbed449c2c5fa9983dfe26ff3434fb7bf7aeadadbbbf7966af719841f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-mounts-description/default.nix
+++ b/distros/humble/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-clearpath-mounts-description";
-  version = "1.3.6-r1";
+  version = "1.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/1.3.6-1.tar.gz";
-    name = "1.3.6-1.tar.gz";
-    sha256 = "0c8d8a7f5409093911fb49531608ea79d755ec7152059b3902fe4390d76716c8";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/1.3.7-1.tar.gz";
+    name = "1.3.7-1.tar.gz";
+    sha256 = "004ee7f7413b8aaa5dc9457db009ac2996003feff30e91bd3c09bfadd1903a72";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform-description/default.nix
+++ b/distros/humble/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform-description";
-  version = "1.3.6-r1";
+  version = "1.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/1.3.6-1.tar.gz";
-    name = "1.3.6-1.tar.gz";
-    sha256 = "b5852d0ffe9c2417a3619e5913ce80592e638782c54857573dd5e7405734cba7";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/1.3.7-1.tar.gz";
+    name = "1.3.7-1.tar.gz";
+    sha256 = "2d2b444c211ec39298ea8babe3055c0e2fa864f1655adaa5220ee6325ae89fca";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-sensors-description/default.nix
+++ b/distros/humble/clearpath-sensors-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-description, realsense2-description, velodyne-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-sensors-description";
-  version = "1.3.6-r1";
+  version = "1.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/1.3.6-1.tar.gz";
-    name = "1.3.6-1.tar.gz";
-    sha256 = "b8f8cc26fba6e1241ad9f1699ba471e45a3c7438a0c74fc56f5efcaa5bdd0793";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/1.3.7-1.tar.gz";
+    name = "1.3.7-1.tar.gz";
+    sha256 = "161dc47e6d6aeb4d40ded74961ed341444df527fb4d79e932d568806ed79d071";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/composition/default.nix
+++ b/distros/humble/composition/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-composition";
-  version = "0.20.5-r1";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/composition/0.20.5-1.tar.gz";
-    name = "0.20.5-1.tar.gz";
-    sha256 = "68e9cbbecb1ca5f517893d5a541779c5d831b6f42d3b0d8c89744aab88e6d01b";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/composition/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "c02b9ba0472954d0e285e4f1a9b8752acb1aa4f09c90e4f390305f50af537ad1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/control-toolbox/default.nix
+++ b/distros/humble/control-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, control-msgs, eigen, filters, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools }:
 buildRosPackage {
   pname = "ros-humble-control-toolbox";
-  version = "3.6.1-r1";
+  version = "3.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/humble/control_toolbox/3.6.1-1.tar.gz";
-    name = "3.6.1-1.tar.gz";
-    sha256 = "1d8bd6fe084f2ab1435e11792fc079fe71660737182ec35533c4b27b04634f45";
+    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/humble/control_toolbox/3.6.2-1.tar.gz";
+    name = "3.6.2-1.tar.gz";
+    sha256 = "5b484971368c3721320c723643e54d18d5490b8fa9a1c4a54af47b7e1703dff4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/costmap-queue/default.nix
+++ b/distros/humble/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-costmap-queue";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/costmap_queue/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "4aad94340044d5d7df91f2e4dab4d81e8409eae89829a141250498243b47f462";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/costmap_queue/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "4b22d656e32657c7f7f44d2601d080d3337a8d69ac29650f7e1345b4433c5cf1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/demo-nodes-cpp-native/default.nix
+++ b/distros/humble/demo-nodes-cpp-native/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rmw-fastrtps-cpp, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-demo-nodes-cpp-native";
-  version = "0.20.5-r1";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/demo_nodes_cpp_native/0.20.5-1.tar.gz";
-    name = "0.20.5-1.tar.gz";
-    sha256 = "d3eb1e849f1c2f5aca6fffa7551a70aa4fd6dc35c264e93f2ead971200e986f0";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/demo_nodes_cpp_native/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "bdc73c0b18eebe60e1505d1452ab680b272ceceb70419923a3ca2147f713d4d7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/demo-nodes-cpp/default.nix
+++ b/distros/humble/demo-nodes-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, launch-xml, rclcpp, rclcpp-components, rcutils, rmw, rmw-implementation-cmake, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-demo-nodes-cpp";
-  version = "0.20.5-r1";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/demo_nodes_cpp/0.20.5-1.tar.gz";
-    name = "0.20.5-1.tar.gz";
-    sha256 = "bae26eb92b56f6fba90320852fc970b58d2b0bbf5ff0962a255e0c74e43b60b0";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/demo_nodes_cpp/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "a2c9e6748e72d3d7a17defe69c9370a4fb7756a3b324933031d309b386f9d753";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/demo-nodes-py/default.nix
+++ b/distros/humble/demo-nodes-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, python3Packages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-demo-nodes-py";
-  version = "0.20.5-r1";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/demo_nodes_py/0.20.5-1.tar.gz";
-    name = "0.20.5-1.tar.gz";
-    sha256 = "91702a23a43ff2e49a0ef50b12edd171a8e9564cb83354b2a6cccbd2017a0b4d";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/demo_nodes_py/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "1174833e8c93260a5d47647df7736d479958a3e03876020c555ef016cf888a54";
   };
 
   buildType = "ament_python";

--- a/distros/humble/dummy-map-server/default.nix
+++ b/distros/humble/dummy-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-dummy-map-server";
-  version = "0.20.5-r1";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/dummy_map_server/0.20.5-1.tar.gz";
-    name = "0.20.5-1.tar.gz";
-    sha256 = "aba096049cc3e550597106f7a2989369d75635e5d8b4c1404c125c1f73c30e37";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/dummy_map_server/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "57ea19d4a42d0997f6f61fb6544b992f3f17b2b57155cca3bb5d7c6d2379436e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dummy-robot-bringup/default.nix
+++ b/distros/humble/dummy-robot-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, dummy-map-server, dummy-sensors, launch, launch-ros, robot-state-publisher }:
 buildRosPackage {
   pname = "ros-humble-dummy-robot-bringup";
-  version = "0.20.5-r1";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/dummy_robot_bringup/0.20.5-1.tar.gz";
-    name = "0.20.5-1.tar.gz";
-    sha256 = "5c0b4bb9fefcb8ee8d53e7a7a21cf3ae4b427286d507aa0d2c09ae044ed4f600";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/dummy_robot_bringup/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "65c7e53340fada1d8192d8c9561ed31bcbc1860c6a4e64b8022798a721d7a168";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dummy-sensors/default.nix
+++ b/distros/humble/dummy-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-dummy-sensors";
-  version = "0.20.5-r1";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/dummy_sensors/0.20.5-1.tar.gz";
-    name = "0.20.5-1.tar.gz";
-    sha256 = "e9dadf78c7f46e887d7db63d142f3a6f6ac938a7531a7e56b93bf4f7f172eb97";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/dummy_sensors/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "a32b953ff39cbf6143b86e1f1562eaf594d9b7648e2892fc5fdc371ece65f6d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-core/default.nix
+++ b/distros/humble/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-core";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_core/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "05596fe536abebdbecb457415fd464e8719acf1a59194d8aa36fe481614abfe6";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_core/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "f3376ee5ac10b8c9bbd7472542dbe56d1b9a36807f02e6fd52bd70be1f800344";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-critics/default.nix
+++ b/distros/humble/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-critics";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_critics/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "6624b59e254c8f393cd8e2a9edb5d5408977ca0b615704eb58c05b5718e575dc";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_critics/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "0a4f19e3cce630bceb177d3e45ff8a1f697d2b922196cf3e165d45b74f706def";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-msgs/default.nix
+++ b/distros/humble/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-msgs";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_msgs/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "7e06ee4dd89fe9cdac0a411eacdda73b1dc4fec89385cdb27f7ea9a941921d4a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_msgs/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "fdafbac7b33ca9b217c8c2888955f437202cfb3d7d61ad906c93de8468276b4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-plugins/default.nix
+++ b/distros/humble/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-dwb-plugins";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_plugins/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "ee3e59d3139f9ec6b889ddea29b4cdd781bb35c776ba5ef10d20fd0b1bd79ed0";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_plugins/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "777f7d00d9628fd868cc87b67a66cdb5401e24338a9ab2aac2bb85950e5e1c9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dynamixel-hardware-interface/default.nix
+++ b/distros/humble/dynamixel-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-interfaces, dynamixel-sdk, hardware-interface, pluginlib, rclcpp, realtime-tools, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-dynamixel-hardware-interface";
-  version = "1.4.14-r1";
+  version = "1.4.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/humble/dynamixel_hardware_interface/1.4.14-1.tar.gz";
-    name = "1.4.14-1.tar.gz";
-    sha256 = "1497aa4655cfe36f31b9cfaa74bad267c24b5aaef8c1186ba15e488e4ef5b9eb";
+    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/humble/dynamixel_hardware_interface/1.4.15-1.tar.gz";
+    name = "1.4.15-1.tar.gz";
+    sha256 = "e3645a9ea35d13110421a4eeba6ee5928352f833e6beeffc6f1aa298fc7d481c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/fastrtps-cmake-module/default.nix
+++ b/distros/humble/fastrtps-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-fastrtps-cmake-module";
-  version = "2.2.2-r2";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/humble/fastrtps_cmake_module/2.2.2-2.tar.gz";
-    name = "2.2.2-2.tar.gz";
-    sha256 = "24d5587a3ff1c8062fe3f636e5da07e5c604458a25c8221d137c32e2803ee0a0";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/humble/fastrtps_cmake_module/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "456b94c899a206105bb5c0bc9e4cc227be4043711e54f96c817e59fa00a79a19";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -526,6 +526,14 @@ self: super: {
 
  base2d-kinematics-msgs = self.callPackage ./base2d-kinematics-msgs {};
 
+ bcr-arm = self.callPackage ./bcr-arm {};
+
+ bcr-arm-description = self.callPackage ./bcr-arm-description {};
+
+ bcr-arm-moveit-config = self.callPackage ./bcr-arm-moveit-config {};
+
+ bcr-arm-ros2 = self.callPackage ./bcr-arm-ros2 {};
+
  bcr-bot = self.callPackage ./bcr-bot {};
 
  behaviortree-cpp = self.callPackage ./behaviortree-cpp {};
@@ -1892,8 +1900,6 @@ self: super: {
 
  mola-gnss-to-markers = self.callPackage ./mola-gnss-to-markers {};
 
- mola-imu-preintegration = self.callPackage ./mola-imu-preintegration {};
-
  mola-input-euroc-dataset = self.callPackage ./mola-input-euroc-dataset {};
 
  mola-input-kitti360-dataset = self.callPackage ./mola-input-kitti360-dataset {};
@@ -1923,12 +1929,6 @@ self: super: {
  mola-pose-list = self.callPackage ./mola-pose-list {};
 
  mola-relocalization = self.callPackage ./mola-relocalization {};
-
- mola-state-estimation = self.callPackage ./mola-state-estimation {};
-
- mola-state-estimation-simple = self.callPackage ./mola-state-estimation-simple {};
-
- mola-state-estimation-smoother = self.callPackage ./mola-state-estimation-smoother {};
 
  mola-test-datasets = self.callPackage ./mola-test-datasets {};
 
@@ -2170,6 +2170,8 @@ self: super: {
 
  nav2-rotation-shim-controller = self.callPackage ./nav2-rotation-shim-controller {};
 
+ nav2-route = self.callPackage ./nav2-route {};
+
  nav2-rviz-plugins = self.callPackage ./nav2-rviz-plugins {};
 
  nav2-simple-commander = self.callPackage ./nav2-simple-commander {};
@@ -2213,8 +2215,6 @@ self: super: {
  nicla-vision-ros2 = self.callPackage ./nicla-vision-ros2 {};
 
  nlohmann-json-schema-validator-vendor = self.callPackage ./nlohmann-json-schema-validator-vendor {};
-
- nmea-hardware-interface = self.callPackage ./nmea-hardware-interface {};
 
  nmea-msgs = self.callPackage ./nmea-msgs {};
 
@@ -2345,6 +2345,10 @@ self: super: {
  osrf-testing-tools-cpp = self.callPackage ./osrf-testing-tools-cpp {};
 
  ouster-msgs = self.callPackage ./ouster-msgs {};
+
+ ouster-ros = self.callPackage ./ouster-ros {};
+
+ ouster-sensor-msgs = self.callPackage ./ouster-sensor-msgs {};
 
  ouxt-common = self.callPackage ./ouxt-common {};
 
@@ -2579,6 +2583,8 @@ self: super: {
  pybind11-vendor = self.callPackage ./pybind11-vendor {};
 
  pyhri = self.callPackage ./pyhri {};
+
+ pymoveit2 = self.callPackage ./pymoveit2 {};
 
  python-cmake-module = self.callPackage ./python-cmake-module {};
 
@@ -3467,6 +3473,8 @@ self: super: {
  tango-icons-vendor = self.callPackage ./tango-icons-vendor {};
 
  tcb-span = self.callPackage ./tcb-span {};
+
+ tecgihan-driver = self.callPackage ./tecgihan-driver {};
 
  teleop-tools = self.callPackage ./teleop-tools {};
 

--- a/distros/humble/image-tools/default.nix
+++ b/distros/humble/image-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, opencv, rclcpp, rclcpp-components, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-image-tools";
-  version = "0.20.5-r1";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/image_tools/0.20.5-1.tar.gz";
-    name = "0.20.5-1.tar.gz";
-    sha256 = "ab27561faea037b3f4590881de1691b196e19699f501ba42e031bbeee2d5c678";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/image_tools/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "84dcbaffe403279dd63ee4412cac8de819e4b9aaf27b4363fdfc1d200abb6020";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/intra-process-demo/default.nix
+++ b/distros/humble/intra-process-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, opencv, rclcpp, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-intra-process-demo";
-  version = "0.20.5-r1";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/intra_process_demo/0.20.5-1.tar.gz";
-    name = "0.20.5-1.tar.gz";
-    sha256 = "a042d7073957db92f9d833e267933075905f2e9c647665f03d162a139f17fe2d";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/intra_process_demo/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "acbc327c7c067217eb8a350a2e62187b8c07c7f0b13777f6d4929833cb8f52f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/lifecycle-py/default.nix
+++ b/distros/humble/lifecycle-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, lifecycle, lifecycle-msgs, rclpy, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-lifecycle-py";
-  version = "0.20.5-r1";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/lifecycle_py/0.20.5-1.tar.gz";
-    name = "0.20.5-1.tar.gz";
-    sha256 = "3bddccd8026629d7a3e7cc1d684790ac7e14c2f7f6de4dc4872a18e1437af061";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/lifecycle_py/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "601f787317b5c83741bf370aebec079fb2b151564bcb51514ef2c104b4ea9dad";
   };
 
   buildType = "ament_python";

--- a/distros/humble/lifecycle/default.nix
+++ b/distros/humble/lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp-lifecycle, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-lifecycle";
-  version = "0.20.5-r1";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/lifecycle/0.20.5-1.tar.gz";
-    name = "0.20.5-1.tar.gz";
-    sha256 = "de63d716016530dbfd4ada49dfc16940d25722165a22b7617f5c7a4b1bf76cc4";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/lifecycle/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "aa1b599649b249c8b06f3aa1a1d01437a108fd0f0bead34e1f7a2ec2b73e355e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/logging-demo/default.nix
+++ b/distros/humble/logging-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-logging-demo";
-  version = "0.20.5-r1";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/logging_demo/0.20.5-1.tar.gz";
-    name = "0.20.5-1.tar.gz";
-    sha256 = "fa7f1d65d9cfe6717c73ff3386cf190f6dcb843253fb269e7c8f879f33438982";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/logging_demo/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "a346d5d3e0017a5e8ccd8da7810aec88b1850aef02daa86dae6e1af7113460d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/message-filters/default.nix
+++ b/distros/humble/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, builtin-interfaces, python-cmake-module, rclcpp, rclcpp-lifecycle, rclpy, rcutils, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-message-filters";
-  version = "4.3.8-r1";
+  version = "4.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/humble/message_filters/4.3.8-1.tar.gz";
-    name = "4.3.8-1.tar.gz";
-    sha256 = "7db6a9f242da89d89b131565a24533b053ddfd60d3eed6fa6787719e801e960d";
+    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/humble/message_filters/4.3.9-1.tar.gz";
+    name = "4.3.9-1.tar.gz";
+    sha256 = "a0383d2bf8c5df44c88a7ffc6bb11c8597790f762b975c1cd5730ccf00f2835d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mqtt-client-interfaces/default.nix
+++ b/distros/humble/mqtt-client-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-mqtt-client-interfaces";
-  version = "2.4.1-r1";
+  version = "2.4.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/humble/mqtt_client_interfaces/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "973eec128abe86e4d714aa7de564b8fbaac653659c83829ab8a0be8094c2c2fa";
+    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/humble/mqtt_client_interfaces/2.4.1-2.tar.gz";
+    name = "2.4.1-2.tar.gz";
+    sha256 = "afdd6c31af604c239df28640f967a4c9229360de7122dd4b34855de55a0423cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mqtt-client/default.nix
+++ b/distros/humble/mqtt-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmt, mqtt-client-interfaces, paho-mqtt-c, paho-mqtt-cpp, rclcpp, rclcpp-components, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-mqtt-client";
-  version = "2.4.1-r1";
+  version = "2.4.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/humble/mqtt_client/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "7c8ae24ab4e91fbf2dce1d93cbb3eb8dd417162b0b2dc0cd10cc9212d158121f";
+    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/humble/mqtt_client/2.4.1-2.tar.gz";
+    name = "2.4.1-2.tar.gz";
+    sha256 = "68d6e36b85282dcac9c2df70a7fcdebb9d04854a40b0c8225b7296ebc72057ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav-2d-msgs/default.nix
+++ b/distros/humble/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav-2d-msgs";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_msgs/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "f2235a0b1c05676fd56b669ed4b1f90145352a5095c10103092091a55b25871e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_msgs/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "f1b9fc266247739c32ce39067e51c39519bd6938d46562d21d2b953471a45315";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav-2d-utils/default.nix
+++ b/distros/humble/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav-2d-utils";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_utils/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "387681da2632060370f0fe93dab7c48537b99692a30540a499fffcb96d165f14";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_utils/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "ecb0c640162e3d949a6030adaf8b93b3191f61905f8679bd4a5913544c0ce4a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-amcl/default.nix
+++ b/distros/humble/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, pluginlib, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-amcl";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_amcl/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "603e5aadc801e73085ae5bc4a761cf11d541f8501f34d25c354ed69d8b291d3f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_amcl/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "8700b3d3f0da401e8053fe8c4f1d186a63b070d544d95ba025e6ec19bbacae78";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-behavior-tree/default.nix
+++ b/distros/humble/nav2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-behavior-tree";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behavior_tree/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "79389a03237e97c7a7f67f7022c943c5e18dcb72f3e99f3d02e42047e06064a7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behavior_tree/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "8557c8b2ce854d2bb37ef157224e7d9b37c36e9e4c479faabbda687eff670239";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-behaviors/default.nix
+++ b/distros/humble/nav2-behaviors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-behaviors";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behaviors/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "ff0b921ee0899c45b93f816149be7845c50d6a14b00f878d581e4bb4c63042fd";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behaviors/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "c9c94336bf41ad268973e8d69423843e8b7317fb894fe95a8d35aa3411de95c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-bringup/default.nix
+++ b/distros/humble/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, nav2-common, navigation2, slam-toolbox }:
 buildRosPackage {
   pname = "ros-humble-nav2-bringup";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bringup/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "237837e677f146e8bfe63af0db229ed873c129fbdd71d77d3962e101758f0a52";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bringup/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "b839cc1f24b39b36ccfdf73a0011483ed2360febc3d9b6633ed7780b3d75d8f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-bt-navigator/default.nix
+++ b/distros/humble/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-bt-navigator";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bt_navigator/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "923a2016476b1410996de9074d2e934388486159b43dfd5d40559ceb64a8cb9a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bt_navigator/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "2de26a473677f0aa1b824a0b7fe023e25c37dd5d937c5e4cd4e8bfe7a06edabb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-collision-monitor/default.nix
+++ b/distros/humble/nav2-collision-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-costmap-2d, nav2-util, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-collision-monitor";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_collision_monitor/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "d1ffe0349b4faf96646f291e628ffe9c92f2366b66e84da034fd88295a2c68dc";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_collision_monitor/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "884ed360a884b280d4d2e6ff7ab293bd026483ab251b6e19baee4e2612465dcc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-common/default.nix
+++ b/distros/humble/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-nav2-common";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_common/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "2d33e196ab8d0a3ce33a7141d64cb946866c6d1f09c92834eb108112a4a4a48a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_common/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "71b1d1203d9daf9bcec4cbd48fd36393d193f4d336e7561f741e6208d4bf4703";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-constrained-smoother/default.nix
+++ b/distros/humble/nav2-constrained-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, ceres-solver, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-nav2-constrained-smoother";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_constrained_smoother/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "a830bdb2949688a46d0f276464cad64ae3ea257552186966103e4230a057b44d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_constrained_smoother/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "0ff298d8a978a387e01cf8d614d6912f0853994392ad13d7e8c984379cb115eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-controller/default.nix
+++ b/distros/humble/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-controller";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_controller/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "9cfed6fb9489d5a9705beac33f20588a65880041098f9c6c9a7717e5204e8d0b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_controller/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "180f2fc9f8879b7241b3d03144c90f92a0e3a2f2225d45b24faf160b0c689b0c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-core/default.nix
+++ b/distros/humble/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-core";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_core/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "1454c68b8fd03686591361e03cbef615e9887ea19be1636f82f7f2faf7e97c3d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_core/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "a13ed1768b8ecb95d0f4ff572313ae969d85cf8cb35fb9af7da4cc5b4019f36f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-costmap-2d/default.nix
+++ b/distros/humble/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-costmap-2d";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_costmap_2d/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "e8a232d82a807d51af61add34403dbabcd2511dd3962a13c6ac0429d9a54e6e2";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_costmap_2d/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "6ad5c28b400a88d51520824612dd36424146f229f31ce5919029a21360df75d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-dwb-controller/default.nix
+++ b/distros/humble/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-humble-nav2-dwb-controller";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_dwb_controller/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "cde6396897747797c7de95f4b0ca9da82f7b3e368fa1c7365514492a04e9a5e1";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_dwb_controller/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "e94b61245c46943f8a1ae53eb0462b720c933d49af178d599fc4d853c531514f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-graceful-controller/default.nix
+++ b/distros/humble/nav2-graceful-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav-2d-utils, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-graceful-controller";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_graceful_controller/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "0d1d29f63be282b0ef951db9c947b3ae587470c9f636bd614d3a9521401ead6a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_graceful_controller/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "a88aba9bc401ad68a183aafdcbc65af34d99d120b9776f795cc7fbaa8fbd966c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-lifecycle-manager/default.nix
+++ b/distros/humble/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bondcpp, diagnostic-updater, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-lifecycle-manager";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_lifecycle_manager/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "309cdba42751a604400ec2f842a697e64fc6b3e925255cb83dba7988c2c211ee";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_lifecycle_manager/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "91be15feb008be49d6367d300c719d02a525f24381207edd3f3abb8706f8e4d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-map-server/default.nix
+++ b/distros/humble/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-nav2-map-server";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_map_server/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "7ff42000251422706a85dba967cce060e712064973eeb40fa0286b6950b792f8";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_map_server/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "626fefa3600cf1ff132409ebf30008306ebd5bfa40430d1f59bde10975016071";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-mppi-controller/default.nix
+++ b/distros/humble/nav2-mppi-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, gbenchmark, geometry-msgs, llvmPackages, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs, xsimd, xtensor }:
 buildRosPackage {
   pname = "ros-humble-nav2-mppi-controller";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_mppi_controller/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "45c7789d94e3db5baef96a5117d135085188265d7e935735fe04355502f10624";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_mppi_controller/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "ae9141c108ab1155a083e78d431bfc830e73534817846fea1e9a005fa97ee17e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-msgs/default.nix
+++ b/distros/humble/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-msgs";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_msgs/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "d4edaae5e8305134864f79b2b01394c54460d614d6092f795d1e7aef6adc38aa";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_msgs/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "ef39415dc202e318bc8931db270ea2b9020e4ea7ed65dacf9cb845906ea2b390";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-navfn-planner/default.nix
+++ b/distros/humble/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-navfn-planner";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_navfn_planner/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "bc72f51d7844a68192e9c9a2b34017069d7e2059d8cbc5669c93048efa81a4db";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_navfn_planner/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "b2b7763a0f3fddf73215b87675b99a7186444788ac89c86ed0cb2916edef314d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-planner/default.nix
+++ b/distros/humble/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-planner";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_planner/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "04cddc97f9ec547f0909b13245e30912623cbabe5aa26270524cb54fc06a95af";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_planner/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "9ed454fc6eb49e8a6d21d05c90b3fb5e4de8e37e5c540b7680e34053cf93c177";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-regulated-pure-pursuit-controller/default.nix
+++ b/distros/humble/nav2-regulated-pure-pursuit-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-regulated-pure-pursuit-controller";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_regulated_pure_pursuit_controller/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "bf4396d2b8185b4b6a56198933025372694762bccde5492ed0f3e445367450ad";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_regulated_pure_pursuit_controller/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "61d7cc0893fa909a31aca5265654a51df626a970ed760ff5e85ce58d2a2a090c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-rotation-shim-controller/default.nix
+++ b/distros/humble/nav2-rotation-shim-controller/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-regulated-pure-pursuit-controller, nav2-util, pluginlib, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-humble-nav2-rotation-shim-controller";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rotation_shim_controller/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "9ebadbeda6bf6253de14f78404302b891d4d131c305578db02c2e2fb15e4f728";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rotation_shim_controller/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "68f8e5992cf5011dd74c392741d4942a8d9783ab6afad4d5451345bb8dfbb22a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common nav2-controller nav2-regulated-pure-pursuit-controller ];
-  propagatedBuildInputs = [ angles geometry-msgs nav2-common nav2-core nav2-costmap-2d nav2-msgs nav2-util pluginlib rclcpp tf2 ];
+  propagatedBuildInputs = [ angles geometry-msgs nav2-common nav2-controller nav2-core nav2-costmap-2d nav2-msgs nav2-util pluginlib rclcpp tf2 ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/nav2-route/default.nix
+++ b/distros/humble/nav2-route/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, launch, launch-testing, nanoflann, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, nlohmann_json, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-humble-nav2-route";
+  version = "1.1.19-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_route/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "1164ada6caa7fa9677f61649b66effc29f17d1f41d130cc44b8a042ab9c82b96";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common launch launch-testing ];
+  propagatedBuildInputs = [ angles geometry-msgs nanoflann nav-msgs nav2-core nav2-costmap-2d nav2-msgs nav2-util nlohmann_json pluginlib rclcpp rclcpp-lifecycle std-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A Route Graph planner to compliment the Planner Server";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/nav2-rviz-plugins/default.nix
+++ b/distros/humble/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-rviz-plugins";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rviz_plugins/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "ea64c733e342773589020c30b78f31c63767b380e3dd1c9c66c180f82b48d6aa";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rviz_plugins/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "4e31e28867c4ab56a28ab52a9dbaa31366ba72f1b738daa46743e58810dfebee";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-simple-commander/default.nix
+++ b/distros/humble/nav2-simple-commander/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, lifecycle-msgs, nav2-msgs, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-nav2-simple-commander";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_simple_commander/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "db0ca852246d9b01f027b6e270744a8ab6a078fa429817e850f50dfcecac271e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_simple_commander/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "10831388539c2699413880badaa470943041d38e82e446ce657e961214eaafe8";
   };
 
   buildType = "ament_python";

--- a/distros/humble/nav2-smac-planner/default.nix
+++ b/distros/humble/nav2-smac-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, builtin-interfaces, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, nlohmann_json, ompl, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-smac-planner";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smac_planner/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "db09b064d4e6595b63f42d9a5d9d56e58deb58be633495e6689245ed4d5a0e17";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smac_planner/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "1792c041487ff179ccf18a5adfbeb8000e8442d3ff2ea84a5078a03b329ad8f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-smoother/default.nix
+++ b/distros/humble/nav2-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-smoother";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smoother/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "bdb81fcd68d169e7e472c5649acc3af90d9787f3e7e544dcd1106b5fd784f055";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smoother/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "55522d5f552446e2517d2b9bdf21fde74e1939a86bf45290eb8b5f1f2c59e58f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-system-tests/default.nix
+++ b/distros/humble/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, gazebo-ros-pkgs, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-behavior-tree, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, python3Packages, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-system-tests";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_system_tests/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "8b6a62218b290fb715640142f522c8b5e1e5a416682b6cfc95a1ef58510b9ffd";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_system_tests/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "d3e55df01799d77516bcf8215d77814e5d194e552a6e5d70ece46da63deb4a4d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-theta-star-planner/default.nix
+++ b/distros/humble/nav2-theta-star-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-theta-star-planner";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_theta_star_planner/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "7df86d2fd27ebb05792958c7d1af8449042eff2707e8b6357d15bdb78cdb5f9a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_theta_star_planner/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "4c640198fdaad6528ee7541e68a5d0c1bf6ef2843102eb048f215344c9642946";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-util/default.nix
+++ b/distros/humble/nav2-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bond, bondcpp, boost, geometry-msgs, launch, launch-testing-ament-cmake, launch-testing-ros, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-util";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_util/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "04485ab6626d87b6867ce66ea87c4ea791d00dbcfaf99015499ae06048d2071c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_util/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "c4b22b19ed2dc2f767084b1217a707f4c490a9789384c519ef1d8be53d416139";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-velocity-smoother/default.nix
+++ b/distros/humble/nav2-velocity-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-util, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-humble-nav2-velocity-smoother";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_velocity_smoother/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "df18b0c29903f512e4e2e95c5000abb84fd3a2c762e4a880c78d159ac255e244";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_velocity_smoother/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "702b4c2ac538d4c4717c49646a314ed10d348a5a1d89e34684b3344b150484c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-voxel-grid/default.nix
+++ b/distros/humble/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-nav2-voxel-grid";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_voxel_grid/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "15ea1fcf7c0c14de2a33159a00471f6fe76cc797e88a6adb3e60e523293b3029";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_voxel_grid/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "87e637cefd99b4772df7f91930f0cc829842bbc70b5cec2ff58e8a923a512317";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-waypoint-follower/default.nix
+++ b/distros/humble/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, nav-msgs, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-waypoint-follower";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_waypoint_follower/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "9954bc4a427dbf0c2637335365994bac0f4c8968a011f9ddbd27171710c6f4a8";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_waypoint_follower/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "ea347fa74ac551961e74f613f95fb1c4aa1f044c6d5bf51555c1a13d2b957e38";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/navigation2/default.nix
+++ b/distros/humble/navigation2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-behaviors, nav2-bt-navigator, nav2-collision-monitor, nav2-constrained-smoother, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-mppi-controller, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-regulated-pure-pursuit-controller, nav2-rotation-shim-controller, nav2-rviz-plugins, nav2-simple-commander, nav2-smac-planner, nav2-smoother, nav2-theta-star-planner, nav2-util, nav2-velocity-smoother, nav2-voxel-grid, nav2-waypoint-follower }:
 buildRosPackage {
   pname = "ros-humble-navigation2";
-  version = "1.1.18-r1";
+  version = "1.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/navigation2/1.1.18-1.tar.gz";
-    name = "1.1.18-1.tar.gz";
-    sha256 = "6cd02f87bf482b5d11e48baff362108f63afad90411419a1d35717c9324e74ca";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/navigation2/1.1.19-1.tar.gz";
+    name = "1.1.19-1.tar.gz";
+    sha256 = "a31de5db60b6b178c83cd6c09e7a124042195d262f8d7e84bcf72825c2fcf4b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/novatel-oem7-driver/default.nix
+++ b/distros/humble/novatel-oem7-driver/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, geographiclib, git, gps-msgs, launch-testing, launch-testing-ament-cmake, launch-testing-ros, nav-msgs, nmea-msgs, novatel-oem7-msgs, pluginlib, rclcpp, rclcpp-components, rclpy, rosbag2, rosidl-runtime-py, sensor-msgs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-novatel-oem7-driver";
-  version = "20.7.0-r1";
+  version = "20.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/humble/novatel_oem7_driver/20.7.0-1.tar.gz";
-    name = "20.7.0-1.tar.gz";
-    sha256 = "9cdb5ca489c3705c66ba7d66e28590628a6b82317d82093555d1c14f71877e35";
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/humble/novatel_oem7_driver/20.8.0-1.tar.gz";
+    name = "20.8.0-1.tar.gz";
+    sha256 = "d876c7a3fda6dd166e2fd7630671a60d487cee9f26b33255d5fe14fa810542bd";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake git ];
+  buildInputs = [ ament-cmake boost git ];
   checkInputs = [ launch-testing launch-testing-ament-cmake launch-testing-ros rclpy rosbag2 rosidl-runtime-py ];
-  propagatedBuildInputs = [ boost geographiclib gps-msgs nav-msgs nmea-msgs novatel-oem7-msgs pluginlib rclcpp rclcpp-components sensor-msgs tf2-geometry-msgs ];
+  propagatedBuildInputs = [ geographiclib gps-msgs nav-msgs nmea-msgs novatel-oem7-msgs pluginlib rclcpp rclcpp-components sensor-msgs tf2-geometry-msgs ];
   nativeBuildInputs = [ ament-cmake git ];
 
   meta = {

--- a/distros/humble/novatel-oem7-msgs/default.nix
+++ b/distros/humble/novatel-oem7-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-novatel-oem7-msgs";
-  version = "20.7.0-r1";
+  version = "20.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/humble/novatel_oem7_msgs/20.7.0-1.tar.gz";
-    name = "20.7.0-1.tar.gz";
-    sha256 = "07870df041eedb254e6e03875600cc0e22b8469648cc80bc9ee1f5196df4ffe8";
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/humble/novatel_oem7_msgs/20.8.0-1.tar.gz";
+    name = "20.8.0-1.tar.gz";
+    sha256 = "919e21c9919c078ee305f4671143c6d421a241b809b669d25df2d7fcdc46f3d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ouster-ros/default.nix
+++ b/distros/humble/ouster-ros/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, curl, cv-bridge, eigen, geometry-msgs, gtest, jsoncpp, launch, launch-ros, libtins, ouster-sensor-msgs, pcl, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, rclcpp-lifecycle, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, spdlog, std-msgs, std-srvs, tf2-eigen, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-ouster-ros";
+  version = "0.13.14-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ouster-ros-release/archive/release/humble/ouster_ros/0.13.14-2.tar.gz";
+    name = "0.13.14-2.tar.gz";
+    sha256 = "1805ac35dfc71c192752624c4b311d828363cfc5e92afe512de8190109be9a10";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake eigen pcl rosidl-default-generators tf2-eigen ];
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ curl cv-bridge geometry-msgs jsoncpp launch launch-ros libtins ouster-sensor-msgs pcl-conversions pcl-ros rclcpp rclcpp-components rclcpp-lifecycle rosidl-default-runtime sensor-msgs spdlog std-msgs std-srvs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "Ouster ROS2 driver";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/ouster-sensor-msgs/default.nix
+++ b/distros/humble/ouster-sensor-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-ouster-sensor-msgs";
+  version = "0.13.14-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ouster-ros-release/archive/release/humble/ouster_sensor_msgs/0.13.14-2.tar.gz";
+    name = "0.13.14-2.tar.gz";
+    sha256 = "e2c6a2be27588ea5b894cc3f18c4ef705741e7d5f301fa16046d5c49cb901892";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "ouster_ros message and service definitions";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/pal-gazebo-plugins/default.nix
+++ b/distros/humble/pal-gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, control-toolbox, gazebo-dev, gazebo-msgs, gazebo-ros, nav-msgs, rclcpp, std-msgs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-pal-gazebo-plugins";
-  version = "4.0.6-r1";
+  version = "4.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_gazebo_plugins-release/archive/release/humble/pal_gazebo_plugins/4.0.6-1.tar.gz";
-    name = "4.0.6-1.tar.gz";
-    sha256 = "0a2011de05061588c0f2f7a3723cc5b69d8c7953df102fd6abf9bb5246b54655";
+    url = "https://github.com/pal-gbp/pal_gazebo_plugins-release/archive/release/humble/pal_gazebo_plugins/4.1.0-1.tar.gz";
+    name = "4.1.0-1.tar.gz";
+    sha256 = "9b1462893a735fd6ec42db5d122fbd9e8dfe89350cd9efdaabe459c3edb61a2b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-statistics-msgs/default.nix
+++ b/distros/humble/pal-statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-pal-statistics-msgs";
-  version = "2.6.4-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/humble/pal_statistics_msgs/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "4ce184b3fd7523541cc3ed48e7571089729be324ec58a19be9fc4b28028abbfc";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/humble/pal_statistics_msgs/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "1f95a186ec5b6f8b20f0e957190ccb44b0ff963bf61f7eedc047b717ee468da2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-statistics/default.nix
+++ b/distros/humble/pal-statistics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, boost, pal-statistics-msgs, rclcpp, rclcpp-lifecycle, rclpy }:
 buildRosPackage {
   pname = "ros-humble-pal-statistics";
-  version = "2.6.4-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/humble/pal_statistics/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "66ed8ec35326a38e3ce3c437d7163532bbbb3cd72fdf07ebfdcf0601273bf59d";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/humble/pal_statistics/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "a46d5c9225c313039091a580c5d9798baeaee97dc26030fd551d8f85645423e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pendulum-control/default.nix
+++ b/distros/humble/pendulum-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pendulum-msgs, rclcpp, rmw-implementation-cmake, ros2run, rttest, tlsf-cpp }:
 buildRosPackage {
   pname = "ros-humble-pendulum-control";
-  version = "0.20.5-r1";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/pendulum_control/0.20.5-1.tar.gz";
-    name = "0.20.5-1.tar.gz";
-    sha256 = "ff1e5528f687d44c8ee4c468fc7308b3a31cfabfa2a33345d777902b227083a8";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/pendulum_control/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "ab09ccc9a93cd3ea91899c3b703533258a6c93aabdd24a3c7ff99de4fad4c595";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pendulum-msgs/default.nix
+++ b/distros/humble/pendulum-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-pendulum-msgs";
-  version = "0.20.5-r1";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/pendulum_msgs/0.20.5-1.tar.gz";
-    name = "0.20.5-1.tar.gz";
-    sha256 = "70dfb77ce939d96a6eb85776d458345cbb7159d6a61d3f1555c3a3f1a36dc62e";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/pendulum_msgs/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "b39707f8791afcb972a5bc463e45ba9a28a66b846e95259d5c88588e1ed321dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/play-motion2-msgs/default.nix
+++ b/distros/humble/play-motion2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-play-motion2-msgs";
-  version = "1.5.3-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/play_motion2-release/archive/release/humble/play_motion2_msgs/1.5.3-1.tar.gz";
-    name = "1.5.3-1.tar.gz";
-    sha256 = "e5422f646bd9b070fa5cfab3dce109cce688c5594e3cff47f260280cab869cc5";
+    url = "https://github.com/pal-gbp/play_motion2-release/archive/release/humble/play_motion2_msgs/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "dc29e66dcf8a3c53b586390497487817eca8e5355927b7c55bc08a537bcb56ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/play-motion2/default.nix
+++ b/distros/humble/play-motion2/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, control-msgs, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, lifecycle-msgs, moveit-ros-planning-interface, play-motion2-msgs, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, realtime-tools, robot-state-publisher, sensor-msgs, std-msgs, trajectory-msgs, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-index-cpp, ament-lint-auto, ament-lint-common, backward-ros, control-msgs, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, lifecycle-msgs, moveit-ros-planning-interface, play-motion2-msgs, pluginlib, rclcpp, rclcpp-action, rclcpp-components, rclcpp-lifecycle, realtime-tools, robot-state-publisher, sensor-msgs, std-msgs, trajectory-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-play-motion2";
-  version = "1.5.3-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/play_motion2-release/archive/release/humble/play_motion2/1.5.3-1.tar.gz";
-    name = "1.5.3-1.tar.gz";
-    sha256 = "93a5d5894f72a5e16420a86b2fb3cc75f88656617ec453d83d2d544e5f74656b";
+    url = "https://github.com/pal-gbp/play_motion2-release/archive/release/humble/play_motion2/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "19a42d86b54fdce1d752c24aa0e3d4a92304d7f288ce27c83c2954c547eba583";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-auto ];
-  checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ament-lint-common controller-interface controller-manager hardware-interface joint-state-broadcaster joint-trajectory-controller launch-testing-ament-cmake pluginlib realtime-tools robot-state-publisher sensor-msgs xacro ];
-  propagatedBuildInputs = [ control-msgs controller-manager-msgs launch launch-ros lifecycle-msgs moveit-ros-planning-interface play-motion2-msgs rclcpp rclcpp-action rclcpp-lifecycle sensor-msgs std-msgs trajectory-msgs ];
-  nativeBuildInputs = [ ament-cmake-auto ];
+  buildInputs = [ ament-cmake-auto ament-cmake-python ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-index-cpp ament-lint-auto ament-lint-common controller-interface controller-manager hardware-interface joint-state-broadcaster joint-trajectory-controller launch-testing-ament-cmake pluginlib realtime-tools robot-state-publisher sensor-msgs xacro ];
+  propagatedBuildInputs = [ backward-ros control-msgs controller-manager-msgs launch launch-ros lifecycle-msgs moveit-ros-planning-interface play-motion2-msgs rclcpp rclcpp-action rclcpp-components rclcpp-lifecycle sensor-msgs std-msgs trajectory-msgs ];
+  nativeBuildInputs = [ ament-cmake-auto ament-cmake-python ];
 
   meta = {
     description = "Play a pre-recorded motion on a robot";

--- a/distros/humble/pymoveit2/default.nix
+++ b/distros/humble/pymoveit2/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-python, control-msgs, geometry-msgs, moveit-msgs, rclpy, sensor-msgs, shape-msgs, std-srvs, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-humble-pymoveit2";
+  version = "4.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/pymoveit2-release/archive/release/humble/pymoveit2/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "756492a1b6528ef4134dad7b5cfa1c0e7dbc2ccdfb9a81cc834204884e0a1b39";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  propagatedBuildInputs = [ action-msgs control-msgs geometry-msgs moveit-msgs rclpy sensor-msgs shape-msgs std-srvs trajectory-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "Basic Python interface for MoveIt 2 built on top of ROS 2 actions and services";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/quality-of-service-demo-cpp/default.nix
+++ b/distros/humble/quality-of-service-demo-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, rclcpp, rclcpp-components, rcutils, rmw, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-quality-of-service-demo-cpp";
-  version = "0.20.5-r1";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/quality_of_service_demo_cpp/0.20.5-1.tar.gz";
-    name = "0.20.5-1.tar.gz";
-    sha256 = "3d01fb8a7e7c276910c989c6400a0de48ed9d8a3c14ccba7a5e63013dd3baf5f";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/quality_of_service_demo_cpp/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "6c9643245ad40ac142d396da48ef8021eafa51604114b397bef36990771f3ffb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/quality-of-service-demo-py/default.nix
+++ b/distros/humble/quality-of-service-demo-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-quality-of-service-demo-py";
-  version = "0.20.5-r1";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/quality_of_service_demo_py/0.20.5-1.tar.gz";
-    name = "0.20.5-1.tar.gz";
-    sha256 = "9e2ab6657ab69d00a2c0eadf09c790ae305258d068709b81d17698ea79ac3f43";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/quality_of_service_demo_py/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "c11c82d7201774adfc27aff0be7020fa5612ff5edef480a9c69c59c200a90abd";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rcpputils/default.nix
+++ b/distros/humble/rcpputils/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, rcutils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, rcutils }:
 buildRosPackage {
   pname = "ros-humble-rcpputils";
-  version = "2.4.5-r1";
+  version = "2.4.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/humble/rcpputils/2.4.5-1.tar.gz";
-    name = "2.4.5-1.tar.gz";
-    sha256 = "108add0031e0f2a685614f54dd42a2e3f940709194133f4f9567a054a7831936";
+    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/humble/rcpputils/2.4.6-1.tar.gz";
+    name = "2.4.6-1.tar.gz";
+    sha256 = "cf99d1c39dd1bc6c012b32d1b7236ba41751f8fb6c5c53680c7906da32686a69";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gen-version-h ament-cmake-ros ];
-  checkInputs = [ ament-cmake-copyright ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-uncrustify ament-cmake-xmllint ];
   propagatedBuildInputs = [ rcutils ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ament-cmake-ros ];
 

--- a/distros/humble/rmw-fastrtps-cpp/default.nix
+++ b/distros/humble/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-cmake, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-humble-rmw-fastrtps-cpp";
-  version = "6.2.8-r1";
+  version = "6.2.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/humble/rmw_fastrtps_cpp/6.2.8-1.tar.gz";
-    name = "6.2.8-1.tar.gz";
-    sha256 = "9d511a078306c6f24c844e849fee715d20019ecb1246bdd931ece1aa6bd61736";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/humble/rmw_fastrtps_cpp/6.2.9-1.tar.gz";
+    name = "6.2.9-1.tar.gz";
+    sha256 = "cc9bc66ba082ec610393b20492fd2c8a0bfef452a2e4e948310b29c450f7b687";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/humble/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rmw-fastrtps-dynamic-cpp";
-  version = "6.2.8-r1";
+  version = "6.2.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/humble/rmw_fastrtps_dynamic_cpp/6.2.8-1.tar.gz";
-    name = "6.2.8-1.tar.gz";
-    sha256 = "6a13c4f0fec32146e24966f2d9f02df561758c6179bfdd7e00eaa956bd4c15d0";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/humble/rmw_fastrtps_dynamic_cpp/6.2.9-1.tar.gz";
+    name = "6.2.9-1.tar.gz";
+    sha256 = "dbb0446fd35d9a281a93810432c03bec93c7e92e809afdfa4c3dee2b7b05d1d9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/humble/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-humble-rmw-fastrtps-shared-cpp";
-  version = "6.2.8-r1";
+  version = "6.2.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/humble/rmw_fastrtps_shared_cpp/6.2.8-1.tar.gz";
-    name = "6.2.8-1.tar.gz";
-    sha256 = "b6610cc8d63ac4c750178a331815b9d88f8d54f403b29d118df874e79494fbe0";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/humble/rmw_fastrtps_shared_cpp/6.2.9-1.tar.gz";
+    name = "6.2.9-1.tar.gz";
+    sha256 = "6749758b946b2b8e9c045d38ff28837d0101be4b97bfcab20460742aeff3cb66";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-typesupport-fastrtps-c/default.nix
+++ b/distros/humble/rosidl-typesupport-fastrtps-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, fastcdr, fastrtps-cmake-module, osrf-testing-tools-cpp, performance-test-fixture, python3, rmw, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-humble-rosidl-typesupport-fastrtps-c";
-  version = "2.2.2-r2";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/humble/rosidl_typesupport_fastrtps_c/2.2.2-2.tar.gz";
-    name = "2.2.2-2.tar.gz";
-    sha256 = "af9689c75a14fe551042d108c2316f396613c1386ff013b214737a602d79b4ff";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/humble/rosidl_typesupport_fastrtps_c/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "13cb71cec6324797690b95a1cdf8b8f8577d2c740adec2eb84303b13db122a85";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-typesupport-fastrtps-cpp/default.nix
+++ b/distros/humble/rosidl-typesupport-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, fastcdr, fastrtps-cmake-module, osrf-testing-tools-cpp, performance-test-fixture, python3, rmw, rosidl-cli, rosidl-cmake, rosidl-generator-cpp, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-humble-rosidl-typesupport-fastrtps-cpp";
-  version = "2.2.2-r2";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/humble/rosidl_typesupport_fastrtps_cpp/2.2.2-2.tar.gz";
-    name = "2.2.2-2.tar.gz";
-    sha256 = "37c033d003c6880716f6585add0e8868aed4961f9d246657152780347d587150";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/humble/rosidl_typesupport_fastrtps_cpp/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "9cd6c6281755321f8350eb5ce83b878702fcf96769e3bcd2549e9b9664f33ecf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rpyutils/default.nix
+++ b/distros/humble/rpyutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-rpyutils";
-  version = "0.2.1-r2";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rpyutils-release/archive/release/humble/rpyutils/0.2.1-2.tar.gz";
-    name = "0.2.1-2.tar.gz";
-    sha256 = "d35a40fddeb91bd9d436fffbf8081b71fec4a60934be2f05555519f62cccb81c";
+    url = "https://github.com/ros2-gbp/rpyutils-release/archive/release/humble/rpyutils/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "482199dbf2de60bfb040c1c411b6cb83d332616a52395cfe39375c75fe5ac70a";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rviz-assimp-vendor/default.nix
+++ b/distros/humble/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-humble-rviz-assimp-vendor";
-  version = "11.2.20-r1";
+  version = "11.2.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_assimp_vendor/11.2.20-1.tar.gz";
-    name = "11.2.20-1.tar.gz";
-    sha256 = "476994761f822909bd23f1a7259934beacf777c30ee77cdd7ef817ee276ff1a7";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_assimp_vendor/11.2.21-1.tar.gz";
+    name = "11.2.21-1.tar.gz";
+    sha256 = "e3359b4bdaebd91a5657434bdcc77647d8672a4a90fb6e8eb579ae1bde39e454";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-common/default.nix
+++ b/distros/humble/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, rcpputils, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rviz-common";
-  version = "11.2.20-r1";
+  version = "11.2.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_common/11.2.20-1.tar.gz";
-    name = "11.2.20-1.tar.gz";
-    sha256 = "6d10ecf30e79dd2ee178725531eac3a6968c006c8910936ef3dbbee69aa3a9ac";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_common/11.2.21-1.tar.gz";
+    name = "11.2.21-1.tar.gz";
+    sha256 = "187956270d000b68db8cdd2e5043263edb839a794e56fae9fdb2cadded9da397";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-default-plugins/default.nix
+++ b/distros/humble/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rviz-default-plugins";
-  version = "11.2.20-r1";
+  version = "11.2.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_default_plugins/11.2.20-1.tar.gz";
-    name = "11.2.20-1.tar.gz";
-    sha256 = "fcdbf71f6852cff1ea1422d0f4e6407ae23afb554da281abc0d8b6caf9ca7e41";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_default_plugins/11.2.21-1.tar.gz";
+    name = "11.2.21-1.tar.gz";
+    sha256 = "3273a050e0a3596f14c67f910b105383a1e4ff65229c678e6631c6b02eed7e5a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-ogre-vendor/default.nix
+++ b/distros/humble/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, freetype, git, glew, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-humble-rviz-ogre-vendor";
-  version = "11.2.20-r1";
+  version = "11.2.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_ogre_vendor/11.2.20-1.tar.gz";
-    name = "11.2.20-1.tar.gz";
-    sha256 = "413855e0921292b2f1cae23362c5523d8dbf65a63a7b4538e0a0c4568bd4e890";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_ogre_vendor/11.2.21-1.tar.gz";
+    name = "11.2.21-1.tar.gz";
+    sha256 = "adc05ffd5d6e21e4e21e57ef12321bb9c900534cb36237129b36ad9fa727c6a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-rendering-tests/default.nix
+++ b/distros/humble/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-humble-rviz-rendering-tests";
-  version = "11.2.20-r1";
+  version = "11.2.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering_tests/11.2.20-1.tar.gz";
-    name = "11.2.20-1.tar.gz";
-    sha256 = "4c91a5c04481524cbee3e835cba030c02ef7843499c583483c7a4bb669dfe1cb";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering_tests/11.2.21-1.tar.gz";
+    name = "11.2.21-1.tar.gz";
+    sha256 = "c8ce6893176242d03cacfc406acf544c4d31164796e57a65672f053455233274";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-rendering/default.nix
+++ b/distros/humble/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-humble-rviz-rendering";
-  version = "11.2.20-r1";
+  version = "11.2.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering/11.2.20-1.tar.gz";
-    name = "11.2.20-1.tar.gz";
-    sha256 = "7b82ffeb526797a6cfcd05ee566b4639332588daa9e71352fc85965a1ae51ee0";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering/11.2.21-1.tar.gz";
+    name = "11.2.21-1.tar.gz";
+    sha256 = "d87767737de0aa9327760da6f6f65cfaa08c52f8d94cec3438894cb1e3a17958";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-visual-testing-framework/default.nix
+++ b/distros/humble/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, qt5, rcutils, rviz-common }:
 buildRosPackage {
   pname = "ros-humble-rviz-visual-testing-framework";
-  version = "11.2.20-r1";
+  version = "11.2.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_visual_testing_framework/11.2.20-1.tar.gz";
-    name = "11.2.20-1.tar.gz";
-    sha256 = "5e6d4620e873e34e2723080bdc4f392d59f0ed9edef612244afd704b917b8388";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_visual_testing_framework/11.2.21-1.tar.gz";
+    name = "11.2.21-1.tar.gz";
+    sha256 = "929fc74ce207e1791818b0c09388f92a0ec7b108ec11c8f7d45d664a83951007";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz2/default.nix
+++ b/distros/humble/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-rviz2";
-  version = "11.2.20-r1";
+  version = "11.2.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz2/11.2.20-1.tar.gz";
-    name = "11.2.20-1.tar.gz";
-    sha256 = "c51265b0dd7288563ae571052042f6c885e77552d29e402f0c43e27ac2744824";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz2/11.2.21-1.tar.gz";
+    name = "11.2.21-1.tar.gz";
+    sha256 = "2ef7dad23e5a08ad3fbcea3a63c38e1085261c1ea1e42c4d366037c02e8764d9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tecgihan-driver/default.nix
+++ b/distros/humble/tecgihan-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, python3Packages, rclpy, xacro }:
+buildRosPackage {
+  pname = "ros-humble-tecgihan-driver";
+  version = "0.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tecgihan/tecgihan_driver-release/archive/release/humble/tecgihan_driver/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "9939a65ea13fcf65c1ef83cdfcc913bae341cf7c0fa5bd853d8feb6999cd392f";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
+  propagatedBuildInputs = [ geometry-msgs python3Packages.pyserial rclpy xacro ];
+
+  meta = {
+    description = "Linux and ROS driver software for Tec Gihan sensor amplifiers for robots";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/topic-monitor/default.nix
+++ b/distros/humble/topic-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, launch, launch-ros, python3Packages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-topic-monitor";
-  version = "0.20.5-r1";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/topic_monitor/0.20.5-1.tar.gz";
-    name = "0.20.5-1.tar.gz";
-    sha256 = "5ceea49c9b70277c3c2932c3a99cfcdcb325419a9d4285a61b12927acdd0ae8d";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/topic_monitor/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "0667b50f034913bfa0a671ef2d5c7c8656255c5ca40a35e8bd8d8e8fec8cfc4e";
   };
 
   buildType = "ament_python";

--- a/distros/humble/topic-statistics-demo/default.nix
+++ b/distros/humble/topic-statistics-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rcutils, sensor-msgs, statistics-msgs }:
 buildRosPackage {
   pname = "ros-humble-topic-statistics-demo";
-  version = "0.20.5-r1";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/topic_statistics_demo/0.20.5-1.tar.gz";
-    name = "0.20.5-1.tar.gz";
-    sha256 = "2454e3022a91267326c7eeabd8ca124bdb1c311c9b66d7391eed55154091b31a";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/topic_statistics_demo/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "4bf85b09ade688c2e529c109311f3015629c4e42aa999262296bdb40a438530b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-bringup/default.nix
+++ b/distros/humble/ur-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, force-torque-sensor-broadcaster, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, position-controllers, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, ur-controllers, ur-description, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-bringup";
-  version = "2.8.1-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_bringup/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "9c5836f4ab8a10ddc50c9a43165b2ae912ab1c329ba414ff76ed0ff93c54f060";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_bringup/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "2ef9ca2ac03d8753cd6cd21958ab33e6216bf5f1600969d52f63bdd6355e9f68";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-calibration/default.nix
+++ b/distros/humble/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-ur-calibration";
-  version = "2.8.1-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_calibration/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "9d34968d37e36a8baaeec4f0474c008471f61ad9223503ab29d99b587398c590";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_calibration/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "100358cfff8735088dfbbefdcf3329f2c3a26c7a1a311b0934c4b94f36a87154";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-controllers/default.nix
+++ b/distros/humble/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, angles, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, trajectory-msgs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-humble-ur-controllers";
-  version = "2.8.1-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_controllers/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "fbbe267f5a7025d3d6b4ecb4ce914282679d52dbf9e065d7d65cfbde80ae00a1";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_controllers/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "513349fe9d1b8872c480db8df1b016a5f83ddb2e19a5cf03632d09ad60dd64ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-dashboard-msgs/default.nix
+++ b/distros/humble/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-ur-dashboard-msgs";
-  version = "2.8.1-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_dashboard_msgs/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "6fc22379615c05f42fab0074c98dfc99ebbe07ddb6019a400ea850e3f46afc69";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_dashboard_msgs/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "ad6076f8bba639b45d4b9c0c71190dfd1c5d5877c15e681edd312d6e5b51574b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-moveit-config/default.nix
+++ b/distros/humble/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, launch, launch-ros, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, rviz2, ur-description, urdf, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-moveit-config";
-  version = "2.8.1-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_moveit_config/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "e4f3848fb4c797f876892d1cd7e95987bf687e9d0929e2194e710a0898c342d2";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_moveit_config/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "2949bf46893f754095971e6a156880488227604e63ea6eca497c3d26fb971784";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-robot-driver/default.nix
+++ b/distros/humble/ur-robot-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, backward-ros, controller-manager, controller-manager-msgs, force-torque-sensor-broadcaster, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, pluginlib, pose-broadcaster, position-controllers, rclcpp, rclcpp-lifecycle, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, socat, std-msgs, std-srvs, tf2-geometry-msgs, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-robot-driver";
-  version = "2.8.1-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_robot_driver/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "378ca4b68e7c5ad43bc287e6af536615931ecff4fcd5a4ebc07c7f57f3a21537";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_robot_driver/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "73d09d511061f52571f75fed6fc5964a533c250810f18b29a68e497ca1d3e89f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-simulation-gz/default.nix
+++ b/distros/humble/ur-simulation-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ign-ros2-control, joint-state-publisher, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, ros-gz-bridge, ros-gz-sim, rviz2, ur-controllers, ur-description, ur-moveit-config, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-simulation-gz";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_simulation_gz-release/archive/release/humble/ur_simulation_gz/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "aa530454f85eaa353a4fa404d3eddda796f513e104a9541c0d03b3d2ae0a29ad";
+    url = "https://github.com/ros2-gbp/ur_simulation_gz-release/archive/release/humble/ur_simulation_gz/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "9660a7414e8b7b31d1adad460f900445557d3c5bcd2aa60d4b11aaf95df685e8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur/default.nix
+++ b/distros/humble/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-humble-ur";
-  version = "2.8.1-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "94c990cf837577ed9d965988d5b34215b65dd10b329214b7cc6d52286dfb2252";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "c693f86b30edd0bee37ba72a007b6beb8235dff974630c50d4686adb04f09a16";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ackermann-nlmpc-msgs/default.nix
+++ b/distros/jazzy/ackermann-nlmpc-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ackermann-nlmpc-msgs";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ackmerann_nlmpc-release/archive/release/jazzy/ackermann_nlmpc_msgs/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "722b38ae5d92abd12a856b239dc36b4c88c3e70ba270a957f177c15bdfe1e786";
+    url = "https://github.com/ros2-gbp/ackmerann_nlmpc-release/archive/release/jazzy/ackermann_nlmpc_msgs/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "8a54b718cdd496ac1d9d523168dd09a2c4b5d3b584941a6cebbc6a5b13dbf492";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ackermann-nlmpc/default.nix
+++ b/distros/jazzy/ackermann-nlmpc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ackermann-nlmpc-msgs, ament-pep257, geometry-msgs, nav-msgs, python3Packages, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ackermann-nlmpc";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ackmerann_nlmpc-release/archive/release/jazzy/ackermann_nlmpc/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "b1baf73beff7d280f8b3299d1a153dd85ab9a8b2de8b498cfda8c7863b91b4c1";
+    url = "https://github.com/ros2-gbp/ackmerann_nlmpc-release/archive/release/jazzy/ackermann_nlmpc/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "0dcb1a4787ece0e8a88edae11952626249c86b1be95deb86f1417000e56de73e";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/action-tutorials-cpp/default.nix
+++ b/distros/jazzy/action-tutorials-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-action, rclcpp-components }:
 buildRosPackage {
   pname = "ros-jazzy-action-tutorials-cpp";
-  version = "0.33.6-r1";
+  version = "0.33.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/action_tutorials_cpp/0.33.6-1.tar.gz";
-    name = "0.33.6-1.tar.gz";
-    sha256 = "96e4dd05bec536f2ca3d3462ef17e9a8b3524359a6a3511ba6d383899bc39cd0";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/action_tutorials_cpp/0.33.7-1.tar.gz";
+    name = "0.33.7-1.tar.gz";
+    sha256 = "84412b6d1aeea9908ff50176375e00743ffb78b03afa602ee951052469a079f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/action-tutorials-interfaces/default.nix
+++ b/distros/jazzy/action-tutorials-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-action-tutorials-interfaces";
-  version = "0.33.6-r1";
+  version = "0.33.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/action_tutorials_interfaces/0.33.6-1.tar.gz";
-    name = "0.33.6-1.tar.gz";
-    sha256 = "cddfc9c4375ffe049f01e76086788b981c61fc54d1f84227135b320a8672fc5b";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/action_tutorials_interfaces/0.33.7-1.tar.gz";
+    name = "0.33.7-1.tar.gz";
+    sha256 = "1471301a455676b11078ed243a7bc660965c6ac0eb9d250483bedb443ac46db5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/action-tutorials-py/default.nix
+++ b/distros/jazzy/action-tutorials-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-copyright, ament-flake8, ament-pep257, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-action-tutorials-py";
-  version = "0.33.6-r1";
+  version = "0.33.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/action_tutorials_py/0.33.6-1.tar.gz";
-    name = "0.33.6-1.tar.gz";
-    sha256 = "e65ef47d3b550ac69c2ddece4ff8eb24753271ed8f6de35d55c9d94a3beb76b5";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/action_tutorials_py/0.33.7-1.tar.gz";
+    name = "0.33.7-1.tar.gz";
+    sha256 = "80d4be0206333f6e244d54358f09a8bfebf91290e49352335cfd8226604159fc";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ads-vendor/default.nix
+++ b/distros/jazzy/ads-vendor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, git }:
+buildRosPackage {
+  pname = "ros-jazzy-ads-vendor";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/b-robotized/ads_vendor-release/archive/release/jazzy/ads_vendor/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "3d5d9c84777a0f52c87eb5e9d01550a0991e772bdc8b04922ac445f48408deb2";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake git ];
+  nativeBuildInputs = [ ament-cmake git ];
+
+  meta = {
+    description = "Package vendoring Beckhoff/ADS library";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/angles/default.nix
+++ b/distros/jazzy/angles/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, python3Packages }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-angles";
-  version = "1.16.0-r5";
+  version = "1.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/angles-release/archive/release/jazzy/angles/1.16.0-5.tar.gz";
-    name = "1.16.0-5.tar.gz";
-    sha256 = "ceca46e4e5a275e95b9d9ef05c4ccf2e33ab76350ba4c0db4e7805677cc76352";
+    url = "https://github.com/ros2-gbp/angles-release/archive/release/jazzy/angles/1.16.1-1.tar.gz";
+    name = "1.16.1-1.tar.gz";
+    sha256 = "b24f9df85187f4216930bcdd34db7ece07711dd0eb49a9c4d368130bbd71bed3";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-python python3Packages.setuptools ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ];
   propagatedBuildInputs = [ ament-cmake ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python python3Packages.setuptools ];
 

--- a/distros/jazzy/clearpath-bt-joy/default.nix
+++ b/distros/jazzy/clearpath-bt-joy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, bluez, joy-linux, python3Packages, twist-mux }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-bt-joy";
-  version = "2.7.3-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bt_joy/2.7.3-1.tar.gz";
-    name = "2.7.3-1.tar.gz";
-    sha256 = "3daa84559c9402e9db7fe9d4bf57695b394f4e0ee9c6b222f12efe2a794af7f0";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bt_joy/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "a0afc4db88f3d3684d3659a3761108b2cbeaae3404d8349ceaafa775115107ac";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/clearpath-common/default.nix
+++ b/distros/jazzy/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-common";
-  version = "2.7.3-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_common/2.7.3-1.tar.gz";
-    name = "2.7.3-1.tar.gz";
-    sha256 = "1e317d31774c0f4f51fa2dc4da486ad4a4ddd5374463e5badff7ba4d57015d62";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_common/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "572b3d6a7a6d45b075612ea61aa2bdfdaa1f1888366b4522242b3fe017d0e5b9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-config/default.nix
+++ b/distros/jazzy/clearpath-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-config";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/jazzy/clearpath_config/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "e41adaf67706a9a5214774d247c35d2804ec0575b153cb4567caacfdf53789d7";
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/jazzy/clearpath_config/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "9ee92cf2cbe21e7c8195e4850c700c0c87a09c8db2da72551ea0a532137b1085";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/clearpath-control/default.nix
+++ b/distros/jazzy/clearpath-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-bt-joy, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, mecanum-drive-controller, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-control";
-  version = "2.7.3-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_control/2.7.3-1.tar.gz";
-    name = "2.7.3-1.tar.gz";
-    sha256 = "3c3ab3d46a67b7b436349aa3c48d069c435216d638306f3ef737693c5151d322";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_control/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "63df7d2f7371b42fda1e2d0567011b4019bf1bef249d1bc9ced8d3544731636b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-customization/default.nix
+++ b/distros/jazzy/clearpath-customization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-customization";
-  version = "2.7.3-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_customization/2.7.3-1.tar.gz";
-    name = "2.7.3-1.tar.gz";
-    sha256 = "cdca857d9ac8ce162e3bc8a8730c5af558947aabc491b6455562ec6d7143a0ab";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_customization/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "11d7643e103af95381eb6b9d44b19bfd3c15b07742f83e888ea7382cc711a7c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-description/default.nix
+++ b/distros/jazzy/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-description";
-  version = "2.7.3-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_description/2.7.3-1.tar.gz";
-    name = "2.7.3-1.tar.gz";
-    sha256 = "e095d82d6677974751b315f0bb069718e2523caee320a92ade3eb23049fe87ec";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_description/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "97dcdee085c0ffce5ceacd1fcedf2ae853a56602d95945ef399c54002ac4f18d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-diagnostics/default.nix
+++ b/distros/jazzy/clearpath-diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-platform-msgs, diagnostic-aggregator, diagnostic-updater, foxglove-bridge, rclcpp, ros2launch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-diagnostics";
-  version = "2.7.3-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_diagnostics/2.7.3-1.tar.gz";
-    name = "2.7.3-1.tar.gz";
-    sha256 = "463137de0a029e1b1b08c3e4c50c19304b9123ca0aeec9a346449d3b586d87c0";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_diagnostics/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "4ba5030992a661141ca3acb66b4218e0c3184dfef8192be20c60b0bf213c79d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-generator-common/default.nix
+++ b/distros/jazzy/clearpath-generator-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-diagnostics, clearpath-manipulators, moveit-setup-srdf-plugins }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-generator-common";
-  version = "2.7.3-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_generator_common/2.7.3-1.tar.gz";
-    name = "2.7.3-1.tar.gz";
-    sha256 = "d2af370bc3b79c66831a7e6c417cbafa0055fbbe3d5c447fae813a8de4e07bd7";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_generator_common/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "c8d59df53f1bb546acbcad2aedd4c89e2dac1a6386eff20c1ffc5a299e06fdb7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-manipulators-description/default.nix
+++ b/distros/jazzy/clearpath-manipulators-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ewellix-description, robot-state-publisher, robotiq-description, ur-description, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-manipulators-description";
-  version = "2.7.3-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators_description/2.7.3-1.tar.gz";
-    name = "2.7.3-1.tar.gz";
-    sha256 = "e68a71afcae67e1e922bc516848c2afb64de7f4a1fb5f9fb6f1f0a179afbea46";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators_description/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "7f74c427bf84d390f0dea8bc2d36cbf6af34c016af47bbd0ad1831541bcac7e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-manipulators/default.nix
+++ b/distros/jazzy/clearpath-manipulators/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, gripper-controllers, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-warehouse, moveit-setup-srdf-plugins, moveit-simple-controller-manager, position-controllers, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-manipulators";
-  version = "2.7.3-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators/2.7.3-1.tar.gz";
-    name = "2.7.3-1.tar.gz";
-    sha256 = "7ae49bb058f5a9ed8ad141f2cdeac44621af04bcadbec1e5940ea84078593175";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "6460c6421f611c742273b0e8d32ca5d00982fc583d0ed597ee3844efbd24cdac";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-mounts-description/default.nix
+++ b/distros/jazzy/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-mounts-description";
-  version = "2.7.3-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_mounts_description/2.7.3-1.tar.gz";
-    name = "2.7.3-1.tar.gz";
-    sha256 = "bce13127e789aa14ff8c89a1e6d484b3709472c95bb27b7d53f365d87f5e1730";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_mounts_description/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "f52acaad38dec502548afe584df8bf30718a754885859446a3376e4b3c52cae5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-platform-description/default.nix
+++ b/distros/jazzy/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-platform-description";
-  version = "2.7.3-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_platform_description/2.7.3-1.tar.gz";
-    name = "2.7.3-1.tar.gz";
-    sha256 = "8324642752f18f1e81df63ece8723ed464ebc78923a2d1f91da296fa31c83cce";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_platform_description/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "08f5004fa991130f846cc296455b72fa3e73d469434b4d8c683283a0f9337893";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-sensors-description/default.nix
+++ b/distros/jazzy/clearpath-sensors-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, axis-description, microstrain-inertial-description, realsense2-description, velodyne-description }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-sensors-description";
-  version = "2.7.3-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_sensors_description/2.7.3-1.tar.gz";
-    name = "2.7.3-1.tar.gz";
-    sha256 = "02310927686696e4ba67f52d6a2fa8bbc5ba100816123b7fd10e3f2b643d4af9";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_sensors_description/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "5d6cc50e2979edb982744f44fe98eddd451a577798665533e31ba9ecd115e078";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/composition/default.nix
+++ b/distros/jazzy/composition/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-composition";
-  version = "0.33.6-r1";
+  version = "0.33.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/composition/0.33.6-1.tar.gz";
-    name = "0.33.6-1.tar.gz";
-    sha256 = "9e489dd6c36edf77a160e1f2bd0998085f82675c946b01c8b047d3bd1fa3819d";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/composition/0.33.7-1.tar.gz";
+    name = "0.33.7-1.tar.gz";
+    sha256 = "f2b0784a8cc34f6e72644429357eb26ae87fa81cf035b13d385f12cd010b9679";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/control-toolbox/default.nix
+++ b/distros/jazzy/control-toolbox/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, eigen, filters, fmt, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-cmake, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, eigen, filters, fmt, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-cmake, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-control-toolbox";
-  version = "4.7.0-r1";
+  version = "4.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/jazzy/control_toolbox/4.7.0-1.tar.gz";
-    name = "4.7.0-1.tar.gz";
-    sha256 = "0b777c45f7150742bd5890e9fcda1aae5ada59572f06f9fe993764d4476789d3";
+    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/jazzy/control_toolbox/4.7.1-1.tar.gz";
+    name = "4.7.1-1.tar.gz";
+    sha256 = "50d22c066b0c5f37853950be76cbf24039c0723983605cd077b5acce3966efc5";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock rclcpp-lifecycle ];
-  propagatedBuildInputs = [ control-msgs eigen filters fmt generate-parameter-library geometry-msgs pluginlib rclcpp rcutils realtime-tools tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ backward-ros control-msgs eigen filters fmt generate-parameter-library geometry-msgs pluginlib rclcpp rcutils realtime-tools tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/costmap-queue/default.nix
+++ b/distros/jazzy/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-costmap-queue";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/costmap_queue/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "027a6ee2861df083441f6ed954be63e04c66d93f5a3f9d51fdf5758183785279";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/costmap_queue/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "03e55cbab83abd8b0322e6b5b5f3c1ec85380ee423bd2f7d904508117837f88a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/demo-nodes-cpp-native/default.nix
+++ b/distros/jazzy/demo-nodes-cpp-native/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rmw-fastrtps-cpp, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-demo-nodes-cpp-native";
-  version = "0.33.6-r1";
+  version = "0.33.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/demo_nodes_cpp_native/0.33.6-1.tar.gz";
-    name = "0.33.6-1.tar.gz";
-    sha256 = "f70bb7a478594edc48837dc598323a450362de10d7b7cee3151b6f97484fda6b";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/demo_nodes_cpp_native/0.33.7-1.tar.gz";
+    name = "0.33.7-1.tar.gz";
+    sha256 = "3099f66c7564a3a1695bf8bb96f4ec01d32a95239aeb821d31b8c8346d3f6cd2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/demo-nodes-cpp/default.nix
+++ b/distros/jazzy/demo-nodes-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, launch-xml, rcl, rcl-interfaces, rclcpp, rclcpp-components, rcpputils, rcutils, rmw, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-demo-nodes-cpp";
-  version = "0.33.6-r1";
+  version = "0.33.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/demo_nodes_cpp/0.33.6-1.tar.gz";
-    name = "0.33.6-1.tar.gz";
-    sha256 = "83e476bf85deeb7d3c601981a03fbcce2af13cd1e656c84fda9103f364f79775";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/demo_nodes_cpp/0.33.7-1.tar.gz";
+    name = "0.33.7-1.tar.gz";
+    sha256 = "1cc9e24a8f5eb2f3630a15ea5db7198149a17363052a48b855c2ceffa29c4d34";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/demo-nodes-py/default.nix
+++ b/distros/jazzy/demo-nodes-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, example-interfaces, python3Packages, rcl-interfaces, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-demo-nodes-py";
-  version = "0.33.6-r1";
+  version = "0.33.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/demo_nodes_py/0.33.6-1.tar.gz";
-    name = "0.33.6-1.tar.gz";
-    sha256 = "7f3612689554accb8ca4356d040a1ef1c2cbf7cbc7f529976624aad5501016b1";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/demo_nodes_py/0.33.7-1.tar.gz";
+    name = "0.33.7-1.tar.gz";
+    sha256 = "d1d38b2c70b46042104df8e5612bd28e5177aa9938fd630765327817aab1f067";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/dummy-map-server/default.nix
+++ b/distros/jazzy/dummy-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-dummy-map-server";
-  version = "0.33.6-r1";
+  version = "0.33.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/dummy_map_server/0.33.6-1.tar.gz";
-    name = "0.33.6-1.tar.gz";
-    sha256 = "5f42d627478958f514817968f02e8a07fc451c94d5dafeb15f4bc26a1c6662bd";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/dummy_map_server/0.33.7-1.tar.gz";
+    name = "0.33.7-1.tar.gz";
+    sha256 = "282812b0b8c2a785bc7f6a36091b2f84913e351079d20219b96e9091ba33fdcb";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dummy-robot-bringup/default.nix
+++ b/distros/jazzy/dummy-robot-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, dummy-map-server, dummy-sensors, launch, launch-ros, robot-state-publisher }:
 buildRosPackage {
   pname = "ros-jazzy-dummy-robot-bringup";
-  version = "0.33.6-r1";
+  version = "0.33.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/dummy_robot_bringup/0.33.6-1.tar.gz";
-    name = "0.33.6-1.tar.gz";
-    sha256 = "6496f0bfd6989c9e2c4c2468caf900d13f23921ffc3a7a331d11b6dbcbd82cfe";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/dummy_robot_bringup/0.33.7-1.tar.gz";
+    name = "0.33.7-1.tar.gz";
+    sha256 = "5c3a1357567d3d0fe2015122f2e02881e5ec096bea4172bde0a55c64880a1e7b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dummy-sensors/default.nix
+++ b/distros/jazzy/dummy-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-dummy-sensors";
-  version = "0.33.6-r1";
+  version = "0.33.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/dummy_sensors/0.33.6-1.tar.gz";
-    name = "0.33.6-1.tar.gz";
-    sha256 = "ac5deefe9c1b5251dfa2fa37cb553c2f12bc1a8ba280ed429395f9c7757f197d";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/dummy_sensors/0.33.7-1.tar.gz";
+    name = "0.33.7-1.tar.gz";
+    sha256 = "c05e495e004924a3e755576f01ee3a37500e589d2fb12bbaa6463d62cc81b35c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dwb-core/default.nix
+++ b/distros/jazzy/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-dwb-core";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/dwb_core/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "32b432220196a51168e5c444cbb4f8fad92085374603eb4cb02543fe446c8f69";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/dwb_core/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "405f5a1ce062a9db3c5cf01ecaca982b3dc8adf98f04253571d129acd8ccacd7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dwb-critics/default.nix
+++ b/distros/jazzy/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-dwb-critics";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/dwb_critics/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "23f303b6344e208d7780395a4e7ec06cc675e3a7f4432d3bfe01d41b9731725e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/dwb_critics/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "2422cdff41d81fca4f8954dadb4b6fe4433523e6f09b31303b4253668d0bb767";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dwb-msgs/default.nix
+++ b/distros/jazzy/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-dwb-msgs";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/dwb_msgs/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "14ed243b7f3f79c387777a94b98f6827c64116c8a1285e086a041b202c37637d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/dwb_msgs/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "5162b4e24819dcb0772ab60d60959721033b93fa28f8e21bf6d1e0ef3ac33eca";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dwb-plugins/default.nix
+++ b/distros/jazzy/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-dwb-plugins";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/dwb_plugins/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "aa5177ebf6b8883ba845b8e4ded47972c386ae02d0bc61c57fc47295e0e4fdad";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/dwb_plugins/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "4756bc3f8c9e7373284c43b867589653031d2b95f88a7172c2da8a380b2d9945";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dynamixel-hardware-interface/default.nix
+++ b/distros/jazzy/dynamixel-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-interfaces, dynamixel-sdk, hardware-interface, pluginlib, rclcpp, realtime-tools, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-dynamixel-hardware-interface";
-  version = "1.4.14-r1";
+  version = "1.4.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/jazzy/dynamixel_hardware_interface/1.4.14-1.tar.gz";
-    name = "1.4.14-1.tar.gz";
-    sha256 = "9d3e9f957dba2ab72c073cb41b8bc2da2b7d63b6b6b9421595b19c7c0c716a4b";
+    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/jazzy/dynamixel_hardware_interface/1.4.15-1.tar.gz";
+    name = "1.4.15-1.tar.gz";
+    sha256 = "9ed676df449ea6335b4ffca0bfa966aaeeea345c565c15796ef0de1dc1301f40";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ffw-bringup/default.nix
+++ b/distros/jazzy/ffw-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, dynamixel-hardware-interface, ffw-description, gz-ros2-control, image-transport-plugins, rclpy, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, ros2-control, ros2-controllers, rviz2, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-ffw-bringup";
-  version = "1.1.11-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ai_worker-release/archive/release/jazzy/ffw_bringup/1.1.11-1.tar.gz";
-    name = "1.1.11-1.tar.gz";
-    sha256 = "b32eabdf956e0ad2f18d2016dbaf42542bc140c76a38e76f302872718cd29c10";
+    url = "https://github.com/ros2-gbp/ai_worker-release/archive/release/jazzy/ffw_bringup/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "2919baf95d58bf7e869155943be76a712d339cf70bdebef3496b575486f4f1a1";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ffw-description/default.nix
+++ b/distros/jazzy/ffw-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, rviz2, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-ffw-description";
-  version = "1.1.11-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ai_worker-release/archive/release/jazzy/ffw_description/1.1.11-1.tar.gz";
-    name = "1.1.11-1.tar.gz";
-    sha256 = "6f7410cc6f3ae6fc3059e1a16e18082f84d819459aa48e35a3e112c3c7eaae4d";
+    url = "https://github.com/ros2-gbp/ai_worker-release/archive/release/jazzy/ffw_description/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "92ea3dc8b18c085569a770ec377d65aeefa631c37339b3655dd1768bfa79e232";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ffw-joint-trajectory-command-broadcaster/default.nix
+++ b/distros/jazzy/ffw-joint-trajectory-command-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-ffw-joint-trajectory-command-broadcaster";
-  version = "1.1.11-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ai_worker-release/archive/release/jazzy/ffw_joint_trajectory_command_broadcaster/1.1.11-1.tar.gz";
-    name = "1.1.11-1.tar.gz";
-    sha256 = "e5fc141c39c03e75573c024932195974c419c1830f098b12dd987c14e3dd778b";
+    url = "https://github.com/ros2-gbp/ai_worker-release/archive/release/jazzy/ffw_joint_trajectory_command_broadcaster/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "bd529df0f57789c45457bb6bd548cc8d0254d1ae5d183fefc19d697129d96653";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ffw-joystick-controller/default.nix
+++ b/distros/jazzy/ffw-joystick-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ffw-joystick-controller";
-  version = "1.1.11-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ai_worker-release/archive/release/jazzy/ffw_joystick_controller/1.1.11-1.tar.gz";
-    name = "1.1.11-1.tar.gz";
-    sha256 = "ac37b9bafe888c88c9525f7fff23a16153988f777ee0d6c0357f18830208c160";
+    url = "https://github.com/ros2-gbp/ai_worker-release/archive/release/jazzy/ffw_joystick_controller/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "fd569d39f2ee54f6ceaf44be1df61b3c6d02551f831b9e20bb1a5176fcab8b9e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ffw-moveit-config/default.nix
+++ b/distros/jazzy/ffw-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, joint-state-publisher, joint-state-publisher-gui, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-ffw-moveit-config";
-  version = "1.1.11-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ai_worker-release/archive/release/jazzy/ffw_moveit_config/1.1.11-1.tar.gz";
-    name = "1.1.11-1.tar.gz";
-    sha256 = "8d511d61c7436ee99a69f0bfa98c8f2469f9e9b593c0de85f314c9eb08dae0e7";
+    url = "https://github.com/ros2-gbp/ai_worker-release/archive/release/jazzy/ffw_moveit_config/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "252dca8881b69f1e9aa6621c8c74b488e62a294b3eeb78f4f92faaf974660a03";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ffw-robot-manager/default.nix
+++ b/distros/jazzy/ffw-robot-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-interface, dynamixel-hardware-interface, dynamixel-interfaces, generate-parameter-library, hardware-interface, pluginlib, rclcpp, ros2-control-cmake, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-ffw-robot-manager";
-  version = "1.1.11-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ai_worker-release/archive/release/jazzy/ffw_robot_manager/1.1.11-1.tar.gz";
-    name = "1.1.11-1.tar.gz";
-    sha256 = "5a805b3b5ae1b89199a3e8261c87c4b0ca57aa8449aead13c4c7cbe711861799";
+    url = "https://github.com/ros2-gbp/ai_worker-release/archive/release/jazzy/ffw_robot_manager/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "8dee4008a0ffbd525528a17d46617fd682451b08113985333dcba447f56f34ce";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ffw-spring-actuator-controller/default.nix
+++ b/distros/jazzy/ffw-spring-actuator-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-ffw-spring-actuator-controller";
-  version = "1.1.11-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ai_worker-release/archive/release/jazzy/ffw_spring_actuator_controller/1.1.11-1.tar.gz";
-    name = "1.1.11-1.tar.gz";
-    sha256 = "145fae7b930e145ea7e77df282d3f5810b6bbd6348b4e7a01d1fdd4b38f6d92e";
+    url = "https://github.com/ros2-gbp/ai_worker-release/archive/release/jazzy/ffw_spring_actuator_controller/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "e512d70134b5324b4aa04b16e5af5c9a63be4ca4ba3856a573c9e780f02b3ea7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ffw-swerve-drive-controller/default.nix
+++ b/distros/jazzy/ffw-swerve-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-lint-auto, ament-lint-common, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ffw-swerve-drive-controller";
-  version = "1.1.11-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ai_worker-release/archive/release/jazzy/ffw_swerve_drive_controller/1.1.11-1.tar.gz";
-    name = "1.1.11-1.tar.gz";
-    sha256 = "b4e09b0f7d72113e025e42c46220d8c718751e7f871c8cb4605db06b2386923e";
+    url = "https://github.com/ros2-gbp/ai_worker-release/archive/release/jazzy/ffw_swerve_drive_controller/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "a5657144afb7abb8141f766c485a4f3a4669647e3e090d2cd050a860905a7532";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ffw-teleop/default.nix
+++ b/distros/jazzy/ffw-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-ffw-teleop";
-  version = "1.1.11-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ai_worker-release/archive/release/jazzy/ffw_teleop/1.1.11-1.tar.gz";
-    name = "1.1.11-1.tar.gz";
-    sha256 = "1430bd72758e80d5d1f5e563157cc8b44585c38934ff6c6a011b03fd5f423232";
+    url = "https://github.com/ros2-gbp/ai_worker-release/archive/release/jazzy/ffw_teleop/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "7f3fd71f80bf1051ddfc96ae0901e223cd47e559d341287a60a69fad08169fed";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ffw/default.nix
+++ b/distros/jazzy/ffw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ffw-bringup, ffw-description, ffw-joint-trajectory-command-broadcaster, ffw-joystick-controller, ffw-moveit-config, ffw-robot-manager, ffw-spring-actuator-controller, ffw-swerve-drive-controller, ffw-teleop }:
 buildRosPackage {
   pname = "ros-jazzy-ffw";
-  version = "1.1.11-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ai_worker-release/archive/release/jazzy/ffw/1.1.11-1.tar.gz";
-    name = "1.1.11-1.tar.gz";
-    sha256 = "8919a4ef9465f9ff458f031495e207889dd785b73fea999e7c85b59fcc7313eb";
+    url = "https://github.com/ros2-gbp/ai_worker-release/archive/release/jazzy/ffw/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "8afe27125e72d3c12d2d7880a0d1e2f80ab5a9a5e333b46db8c21b2774cd18e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -30,6 +30,8 @@ self: super: {
 
  admittance-controller = self.callPackage ./admittance-controller {};
 
+ ads-vendor = self.callPackage ./ads-vendor {};
+
  ament-acceleration = self.callPackage ./ament-acceleration {};
 
  ament-black = self.callPackage ./ament-black {};
@@ -1536,8 +1538,6 @@ self: super: {
 
  mola-gnss-to-markers = self.callPackage ./mola-gnss-to-markers {};
 
- mola-imu-preintegration = self.callPackage ./mola-imu-preintegration {};
-
  mola-input-euroc-dataset = self.callPackage ./mola-input-euroc-dataset {};
 
  mola-input-kitti360-dataset = self.callPackage ./mola-input-kitti360-dataset {};
@@ -1567,12 +1567,6 @@ self: super: {
  mola-pose-list = self.callPackage ./mola-pose-list {};
 
  mola-relocalization = self.callPackage ./mola-relocalization {};
-
- mola-state-estimation = self.callPackage ./mola-state-estimation {};
-
- mola-state-estimation-simple = self.callPackage ./mola-state-estimation-simple {};
-
- mola-state-estimation-smoother = self.callPackage ./mola-state-estimation-smoother {};
 
  mola-test-datasets = self.callPackage ./mola-test-datasets {};
 
@@ -1828,6 +1822,8 @@ self: super: {
 
  nav2-rotation-shim-controller = self.callPackage ./nav2-rotation-shim-controller {};
 
+ nav2-route = self.callPackage ./nav2-route {};
+
  nav2-rviz-plugins = self.callPackage ./nav2-rviz-plugins {};
 
  nav2-simple-commander = self.callPackage ./nav2-simple-commander {};
@@ -1865,8 +1861,6 @@ self: super: {
  nicla-vision-ros2 = self.callPackage ./nicla-vision-ros2 {};
 
  nlohmann-json-schema-validator-vendor = self.callPackage ./nlohmann-json-schema-validator-vendor {};
-
- nmea-hardware-interface = self.callPackage ./nmea-hardware-interface {};
 
  nmea-msgs = self.callPackage ./nmea-msgs {};
 
@@ -1913,6 +1907,32 @@ self: super: {
  odom-to-tf-ros2 = self.callPackage ./odom-to-tf-ros2 {};
 
  odri-master-board-sdk = self.callPackage ./odri-master-board-sdk {};
+
+ off-highway-can = self.callPackage ./off-highway-can {};
+
+ off-highway-general-purpose-radar = self.callPackage ./off-highway-general-purpose-radar {};
+
+ off-highway-general-purpose-radar-msgs = self.callPackage ./off-highway-general-purpose-radar-msgs {};
+
+ off-highway-premium-radar = self.callPackage ./off-highway-premium-radar {};
+
+ off-highway-premium-radar-msgs = self.callPackage ./off-highway-premium-radar-msgs {};
+
+ off-highway-premium-radar-sample = self.callPackage ./off-highway-premium-radar-sample {};
+
+ off-highway-premium-radar-sample-msgs = self.callPackage ./off-highway-premium-radar-sample-msgs {};
+
+ off-highway-radar = self.callPackage ./off-highway-radar {};
+
+ off-highway-radar-msgs = self.callPackage ./off-highway-radar-msgs {};
+
+ off-highway-sensor-drivers = self.callPackage ./off-highway-sensor-drivers {};
+
+ off-highway-sensor-drivers-examples = self.callPackage ./off-highway-sensor-drivers-examples {};
+
+ off-highway-uss = self.callPackage ./off-highway-uss {};
+
+ off-highway-uss-msgs = self.callPackage ./off-highway-uss-msgs {};
 
  om-gravity-compensation-controller = self.callPackage ./om-gravity-compensation-controller {};
 
@@ -2144,6 +2164,8 @@ self: super: {
 
  pybind11-vendor = self.callPackage ./pybind11-vendor {};
 
+ pymoveit2 = self.callPackage ./pymoveit2 {};
+
  python-cmake-module = self.callPackage ./python-cmake-module {};
 
  python-mrpt = self.callPackage ./python-mrpt {};
@@ -2279,6 +2301,14 @@ self: super: {
  rcss3d-nao = self.callPackage ./rcss3d-nao {};
 
  rcutils = self.callPackage ./rcutils {};
+
+ rdl = self.callPackage ./rdl {};
+
+ rdl-benchmark = self.callPackage ./rdl-benchmark {};
+
+ rdl-dynamics = self.callPackage ./rdl-dynamics {};
+
+ rdl-urdfreader = self.callPackage ./rdl-urdfreader {};
 
  realsense2-camera = self.callPackage ./realsense2-camera {};
 
@@ -3003,6 +3033,8 @@ self: super: {
  tango-icons-vendor = self.callPackage ./tango-icons-vendor {};
 
  tcb-span = self.callPackage ./tcb-span {};
+
+ tecgihan-driver = self.callPackage ./tecgihan-driver {};
 
  teleop-tools = self.callPackage ./teleop-tools {};
 

--- a/distros/jazzy/image-tools/default.nix
+++ b/distros/jazzy/image-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, opencv, rclcpp, rclcpp-components, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-image-tools";
-  version = "0.33.6-r1";
+  version = "0.33.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/image_tools/0.33.6-1.tar.gz";
-    name = "0.33.6-1.tar.gz";
-    sha256 = "79672bb91cfd2a5a3f4db6e62374f76f0e6f83b92babfe65472f390a60dbb9df";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/image_tools/0.33.7-1.tar.gz";
+    name = "0.33.7-1.tar.gz";
+    sha256 = "8944a0409de41753b2b769453b2fbac1015cbc9676a92b57d015ce19be4f850f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/insight-gui/default.nix
+++ b/distros/jazzy/insight-gui/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, adwaita-icon-theme, ament-copyright, ament-flake8, ament-pep257, glib, gobject-introspection, gtk4, libadwaita, python3Packages, rclpy, ros2cli, ros2launch, turtlesim }:
+{ lib, buildRosPackage, fetchurl, adwaita-icon-theme, ament-copyright, ament-flake8, ament-pep257, glib, gobject-introspection, gtk4, libadwaita, python3Packages, rclpy, ros2cli, ros2launch, tf-transformations, tf2-ros, turtlesim }:
 buildRosPackage {
   pname = "ros-jazzy-insight-gui";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/insight_gui-release/archive/release/jazzy/insight_gui/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "59a77eb89f88f97b4e1169070f900efab89effbd5207e87e27f2353cb00de2b0";
+    url = "https://github.com/ros2-gbp/insight_gui-release/archive/release/jazzy/insight_gui/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "ba5df5559e1435337f9d469601c733725eb1c6af2fc8b8f10ea05808ec715940";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
-  propagatedBuildInputs = [ adwaita-icon-theme glib gobject-introspection gtk4 libadwaita python3Packages.networkx python3Packages.pygobject3 python3Packages.pygraphviz rclpy ros2cli ros2launch turtlesim ];
+  propagatedBuildInputs = [ adwaita-icon-theme glib gobject-introspection gtk4 libadwaita python3Packages.networkx python3Packages.pygobject3 python3Packages.pygraphviz rclpy ros2cli ros2launch tf-transformations tf2-ros turtlesim ];
 
   meta = {
     description = "Insight is a minimalist GUI alternative to rqt. It is a GTK4-based tool for exploring ROS2 topics, services, and messages, featuring the GNOME Adwaita style.";

--- a/distros/jazzy/intra-process-demo/default.nix
+++ b/distros/jazzy/intra-process-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, opencv, rclcpp, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-intra-process-demo";
-  version = "0.33.6-r1";
+  version = "0.33.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/intra_process_demo/0.33.6-1.tar.gz";
-    name = "0.33.6-1.tar.gz";
-    sha256 = "29b1b7cfcf67c2335b277d4026fee169efb1c6a5ee0a594de35f5cef780ec28a";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/intra_process_demo/0.33.7-1.tar.gz";
+    name = "0.33.7-1.tar.gz";
+    sha256 = "4f03336a6706229548d67d6278dd5cc633a80ffe891c1e1997f9f4dadb0e53f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/lifecycle-py/default.nix
+++ b/distros/jazzy/lifecycle-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, lifecycle, lifecycle-msgs, rclpy, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-lifecycle-py";
-  version = "0.33.6-r1";
+  version = "0.33.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/lifecycle_py/0.33.6-1.tar.gz";
-    name = "0.33.6-1.tar.gz";
-    sha256 = "70cf00da4b05a2ed1359735ff1c0e974801bad9a940d2e41b31fa4e5e200d899";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/lifecycle_py/0.33.7-1.tar.gz";
+    name = "0.33.7-1.tar.gz";
+    sha256 = "6ceaa47434f587831f6e2f041c9085d80a86072afcec9a709f8cc24ee3b5dd7f";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/lifecycle/default.nix
+++ b/distros/jazzy/lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-lifecycle";
-  version = "0.33.6-r1";
+  version = "0.33.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/lifecycle/0.33.6-1.tar.gz";
-    name = "0.33.6-1.tar.gz";
-    sha256 = "696d3cd28ba3b6e36a15700c87526420449582dacd30c979603cd34b8c732e03";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/lifecycle/0.33.7-1.tar.gz";
+    name = "0.33.7-1.tar.gz";
+    sha256 = "fb07fe80b1ccb24f6ffab5e7963b32d7a49773ac86eaf73aa6f48e2e6db0aee3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/logging-demo/default.nix
+++ b/distros/jazzy/logging-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-logging-demo";
-  version = "0.33.6-r1";
+  version = "0.33.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/logging_demo/0.33.6-1.tar.gz";
-    name = "0.33.6-1.tar.gz";
-    sha256 = "d66fb8f4b6337650b140f07059b513686a41bea629ab8bfd362c98e56019b383";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/logging_demo/0.33.7-1.tar.gz";
+    name = "0.33.7-1.tar.gz";
+    sha256 = "15e0d7a8a04dd2225ff82ed2a9c85d1df02664e032cf454d25c6340edae6e867";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mqtt-client-interfaces/default.nix
+++ b/distros/jazzy/mqtt-client-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mqtt-client-interfaces";
-  version = "2.4.1-r1";
+  version = "2.4.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/jazzy/mqtt_client_interfaces/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "066c8abc4e112d883515003aeddbe5a06d3e4ee1d07d3aed232dd585c421f4df";
+    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/jazzy/mqtt_client_interfaces/2.4.1-2.tar.gz";
+    name = "2.4.1-2.tar.gz";
+    sha256 = "929f32363f52f9da208d64340dc5d68729b52776a52245529096ce6c58ad50ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mqtt-client/default.nix
+++ b/distros/jazzy/mqtt-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmt, mqtt-client-interfaces, paho-mqtt-c, paho-mqtt-cpp, rclcpp, rclcpp-components, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mqtt-client";
-  version = "2.4.1-r1";
+  version = "2.4.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/jazzy/mqtt_client/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "0ca000e298a428bb3f70102652b5af8946a02449ddd6805f5c30dd1565020684";
+    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/jazzy/mqtt_client/2.4.1-2.tar.gz";
+    name = "2.4.1-2.tar.gz";
+    sha256 = "acfd6dc953757fd9e92ccaa2dc9043c5a2bf9680e8ca90f4610a05edb5d59944";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav-2d-msgs/default.nix
+++ b/distros/jazzy/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav-2d-msgs";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav_2d_msgs/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "164cfeb1a4d5d25a72b4c866b889585e143085d120235354b02c6577be5dcbb4";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav_2d_msgs/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "890d61a3cac5f1fd97f81564f28bc0567e414d4f541f62da89f9affd9d9fc2cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav-2d-utils/default.nix
+++ b/distros/jazzy/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav-2d-utils";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav_2d_utils/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "95690baffc3ed7c007c4fbcdb8214442b200ce198f48922c0b1c260038f4cfc0";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav_2d_utils/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "4d76d3b778db159bde404b5c66d184980e88451c6553dfd64d3411c0a07f8590";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-amcl/default.nix
+++ b/distros/jazzy/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, pluginlib, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-amcl";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_amcl/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "5c5ae055eccee296055743f6a712c7d02f90d55803cbffa759040e9630fb7219";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_amcl/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "d4ef3bbce02449934ea7429600d7ba3f9079ba57236af46468e5b8489c012e77";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-behavior-tree/default.nix
+++ b/distros/jazzy/nav2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-behavior-tree";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_behavior_tree/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "ddbf7dafad07e091fc4e9025e6afcae9de706384c8da477fa33856c11a3b4ead";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_behavior_tree/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "cf567ea39688d0ad38ab7459a26fb56e8c1cfc84cc0a9d42bbf2cdd21a284624";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-behaviors/default.nix
+++ b/distros/jazzy/nav2-behaviors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-behaviors";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_behaviors/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "3f3a6c2851b97e249c03f18d6d7ff68e84130b8d7240e58a7082772a7c487db6";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_behaviors/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "09588e8b70ffd0425a5080f81790f25eb6469cb7fce149ac2c3399eb662be347";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-bringup/default.nix
+++ b/distros/jazzy/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, diff-drive-controller, joint-state-broadcaster, launch, launch-ros, launch-testing, nav2-common, nav2-minimal-tb3-sim, nav2-minimal-tb4-sim, navigation2, ros-gz-bridge, ros-gz-sim, slam-toolbox, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-bringup";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_bringup/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "51837950ccbe99694e07e046e2515c8147e9b8dad2fa20f9f74279e6007033ea";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_bringup/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "0993d1d64fd36f5affe42ab9d57e5ba6b9feb797c48863e368c9f6645d53cfb5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-bt-navigator/default.nix
+++ b/distros/jazzy/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-bt-navigator";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_bt_navigator/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "87e959f33923a8003bf0ca070a02327e46077926b53c9830e571f588fad44689";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_bt_navigator/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "bd8d8fa9602ad7d8f5f15011ad07db0d4e20ea8a002d955d12dfad657c161bc9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-collision-monitor/default.nix
+++ b/distros/jazzy/nav2-collision-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-costmap-2d, nav2-msgs, nav2-util, rclcpp, rclcpp-components, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-collision-monitor";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_collision_monitor/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "43c561c1fdbfde86daf57d7dc95d58ddc4081e726e6af23a363aa54ed4b31d07";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_collision_monitor/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "9714aff771ea2339e630f18bb9c2e7acb22d697cbe52a5900f4df503fdd7f12b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-common/default.nix
+++ b/distros/jazzy/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-common";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_common/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "5c6536d1b08059d862792c14dc923150c48b201c6bd91f53f154f10464f7f3a4";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_common/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "88dbc45473503687d144431437806db77fde2720efda8b12a701ce7e25545420";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-constrained-smoother/default.nix
+++ b/distros/jazzy/nav2-constrained-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, ceres-solver, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-constrained-smoother";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_constrained_smoother/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "0a8490bec36654dc66853aa4028054f6b27db5001b3ab7fe552d4c8817e59e17";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_constrained_smoother/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "e8bfcdfd7b2ab0737bffaa979e4af39641f29696343c202218f66354df0747b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-controller/default.nix
+++ b/distros/jazzy/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-controller";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_controller/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "19b942c103ae256680c270f7c01e23d0a74fa213d98a44fb4875f6e7b563658f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_controller/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "3a17acf1f49ea0b8a88f2b2b3551b75e9da7439c090c11b132cc3a7ed8881618";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-core/default.nix
+++ b/distros/jazzy/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-behavior-tree, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-core";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_core/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "b571e252b0623ed50620c952a5960c5cfe29830cc1fdf421ca11084e7d68146b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_core/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "2758ff518c7a56e60e116373c5f118db4dff0941f2b1cea378dfe81b60d76f30";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-costmap-2d/default.nix
+++ b/distros/jazzy/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-costmap-2d";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_costmap_2d/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "3106998fc0b4b7edfcc1e3f97691af459428759b2d550477dead9d1448ee148b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_costmap_2d/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "91e03d16960b2313905d8038c1f4d3aae1d8fdaa1a876e761c4da74333a0c6f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-dwb-controller/default.nix
+++ b/distros/jazzy/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-dwb-controller";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_dwb_controller/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "249dcb370feb61a6c65f2e238903c62c67f303608a5ad14c74aab0e96210e8e2";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_dwb_controller/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "fd4afcce316761ce0ff57d6404878ee7b48307e7d48096dcd9d557c8198aae2f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-graceful-controller/default.nix
+++ b/distros/jazzy/nav2-graceful-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav-2d-utils, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-graceful-controller";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_graceful_controller/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "cc29878e5f0f119d9cc52a4e6b7c06642d158b5fba4b9385632669637b3199d7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_graceful_controller/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "39406c73b3d40ed6e95632ce617695abfd214d82b611ff719f0c91740d9adf45";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-lifecycle-manager/default.nix
+++ b/distros/jazzy/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bondcpp, diagnostic-updater, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-lifecycle-manager";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_lifecycle_manager/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "c6b7a69c650a324a55061e8ed800cd61c11a79cc25d1db77d6e9db996f205ef5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_lifecycle_manager/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "3924bcfea0ad6eb8362e3691b01f4da8b32e5438c77b1a7cc58ce5c41c4897b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-loopback-sim/default.nix
+++ b/distros/jazzy/nav2-loopback-sim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, nav-msgs, nav2-simple-commander, python3Packages, rclpy, tf-transformations, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-loopback-sim";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_loopback_sim/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "5ae714ba190a3c683ca51f86e8ccd9fff89815a54ea1b8e87f67c57214a20391";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_loopback_sim/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "62a02eaf94ebc96bcac23e549d8385f31debc1bae83c9748d99d35a08af448b3";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/nav2-map-server/default.nix
+++ b/distros/jazzy/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-map-server";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_map_server/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "5a19f202afe672dd311e16c179e7a16e1736e5e7ab623e5e757817fb00bc045b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_map_server/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "b3a66707fd0c8be1b867616bdf80153ae96b3524b05b4938020f08c89159e0de";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-mppi-controller/default.nix
+++ b/distros/jazzy/nav2-mppi-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, gbenchmark, geometry-msgs, llvmPackages, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs, xsimd, xtensor }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-mppi-controller";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_mppi_controller/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "3e28b30c569e928eca16405b90da7f7ef8d9fc6e3b2da76994cc3bcf05eb28d6";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_mppi_controller/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "8d8a89e012faa371a658b24f016e5cb02018f04bb9b2a99b2ff9dd6d2db27dad";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-msgs/default.nix
+++ b/distros/jazzy/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geographic-msgs, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-msgs";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_msgs/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "e7e3fd6c9eae6ad422e536d99463094cda84544993a6bd27a236c71ffb1b9d02";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_msgs/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "c475a650f3e388b854067e431f3bfda52993761c17e12cb10d29d6de7b6a8c9e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-navfn-planner/default.nix
+++ b/distros/jazzy/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-navfn-planner";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_navfn_planner/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "430a025d537a4a73ea785fcdfc478d00d978cc64208ecefe690c18a284b8afe7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_navfn_planner/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "07e913883e4d0d06684a3bd386f887b83d7d10c54ecf53470f9700bfe63a4052";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-planner/default.nix
+++ b/distros/jazzy/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-planner";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_planner/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "4d2e0799ce7e0c04e60245588bcd2e942abf35578127ee44d5820ee9c2c43457";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_planner/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "120d6bdaec50171cbad7eeb4b661e56d29bed3001691313e51f2e12d67200d26";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-regulated-pure-pursuit-controller/default.nix
+++ b/distros/jazzy/nav2-regulated-pure-pursuit-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-regulated-pure-pursuit-controller";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_regulated_pure_pursuit_controller/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "ee4f6e437a9693be224f7920012f408384f53e819ffec05c65bd2d43f67584e6";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_regulated_pure_pursuit_controller/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "898356cbe56a7c2bf82f342130a90692f71d61bcbb4d9d55dc84d14ef362302b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-rotation-shim-controller/default.nix
+++ b/distros/jazzy/nav2-rotation-shim-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-regulated-pure-pursuit-controller, nav2-util, pluginlib, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-rotation-shim-controller";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_rotation_shim_controller/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "c8ad851f0cf6ebf1d77bdab2aa4fa5a0db577b24fafc35695a06d13f9539dfd4";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_rotation_shim_controller/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "0792cdcc381bbebf26077f8cebf1aa655f089f421a174425956124f1fae95680";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-route/default.nix
+++ b/distros/jazzy/nav2-route/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, backward-ros, geometry-msgs, launch, launch-testing, nanoflann, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, nlohmann_json, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-nav2-route";
+  version = "1.3.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_route/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "5abbee555edec4d7e140af48662a9ab8a611b21c40e4724a12611c12beacabde";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common launch launch-testing ];
+  propagatedBuildInputs = [ angles backward-ros geometry-msgs nanoflann nav-msgs nav2-core nav2-costmap-2d nav2-msgs nav2-util nlohmann_json pluginlib rclcpp rclcpp-lifecycle std-msgs tf2 tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A Route Graph planner to compliment the Planner Server";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/nav2-rviz-plugins/default.nix
+++ b/distros/jazzy/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, urdf, visualization-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-rviz-plugins";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_rviz_plugins/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "85f3b90bbd301570af2841940eb3d32f26e65bb066c8a4179223d45fb524143e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_rviz_plugins/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "eeb1b7b36d9a12c7df6db09afc322b9217f65e3f834a3c2c054d8f7e470d6729";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-simple-commander/default.nix
+++ b/distros/jazzy/nav2-simple-commander/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, lifecycle-msgs, nav2-msgs, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-simple-commander";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_simple_commander/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "cad1ea01600593921daf472ad44a1923f15033362053c61044e5a823d8833705";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_simple_commander/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "6960ee7dbd400d23fc8cd32e497cc5ff75099210c02ae7b107eb195727e5395e";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/nav2-smac-planner/default.nix
+++ b/distros/jazzy/nav2-smac-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, builtin-interfaces, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, nlohmann_json, ompl, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-smac-planner";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_smac_planner/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "63600bd81fecfd60c72fcc63943b4d80e77ac0199fb5b35f8de6dfbbd90a316b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_smac_planner/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "0ab2a15a4a4e2a5c5284612a1245fc54eca05fcd41490146b269063c7bfcda52";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-smoother/default.nix
+++ b/distros/jazzy/nav2-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-smoother";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_smoother/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "5f4042d91c7745c7c8ff540b40752bc11a787b59213817de4ce1008cc32fbf60";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_smoother/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "bebf392faa740dffcb95ba30339dfd54e21e6bfb22486bd9daf2be5b32a72b94";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-system-tests/default.nix
+++ b/distros/jazzy/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-behavior-tree, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-minimal-tb3-sim, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, python3Packages, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-system-tests";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_system_tests/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "6d7b62f5694b0e6437502252a1ebb1232646d3308cf473f581dd65caac44b6b0";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_system_tests/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "8cf8a482a6c99f5b128b27a489dd756196675611aab85d2b408a9bbde4ac8b55";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-theta-star-planner/default.nix
+++ b/distros/jazzy/nav2-theta-star-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-theta-star-planner";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_theta_star_planner/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "d19b8b8c7e6a3ab4b45de76341b696f8f7e522de4ca56a6d7976885d90955cd5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_theta_star_planner/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "f06d4390e7fb84c40b618e2b99dcc90bbedc6773e98a967cf5d2819c01b084b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-util/default.nix
+++ b/distros/jazzy/nav2-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bond, bondcpp, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-util";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_util/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "1034ca5b0232d91462e04135373bb8bad26c1018efab59d038295e39f7f46931";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_util/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "867ba7939ec0132d39c83973b5fe62905006501cd321d53ff9ea654b41de687d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-velocity-smoother/default.nix
+++ b/distros/jazzy/nav2-velocity-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-util, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-velocity-smoother";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_velocity_smoother/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "c0aed77ecea4156ffe0c99ec64499f29f397791f83fc84526fed93815e4012c3";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_velocity_smoother/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "a974cced9c32dcaeccab2b89b25e15fd37f85880bd1360f41f4db855e9e8c71e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-voxel-grid/default.nix
+++ b/distros/jazzy/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-voxel-grid";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_voxel_grid/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "bb8bad33934a2866553ef5914a7517e23b162af9cf6a12472c780a89b32b2e49";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_voxel_grid/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "e5f1c9c064edfd04a5d1f1ca18e50dc70894d3515809072f37a9293a0928f723";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-waypoint-follower/default.nix
+++ b/distros/jazzy/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, geographic-msgs, image-transport, nav-msgs, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, robot-localization, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-waypoint-follower";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_waypoint_follower/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "57373ed59b49fc4e4ae21ef6682dd1c1837bc82a17d5e695523ea3acde55dcb8";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_waypoint_follower/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "61d4aafb60d6fd3cc479b99a6d36a82a09c7c8f4342a6ef3f762bca4406b1779";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/navigation2/default.nix
+++ b/distros/jazzy/navigation2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-behaviors, nav2-bt-navigator, nav2-collision-monitor, nav2-constrained-smoother, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-graceful-controller, nav2-lifecycle-manager, nav2-map-server, nav2-mppi-controller, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-regulated-pure-pursuit-controller, nav2-rotation-shim-controller, nav2-rviz-plugins, nav2-simple-commander, nav2-smac-planner, nav2-smoother, nav2-theta-star-planner, nav2-util, nav2-velocity-smoother, nav2-voxel-grid, nav2-waypoint-follower, opennav-docking, opennav-docking-bt, opennav-docking-core }:
 buildRosPackage {
   pname = "ros-jazzy-navigation2";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/navigation2/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "0322266131d9b484620b0823b4424e759bd91a41c72a627ae8d6195ff81a0dae";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/navigation2/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "ea7460f72c124873f06178be3db39c098fd063702aac57022350eda7420870da";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/novatel-oem7-driver/default.nix
+++ b/distros/jazzy/novatel-oem7-driver/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, geographiclib, git, gps-msgs, launch-testing, launch-testing-ament-cmake, launch-testing-ros, nav-msgs, nmea-msgs, novatel-oem7-msgs, pluginlib, rclcpp, rclcpp-components, rclpy, rosbag2, rosidl-runtime-py, sensor-msgs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-novatel-oem7-driver";
-  version = "24.1.0-r1";
+  version = "24.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/jazzy/novatel_oem7_driver/24.1.0-1.tar.gz";
-    name = "24.1.0-1.tar.gz";
-    sha256 = "7f5b6c58227e847ea37be785ec4159bab86ef64b60579c8d95eae80bfe1a4346";
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/jazzy/novatel_oem7_driver/24.2.0-1.tar.gz";
+    name = "24.2.0-1.tar.gz";
+    sha256 = "a10476faf1249c582dea70bd185955fb7ee0e7951c83a9b6ff5db51c73d4c373";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake git ];
+  buildInputs = [ ament-cmake boost git ];
   checkInputs = [ launch-testing launch-testing-ament-cmake launch-testing-ros rclpy rosbag2 rosidl-runtime-py ];
-  propagatedBuildInputs = [ boost geographiclib gps-msgs nav-msgs nmea-msgs novatel-oem7-msgs pluginlib rclcpp rclcpp-components sensor-msgs tf2-geometry-msgs ];
+  propagatedBuildInputs = [ geographiclib gps-msgs nav-msgs nmea-msgs novatel-oem7-msgs pluginlib rclcpp rclcpp-components sensor-msgs tf2-geometry-msgs ];
   nativeBuildInputs = [ ament-cmake git ];
 
   meta = {

--- a/distros/jazzy/novatel-oem7-msgs/default.nix
+++ b/distros/jazzy/novatel-oem7-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-novatel-oem7-msgs";
-  version = "24.1.0-r1";
+  version = "24.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/jazzy/novatel_oem7_msgs/24.1.0-1.tar.gz";
-    name = "24.1.0-1.tar.gz";
-    sha256 = "d4ee5f0e2973ded03a15b85f2d483977c93fe30e18d8fda41fa4115c63f2f297";
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/jazzy/novatel_oem7_msgs/24.2.0-1.tar.gz";
+    name = "24.2.0-1.tar.gz";
+    sha256 = "0b5cf6fd0bd3732a45f54f162c9262574d3c2d5d16e9e38357908d27b0659ca7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/off-highway-can/default.nix
+++ b/distros/jazzy/off-highway-can/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, can-msgs, diagnostic-updater, rclcpp, ros2-socketcan-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-off-highway-can";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/jazzy/off_highway_can/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "5e010674e1a0907aed61c15beaf925fc7bcb6065b14a84d48d1864d58aab3ecc";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ can-msgs diagnostic-updater rclcpp ros2-socketcan-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The off_highway_can package";
+    license = with lib.licenses; [ "Apache-2.0,-MIT" ];
+  };
+}

--- a/distros/jazzy/off-highway-general-purpose-radar-msgs/default.nix
+++ b/distros/jazzy/off-highway-general-purpose-radar-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-off-highway-general-purpose-radar-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/jazzy/off_highway_general_purpose_radar_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "727ebb493a5644a35bf27c1d241fbc18464226e0bb0a1adde272ee66f98f1de8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "The off_highway_general_purpose_radar_msgs package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/off-highway-general-purpose-radar/default.nix
+++ b/distros/jazzy/off-highway-general-purpose-radar/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, can-msgs, off-highway-can, off-highway-general-purpose-radar-msgs, pcl, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-off-highway-general-purpose-radar";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/jazzy/off_highway_general_purpose_radar/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "339554357495aaaa07f05ac9135ac2621fbed86d4242d7be16359e6f8ad6c66b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake pcl-conversions ];
+  checkInputs = [ ament-cmake-ros ament-lint-auto ament-lint-common pcl-ros ];
+  propagatedBuildInputs = [ can-msgs off-highway-can off-highway-general-purpose-radar-msgs pcl rclcpp rclcpp-components sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The off_highway_general_purpose_radar package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/off-highway-premium-radar-msgs/default.nix
+++ b/distros/jazzy/off-highway-premium-radar-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-off-highway-premium-radar-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/jazzy/off_highway_premium_radar_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "697f0912f437bcf24ee601afe90e4ebef1d335fa4ccbe2c500de59a9633482fb";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The off_highway_premium_radar_msgs package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/off-highway-premium-radar-sample-msgs/default.nix
+++ b/distros/jazzy/off-highway-premium-radar-sample-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-off-highway-premium-radar-sample-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/jazzy/off_highway_premium_radar_sample_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "2895ac5b983e90d5c1c26fa8e7bb699e953dbbee1e93467508b0d473563ef6d3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "The off_highway_premium_radar_sample_msgs package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/off-highway-premium-radar-sample/default.nix
+++ b/distros/jazzy/off-highway-premium-radar-sample/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, asio, asio-cmake-module, diagnostic-updater, io-context, off-highway-premium-radar-sample-msgs, pcl, pcl-conversions, rclcpp, rclcpp-components, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-off-highway-premium-radar-sample";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/jazzy/off_highway_premium_radar_sample/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "9f602c9a9963b35d3ed7abf5e3419bfb0b329843621e8cd8cd74de7d5757c960";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake asio-cmake-module pcl-conversions ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ asio diagnostic-updater io-context off-highway-premium-radar-sample-msgs pcl rclcpp rclcpp-components sensor-msgs std-msgs tf2 tf2-geometry-msgs ];
+  nativeBuildInputs = [ ament-cmake asio-cmake-module ];
+
+  meta = {
+    description = "The off_highway_premium_radar_sample package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/off-highway-premium-radar/default.nix
+++ b/distros/jazzy/off-highway-premium-radar/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, asio, asio-cmake-module, diagnostic-updater, io-context, off-highway-premium-radar-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-off-highway-premium-radar";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/jazzy/off_highway_premium_radar/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "0269fbd358678ffd34b26a811bedfc4f228dc90ed83dd15c9fe61348e0dc3f65";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake asio-cmake-module ];
+  checkInputs = [ ament-cmake-ros ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ asio diagnostic-updater io-context off-highway-premium-radar-msgs rclcpp rclcpp-components sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake asio-cmake-module ];
+
+  meta = {
+    description = "The off_highway_premium_radar package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/off-highway-radar-msgs/default.nix
+++ b/distros/jazzy/off-highway-radar-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-off-highway-radar-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/jazzy/off_highway_radar_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "7bfc810cb6b231578dd39527cc920f69c5d2b0afd6acca233d79b8d944299baf";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "The off_highway_radar_msgs package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/off-highway-radar/default.nix
+++ b/distros/jazzy/off-highway-radar/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, can-msgs, off-highway-can, off-highway-radar-msgs, pcl, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-off-highway-radar";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/jazzy/off_highway_radar/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "0db10090043444e2f036e99d42fe232930640f06f45224092ac0fea21d96891c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake pcl-conversions ];
+  checkInputs = [ ament-cmake-ros ament-lint-auto ament-lint-common pcl-ros ];
+  propagatedBuildInputs = [ can-msgs off-highway-can off-highway-radar-msgs pcl rclcpp rclcpp-components sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The off_highway_radar package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/off-highway-sensor-drivers-examples/default.nix
+++ b/distros/jazzy/off-highway-sensor-drivers-examples/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, off-highway-premium-radar, off-highway-radar, rclcpp, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-jazzy-off-highway-sensor-drivers-examples";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/jazzy/off_highway_sensor_drivers_examples/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "524853305779e1283f238805f4eed959a3d6fc2140e8862867af04b1a248aa51";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs nav-msgs off-highway-premium-radar off-highway-radar rclcpp rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The off_highway_sensor_drivers_examples package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/off-highway-sensor-drivers/default.nix
+++ b/distros/jazzy/off-highway-sensor-drivers/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, off-highway-can, off-highway-general-purpose-radar, off-highway-general-purpose-radar-msgs, off-highway-premium-radar, off-highway-premium-radar-msgs, off-highway-premium-radar-sample, off-highway-premium-radar-sample-msgs, off-highway-radar, off-highway-radar-msgs, off-highway-uss, off-highway-uss-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-off-highway-sensor-drivers";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/jazzy/off_highway_sensor_drivers/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "3a678104785e7891d1b87585a7ddc42d46524a1a7ee585a56094bf1a61184c04";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ off-highway-can off-highway-general-purpose-radar off-highway-general-purpose-radar-msgs off-highway-premium-radar off-highway-premium-radar-msgs off-highway-premium-radar-sample off-highway-premium-radar-sample-msgs off-highway-radar off-highway-radar-msgs off-highway-uss off-highway-uss-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The off_highway_sensor_drivers package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/off-highway-uss-msgs/default.nix
+++ b/distros/jazzy/off-highway-uss-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-off-highway-uss-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/jazzy/off_highway_uss_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "b66398c661056c00d9ed65bf02439c506762357cd29967e91f4647a18d597f49";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "The off_highway_uss_msgs package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/off-highway-uss/default.nix
+++ b/distros/jazzy/off-highway-uss/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, can-msgs, off-highway-can, off-highway-uss-msgs, pcl, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-off-highway-uss";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/jazzy/off_highway_uss/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "9c5e269701ed281d5efa927bad6db700940f2a2313d0e51bbba9cfcd40ee128d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake pcl-conversions ];
+  checkInputs = [ ament-cmake-ros ament-lint-auto ament-lint-common pcl-ros ];
+  propagatedBuildInputs = [ can-msgs off-highway-can off-highway-uss-msgs pcl rclcpp rclcpp-components sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The off_highway_uss package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/opennav-docking-bt/default.nix
+++ b/distros/jazzy/opennav-docking-bt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-core, nav2-msgs, nav2-util, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-jazzy-opennav-docking-bt";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/opennav_docking_bt/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "49f8691c2139121a4e3f1184c28b55669977a37310df34d9e8df8df891e2a6a9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/opennav_docking_bt/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "ec2eb8e63f601da8c26f880138f4ac52aa50a9e1e6a5f7b919c85ab25fac2324";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/opennav-docking-core/default.nix
+++ b/distros/jazzy/opennav-docking-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-jazzy-opennav-docking-core";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/opennav_docking_core/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "6fc1f4689c6a2539204cc4466ebf5358518422b874bc1ca6c5cdeeb82f0ba5b4";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/opennav_docking_core/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "48ebdd8ea86d9b74f0d876ee82fa9c9ee79714386f6f27c07827c10de041ef2c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/opennav-docking/default.nix
+++ b/distros/jazzy/opennav-docking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, builtin-interfaces, geometry-msgs, nav-msgs, nav2-graceful-controller, nav2-msgs, nav2-util, opennav-docking-core, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, tf2-ros, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-opennav-docking";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/opennav_docking/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "ebce8f1d9e847e856d6daf7a94598746f32c7acfa57c8eef58984777b5d37ea4";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/opennav_docking/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "aabc5c42939f82cca8903e50a03c870cd750d35843f80d293fdc6554e408f8d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pal-statistics-msgs/default.nix
+++ b/distros/jazzy/pal-statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-pal-statistics-msgs";
-  version = "2.6.4-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/jazzy/pal_statistics_msgs/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "de699ad8e8547146edd8a6202de378ca12bcef0168791db0a4ff9e7b39fbe234";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/jazzy/pal_statistics_msgs/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "6cd7b348b2469e0758675c6d75d0a451abc2e2700149e6179080c8b39d08d9b9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pal-statistics/default.nix
+++ b/distros/jazzy/pal-statistics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, boost, pal-statistics-msgs, rclcpp, rclcpp-lifecycle, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-pal-statistics";
-  version = "2.6.4-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/jazzy/pal_statistics/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "151349aeccf31f12bf1c33fffee40bf2aa1a20a2ef68125cbfc45e7359875dc1";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/jazzy/pal_statistics/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "f93980f2252e81ce196bcb28de88e1440e7f86e484ff7ec60b0aafbccb292b1e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pendulum-control/default.nix
+++ b/distros/jazzy/pendulum-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pendulum-msgs, rclcpp, rmw-implementation-cmake, ros2run, rttest, tlsf-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-pendulum-control";
-  version = "0.33.6-r1";
+  version = "0.33.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/pendulum_control/0.33.6-1.tar.gz";
-    name = "0.33.6-1.tar.gz";
-    sha256 = "c97171c43046d25e3756a408050f41aa0cedab1f46ae3cd17cb2b978bd5bab53";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/pendulum_control/0.33.7-1.tar.gz";
+    name = "0.33.7-1.tar.gz";
+    sha256 = "71b728c987df191a79bf82c67073767b6d39dd97311d7d508280a878a8f98def";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pendulum-msgs/default.nix
+++ b/distros/jazzy/pendulum-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-pendulum-msgs";
-  version = "0.33.6-r1";
+  version = "0.33.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/pendulum_msgs/0.33.6-1.tar.gz";
-    name = "0.33.6-1.tar.gz";
-    sha256 = "9dab89c6a61a2ce8a8078401206b60a22c9ded02864a5521b5221c22ef41db16";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/pendulum_msgs/0.33.7-1.tar.gz";
+    name = "0.33.7-1.tar.gz";
+    sha256 = "69e8cd49b4725b61f51a11edb4a82a2d75556b91970e113983b3af91b5fbaf19";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pymoveit2/default.nix
+++ b/distros/jazzy/pymoveit2/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-python, control-msgs, geometry-msgs, moveit-msgs, rclpy, sensor-msgs, shape-msgs, std-srvs, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-pymoveit2";
+  version = "4.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/pymoveit2-release/archive/release/jazzy/pymoveit2/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "dd9206b07c4b98eab29196df1f8feaf24e9441351a03e5a8a00bf781d536a17b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  propagatedBuildInputs = [ action-msgs control-msgs geometry-msgs moveit-msgs rclpy sensor-msgs shape-msgs std-srvs trajectory-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "Basic Python interface for MoveIt 2 built on top of ROS 2 actions and services";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/quality-of-service-demo-cpp/default.nix
+++ b/distros/jazzy/quality-of-service-demo-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, rclcpp, rclcpp-components, rcutils, rmw, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-quality-of-service-demo-cpp";
-  version = "0.33.6-r1";
+  version = "0.33.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/quality_of_service_demo_cpp/0.33.6-1.tar.gz";
-    name = "0.33.6-1.tar.gz";
-    sha256 = "563585f40b26981c9175da87dd8e01d61fba30c138a51bf8f867eedcdba9d8ed";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/quality_of_service_demo_cpp/0.33.7-1.tar.gz";
+    name = "0.33.7-1.tar.gz";
+    sha256 = "b2b06b8462db04330377a46dac682681625a3f1a97f4b7598c82b9d85b4ce56c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/quality-of-service-demo-py/default.nix
+++ b/distros/jazzy/quality-of-service-demo-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-quality-of-service-demo-py";
-  version = "0.33.6-r1";
+  version = "0.33.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/quality_of_service_demo_py/0.33.6-1.tar.gz";
-    name = "0.33.6-1.tar.gz";
-    sha256 = "70817e71a51db1532d4b41f88936ebe09763215612af395681271f48e4fcdf2f";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/quality_of_service_demo_py/0.33.7-1.tar.gz";
+    name = "0.33.7-1.tar.gz";
+    sha256 = "fe96bab495fd1797304c4ab96bc78d6b11dc810b4365f83ed9e7efda7def17ee";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rdl-benchmark/default.nix
+++ b/distros/jazzy/rdl-benchmark/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint, boost, rdl-dynamics, rdl-urdfreader }:
+buildRosPackage {
+  pname = "ros-jazzy-rdl-benchmark";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/jlack1987/rdl-release/archive/release/jazzy/rdl_benchmark/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "7ad7d9006121025d008f97f495f8db42cceb2ff13a32b6a22611864e8ff4fb86";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-xmllint ament-lint ];
+  propagatedBuildInputs = [ boost rdl-dynamics rdl-urdfreader ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The rdl_benchmark package";
+    license = with lib.licenses; [ "Zlib" ];
+  };
+}

--- a/distros/jazzy/rdl-dynamics/default.nix
+++ b/distros/jazzy/rdl-dynamics/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint, boost, doxygen, eigen, eigen3-cmake-module, graphviz, rclcpp }:
+buildRosPackage {
+  pname = "ros-jazzy-rdl-dynamics";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/jlack1987/rdl-release/archive/release/jazzy/rdl_dynamics/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "2f07e473d7ae159d1dd8061c44cea17069b577c45d207cceac597965e716e02f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-xmllint ament-lint ];
+  propagatedBuildInputs = [ boost doxygen eigen eigen3-cmake-module graphviz rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The rdl_dynamics package";
+    license = with lib.licenses; [ "Zlib" ];
+  };
+}

--- a/distros/jazzy/rdl-urdfreader/default.nix
+++ b/distros/jazzy/rdl-urdfreader/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-index-cpp, ament-lint, rclcpp, rdl-dynamics, tinyxml, tinyxml-vendor, urdf }:
+buildRosPackage {
+  pname = "ros-jazzy-rdl-urdfreader";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/jlack1987/rdl-release/archive/release/jazzy/rdl_urdfreader/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "9ba5ae22a5b205b091d67bd7e58bb76e664ed68840ee95f2acd1242f4f304a3f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-xmllint ament-index-cpp ament-lint ];
+  propagatedBuildInputs = [ rclcpp rdl-dynamics tinyxml tinyxml-vendor urdf ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The rdl_urdfreader package";
+    license = with lib.licenses; [ "Zlib" ];
+  };
+}

--- a/distros/jazzy/rdl/default.nix
+++ b/distros/jazzy/rdl/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rdl-benchmark, rdl-dynamics, rdl-urdfreader }:
+buildRosPackage {
+  pname = "ros-jazzy-rdl";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/jlack1987/rdl-release/archive/release/jazzy/rdl/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "6ed6dfc04dfc127cc5a14cf9503c2fa90c084d4604cd6756a649758527444097";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ rdl-benchmark rdl-dynamics rdl-urdfreader ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The rdl meta-package";
+    license = with lib.licenses; [ "Zlib" ];
+  };
+}

--- a/distros/jazzy/realtime-tools/default.nix
+++ b/distros/jazzy/realtime-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, boost, libcap, lifecycle-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2-control-cmake, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-realtime-tools";
-  version = "3.8.0-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/jazzy/realtime_tools/3.8.0-1.tar.gz";
-    name = "3.8.0-1.tar.gz";
-    sha256 = "7fe2c44a1cc1108376ca3b845c1d121910ce102f05bb94e5646440801b3efc1a";
+    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/jazzy/realtime_tools/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "8ecabe7f83f329939527da7f01a5630647da84faf2987e2c2e1654907ac4c898";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rpyutils/default.nix
+++ b/distros/jazzy/rpyutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-rpyutils";
-  version = "0.4.1-r3";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rpyutils-release/archive/release/jazzy/rpyutils/0.4.1-3.tar.gz";
-    name = "0.4.1-3.tar.gz";
-    sha256 = "1f291e9c13830ab9f11960b6fb1d2c72b6dbf830088fc1814e43f5fe47e65ad1";
+    url = "https://github.com/ros2-gbp/rpyutils-release/archive/release/jazzy/rpyutils/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "185d0d5fd73effe331f4354ce6e7698be8325f4f0a75e1aac65474e6423a9470";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rviz-assimp-vendor/default.nix
+++ b/distros/jazzy/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-assimp-vendor";
-  version = "14.1.14-r1";
+  version = "14.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_assimp_vendor/14.1.14-1.tar.gz";
-    name = "14.1.14-1.tar.gz";
-    sha256 = "4eea96a4d3746743c3ae72b8125b267ccb133804bfcfe0b8f5befb4d254ae72a";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_assimp_vendor/14.1.15-1.tar.gz";
+    name = "14.1.15-1.tar.gz";
+    sha256 = "bcdd3e9ed510f2ae68af05c42b886e710e63fe2501714b17f4c0229e8385fae1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-common/default.nix
+++ b/distros/jazzy/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-common";
-  version = "14.1.14-r1";
+  version = "14.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_common/14.1.14-1.tar.gz";
-    name = "14.1.14-1.tar.gz";
-    sha256 = "0c928aab82e671fc8d9e82c90aa8f9e6985cf5e5cf856dd55ec3533fe120cb5e";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_common/14.1.15-1.tar.gz";
+    name = "14.1.15-1.tar.gz";
+    sha256 = "6d164df586a39e003b7acca618e700f5eb36644ee38291a6cf9c5e99335cb5f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-default-plugins/default.nix
+++ b/distros/jazzy/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, gz-math-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-default-plugins";
-  version = "14.1.14-r1";
+  version = "14.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_default_plugins/14.1.14-1.tar.gz";
-    name = "14.1.14-1.tar.gz";
-    sha256 = "263d48ceb29e98e5eeadd3c34f1f8f1a822937fa05c2a6e715e237d8c07b8b2a";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_default_plugins/14.1.15-1.tar.gz";
+    name = "14.1.15-1.tar.gz";
+    sha256 = "ecf7d65da1f6e2ebe530f8ea8eba1b731445d2fefe5b4c4d0e52361df1a31974";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-ogre-vendor/default.nix
+++ b/distros/jazzy/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, glew, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-ogre-vendor";
-  version = "14.1.14-r1";
+  version = "14.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_ogre_vendor/14.1.14-1.tar.gz";
-    name = "14.1.14-1.tar.gz";
-    sha256 = "0e1d0105b7ae3c8d593bf33073ed2924f210e0df5a5ac2f55d67f38389473048";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_ogre_vendor/14.1.15-1.tar.gz";
+    name = "14.1.15-1.tar.gz";
+    sha256 = "990bb94c8f1ecbbd38eaaf7a36cf1f7fcf5e6ae48695e936c6fc8210d62b1e0c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-rendering-tests/default.nix
+++ b/distros/jazzy/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-rendering-tests";
-  version = "14.1.14-r1";
+  version = "14.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_rendering_tests/14.1.14-1.tar.gz";
-    name = "14.1.14-1.tar.gz";
-    sha256 = "97cc5ee7a7f39d02d2a785bfec53c8625a3a5624051432c03a9adeb9096069ed";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_rendering_tests/14.1.15-1.tar.gz";
+    name = "14.1.15-1.tar.gz";
+    sha256 = "112d0489e0400c197cc71498a26becb50b86a6bff652aca062bcb32336276dec";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-rendering/default.nix
+++ b/distros/jazzy/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-rendering";
-  version = "14.1.14-r1";
+  version = "14.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_rendering/14.1.14-1.tar.gz";
-    name = "14.1.14-1.tar.gz";
-    sha256 = "f87abf95f9adefff524b43f8cc4a3f6443d9c3ad9e8e87586b509ea11a0c0ea7";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_rendering/14.1.15-1.tar.gz";
+    name = "14.1.15-1.tar.gz";
+    sha256 = "937401ecb9b3f9599adf1cf495e8f000a620d95b784f81bd42e7a2dae6a9b5f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-visual-testing-framework/default.nix
+++ b/distros/jazzy/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-visual-testing-framework";
-  version = "14.1.14-r1";
+  version = "14.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_visual_testing_framework/14.1.14-1.tar.gz";
-    name = "14.1.14-1.tar.gz";
-    sha256 = "29e6f69e054d1cb714da1bd4cb2b5df0caa95ab8d52e45777a75c25cf27d71c6";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_visual_testing_framework/14.1.15-1.tar.gz";
+    name = "14.1.15-1.tar.gz";
+    sha256 = "057c8bb1808b0e0cabef98fa897d076c0d53661caa056f41cfb1727bdb255c44";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz2/default.nix
+++ b/distros/jazzy/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rviz2";
-  version = "14.1.14-r1";
+  version = "14.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz2/14.1.14-1.tar.gz";
-    name = "14.1.14-1.tar.gz";
-    sha256 = "995ba76f4d26054c787beddd505e1401e01383ab5ae0e18df9311d01453236ee";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz2/14.1.15-1.tar.gz";
+    name = "14.1.15-1.tar.gz";
+    sha256 = "50e514b8b50f2e4f50f4bf63f09175a1c5e9fffbd1754361c385874c518dfcd9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tecgihan-driver/default.nix
+++ b/distros/jazzy/tecgihan-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, python3Packages, rclpy, xacro }:
+buildRosPackage {
+  pname = "ros-jazzy-tecgihan-driver";
+  version = "0.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tecgihan/tecgihan_driver-release/archive/release/jazzy/tecgihan_driver/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "713eb1f90b49c3ef0197fb6ea843f5fb5b7cca7dfbe9c68099742962045c171d";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
+  propagatedBuildInputs = [ geometry-msgs python3Packages.pyserial rclpy xacro ];
+
+  meta = {
+    description = "Linux and ROS driver software for Tec Gihan sensor amplifiers for robots";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/topic-monitor/default.nix
+++ b/distros/jazzy/topic-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, launch, launch-ros, python3Packages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-topic-monitor";
-  version = "0.33.6-r1";
+  version = "0.33.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/topic_monitor/0.33.6-1.tar.gz";
-    name = "0.33.6-1.tar.gz";
-    sha256 = "2607acc41bebf85fac8fd9e4643e022c6fd553ea4d79702381ad02bb9e4103f2";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/topic_monitor/0.33.7-1.tar.gz";
+    name = "0.33.7-1.tar.gz";
+    sha256 = "82a3a4a8db3a294a6488dc95b203ef48684abe2d9e72f121d4f144711c1ead21";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/topic-statistics-demo/default.nix
+++ b/distros/jazzy/topic-statistics-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rcutils, sensor-msgs, statistics-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-topic-statistics-demo";
-  version = "0.33.6-r1";
+  version = "0.33.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/topic_statistics_demo/0.33.6-1.tar.gz";
-    name = "0.33.6-1.tar.gz";
-    sha256 = "a1db9b8546b3de7f85097cde032746df177e1a06b1431bd64c68d18597657fc2";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/topic_statistics_demo/0.33.7-1.tar.gz";
+    name = "0.33.7-1.tar.gz";
+    sha256 = "b77c174845a1960200ed6b73bbbb992d027d44482a3660cff55d251e0357dc44";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-simulation-gz/default.nix
+++ b/distros/jazzy/ur-simulation-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, gz-ros2-control, joint-state-publisher, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, ros-gz-bridge, ros-gz-sim, rviz2, ur-controllers, ur-description, ur-moveit-config, urdf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-ur-simulation-gz";
-  version = "2.3.0-r2";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_simulation_gz-release/archive/release/jazzy/ur_simulation_gz/2.3.0-2.tar.gz";
-    name = "2.3.0-2.tar.gz";
-    sha256 = "8157b928c4f8b482967da1f3d990e31a2a21a57189f729d4cc78071898839b50";
+    url = "https://github.com/ros2-gbp/ur_simulation_gz-release/archive/release/jazzy/ur_simulation_gz/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "f7e9ab0879de3285b213e519474ef8376ea1eebd4f6f42a0c9ca635d210025c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ackermann-nlmpc-msgs/default.nix
+++ b/distros/kilted/ackermann-nlmpc-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ackermann-nlmpc-msgs";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ackmerann_nlmpc-release/archive/release/kilted/ackermann_nlmpc_msgs/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "a9286c9b1a35d38524a20225f21e0aedadbd7f5c8b7349475a8302b6c6472868";
+    url = "https://github.com/ros2-gbp/ackmerann_nlmpc-release/archive/release/kilted/ackermann_nlmpc_msgs/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "992b45ec1b6203c7fe6ae29d5d2fa1d18619208678d81a7963a1b2dac0f08097";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ackermann-nlmpc/default.nix
+++ b/distros/kilted/ackermann-nlmpc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ackermann-nlmpc-msgs, ament-pep257, geometry-msgs, nav-msgs, python3Packages, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ackermann-nlmpc";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ackmerann_nlmpc-release/archive/release/kilted/ackermann_nlmpc/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "5db78777717bd64c88d4217c960b54acff12cf162336be55939c375b5cc491a1";
+    url = "https://github.com/ros2-gbp/ackmerann_nlmpc-release/archive/release/kilted/ackermann_nlmpc/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "fb756b20db260a62f1da8710dce06111716704b2a28135157cd9999fdefb8143";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/action-tutorials-cpp/default.nix
+++ b/distros/kilted/action-tutorials-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rclcpp-action, rclcpp-components }:
 buildRosPackage {
   pname = "ros-kilted-action-tutorials-cpp";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/action_tutorials_cpp/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "986a4024e7e644a3b5643ad011e013cd173d7ccb66aa5d12c73a36cb2040f527";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/action_tutorials_cpp/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "7c850d2e71468121449a42dee760b1b58008c626a411e2eb3a028bda85ceae15";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/action-tutorials-py/default.nix
+++ b/distros/kilted/action-tutorials-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, example-interfaces, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-kilted-action-tutorials-py";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/action_tutorials_py/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "99ec7c76486678eebaf0b28ee2cdf993acf0189954ebfe9304392aedc2450319";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/action_tutorials_py/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "a0b0e724b3a299f6a75fbf2f4b42314794c2cd602719ad7ee4e82f227c688dad";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/ads-vendor/default.nix
+++ b/distros/kilted/ads-vendor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, git }:
+buildRosPackage {
+  pname = "ros-kilted-ads-vendor";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/b-robotized/ads_vendor-release/archive/release/kilted/ads_vendor/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "f2c5ebeab813bf1fa7357b4464cff8c8003e26f5d79112d585ce910488e417c9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake git ];
+  nativeBuildInputs = [ ament-cmake git ];
+
+  meta = {
+    description = "Package vendoring Beckhoff/ADS library";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kilted/angles/default.nix
+++ b/distros/kilted/angles/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, python3Packages }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, python3Packages }:
 buildRosPackage {
   pname = "ros-kilted-angles";
-  version = "1.16.0-r5";
+  version = "1.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/angles-release/archive/release/kilted/angles/1.16.0-5.tar.gz";
-    name = "1.16.0-5.tar.gz";
-    sha256 = "c3cbfafdb7ef9ebdb3846791bb69ffd8826daaed1db055e08b8be2618be679b1";
+    url = "https://github.com/ros2-gbp/angles-release/archive/release/kilted/angles/1.16.1-1.tar.gz";
+    name = "1.16.1-1.tar.gz";
+    sha256 = "e6ae63c398180ac88ea8d051252137de363eaeb0bae5d4ede242bda153b1a38a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-python python3Packages.setuptools ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ];
   propagatedBuildInputs = [ ament-cmake ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python python3Packages.setuptools ];
 

--- a/distros/kilted/composition/default.nix
+++ b/distros/kilted/composition/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-composition";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/composition/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "7b44d9c92ad1bb650615e7b684369bf552a5ccc875345d682a5196e73212a734";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/composition/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "2b29ef9a6d4fdb931b2c4cb668cb416eb8dcacf77c5137f2ea414c638e7df3fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/control-toolbox/default.nix
+++ b/distros/kilted/control-toolbox/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, eigen, filters, fmt, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-cmake, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, eigen, filters, fmt, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-cmake, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-control-toolbox";
-  version = "5.6.0-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/kilted/control_toolbox/5.6.0-1.tar.gz";
-    name = "5.6.0-1.tar.gz";
-    sha256 = "9a471883abc79cb59067f2489fab904720982622585f7753a8c1ac5360a4d5a6";
+    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/kilted/control_toolbox/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "18ce82e0520f014da324fff69d137331cefb3972894f1b5e7738e2089da4e52f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake fmt ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock rclcpp-lifecycle ];
-  propagatedBuildInputs = [ control-msgs eigen filters generate-parameter-library geometry-msgs pluginlib rclcpp rcutils realtime-tools tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ backward-ros control-msgs eigen filters generate-parameter-library geometry-msgs pluginlib rclcpp rcutils realtime-tools tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/costmap-queue/default.nix
+++ b/distros/kilted/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-kilted-costmap-queue";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/costmap_queue/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "ace57d4b0fdfaa0f8fc83cf748d330dd67092bbb70069d5aef7483c500a6fee0";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/costmap_queue/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "a8516a51e47bc6cdc68cff741d266c9fac9bd9c3e0e289495c8e557dff4c8c44";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/demo-nodes-cpp-native/default.nix
+++ b/distros/kilted/demo-nodes-cpp-native/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rmw-fastrtps-cpp, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-demo-nodes-cpp-native";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/demo_nodes_cpp_native/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "8752b7a22890d790546d0c1059df30fb6a833722c29d4bb375663cfc23fceadf";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/demo_nodes_cpp_native/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "9aebc0f0659e1c4d369bb5b8148ed6413b15eeab625e5b6ea245b654c872c800";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/demo-nodes-cpp/default.nix
+++ b/distros/kilted/demo-nodes-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, launch-xml, rcl, rcl-interfaces, rclcpp, rclcpp-components, rcpputils, rcutils, rmw, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-demo-nodes-cpp";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/demo_nodes_cpp/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "23eaa9d405a6cb941f1c1a78426d1183619e0f9f07ec061de18f6761979160eb";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/demo_nodes_cpp/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "d43b619816c7663e2e6d9892659ee22c35f8437cc0c37d0fbf0d5dc4bb5bf86e";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/demo-nodes-py/default.nix
+++ b/distros/kilted/demo-nodes-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, example-interfaces, python3Packages, rcl-interfaces, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-demo-nodes-py";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/demo_nodes_py/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "e40e0a0c11b5f0e774149cbc7c72b4c803bb67ee5cc0ec1f5b3beae2fe3f98ed";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/demo_nodes_py/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "63340b1da2b6782f25fdf54a8752d296ebe15211fcd99fde6ae5aca57900a82d";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/dummy-map-server/default.nix
+++ b/distros/kilted/dummy-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-kilted-dummy-map-server";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/dummy_map_server/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "22469b62c84565c8d1c439068efb387256224b2b227be1f9efdfb3d3de7cf25f";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/dummy_map_server/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "e771446cbf58889af69b057fbd4f0d0c44dfda635ed97bfb7fcf9bd5dbde1c9e";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/dummy-robot-bringup/default.nix
+++ b/distros/kilted/dummy-robot-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, dummy-map-server, dummy-sensors, launch, launch-ros, robot-state-publisher }:
 buildRosPackage {
   pname = "ros-kilted-dummy-robot-bringup";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/dummy_robot_bringup/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "102f661ad6b996bb06fe73b910824933dbbf21eec427741bd6bdb2152d31b9a1";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/dummy_robot_bringup/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "d5854375f32087cdfd7319298da99a95ff60561adb7efb716e0ab80c22a6776b";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/dummy-sensors/default.nix
+++ b/distros/kilted/dummy-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-dummy-sensors";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/dummy_sensors/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "9b653f0c450edab4b24a9d32619f874c0d7229dd6f67c6d1a016274dfe6bb7df";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/dummy_sensors/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "b43dd495060026f04d9a7b15298242b06518f2ec5435233433bcb29b34e1cbb7";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/dwb-core/default.nix
+++ b/distros/kilted/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-dwb-core";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/dwb_core/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "38938074500a277b7886f400fe403683f2270ac35c26370c926a8a08c92da612";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/dwb_core/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "87e8283b6fe2e796b819bf9bb3390a55fa248035f5890d94029e0ebc71f894d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/dwb-critics/default.nix
+++ b/distros/kilted/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-kilted-dwb-critics";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/dwb_critics/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "582fe46d655a70692b69003ef619dc34d069808818f4390dd524b66c604f3ef6";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/dwb_critics/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "ff3f0f124d7fea56340679d7e7bd3579ed3eb57d56d12f2dd0200553d53813db";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/dwb-msgs/default.nix
+++ b/distros/kilted/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-dwb-msgs";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/dwb_msgs/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "6e1cd5736a4f1d5686231fbda9206890146048dc0159e075cd4cb7bd3ae91951";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/dwb_msgs/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "8fb6650adddc6c9ce7890fd2e6434ae9b79a28706bbfd50409b6fea4d918e944";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/dwb-plugins/default.nix
+++ b/distros/kilted/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, dwb-core, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rcl-interfaces, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-kilted-dwb-plugins";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/dwb_plugins/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "b8b8d756c6fd0697ac535b22c8e556b19299e592fbae3af5a5da438a28585860";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/dwb_plugins/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "ddec76049a811a207827d72d464f4d908fece6ad756bdb040f79f16bb27149bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/dynamixel-hardware-interface/default.nix
+++ b/distros/kilted/dynamixel-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-interfaces, dynamixel-sdk, hardware-interface, pluginlib, rclcpp, realtime-tools, std-srvs }:
 buildRosPackage {
   pname = "ros-kilted-dynamixel-hardware-interface";
-  version = "1.4.14-r1";
+  version = "1.4.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/kilted/dynamixel_hardware_interface/1.4.14-1.tar.gz";
-    name = "1.4.14-1.tar.gz";
-    sha256 = "66c3d92ccef8022d50e1778f4ed9d4eab623dd84832554e956347c49e82dd94e";
+    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/kilted/dynamixel_hardware_interface/1.4.15-1.tar.gz";
+    name = "1.4.15-1.tar.gz";
+    sha256 = "bbf70801619403fc8486a192c92f8f821e94c8773a62ff3a6332d5f7a7903093";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/generated.nix
+++ b/distros/kilted/generated.nix
@@ -28,6 +28,8 @@ self: super: {
 
  admittance-controller = self.callPackage ./admittance-controller {};
 
+ ads-vendor = self.callPackage ./ads-vendor {};
+
  ament-acceleration = self.callPackage ./ament-acceleration {};
 
  ament-black = self.callPackage ./ament-black {};
@@ -1280,8 +1282,6 @@ self: super: {
 
  mola-gnss-to-markers = self.callPackage ./mola-gnss-to-markers {};
 
- mola-imu-preintegration = self.callPackage ./mola-imu-preintegration {};
-
  mola-input-euroc-dataset = self.callPackage ./mola-input-euroc-dataset {};
 
  mola-input-kitti360-dataset = self.callPackage ./mola-input-kitti360-dataset {};
@@ -1311,12 +1311,6 @@ self: super: {
  mola-pose-list = self.callPackage ./mola-pose-list {};
 
  mola-relocalization = self.callPackage ./mola-relocalization {};
-
- mola-state-estimation = self.callPackage ./mola-state-estimation {};
-
- mola-state-estimation-simple = self.callPackage ./mola-state-estimation-simple {};
-
- mola-state-estimation-smoother = self.callPackage ./mola-state-estimation-smoother {};
 
  mola-test-datasets = self.callPackage ./mola-test-datasets {};
 
@@ -1603,8 +1597,6 @@ self: super: {
  network-bridge = self.callPackage ./network-bridge {};
 
  nlohmann-json-schema-validator-vendor = self.callPackage ./nlohmann-json-schema-validator-vendor {};
-
- nmea-hardware-interface = self.callPackage ./nmea-hardware-interface {};
 
  nmea-msgs = self.callPackage ./nmea-msgs {};
 

--- a/distros/kilted/gz-msgs-vendor/default.nix
+++ b/distros/kilted/gz-msgs-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, gz-math-vendor, gz-tools-vendor, protobuf, python3, python3Packages, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-kilted-gz-msgs-vendor";
-  version = "0.2.2-r2";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_msgs_vendor-release/archive/release/kilted/gz_msgs_vendor/0.2.2-2.tar.gz";
-    name = "0.2.2-2.tar.gz";
-    sha256 = "1e062fb8d66ff2ad91e7e1bbb2aac0b2c9e0e4a9b6fb8d3ed5499b88d11ca124";
+    url = "https://github.com/ros2-gbp/gz_msgs_vendor-release/archive/release/kilted/gz_msgs_vendor/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "a25699e610855a784527c5d8953b763eb395428c1ff3bacb741542204b9f9285";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-msgs11 11.0.2
+    description = "Vendor package for: gz-msgs11 11.1.0
 
     Gazebo Messages: Protobuf messages and functions for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/kilted/gz-msgs-vendor/vendored-source.json
+++ b/distros/kilted/gz-msgs-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_msgs_vendor": {
     "url": "https://github.com/gazebosim/gz-msgs.git",
-    "rev": "gz-msgs11_11.0.2",
-    "hash": "sha256-PUhFOmVPRiOVWfOjAU8z8dcxKPdcoTrgRwDGXP/vsUs="
+    "rev": "gz-msgs11_11.1.0",
+    "hash": "sha256-M/rzUrL6uzpaRNLWJsGViY6Jk0bLtooEe+0eEEPS7PA="
   }
 }

--- a/distros/kilted/gz-plugin-vendor/default.nix
+++ b/distros/kilted/gz-plugin-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, gz-tools-vendor, gz-utils-vendor }:
 buildRosPackage {
   pname = "ros-kilted-gz-plugin-vendor";
-  version = "0.2.1-r2";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_plugin_vendor-release/archive/release/kilted/gz_plugin_vendor/0.2.1-2.tar.gz";
-    name = "0.2.1-2.tar.gz";
-    sha256 = "377e3921fc25a6f6ffe6aae134360a05a5ed5c9a3d8344f113b5ea275d6c5a1e";
+    url = "https://github.com/ros2-gbp/gz_plugin_vendor-release/archive/release/kilted/gz_plugin_vendor/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "88ce2d69decaf082a393ed077c63db84b51c7563185458d8d654517dfc2c3d81";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-plugin3 3.0.1
+    description = "Vendor package for: gz-plugin3 3.1.0
 
     Gazebo Plugin : Cross-platform C++ library for dynamically loading plugins.";
     license = with lib.licenses; [ asl20 ];

--- a/distros/kilted/gz-plugin-vendor/vendored-source.json
+++ b/distros/kilted/gz-plugin-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_plugin_vendor": {
     "url": "https://github.com/gazebosim/gz-plugin.git",
-    "rev": "gz-plugin3_3.0.1",
-    "hash": "sha256-7v6fzylJ4R1uoyQFM+eyl2/bXVy5MGC5dPjS7/taB8U="
+    "rev": "gz-plugin3_3.1.0",
+    "hash": "sha256-3La9TqxljV1Lko6ju+b8CCspDbhXGPLOGMivqYElTXM="
   }
 }

--- a/distros/kilted/gz-rendering-vendor/default.nix
+++ b/distros/kilted/gz-rendering-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, freeglut, freeimage, glew, gz-cmake-vendor, gz-common-vendor, gz-math-vendor, gz-ogre-next-vendor, gz-plugin-vendor, gz-utils-vendor, ogre1_9, util-linux, vulkan-loader, xorg }:
 buildRosPackage {
   pname = "ros-kilted-gz-rendering-vendor";
-  version = "0.2.4-r1";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_rendering_vendor-release/archive/release/kilted/gz_rendering_vendor/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "5ef41e8378fc4030cda830919427923cbc7bf89096d53a63c606c15e655f55d4";
+    url = "https://github.com/ros2-gbp/gz_rendering_vendor-release/archive/release/kilted/gz_rendering_vendor/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "7629ca10ed1f9744f15da4f26f6b0948471258ed82d1c0f72127bd66b1a62c17";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-rendering9 9.3.0
+    description = "Vendor package for: gz-rendering9 9.4.0
 
     Gazebo Rendering: Rendering library for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/kilted/gz-rendering-vendor/vendored-source.json
+++ b/distros/kilted/gz-rendering-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_rendering_vendor": {
     "url": "https://github.com/gazebosim/gz-rendering.git",
-    "rev": "gz-rendering9_9.3.0",
-    "hash": "sha256-mNDjqp54Y13BzZQdKvIfZkxXPq2Kn26sO9Gf+/aCaPk="
+    "rev": "gz-rendering9_9.4.0",
+    "hash": "sha256-sCt3JvmaACcAaJiH1pzCagRILDtwGycGqoq6VMHNbJg="
   }
 }

--- a/distros/kilted/gz-sim-vendor/default.nix
+++ b/distros/kilted/gz-sim-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, freeglut, freeimage, gbenchmark, glew, gz-cmake-vendor, gz-common-vendor, gz-fuel-tools-vendor, gz-gui-vendor, gz-math-vendor, gz-msgs-vendor, gz-physics-vendor, gz-plugin-vendor, gz-rendering-vendor, gz-sensors-vendor, gz-tools-vendor, gz-transport-vendor, gz-utils-vendor, protobuf, python3Packages, qt5, sdformat-vendor, tinyxml-2, util-linux, xorg }:
 buildRosPackage {
   pname = "ros-kilted-gz-sim-vendor";
-  version = "0.2.1-r2";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_sim_vendor-release/archive/release/kilted/gz_sim_vendor/0.2.1-2.tar.gz";
-    name = "0.2.1-2.tar.gz";
-    sha256 = "4a61d29465f5abc5f6bea0c106a3289885703f51c9d99bc1596b2b89a000a276";
+    url = "https://github.com/ros2-gbp/gz_sim_vendor-release/archive/release/kilted/gz_sim_vendor/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "917cd9161ae519929cbd64616315dc56c621e0039f228fb2be27284267210491";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-sim9 9.1.0
+    description = "Vendor package for: gz-sim9 9.4.0
 
     Gazebo Sim : A Robotic Simulator";
     license = with lib.licenses; [ asl20 ];

--- a/distros/kilted/gz-sim-vendor/vendored-source.json
+++ b/distros/kilted/gz-sim-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_sim_vendor": {
     "url": "https://github.com/gazebosim/gz-sim.git",
-    "rev": "gz-sim9_9.1.0",
-    "hash": "sha256-niVXuqMvEhwCW2NcrEhIChh3DsD2M8ZTspDi+zF0kBc="
+    "rev": "gz-sim9_9.4.0",
+    "hash": "sha256-Em+sQ/wygnLX/gjDqVrPpkh0kZmne4Z4WElz/nBRawI="
   }
 }

--- a/distros/kilted/gz-transport-vendor/default.nix
+++ b/distros/kilted/gz-transport-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, cppzmq, gz-cmake-vendor, gz-math-vendor, gz-msgs-vendor, gz-tools-vendor, gz-utils-vendor, pkg-config, protobuf, python3, python3Packages, sqlite, util-linux }:
 buildRosPackage {
   pname = "ros-kilted-gz-transport-vendor";
-  version = "0.2.1-r2";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_transport_vendor-release/archive/release/kilted/gz_transport_vendor/0.2.1-2.tar.gz";
-    name = "0.2.1-2.tar.gz";
-    sha256 = "deb8fdf03342606ba3e78ba99e56d51b16ea2c482308fa6d1e0950febe515659";
+    url = "https://github.com/ros2-gbp/gz_transport_vendor-release/archive/release/kilted/gz_transport_vendor/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "50c13891a22b5d2040e858f0338811e0f1f9478782f34299646cc49052f310e6";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-transport14 14.0.1
+    description = "Vendor package for: gz-transport14 14.1.0
 
     Gazebo Transport: Provides fast and efficient asynchronous message passing, services, and data logging.";
     license = with lib.licenses; [ asl20 ];

--- a/distros/kilted/gz-transport-vendor/vendored-source.json
+++ b/distros/kilted/gz-transport-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_transport_vendor": {
     "url": "https://github.com/gazebosim/gz-transport.git",
-    "rev": "gz-transport14_14.0.1",
-    "hash": "sha256-pSoadkpVaAEswmZuK13Y7PhxgvzTK1G2wI5+Fomlm/o="
+    "rev": "gz-transport14_14.1.0",
+    "hash": "sha256-45jD5lwNDJRJw8TKxCVBifKJYZ+NZcygSJozrynbs9g="
   }
 }

--- a/distros/kilted/image-tools/default.nix
+++ b/distros/kilted/image-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, opencv, rclcpp, rclcpp-components, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-image-tools";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/image_tools/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "e6795457bf676645ae79776a234530f7d9eda72cac408c2f8d7c90d117bf4ea7";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/image_tools/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "6014af385ce1d9a9cf9a6e4caee103458525c43d52d6a3931315645ba8fbd878";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/intra-process-demo/default.nix
+++ b/distros/kilted/intra-process-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, opencv, rclcpp, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-intra-process-demo";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/intra_process_demo/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "92ed255eac67bd4b880a30d121591f7d82cff54d0339f5fe921c84f417b09b8b";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/intra_process_demo/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "22fbf7ff08daf476b39004c2b362f1f17ed00c9ff1f7014bfbb026bec8f03f06";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/lifecycle-py/default.nix
+++ b/distros/kilted/lifecycle-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, lifecycle, lifecycle-msgs, rclpy, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-lifecycle-py";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/lifecycle_py/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "0c942366666784b02b8ccb266c1bf5493732dd123c0abb0832b7981aa74c4a92";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/lifecycle_py/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "13582e54526f4c3dd5538639da559856ff6735cf756741d91e1f6f7925f8ae5a";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/lifecycle/default.nix
+++ b/distros/kilted/lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-lifecycle";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/lifecycle/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "7a41ad643fb863d73d7a97da1cd2ba3494576bb3afa7fce26b17132aac9c07c2";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/lifecycle/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "d967eb3a08bd13a7bad16579adabd4325fafb2d478be5b8ad0670c64445283ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/logging-demo/default.nix
+++ b/distros/kilted/logging-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-logging-demo";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/logging_demo/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "55f5c55f391cbddf3d9afba2c960f9a32eadb41a5294b289b11ff646eea0e462";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/logging_demo/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "e9ba2dc71afd2172f95ac30bdaf4b0c136bc6a57afd70811a03b67a32f9c6399";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/message-filters/default.nix
+++ b/distros/kilted/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, rclcpp, rclcpp-lifecycle, rclpy, rcutils, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-message-filters";
-  version = "7.1.1-r1";
+  version = "7.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/kilted/message_filters/7.1.1-1.tar.gz";
-    name = "7.1.1-1.tar.gz";
-    sha256 = "3ffa1e666e1260a7599f75c4d5dfe5d9a7c566f5d69af7e8cf8a9b644c482396";
+    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/kilted/message_filters/7.1.2-1.tar.gz";
+    name = "7.1.2-1.tar.gz";
+    sha256 = "b4a4a7103ff846b9163ecddd4a0bdfd9f1cd7c9fbe989b7533571de845de6075";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mqtt-client-interfaces/default.nix
+++ b/distros/kilted/mqtt-client-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mqtt-client-interfaces";
-  version = "2.4.1-r1";
+  version = "2.4.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/kilted/mqtt_client_interfaces/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "df6f9747f4f2b0e57152678e4651ddd4ac96468f6e2f481b02f90bff987dc415";
+    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/kilted/mqtt_client_interfaces/2.4.1-2.tar.gz";
+    name = "2.4.1-2.tar.gz";
+    sha256 = "5b1d2dcee65c7612e77c0dff42c595514ff3a67483ac540042f6f96f0ae05c16";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mqtt-client/default.nix
+++ b/distros/kilted/mqtt-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmt, mqtt-client-interfaces, paho-mqtt-c, paho-mqtt-cpp, rclcpp, rclcpp-components, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mqtt-client";
-  version = "2.4.1-r1";
+  version = "2.4.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/kilted/mqtt_client/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "b9bbb15c8fa11e0eb7bdab30cbe18cd95afd4b04783c011f16703b2aca87d2c3";
+    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/kilted/mqtt_client/2.4.1-2.tar.gz";
+    name = "2.4.1-2.tar.gz";
+    sha256 = "b9a29546e323c3938bcb6eba808ee5963a1c42807a73a475ea03fa71e8b4e31b";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav-2d-msgs/default.nix
+++ b/distros/kilted/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-nav-2d-msgs";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav_2d_msgs/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "92bf43223c1deac3df90fa2330260b0732c5ea1b422bab68a3c1225720d75707";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav_2d_msgs/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "63f81d06b78a8a33b26279e5a9417760799555ac87d4e33993173c5673fa89d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav-2d-utils/default.nix
+++ b/distros/kilted/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-nav-2d-utils";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav_2d_utils/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "9ac525b48a1adb384eca5fa459c75098e6e9755be8329e3809390725017cd738";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav_2d_utils/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "ce8ea930caf0f9498f7bad0d660c136153362b1f0184899206cc0beff5c29d85";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-amcl/default.nix
+++ b/distros/kilted/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-nav2-amcl";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_amcl/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "2781ac1d995a13694ed6f1d95a23890f108501323364201b4568226774749d63";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_amcl/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "f6db0c7957898921e15637d9b7d7eb431daafbdc9059da6e97e32cfa7db50cec";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-behavior-tree/default.nix
+++ b/distros/kilted/nav2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, test-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-nav2-behavior-tree";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_behavior_tree/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "326f5b7ce377879447443286198557e0125b1b6f71cdae0507c29d0d8a7c90c7";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_behavior_tree/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "cdbb83a0ea2f158c03029283354e3c3a6384ee7a01c2c3d08e4ef4c01a3703cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-behaviors/default.nix
+++ b/distros/kilted/nav2-behaviors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-components, rclcpp-lifecycle, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-nav2-behaviors";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_behaviors/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "3fb510a7844a86b5ad7852e176b4e1315456371ef66d938ebe1a57ac701e6520";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_behaviors/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "db85c36b337c0d68b8245c1853a96ad347a3d7f954098cacb790d733e6c2cd94";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-bringup/default.nix
+++ b/distros/kilted/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, diff-drive-controller, joint-state-broadcaster, launch, launch-ros, launch-testing, nav2-common, nav2-minimal-tb3-sim, nav2-minimal-tb4-sim, navigation2, ros-gz-bridge, ros-gz-sim, slam-toolbox, xacro }:
 buildRosPackage {
   pname = "ros-kilted-nav2-bringup";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_bringup/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "d4439c8df50ea021839c38c9fdb12ac8db6f8890822d85864df6fbca291517c7";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_bringup/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "f983e037ed16588bd7522f93bc65828929796a07930e4cca7ea3bff976306488";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-bt-navigator/default.nix
+++ b/distros/kilted/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-components, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-nav2-bt-navigator";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_bt_navigator/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "ab6fb036cda8d8425a2d0eeab70ecf2aea95d3f0cb6d154360eb74201ac55ed5";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_bt_navigator/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "79d5189516471989610ea533fe554285daa1837d6f129cad7de575660bd98ca0";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-collision-monitor/default.nix
+++ b/distros/kilted/nav2-collision-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-costmap-2d, nav2-msgs, nav2-util, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-msgs, tf2, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-nav2-collision-monitor";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_collision_monitor/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "25441cd28253d7d725799df99ca3468dd410ff1068d88352c974f937dc6f3929";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_collision_monitor/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "a92dbe7079bab3b1c621349d6fc909d73efec581c3bacc60d277c9dc58870756";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-constrained-smoother/default.nix
+++ b/distros/kilted/nav2-constrained-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, ceres-solver, eigen, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-nav2-constrained-smoother";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_constrained_smoother/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "ec7f125b7a9bb1fc9db74191e157727ddec7d3ba10cae1a73b0056533c58728f";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_constrained_smoother/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "a59a47c8c0b715d9732a19040901403bbc8b602981489ed55c7f60b9fe9ecc03";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-controller/default.nix
+++ b/distros/kilted/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, lifecycle-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rcl-interfaces, rclcpp, rclcpp-components, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-nav2-controller";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_controller/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "92425d7d301baf8485c42a7f13ceb0e39028c23bcaa985629c938ce8e598363b";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_controller/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "63acf799994668bc446664c4a3ae3fa98f5ddda431b02eae5b29c49284f11908";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-core/default.nix
+++ b/distros/kilted/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-nav2-core";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_core/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "3c4b3690336f60bfce127001e9a76e62e6fdf3ab5f33bb6a51616e6a694f8cad";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_core/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "63c96f6d42bdad6884c4b959686b529d95cb9537ace0cad453251cb1e7cd8ea5";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-costmap-2d/default.nix
+++ b/distros/kilted/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, rmw, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-nav2-costmap-2d";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_costmap_2d/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "b750582045f08a83d63707b51a48a8e29f41c8878b371b369daa8547cf994e08";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_costmap_2d/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "3a56ba340227881080ee25c9370dbe5d5447f5bf340adb9a0fb77c397e1dffea";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-dwb-controller/default.nix
+++ b/distros/kilted/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils, nav2-common }:
 buildRosPackage {
   pname = "ros-kilted-nav2-dwb-controller";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_dwb_controller/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "d04579449603bfba89a609c278bec60f4eb9a141a6e67039d316fd98787ce0d3";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_dwb_controller/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "73250c7e280e708914dcbbfb016c5d606614b65f16c88802d081e1bfe59e4b09";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-graceful-controller/default.nix
+++ b/distros/kilted/nav2-graceful-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rcl-interfaces, rclcpp, rclcpp-lifecycle, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-nav2-graceful-controller";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_graceful_controller/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "aa59634e85c4ee23088d7e54b95c2a9f09d875910e75be9bc3f4aca0cbb12e3c";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_graceful_controller/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "9680d3a2d88290b087b274c32b29ac3af3085f5d5c09c65ff426e1f12c838ffb";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-lifecycle-manager/default.nix
+++ b/distros/kilted/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bondcpp, diagnostic-updater, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-components, rclcpp-lifecycle, std-srvs }:
 buildRosPackage {
   pname = "ros-kilted-nav2-lifecycle-manager";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_lifecycle_manager/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "a5c56feb90f6e06b40ad788f0982dcdaf1df3c5f832f2dc3d10c45568a014a56";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_lifecycle_manager/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "2db5c7fd72b67510acb54ad65d31b2471fd19a70304dcc7921acd3675583add4";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-loopback-sim/default.nix
+++ b/distros/kilted/nav2-loopback-sim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, nav-msgs, nav2-simple-commander, python3Packages, rclpy, tf-transformations, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-nav2-loopback-sim";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_loopback_sim/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "170901963769f2887183a7616d0a33674d1b0a08f60f23897df7b634e394e4d1";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_loopback_sim/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "a9e241f0fa3f5fb2d474e0872f1474f5cc1f699205928dce914511fc7823a8f5";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/nav2-map-server/default.nix
+++ b/distros/kilted/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-kilted-nav2-map-server";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_map_server/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "9327f54a32aa716aa31f9fcc0478fa9311aba62efe127574707537de3a278e95";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_map_server/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "ae0728420fbad1db89e34a33bdb7d9fdc3c3206504d0dca08d349706d0f8c913";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-mppi-controller/default.nix
+++ b/distros/kilted/nav2-mppi-controller/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, angles, eigen, eigen3-cmake-module, geometry-msgs, llvmPackages, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, angles, backward-ros, eigen, eigen3-cmake-module, gbenchmark, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-nav2-mppi-controller";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_mppi_controller/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "ed0bf36e03c446bb6248f22ed9e1be3005b90f3a94d262d31e8bc6161e001acb";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_mppi_controller/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "ab9f1716789363eb83aad8d548dab7ecd3d534f5fee74ffb79d22277a22e9901";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ angles eigen eigen3-cmake-module geometry-msgs llvmPackages.openmp nav-msgs nav2-common nav2-core nav2-costmap-2d nav2-util pluginlib rclcpp rclcpp-lifecycle std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ angles backward-ros eigen eigen3-cmake-module gbenchmark geometry-msgs nav-msgs nav2-common nav2-core nav2-costmap-2d nav2-msgs nav2-util pluginlib rclcpp rclcpp-lifecycle std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 
   meta = {

--- a/distros/kilted/nav2-msgs/default.nix
+++ b/distros/kilted/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geographic-msgs, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-nav2-msgs";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_msgs/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "dcefafb2890c9b291154a85f829068cefd0c3957bb88fb0b935dea432d3dd5e7";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_msgs/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "2919e0a2ed757cd09e6c80baf294a038a9c8b8ccc5adb38a7302dd6e130f1dfb";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-navfn-planner/default.nix
+++ b/distros/kilted/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-nav2-navfn-planner";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_navfn_planner/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "1de334d7ad3b7eaf6a05c5972ea144fc407b47f32d6400e094568fd2c98b9b02";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_navfn_planner/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "1cb3c830094a0c7da13ce2b9aa937a38dfcb0fd64c284ba6fc32a405adeaeb9a";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-planner/default.nix
+++ b/distros/kilted/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-components, rclcpp-lifecycle, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-nav2-planner";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_planner/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "8c92d9df010acc5bcb6a75a8eb9bce78831a0495b78c1549fe5b0885ea258947";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_planner/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "3e37637f4e8141252052e855c864ded7e5e62cca73fcd4bab4d1f343b7817025";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-regulated-pure-pursuit-controller/default.nix
+++ b/distros/kilted/nav2-regulated-pure-pursuit-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rcl-interfaces, rclcpp, rclcpp-lifecycle, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-nav2-regulated-pure-pursuit-controller";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_regulated_pure_pursuit_controller/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "8c033e7b4625551323b2014f81a89aa4a221fd2f53d5b41d2b68c934506e1011";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_regulated_pure_pursuit_controller/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "c610fe1e750db1419d5dc3aaa4d8939cb97ea9a943ec455e9ea5ee3dccf1b7da";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-rotation-shim-controller/default.nix
+++ b/distros/kilted/nav2-rotation-shim-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-regulated-pure-pursuit-controller, nav2-util, pluginlib, rcl-interfaces, rclcpp, rclcpp-lifecycle, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-nav2-rotation-shim-controller";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_rotation_shim_controller/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "d90d633e2332aa3bf837c4fbe90dabe9201c76d0b07954f9debe0de99cfa1f83";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_rotation_shim_controller/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "482fb771b4596b3ca85437e4e7f8d4d250f0afa1799d4a4226e909bdfc5c5cd4";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-route/default.nix
+++ b/distros/kilted/nav2-route/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, launch, launch-testing, nanoflann, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, nlohmann_json, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-nav2-route";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_route/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "2e13c1152de22e1329afdc3451716aad54458c942915a1615cc52269bbfdeadd";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_route/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "9060221a7d8460c654a6fb834c8d3480984ed5bb28a16dcefef071ccab5163d0";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-rviz-plugins/default.nix
+++ b/distros/kilted/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-msgs, nav2-route, nav2-util, pluginlib, qt5, rclcpp, rclcpp-action, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, visualization-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-kilted-nav2-rviz-plugins";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_rviz_plugins/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "028921aeb39896c78ea0e63dc9cc04217f3d283d1d7410e66399c059e1151dc5";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_rviz_plugins/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "4e38c81ec89c38fbfaeedbac2afcccce1c140c5aba6b0e2e5abfe5c867eaf036";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-simple-commander/default.nix
+++ b/distros/kilted/nav2-simple-commander/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, lifecycle-msgs, nav2-msgs, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-kilted-nav2-simple-commander";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_simple_commander/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "de81aed29877e8f85db012b0c67f692080396fe5da167da6d19a85f458528ac2";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_simple_commander/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "ad768286621723205495ae0e9772ba1bf963fb5a6a5a98b7add04f8796366536";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/nav2-smac-planner/default.nix
+++ b/distros/kilted/nav2-smac-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, eigen, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, nlohmann_json, ompl, pluginlib, rcl-interfaces, rclcpp, rclcpp-lifecycle, tf2, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-nav2-smac-planner";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_smac_planner/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "64dbda1eef16c888668040d544b262f1613f37a4d6b5e569f894e3833be93bd2";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_smac_planner/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "4706f3cd45bb8ca7b1169dab5d8bc9e0a47b8418f1f35ffe88af340ce13e18e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-smoother/default.nix
+++ b/distros/kilted/nav2-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, nav-2d-utils, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-components, rclcpp-lifecycle, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-nav2-smoother";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_smoother/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "6dbce3ba7524f34399ffea6520fa5d6c8517307effd016fda37d58d7c04144fc";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_smoother/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "90cbded8c49dd86ffc03e42aec9a5acb0a71b605057675523207b5034804b268";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-system-tests/default.nix
+++ b/distros/kilted/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-behavior-tree, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-minimal-tb3-sim, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, python3Packages, rclcpp, rclcpp-lifecycle, rclpy, robot-state-publisher, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-nav2-system-tests";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_system_tests/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "bd1a032ce6cbcc6d6bf10c0206704cd7bc1b551dca6052f18757e323c285c2a0";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_system_tests/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "eed53e5c337fa75f20086d30b4d8e14b9d80f2b09735bd3ddaf1586781a41929";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-theta-star-planner/default.nix
+++ b/distros/kilted/nav2-theta-star-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rcl-interfaces, rclcpp, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-nav2-theta-star-planner";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_theta_star_planner/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "dcaa997029274f9522431d61c10273ee872b9f8c19beee124401bf1c3f357677";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_theta_star_planner/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "2c5ae222ad860ef4b29ad94dd32164b704d8a83f1c8f565104d7e7f17a889183";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-util/default.nix
+++ b/distros/kilted/nav2-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bond, bondcpp, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, pluginlib, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-nav2-util";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_util/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "967a071884ade94180f5656a3d5882170ba589f5adfad16fbed210c684c12246";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_util/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "cd783067c2ba368268a107af0a701b76624d10448f5a19242edd4c0b0c4e0771";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-velocity-smoother/default.nix
+++ b/distros/kilted/nav2-velocity-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-common, nav2-util, rclcpp, rclcpp-components, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-kilted-nav2-velocity-smoother";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_velocity_smoother/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "10955257504a3b4cb0981daf432ad0cc9db8104dc029a95ea4cb3f2d923a90ac";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_velocity_smoother/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "80e4e01c27a17f17cca8426b5998caffb7bb75756c2a323db815eb32afc724fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-voxel-grid/default.nix
+++ b/distros/kilted/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-kilted-nav2-voxel-grid";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_voxel_grid/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "46a38322ccb509b3ac81a11ddf1054fa59e114b9caa8c63ae05011a1d88aa587";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_voxel_grid/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "096337ce5c76b2832f30680901a87298883b3f2a3cfb3556d54b4823d00bf513";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nav2-waypoint-follower/default.nix
+++ b/distros/kilted/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cv-bridge, geographic-msgs, geometry-msgs, image-transport, nav-msgs, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-components, rclcpp-lifecycle, robot-localization, sensor-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-nav2-waypoint-follower";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_waypoint_follower/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "740ced666304df20ffa54014de39abaf40199c58bab5f04e471e9074807aa4fa";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/nav2_waypoint_follower/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "3a1df2e1e3478d329c60260b5b9889a86a1ed591ad86de0f9c41c48a00de5721";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/navigation2/default.nix
+++ b/distros/kilted/navigation2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-behaviors, nav2-bt-navigator, nav2-collision-monitor, nav2-common, nav2-constrained-smoother, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-graceful-controller, nav2-lifecycle-manager, nav2-map-server, nav2-mppi-controller, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-regulated-pure-pursuit-controller, nav2-rotation-shim-controller, nav2-route, nav2-rviz-plugins, nav2-simple-commander, nav2-smac-planner, nav2-smoother, nav2-theta-star-planner, nav2-util, nav2-velocity-smoother, nav2-voxel-grid, nav2-waypoint-follower, opennav-docking, opennav-docking-bt, opennav-docking-core }:
 buildRosPackage {
   pname = "ros-kilted-navigation2";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/navigation2/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "41b46817b5dc2fbfd19177e49c91ea40c02d9dc6e8d2d0e2d0581c5396207d34";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/navigation2/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "b81f132f3aaee3599da1a5591268dbccd978e97a7b027ce79c495fa3d4198f04";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/opennav-docking-bt/default.nix
+++ b/distros/kilted/opennav-docking-bt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-msgs, nav2-util, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-kilted-opennav-docking-bt";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/opennav_docking_bt/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "c56fdf7859fe185a6b45891341431c8ffd2fec69404773ca544fa3460a67f64c";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/opennav_docking_bt/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "bf2e9d2c98292f812845f335c81c4b91cd510dbba7838984cea7665aab34a355";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/opennav-docking-core/default.nix
+++ b/distros/kilted/opennav-docking-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-opennav-docking-core";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/opennav_docking_core/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "6b06bdef1e1dde5d0564c8e5fbbea7f295660a0e24a389a461b040508cd98150";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/opennav_docking_core/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "b6476f3518139409f9181c304e3bc2836145f0b74e025d4b00a65f3467445e68";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/opennav-docking/default.nix
+++ b/distros/kilted/opennav-docking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav-msgs, nav2-common, nav2-graceful-controller, nav2-msgs, nav2-util, opennav-docking-core, pluginlib, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rclcpp-lifecycle, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-kilted-opennav-docking";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/opennav_docking/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "b706aab305fb203f93be59e1495a85daf9ca4706e996066ff6b06a8906f0b529";
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/kilted/opennav_docking/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "fc9745183bdb0a536ed378b6f5e52c7b5661bcc938a8b92a527acfb59b74a848";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/pal-statistics-msgs/default.nix
+++ b/distros/kilted/pal-statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-pal-statistics-msgs";
-  version = "2.6.3-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/kilted/pal_statistics_msgs/2.6.3-1.tar.gz";
-    name = "2.6.3-1.tar.gz";
-    sha256 = "c108a3694ec4c1cf0d83dc01dddc895503ef306e6a305f6ee00fa69f01c3c909";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/kilted/pal_statistics_msgs/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "48d11d6b96f99aa951f0a7e56ef41fb77f10d3cb6a7276b426a0005c5b4a2bbe";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/pal-statistics/default.nix
+++ b/distros/kilted/pal-statistics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, boost, pal-statistics-msgs, rclcpp, rclcpp-lifecycle, rclpy }:
 buildRosPackage {
   pname = "ros-kilted-pal-statistics";
-  version = "2.6.3-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/kilted/pal_statistics/2.6.3-1.tar.gz";
-    name = "2.6.3-1.tar.gz";
-    sha256 = "ce046021ff10bceccfbd90dcc36e0801f00aa0e75bfad5979bd6766630953cb4";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/kilted/pal_statistics/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "44b37c245841294051ec4a1f08320ba59c86357a61ce61463c9f59d780fcfa0a";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/pendulum-control/default.nix
+++ b/distros/kilted/pendulum-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pendulum-msgs, rclcpp, rmw-implementation-cmake, ros2run, rttest, tlsf-cpp }:
 buildRosPackage {
   pname = "ros-kilted-pendulum-control";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/pendulum_control/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "d4960be1464b79d8a5c94e3276ba35323bc75690f89845b2e6685c50e72a8b7b";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/pendulum_control/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "44cf857059f0ccf1f8ff86a5c0350630d43c9597772572e152ae74f050813d82";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/pendulum-msgs/default.nix
+++ b/distros/kilted/pendulum-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-kilted-pendulum-msgs";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/pendulum_msgs/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "79de56721ceb3faba764ac48c28f5b22bd9c87122071e5606ac4df062f8759a9";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/pendulum_msgs/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "4b7e50d9cf406e34741d13255cd68c7e69846d0bbcec45bea0994a085d13e98e";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/quality-of-service-demo-cpp/default.nix
+++ b/distros/kilted/quality-of-service-demo-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, rclcpp, rclcpp-components, rcutils, rmw, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-quality-of-service-demo-cpp";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/quality_of_service_demo_cpp/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "92a1bda1ae93cb596d8d86642b6523be9e60214b957b1f722f41f556eb0537ab";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/quality_of_service_demo_cpp/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "0f49bec40a60f0c5b0b70c1eff3a35d7bbcfe29f91a6228b338a1f7404117cda";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/quality-of-service-demo-py/default.nix
+++ b/distros/kilted/quality-of-service-demo-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-quality-of-service-demo-py";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/quality_of_service_demo_py/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "fe7ae3dcde24129c758681bc87ff631af007da3927997c4a8c464c2752621e6f";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/quality_of_service_demo_py/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "2cb971d7cd1ec03670fdbab32cdec44e3276f922941beae5bca111ae08c26aa0";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/rcpputils/default.nix
+++ b/distros/kilted/rcpputils/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-ros-core, ament-cmake-uncrustify, ament-cmake-xmllint, rcutils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros-core, ament-cmake-uncrustify, ament-cmake-xmllint, rcutils }:
 buildRosPackage {
   pname = "ros-kilted-rcpputils";
-  version = "2.13.4-r2";
+  version = "2.13.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/kilted/rcpputils/2.13.4-2.tar.gz";
-    name = "2.13.4-2.tar.gz";
-    sha256 = "2253309959a73ac41daaaa1a14865f182126121f1f537a39fee7543b8d99c834";
+    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/kilted/rcpputils/2.13.5-1.tar.gz";
+    name = "2.13.5-1.tar.gz";
+    sha256 = "52b91d4cef7617aa1c81e48a4858709aa32f4dc58303466e4ca23eac4e06c78b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gen-version-h ament-cmake-ros-core ];
-  checkInputs = [ ament-cmake-copyright ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-uncrustify ament-cmake-xmllint ];
   propagatedBuildInputs = [ rcutils ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ament-cmake-ros-core ];
 

--- a/distros/kilted/realtime-tools/default.nix
+++ b/distros/kilted/realtime-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, boost, libcap, lifecycle-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2-control-cmake, test-msgs }:
 buildRosPackage {
   pname = "ros-kilted-realtime-tools";
-  version = "4.5.0-r1";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/kilted/realtime_tools/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "f70e6869c1d32a8707521958514b06fb902fbbab0b4004469a0043e058e56be5";
+    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/kilted/realtime_tools/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "49b28053cc5a8c704f102b7871a9d1ef8961f22e5b65d0a6fa08b2ae7f25b46a";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rmw-dds-common/default.nix
+++ b/distros/kilted/rmw-dds-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils, rmw, rmw-security-common, rosidl-default-generators, rosidl-default-runtime, rosidl-runtime-c, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-kilted-rmw-dds-common";
-  version = "3.2.1-r2";
+  version = "4.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_dds_common-release/archive/release/kilted/rmw_dds_common/3.2.1-2.tar.gz";
-    name = "3.2.1-2.tar.gz";
-    sha256 = "ef2e5fafa976eb0fe5172be8adf63be6d2204d37d5aa835267c9a6dbee1d9182";
+    url = "https://github.com/ros2-gbp/rmw_dds_common-release/archive/release/kilted/rmw_dds_common/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "a8151d788e20ebd9fcf2aca2bd5638d834be4fe5eb76947b354cdb0de39a7091";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rmw-fastrtps-cpp/default.nix
+++ b/distros/kilted/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros-core, ament-lint-auto, ament-lint-common, fastcdr, fastdds, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-dynamic-typesupport, rosidl-dynamic-typesupport-fastrtps, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-kilted-rmw-fastrtps-cpp";
-  version = "9.3.2-r2";
+  version = "9.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/kilted/rmw_fastrtps_cpp/9.3.2-2.tar.gz";
-    name = "9.3.2-2.tar.gz";
-    sha256 = "9a9c63a7cf1d4aa5f2f9f0d9ff69ce559e6b6402dc78dcc424f4ebd43e26f1c3";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/kilted/rmw_fastrtps_cpp/9.3.3-1.tar.gz";
+    name = "9.3.3-1.tar.gz";
+    sha256 = "dbf624b4aed3cd7110c5f854d995ae77e2b0e5f8e343c144296bac8693ec257e";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/kilted/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros-core, ament-lint-auto, ament-lint-common, fastcdr, fastdds, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-kilted-rmw-fastrtps-dynamic-cpp";
-  version = "9.3.2-r2";
+  version = "9.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/kilted/rmw_fastrtps_dynamic_cpp/9.3.2-2.tar.gz";
-    name = "9.3.2-2.tar.gz";
-    sha256 = "18c409f74100a6446e4e0e9f961ed1af7b759116ad14344b69d427eb606ce020";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/kilted/rmw_fastrtps_dynamic_cpp/9.3.3-1.tar.gz";
+    name = "9.3.3-1.tar.gz";
+    sha256 = "c9df667938c3046617bfdc6445b9082c0edff4fc2f6b83c8aac1af88c41eee56";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/kilted/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros-core, ament-lint-auto, ament-lint-common, fastcdr, fastdds, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-security-common, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-kilted-rmw-fastrtps-shared-cpp";
-  version = "9.3.2-r2";
+  version = "9.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/kilted/rmw_fastrtps_shared_cpp/9.3.2-2.tar.gz";
-    name = "9.3.2-2.tar.gz";
-    sha256 = "1b06480d4be5b44c9291a5c5fab52e3d7b2eddcb496a9034559a713ab8e9864f";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/kilted/rmw_fastrtps_shared_cpp/9.3.3-1.tar.gz";
+    name = "9.3.3-1.tar.gz";
+    sha256 = "a37e29648b7c363cfa4bb777bc6e4c33d1ccae9ccb64b5f0b51d5b7de0537261";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rosidl-typesupport-fastrtps-c/default.nix
+++ b/distros/kilted/rosidl-typesupport-fastrtps-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros-core, ament-index-python, ament-lint-auto, ament-lint-common, fastcdr, osrf-testing-tools-cpp, performance-test-fixture, python3, rcutils, rmw, rosidl-cli, rosidl-generator-c, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-kilted-rosidl-typesupport-fastrtps-c";
-  version = "3.8.0-r2";
+  version = "3.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/kilted/rosidl_typesupport_fastrtps_c/3.8.0-2.tar.gz";
-    name = "3.8.0-2.tar.gz";
-    sha256 = "b392c1050953aff19843a4b7ea87c46f98ad85f43dcd58d604c292e47452836e";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/kilted/rosidl_typesupport_fastrtps_c/3.8.1-1.tar.gz";
+    name = "3.8.1-1.tar.gz";
+    sha256 = "06e85758a151536dc1f94819ac3be633c9aeab1259a2c84504911e24f4fc416d";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rosidl-typesupport-fastrtps-cpp/default.nix
+++ b/distros/kilted/rosidl-typesupport-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros-core, ament-index-python, ament-lint-auto, ament-lint-common, fastcdr, osrf-testing-tools-cpp, performance-test-fixture, python3, rcutils, rmw, rosidl-cli, rosidl-generator-c, rosidl-generator-cpp, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-kilted-rosidl-typesupport-fastrtps-cpp";
-  version = "3.8.0-r2";
+  version = "3.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/kilted/rosidl_typesupport_fastrtps_cpp/3.8.0-2.tar.gz";
-    name = "3.8.0-2.tar.gz";
-    sha256 = "4cdbdded377b88b7ee03e8b66a7ad5dd3e73ea9b597c1af0adb2a7585492617b";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/kilted/rosidl_typesupport_fastrtps_cpp/3.8.1-1.tar.gz";
+    name = "3.8.1-1.tar.gz";
+    sha256 = "bff1ef76f49268e6822e6a79d0ef57a72f15b4ed76e2257288770d7f4a7ad7b2";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rpyutils/default.nix
+++ b/distros/kilted/rpyutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-kilted-rpyutils";
-  version = "0.6.2-r2";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rpyutils-release/archive/release/kilted/rpyutils/0.6.2-2.tar.gz";
-    name = "0.6.2-2.tar.gz";
-    sha256 = "7c28ca9c0c2a680a7ded5f9b95e26b6ba63ffe4e9a78fbcbdf3c0b71448621e2";
+    url = "https://github.com/ros2-gbp/rpyutils-release/archive/release/kilted/rpyutils/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "3232f835bcadc1d091ffb9afdfcd0af6f2ec75e95fa1cd0e45c5fd837702b54c";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/rviz-assimp-vendor/default.nix
+++ b/distros/kilted/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-kilted-rviz-assimp-vendor";
-  version = "15.0.5-r1";
+  version = "15.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_assimp_vendor/15.0.5-1.tar.gz";
-    name = "15.0.5-1.tar.gz";
-    sha256 = "ce1039300af6fda018f317e0cb62d9160176f2e9f705a2686c4b0bd95d1c5f0a";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_assimp_vendor/15.0.6-1.tar.gz";
+    name = "15.0.6-1.tar.gz";
+    sha256 = "ca149af595b47ac16bed07ca25423d1d2371c04e3566cf7669742695af2d9a86";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rviz-common/default.nix
+++ b/distros/kilted/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-kilted-rviz-common";
-  version = "15.0.5-r1";
+  version = "15.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_common/15.0.5-1.tar.gz";
-    name = "15.0.5-1.tar.gz";
-    sha256 = "59ffe7e5dfb512c91cdc2c9f10c8760de7ad2a3068ddcd6140a6b188867d33f8";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_common/15.0.6-1.tar.gz";
+    name = "15.0.6-1.tar.gz";
+    sha256 = "3a25f712c9914935895946efa2874ea53ede10b3de4693940693a107cff10507";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rviz-default-plugins/default.nix
+++ b/distros/kilted/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, gz-math-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-resource-interfaces, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-rviz-default-plugins";
-  version = "15.0.5-r1";
+  version = "15.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_default_plugins/15.0.5-1.tar.gz";
-    name = "15.0.5-1.tar.gz";
-    sha256 = "20031e7600dd0531fcc63a1a5eb8b0e1f909213c1431819e5493c4f074a11b65";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_default_plugins/15.0.6-1.tar.gz";
+    name = "15.0.6-1.tar.gz";
+    sha256 = "43182dda1efcefd97a6bc00e0fad3e31e83c0fbc7b5037a3ef1c51698ab67b7c";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rviz-ogre-vendor/default.nix
+++ b/distros/kilted/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, glew, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-kilted-rviz-ogre-vendor";
-  version = "15.0.5-r1";
+  version = "15.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_ogre_vendor/15.0.5-1.tar.gz";
-    name = "15.0.5-1.tar.gz";
-    sha256 = "0145f9e87aaf5561872936e63c2b1440b822c70830e5667da9ec6c62e8f85df1";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_ogre_vendor/15.0.6-1.tar.gz";
+    name = "15.0.6-1.tar.gz";
+    sha256 = "5049c8f178607683737c384d34c894c210a4925add309fc0752da684d479442b";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rviz-rendering-tests/default.nix
+++ b/distros/kilted/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-kilted-rviz-rendering-tests";
-  version = "15.0.5-r1";
+  version = "15.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_rendering_tests/15.0.5-1.tar.gz";
-    name = "15.0.5-1.tar.gz";
-    sha256 = "2fee64263de6a00f299e1e35d1229bb336aa8f23ebc0c788cc09d1e530f181b8";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_rendering_tests/15.0.6-1.tar.gz";
+    name = "15.0.6-1.tar.gz";
+    sha256 = "f689c8e74c0814a30f322bdd42af0c5dce2dbb9bd2cae0c487082a3529236095";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rviz-rendering/default.nix
+++ b/distros/kilted/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-kilted-rviz-rendering";
-  version = "15.0.5-r1";
+  version = "15.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_rendering/15.0.5-1.tar.gz";
-    name = "15.0.5-1.tar.gz";
-    sha256 = "542d1f3c485736479cef5ab1bb94f07e2154c6d0224ee5957ab6b5eb767ad734";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_rendering/15.0.6-1.tar.gz";
+    name = "15.0.6-1.tar.gz";
+    sha256 = "5a3e2c7d8a9cd51927cfe45faef236d2557b64ee1cd89c51fb0150254fa528b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rviz-resource-interfaces/default.nix
+++ b/distros/kilted/rviz-resource-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-kilted-rviz-resource-interfaces";
-  version = "15.0.5-r1";
+  version = "15.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_resource_interfaces/15.0.5-1.tar.gz";
-    name = "15.0.5-1.tar.gz";
-    sha256 = "806296284374c1dd0a2fe46c4b92ebebb471b9aa7102dd09c8e3402656e620ae";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_resource_interfaces/15.0.6-1.tar.gz";
+    name = "15.0.6-1.tar.gz";
+    sha256 = "ec1d4e2d1be45b84e4d2db8413965792e86f5449e542cd79e779c0e3b5ca195a";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rviz-visual-testing-framework/default.nix
+++ b/distros/kilted/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-rviz-visual-testing-framework";
-  version = "15.0.5-r1";
+  version = "15.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_visual_testing_framework/15.0.5-1.tar.gz";
-    name = "15.0.5-1.tar.gz";
-    sha256 = "8749e6a57d4766d3c7ca6370ae77afcd8a3916dca76850c8ac3e86a9de6ef307";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_visual_testing_framework/15.0.6-1.tar.gz";
+    name = "15.0.6-1.tar.gz";
+    sha256 = "3737ab5734f605e88bc5d3463474210e9d0da8c7ede706f44d86ea7d6328bd30";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rviz2/default.nix
+++ b/distros/kilted/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-rviz2";
-  version = "15.0.5-r1";
+  version = "15.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz2/15.0.5-1.tar.gz";
-    name = "15.0.5-1.tar.gz";
-    sha256 = "9d897119221b48f61a10be419c442b85a3e17dd0ac17e156dfb1e689fc0b95d2";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz2/15.0.6-1.tar.gz";
+    name = "15.0.6-1.tar.gz";
+    sha256 = "7b51f626906d401e1762aea2453823d041507b27010f5bfee8f17a2364f1ffd0";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/topic-monitor/default.nix
+++ b/distros/kilted/topic-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, python3Packages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-topic-monitor";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/topic_monitor/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "272400c35302943104b7e1ed6a2ffcaf7719ca70abe28a7f6c1698fc25f1c80e";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/topic_monitor/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "370b98741c6865585b9768235c3733136f2d07c275b678fdce838e860069a96c";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/topic-statistics-demo/default.nix
+++ b/distros/kilted/topic-statistics-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rcutils, sensor-msgs, statistics-msgs }:
 buildRosPackage {
   pname = "ros-kilted-topic-statistics-demo";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/topic_statistics_demo/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "704ebe0b520ec52d8d28910320af6882d3ba71092e49e922f20413c34a920c5c";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/kilted/topic_statistics_demo/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "2fee57bf33234d9b71650f5c39d66c868a6545ec94aba9131c778748dc947be2";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ur-simulation-gz/default.nix
+++ b/distros/kilted/ur-simulation-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, gz-ros2-control, joint-state-publisher, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, ros-gz-bridge, ros-gz-sim, rviz2, ur-controllers, ur-description, ur-moveit-config, urdf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-kilted-ur-simulation-gz";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_simulation_gz-release/archive/release/kilted/ur_simulation_gz/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "87531c4ccf88d5c4f11fecec21d45544bd623723e29c6937c30c5d9ac44960e8";
+    url = "https://github.com/ros2-gbp/ur_simulation_gz-release/archive/release/kilted/ur_simulation_gz/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "d193b7a5127155c2eb66127ed3f780e56e6c19b109605c53b098ac6a512e38bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ackermann-nlmpc-msgs/default.nix
+++ b/distros/rolling/ackermann-nlmpc-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ackermann-nlmpc-msgs";
-  version = "1.0.2-r2";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ackmerann_nlmpc-release/archive/release/rolling/ackermann_nlmpc_msgs/1.0.2-2.tar.gz";
-    name = "1.0.2-2.tar.gz";
-    sha256 = "f886d626cec027ebf4e12494ef4262fc2b84dfe668378b776d7c6a2f9a01fe55";
+    url = "https://github.com/ros2-gbp/ackmerann_nlmpc-release/archive/release/rolling/ackermann_nlmpc_msgs/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "23adb09ab6a8e7f44106847e770446f500a6739f2d63bd519200f27630f22138";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ackermann-nlmpc/default.nix
+++ b/distros/rolling/ackermann-nlmpc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ackermann-nlmpc-msgs, ament-pep257, geometry-msgs, nav-msgs, python3Packages, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ackermann-nlmpc";
-  version = "1.0.2-r2";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ackmerann_nlmpc-release/archive/release/rolling/ackermann_nlmpc/1.0.2-2.tar.gz";
-    name = "1.0.2-2.tar.gz";
-    sha256 = "95c85b949a5530798482f0e004ee4b4502eafafff1a9e86824ea1417840f9d1b";
+    url = "https://github.com/ros2-gbp/ackmerann_nlmpc-release/archive/release/rolling/ackermann_nlmpc/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "f48fcd53cfcd04a812adf7cf115cdc53ada77fec53cba327f8ef97c5846e25df";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/action-tutorials-cpp/default.nix
+++ b/distros/rolling/action-tutorials-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rclcpp-action, rclcpp-components }:
 buildRosPackage {
   pname = "ros-rolling-action-tutorials-cpp";
-  version = "0.37.2-r1";
+  version = "0.37.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_cpp/0.37.2-1.tar.gz";
-    name = "0.37.2-1.tar.gz";
-    sha256 = "3a4c03026ffc0849cd5849e66461d78fae4e92adf9ab1da1ae2075a3e8ab1f19";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_cpp/0.37.3-1.tar.gz";
+    name = "0.37.3-1.tar.gz";
+    sha256 = "02cb2d66de46070bbda4dbe152517066ae75a085b6b74bd7bd8193bb748a0655";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/action-tutorials-py/default.nix
+++ b/distros/rolling/action-tutorials-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, example-interfaces, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-action-tutorials-py";
-  version = "0.37.2-r1";
+  version = "0.37.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_py/0.37.2-1.tar.gz";
-    name = "0.37.2-1.tar.gz";
-    sha256 = "8544c0b0ef166d37a6b446fab40342c51371b338a9510866dbdb8cd7d13b5fbb";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_py/0.37.3-1.tar.gz";
+    name = "0.37.3-1.tar.gz";
+    sha256 = "7d497354af43f9cf92d232cd1a314ef784b5a445bd0436c43c1c40742fe127f7";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ads-vendor/default.nix
+++ b/distros/rolling/ads-vendor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, git }:
+buildRosPackage {
+  pname = "ros-rolling-ads-vendor";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/b-robotized/ads_vendor-release/archive/release/rolling/ads_vendor/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "25e566e2d9dd0f736cf5a0ca7d2b8661092f2646704976b68cf10977b4b6bd98";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake git ];
+  nativeBuildInputs = [ ament-cmake git ];
+
+  meta = {
+    description = "Package vendoring Beckhoff/ADS library";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/angles/default.nix
+++ b/distros/rolling/angles/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, python3Packages }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-angles";
-  version = "1.16.0-r4";
+  version = "1.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/angles-release/archive/release/rolling/angles/1.16.0-4.tar.gz";
-    name = "1.16.0-4.tar.gz";
-    sha256 = "297093231562a7f1de65c3bffc74164466b33bc17089c21ed0f0c266390adc78";
+    url = "https://github.com/ros2-gbp/angles-release/archive/release/rolling/angles/1.16.1-1.tar.gz";
+    name = "1.16.1-1.tar.gz";
+    sha256 = "d49d55efb83a16eab3b611081621d64a13ac052eae3837b4d621834e66ad3a8b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-python python3Packages.setuptools ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ];
   propagatedBuildInputs = [ ament-cmake ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python python3Packages.setuptools ];
 

--- a/distros/rolling/composition/default.nix
+++ b/distros/rolling/composition/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-composition";
-  version = "0.37.2-r1";
+  version = "0.37.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/composition/0.37.2-1.tar.gz";
-    name = "0.37.2-1.tar.gz";
-    sha256 = "5e8f336b316e822be3ae94928b8fd336e3f73dc23f289cdd327706e601a1fc97";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/composition/0.37.3-1.tar.gz";
+    name = "0.37.3-1.tar.gz";
+    sha256 = "7b1148d9bc7d2feccd59d750d04c04a1eedbad00140bfe4f7d5b2a321c07a195";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/control-toolbox/default.nix
+++ b/distros/rolling/control-toolbox/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, eigen, filters, fmt, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-cmake, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, eigen, filters, fmt, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-cmake, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-control-toolbox";
-  version = "5.6.0-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/rolling/control_toolbox/5.6.0-1.tar.gz";
-    name = "5.6.0-1.tar.gz";
-    sha256 = "42f27f0b1509c551310566194242c5d06f204ba65d82abc487578d816f68839e";
+    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/rolling/control_toolbox/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "a32e732ff65dffe307b092f838d941bc0e4806cea519e3cc4b87eb9727e25eaf";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake fmt ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock rclcpp-lifecycle ];
-  propagatedBuildInputs = [ control-msgs eigen filters generate-parameter-library geometry-msgs pluginlib rclcpp rcutils realtime-tools tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ backward-ros control-msgs eigen filters generate-parameter-library geometry-msgs pluginlib rclcpp rcutils realtime-tools tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/demo-nodes-cpp-native/default.nix
+++ b/distros/rolling/demo-nodes-cpp-native/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rmw-fastrtps-cpp, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-demo-nodes-cpp-native";
-  version = "0.37.2-r1";
+  version = "0.37.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp_native/0.37.2-1.tar.gz";
-    name = "0.37.2-1.tar.gz";
-    sha256 = "be743a0e121094e46943f117109bd7811fa68d7372822f1508421d4e0a590f11";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp_native/0.37.3-1.tar.gz";
+    name = "0.37.3-1.tar.gz";
+    sha256 = "aec7012dcc2687476bb69886bb1eabd4ce0ebad3746d174f99af36d47bddf298";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/demo-nodes-cpp/default.nix
+++ b/distros/rolling/demo-nodes-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, launch-xml, rcl, rcl-interfaces, rclcpp, rclcpp-components, rcpputils, rcutils, rmw, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-demo-nodes-cpp";
-  version = "0.37.2-r1";
+  version = "0.37.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp/0.37.2-1.tar.gz";
-    name = "0.37.2-1.tar.gz";
-    sha256 = "c9b4b938572744b47b463c21aeee69be2cd67458ca176f3a7654b21f2131db01";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp/0.37.3-1.tar.gz";
+    name = "0.37.3-1.tar.gz";
+    sha256 = "37044cb294397149d2215e2d6d1a17270887c06b9b1b407416f3aed8744240ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/demo-nodes-py/default.nix
+++ b/distros/rolling/demo-nodes-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, example-interfaces, python3Packages, rcl-interfaces, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-demo-nodes-py";
-  version = "0.37.2-r1";
+  version = "0.37.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_py/0.37.2-1.tar.gz";
-    name = "0.37.2-1.tar.gz";
-    sha256 = "9e39cee99bd0394646f48b2476c693bf046bff74c09230b32984669789f51c35";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_py/0.37.3-1.tar.gz";
+    name = "0.37.3-1.tar.gz";
+    sha256 = "029e8599c98577285cc9c7009aa9e54530c0b81fd0b8d0b3f338ae46e6a0692e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/dummy-map-server/default.nix
+++ b/distros/rolling/dummy-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-dummy-map-server";
-  version = "0.37.2-r1";
+  version = "0.37.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_map_server/0.37.2-1.tar.gz";
-    name = "0.37.2-1.tar.gz";
-    sha256 = "40e4bb6c1bd8f7c621513513b812166674147b6797043fc8257adb25f4e758b4";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_map_server/0.37.3-1.tar.gz";
+    name = "0.37.3-1.tar.gz";
+    sha256 = "8e4dceb97cdcc10058a5fb220c24f708f7580cda716f9456835e654482292172";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dummy-robot-bringup/default.nix
+++ b/distros/rolling/dummy-robot-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, dummy-map-server, dummy-sensors, launch, launch-ros, robot-state-publisher }:
 buildRosPackage {
   pname = "ros-rolling-dummy-robot-bringup";
-  version = "0.37.2-r1";
+  version = "0.37.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_robot_bringup/0.37.2-1.tar.gz";
-    name = "0.37.2-1.tar.gz";
-    sha256 = "eb522fc938d97c7593ef2dfa267d084196a3ccf427d8534f3487d5a22a846257";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_robot_bringup/0.37.3-1.tar.gz";
+    name = "0.37.3-1.tar.gz";
+    sha256 = "49f95b6caabb6dd4b587aa8e9bede9af4bfb7a9726e1f2d53cdde8bc162d1388";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dummy-sensors/default.nix
+++ b/distros/rolling/dummy-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-dummy-sensors";
-  version = "0.37.2-r1";
+  version = "0.37.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_sensors/0.37.2-1.tar.gz";
-    name = "0.37.2-1.tar.gz";
-    sha256 = "dff01e82bfb46daf8b2cabe938ab39fce55d69d4be5255959c78b9ea4794d70a";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_sensors/0.37.3-1.tar.gz";
+    name = "0.37.3-1.tar.gz";
+    sha256 = "e587f07cd912c1b51926aa1baa91a20aca6913cf337b706dd5acdc1049860e5a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dynamixel-hardware-interface/default.nix
+++ b/distros/rolling/dynamixel-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-interfaces, dynamixel-sdk, hardware-interface, pluginlib, rclcpp, realtime-tools, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-dynamixel-hardware-interface";
-  version = "1.4.14-r1";
+  version = "1.4.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/rolling/dynamixel_hardware_interface/1.4.14-1.tar.gz";
-    name = "1.4.14-1.tar.gz";
-    sha256 = "7e1cebadcf6d69f0ba3486cc97bbc2ce52d1d9e54829c63c9405420ea71fd4c9";
+    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/rolling/dynamixel_hardware_interface/1.4.15-1.tar.gz";
+    name = "1.4.15-1.tar.gz";
+    sha256 = "1e7d1ddbd5b1485e9739d9f794c6b427f39e2303314527afbaf773bb80eec039";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/foxglove-bridge/default.nix
+++ b/distros/rolling/foxglove-bridge/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, rosx-introspection, std-msgs, std-srvs, websocketpp, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, rosx-introspection, std-msgs, std-srvs, websocketpp }:
 buildRosPackage {
   pname = "ros-rolling-foxglove-bridge";
-  version = "0.8.5-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "5f225dee0f445364c27117aad29884058be35c25cc92167228616e214ffa07f6";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "583779f28c2d1292db4745884effe94e41abddaf6fd8368876a01f1aecaddec2";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake asio nlohmann_json ros-environment websocketpp ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto std-msgs std-srvs ];
-  propagatedBuildInputs = [ ament-index-cpp openssl rclcpp rclcpp-components resource-retriever rosgraph-msgs rosx-introspection zlib ];
+  buildInputs = [ ament-cmake asio nlohmann_json ros-environment ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto openssl std-msgs std-srvs websocketpp ];
+  propagatedBuildInputs = [ ament-index-cpp rclcpp rclcpp-components resource-retriever rosgraph-msgs rosx-introspection ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/foxglove-msgs/default.nix
+++ b/distros/rolling/foxglove-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-foxglove-msgs";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_foxglove_msgs-release/archive/release/rolling/foxglove_msgs/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "0c00e8b1102b0d24598aba83e9a78af7b643977186e96999d9de58060cc44cf7";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_msgs/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "c532f77a4c0ce5b807b4bc3f729845b15c90782c6c8a42ac9d86d30e3aba3913";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
   checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime visualization-msgs ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -26,6 +26,8 @@ self: super: {
 
  admittance-controller = self.callPackage ./admittance-controller {};
 
+ ads-vendor = self.callPackage ./ads-vendor {};
+
  ament-acceleration = self.callPackage ./ament-acceleration {};
 
  ament-black = self.callPackage ./ament-black {};
@@ -1200,8 +1202,6 @@ self: super: {
 
  mola-gnss-to-markers = self.callPackage ./mola-gnss-to-markers {};
 
- mola-imu-preintegration = self.callPackage ./mola-imu-preintegration {};
-
  mola-input-euroc-dataset = self.callPackage ./mola-input-euroc-dataset {};
 
  mola-input-kitti360-dataset = self.callPackage ./mola-input-kitti360-dataset {};
@@ -1231,12 +1231,6 @@ self: super: {
  mola-pose-list = self.callPackage ./mola-pose-list {};
 
  mola-relocalization = self.callPackage ./mola-relocalization {};
-
- mola-state-estimation = self.callPackage ./mola-state-estimation {};
-
- mola-state-estimation-simple = self.callPackage ./mola-state-estimation-simple {};
-
- mola-state-estimation-smoother = self.callPackage ./mola-state-estimation-smoother {};
 
  mola-test-datasets = self.callPackage ./mola-test-datasets {};
 
@@ -1452,8 +1446,6 @@ self: super: {
 
  nlohmann-json-schema-validator-vendor = self.callPackage ./nlohmann-json-schema-validator-vendor {};
 
- nmea-hardware-interface = self.callPackage ./nmea-hardware-interface {};
-
  nmea-msgs = self.callPackage ./nmea-msgs {};
 
  nmea-navsat-driver = self.callPackage ./nmea-navsat-driver {};
@@ -1524,6 +1516,8 @@ self: super: {
 
  ompl = self.callPackage ./ompl {};
 
+ open3d-vendor = self.callPackage ./open3d-vendor {};
+
  open-manipulator = self.callPackage ./open-manipulator {};
 
  open-manipulator-bringup = self.callPackage ./open-manipulator-bringup {};
@@ -1569,6 +1563,8 @@ self: super: {
  pangolin = self.callPackage ./pangolin {};
 
  parallel-gripper-controller = self.callPackage ./parallel-gripper-controller {};
+
+ parameter-expression = self.callPackage ./parameter-expression {};
 
  parameter-traits = self.callPackage ./parameter-traits {};
 
@@ -1694,6 +1690,8 @@ self: super: {
 
  pybind11-vendor = self.callPackage ./pybind11-vendor {};
 
+ pymoveit2 = self.callPackage ./pymoveit2 {};
+
  python-cmake-module = self.callPackage ./python-cmake-module {};
 
  python-mrpt = self.callPackage ./python-mrpt {};
@@ -1721,8 +1719,6 @@ self: super: {
  quality-of-service-demo-cpp = self.callPackage ./quality-of-service-demo-cpp {};
 
  quality-of-service-demo-py = self.callPackage ./quality-of-service-demo-py {};
-
- quaternion-operation = self.callPackage ./quaternion-operation {};
 
  r2r-spl-7 = self.callPackage ./r2r-spl-7 {};
 

--- a/distros/rolling/gz-common-vendor/default.nix
+++ b/distros/rolling/gz-common-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, assimp, cmake, ffmpeg, freeimage, gdal, gz-cmake-vendor, gz-math-vendor, gz-utils-vendor, pkg-config, spdlog-vendor, tinyxml-2, util-linux }:
 buildRosPackage {
   pname = "ros-rolling-gz-common-vendor";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_common_vendor-release/archive/release/rolling/gz_common_vendor/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "3c3510a5b24cd3245127664af084e0f66b87e05ce833844c8299735d6366c7c4";
+    url = "https://github.com/ros2-gbp/gz_common_vendor-release/archive/release/rolling/gz_common_vendor/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "c6304e499c2e05f0f84a9252f92a4816e4446d9a0fe6cfd441a3d7f45daed765";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-common-vendor/vendored-source.json
+++ b/distros/rolling/gz-common-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_common_vendor": {
     "url": "https://github.com/gazebosim/gz-common.git",
-    "rev": "gz-common7_7.0.0-pre1",
-    "hash": "sha256-j3hPmUoXGefXNk+YUlpwx8XHZDPAqvz0vpUhs9xx0Kg="
+    "rev": "gz-common7_7.0.0-pre2",
+    "hash": "sha256-K5yGyLxy134lBtG9GAF3JyUzEYiNShUTSxoxUKZ/qvU="
   }
 }

--- a/distros/rolling/gz-math-vendor/default.nix
+++ b/distros/rolling/gz-math-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, eigen, gz-cmake-vendor, gz-utils-vendor, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-gz-math-vendor";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_math_vendor-release/archive/release/rolling/gz_math_vendor/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "6eeb2142716babc8053eb0536c80ffd66fc4ef9c9157c8806e30dd2c92f61d7b";
+    url = "https://github.com/ros2-gbp/gz_math_vendor-release/archive/release/rolling/gz_math_vendor/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "f6589ebb2de0ef5f60939f3ac7367c6ea1b76ff921bda7277eea7152850cca30";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-math-vendor/vendored-source.json
+++ b/distros/rolling/gz-math-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_math_vendor": {
     "url": "https://github.com/gazebosim/gz-math.git",
-    "rev": "gz-math9_9.0.0-pre1",
-    "hash": "sha256-htdoBQjaLUYhlAVAIznVGdyJkquuXRbBlBE1PTT04sE="
+    "rev": "gz-math9_9.0.0-pre2",
+    "hash": "sha256-cfo+t6GsktuLBA4vNRJg1VNqVgmT71nkqJIMsgUxu2I="
   }
 }

--- a/distros/rolling/gz-msgs-vendor/default.nix
+++ b/distros/rolling/gz-msgs-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, gz-math-vendor, gz-tools-vendor, protobuf, python3, python3Packages, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-rolling-gz-msgs-vendor";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_msgs_vendor-release/archive/release/rolling/gz_msgs_vendor/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "7948f7d0f83ab75454e6dcf240aecf74f55166952a12c573813b17d3f125511c";
+    url = "https://github.com/ros2-gbp/gz_msgs_vendor-release/archive/release/rolling/gz_msgs_vendor/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "3df0e75a257a6011b598a92de5e14e9092bb72c09fe629486c1d8db8d9da98b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-msgs-vendor/vendored-source.json
+++ b/distros/rolling/gz-msgs-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_msgs_vendor": {
     "url": "https://github.com/gazebosim/gz-msgs.git",
-    "rev": "gz-msgs12_12.0.0-pre1",
-    "hash": "sha256-tXh/sqwISjkEgrVL7pQ010Qb2GAn54SbDbOJHSFsKi0="
+    "rev": "gz-msgs12_12.0.0-pre2",
+    "hash": "sha256-yaPG8hzntlSQ/G8Wf0AOtq2F7ZqvdMQkFHlwTkTRTjY="
   }
 }

--- a/distros/rolling/gz-physics-vendor/default.nix
+++ b/distros/rolling/gz-physics-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, bullet, cmake, eigen, gbenchmark, gz-cmake-vendor, gz-common-vendor, gz-dartsim-vendor, gz-math-vendor, gz-plugin-vendor, gz-utils-vendor, sdformat-vendor }:
 buildRosPackage {
   pname = "ros-rolling-gz-physics-vendor";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_physics_vendor-release/archive/release/rolling/gz_physics_vendor/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "9202fbd2b34ea19d7402940b52ab029890d0aa49d5c99678af82dc62365d9d77";
+    url = "https://github.com/ros2-gbp/gz_physics_vendor-release/archive/release/rolling/gz_physics_vendor/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "5694fd31a4351def384819c285e803bda736bb4f8c95609a9fb4b5f7dd91ff93";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-physics-vendor/vendored-source.json
+++ b/distros/rolling/gz-physics-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_physics_vendor": {
     "url": "https://github.com/gazebosim/gz-physics.git",
-    "rev": "gz-physics9_9.0.0-pre1",
-    "hash": "sha256-BMLbjbYR8+nmbE1xI0BzmMxHTR4roBMwndj9+Y+jYTs="
+    "rev": "gz-physics9_9.0.0-pre2",
+    "hash": "sha256-jwlMVK5Rkgfbv6MmruKAuckCegEpCyuCK4FgNmyfANs="
   }
 }

--- a/distros/rolling/gz-rendering-vendor/default.nix
+++ b/distros/rolling/gz-rendering-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, freeglut, freeimage, glew, gz-cmake-vendor, gz-common-vendor, gz-math-vendor, gz-ogre-next-vendor, gz-plugin-vendor, gz-utils-vendor, ogre1_9, util-linux, vulkan-loader, xorg }:
 buildRosPackage {
   pname = "ros-rolling-gz-rendering-vendor";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_rendering_vendor-release/archive/release/rolling/gz_rendering_vendor/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "99e16d856dbf7b4f8a0b9c33efc0f8a7b3a6e841eb01915f6261237692724bcb";
+    url = "https://github.com/ros2-gbp/gz_rendering_vendor-release/archive/release/rolling/gz_rendering_vendor/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "63f4ec4c4045421f5d6e91d1a1d8ce7d8037178e3fd0e2748f5aae9c630952d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-rendering-vendor/vendored-source.json
+++ b/distros/rolling/gz-rendering-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_rendering_vendor": {
     "url": "https://github.com/gazebosim/gz-rendering.git",
-    "rev": "gz-rendering10_10.0.0-pre1",
-    "hash": "sha256-tVRKcMfNThrgyC0vLLOVipdo77HIPl72CN/PsXvtMbg="
+    "rev": "gz-rendering10_10.0.0-pre2",
+    "hash": "sha256-DBqamhfkQHiCkLPs6I9jwunLebRkVeK1QcQ6LouoCzg="
   }
 }

--- a/distros/rolling/gz-transport-vendor/default.nix
+++ b/distros/rolling/gz-transport-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, cppzmq, gz-cmake-vendor, gz-math-vendor, gz-msgs-vendor, gz-tools-vendor, gz-utils-vendor, pkg-config, protobuf, python3, python3Packages, sqlite, util-linux, zenoh-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-gz-transport-vendor";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_transport_vendor-release/archive/release/rolling/gz_transport_vendor/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "9029db299481cf03ac3e81d211da36110ddf238d44c16444857221632b4d5db3";
+    url = "https://github.com/ros2-gbp/gz_transport_vendor-release/archive/release/rolling/gz_transport_vendor/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "c1b027a1bae62291f0ce97f6160ba3610229aaf7d446705c5d1cef10f3313356";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-transport-vendor/vendored-source.json
+++ b/distros/rolling/gz-transport-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_transport_vendor": {
     "url": "https://github.com/gazebosim/gz-transport.git",
-    "rev": "gz-transport15_15.0.0-pre1",
-    "hash": "sha256-1aunwBt20R9MfvMCfzokGnltmXSUOtqJQakDS9vvhnw="
+    "rev": "gz-transport15_15.0.0-pre2",
+    "hash": "sha256-WgvuEeiFReqbB4L2T2CMI6SdJ2X8UlBiNIu+ZlY/IYU="
   }
 }

--- a/distros/rolling/image-tools/default.nix
+++ b/distros/rolling/image-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, opencv, rclcpp, rclcpp-components, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-image-tools";
-  version = "0.37.2-r1";
+  version = "0.37.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/image_tools/0.37.2-1.tar.gz";
-    name = "0.37.2-1.tar.gz";
-    sha256 = "463d2ce5fda6d8913330a6f5c4b04edb951805601aae884638e9b7411cddb20e";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/image_tools/0.37.3-1.tar.gz";
+    name = "0.37.3-1.tar.gz";
+    sha256 = "1f39607ad375d5b22b8db969d51c31ed84cf08ed6529cd1b52f4e7c0c015a24a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/intra-process-demo/default.nix
+++ b/distros/rolling/intra-process-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, opencv, rclcpp, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-intra-process-demo";
-  version = "0.37.2-r1";
+  version = "0.37.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/intra_process_demo/0.37.2-1.tar.gz";
-    name = "0.37.2-1.tar.gz";
-    sha256 = "4d3f3046f1792a1f21ba22490f14dfc0e7a30b7889e19299e8ab6c981f369650";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/intra_process_demo/0.37.3-1.tar.gz";
+    name = "0.37.3-1.tar.gz";
+    sha256 = "e3411bb2aa5a9f1b0380136946446423fe4ac3caf4c2df04ac8ec9e29226dd75";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/lifecycle-py/default.nix
+++ b/distros/rolling/lifecycle-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, lifecycle, lifecycle-msgs, rclpy, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-lifecycle-py";
-  version = "0.37.2-r1";
+  version = "0.37.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle_py/0.37.2-1.tar.gz";
-    name = "0.37.2-1.tar.gz";
-    sha256 = "d3c7993ef5ecb2337d4ad96b0c8c3f110af2b9e94788399a276a61dcc59769b8";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle_py/0.37.3-1.tar.gz";
+    name = "0.37.3-1.tar.gz";
+    sha256 = "d7233036da90330b5c76248603721a38765010e4713cbbedb7bd354412aa38e3";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/lifecycle/default.nix
+++ b/distros/rolling/lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-lifecycle";
-  version = "0.37.2-r1";
+  version = "0.37.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle/0.37.2-1.tar.gz";
-    name = "0.37.2-1.tar.gz";
-    sha256 = "cde2576959276a9c5921aab1701324971591db0e2b243387ef3306c5d98ee993";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle/0.37.3-1.tar.gz";
+    name = "0.37.3-1.tar.gz";
+    sha256 = "a26bf3cc3cc41061c867950da94e071cdb1755839ddc33a02a570ae14814671a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/logging-demo/default.nix
+++ b/distros/rolling/logging-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-logging-demo";
-  version = "0.37.2-r1";
+  version = "0.37.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/logging_demo/0.37.2-1.tar.gz";
-    name = "0.37.2-1.tar.gz";
-    sha256 = "946aeaca9cfba05bdf9e8f631d2a132c66d70a8848b4093422598163a3c44bb4";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/logging_demo/0.37.3-1.tar.gz";
+    name = "0.37.3-1.tar.gz";
+    sha256 = "0273d29dfcd9d4139148e3df38f17e2ebe5dec6a9467715af16a7a05d5d9e2da";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/message-filters/default.nix
+++ b/distros/rolling/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, rclcpp, rclcpp-lifecycle, rclpy, rcutils, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-message-filters";
-  version = "7.3.0-r1";
+  version = "7.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/rolling/message_filters/7.3.0-1.tar.gz";
-    name = "7.3.0-1.tar.gz";
-    sha256 = "0211070af54d1a7994668eb7ec67ef323a0f0c4da582dbab617f3b1ff3b9e880";
+    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/rolling/message_filters/7.3.1-1.tar.gz";
+    name = "7.3.1-1.tar.gz";
+    sha256 = "327c62587ac8daad1bcdcec92b9b991df2c61752027d036aadeec30c0315f110";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mqtt-client-interfaces/default.nix
+++ b/distros/rolling/mqtt-client-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mqtt-client-interfaces";
-  version = "2.4.1-r1";
+  version = "2.4.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/rolling/mqtt_client_interfaces/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "7b3d6fa955e598bb983c3fa31bd598273d88618f6e72ccad82d988b387a6d1c8";
+    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/rolling/mqtt_client_interfaces/2.4.1-2.tar.gz";
+    name = "2.4.1-2.tar.gz";
+    sha256 = "6b0a913bd089c43e469ab45a270995fa73d7e9648b0cfe8e7bd85e51a0340a7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mqtt-client/default.nix
+++ b/distros/rolling/mqtt-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmt, mqtt-client-interfaces, paho-mqtt-c, paho-mqtt-cpp, rclcpp, rclcpp-components, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mqtt-client";
-  version = "2.4.1-r1";
+  version = "2.4.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/rolling/mqtt_client/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "52848a62915e72755ecbb0c8526697229fed1a1899c62f46f6c46a82abc62eff";
+    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/rolling/mqtt_client/2.4.1-2.tar.gz";
+    name = "2.4.1-2.tar.gz";
+    sha256 = "730c20a0d7fb71f62dc2fd537c98ff2add839cff28ba09fc13279b82de725eb9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/open3d-vendor/default.nix
+++ b/distros/rolling/open3d-vendor/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, libGL, libGLU, libcxx, xorg }:
+buildRosPackage {
+  pname = "ros-rolling-open3d-vendor";
+  version = "0.19.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/open3d_vendor-release/archive/release/rolling/open3d_vendor/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "3a16dc07948c82cd622ad7fcc7265adf04ac0d3b1b992ae2a3de6c5c1529cb70";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ libGL libGLU libcxx xorg.libX11 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Open3D is an open-source library that supports rapid development of software that deals with 3D data.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/pal-statistics-msgs/default.nix
+++ b/distros/rolling/pal-statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-pal-statistics-msgs";
-  version = "2.6.4-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/rolling/pal_statistics_msgs/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "8a3068474fcfd91dc2843646824f82c00ae882150acfd7cfd7d01cd008f22cfd";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/rolling/pal_statistics_msgs/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "9b7396d84d697af38b7e9e4bc1465d53ae38ae4b7d3fdd4e7d2a5314156c0a2e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pal-statistics/default.nix
+++ b/distros/rolling/pal-statistics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, boost, pal-statistics-msgs, rclcpp, rclcpp-lifecycle, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-pal-statistics";
-  version = "2.6.4-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/rolling/pal_statistics/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "e3d83e73c0fc58fc7ffa9735f2c5a6d3c7d0d57bbc3d709a268614702c0274ea";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/rolling/pal_statistics/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "bc1211651049a10bd842ee3378f29f1536b6a72e2fe199c6dd484ec53b6785bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/parameter-expression/default.nix
+++ b/distros/rolling/parameter-expression/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, muparser, pkg-config, rclcpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-parameter-expression";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/parameter_expression-release/archive/release/rolling/parameter_expression/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "a95943d8d3738951c44a5e9b2b1bcb171819bed4eb3b79d1584b6c8f783c106d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto pkg-config ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ muparser rclcpp std-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ];
+
+  meta = {
+    description = "Using mathematical expression in ROS 2 parameter";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/pendulum-control/default.nix
+++ b/distros/rolling/pendulum-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pendulum-msgs, rclcpp, rmw-implementation-cmake, ros2run, rttest, tlsf-cpp }:
 buildRosPackage {
   pname = "ros-rolling-pendulum-control";
-  version = "0.37.2-r1";
+  version = "0.37.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_control/0.37.2-1.tar.gz";
-    name = "0.37.2-1.tar.gz";
-    sha256 = "a7446602ef4d048bfcfe7934ef596b8b1865e2aaa6706c9d25ef51707d7ba19d";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_control/0.37.3-1.tar.gz";
+    name = "0.37.3-1.tar.gz";
+    sha256 = "b6ae22f648cb0cf19b7f93884e09faf5c93c3e219976872327d42ce0b7b2f9da";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pendulum-msgs/default.nix
+++ b/distros/rolling/pendulum-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-pendulum-msgs";
-  version = "0.37.2-r1";
+  version = "0.37.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_msgs/0.37.2-1.tar.gz";
-    name = "0.37.2-1.tar.gz";
-    sha256 = "ebc21a67cc7f6ada7ecd5852b88cd81451e093a854f1242ea5c59daeeb7b8f7a";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_msgs/0.37.3-1.tar.gz";
+    name = "0.37.3-1.tar.gz";
+    sha256 = "2b830e51d8b79bd01567b38e9eca4106a60c1ce4eb609ea6a7114e062483debc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/plotjuggler/default.nix
+++ b/distros/rolling/plotjuggler/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, data-tamer-cpp, fastcdr, fmt, lua, lz4, mcap-vendor, nlohmann_json, protobuf, qt5, rclcpp, zstd }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, data-tamer-cpp, fmt, lua, lz4, nlohmann_json, protobuf, qt5, rclcpp, zstd }:
 buildRosPackage {
   pname = "ros-rolling-plotjuggler";
-  version = "3.10.11-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/rolling/plotjuggler/3.10.11-1.tar.gz";
-    name = "3.10.11-1.tar.gz";
-    sha256 = "c20606728735db8de32592fe09c46405530234ef2c40412c3aa9b17b53ca3619";
+    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/rolling/plotjuggler/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "b5e027d7d33e55dcc4540e957787ab289ec6b1aba2a8b106da55461312788273";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-index-cpp binutils boost cppzmq data-tamer-cpp fastcdr fmt lua lz4 mcap-vendor nlohmann_json protobuf qt5.qtbase qt5.qtsvg qt5.qtwebsockets qt5.qtx11extras rclcpp zstd ];
+  propagatedBuildInputs = [ ament-index-cpp binutils boost cppzmq data-tamer-cpp fmt lua lz4 nlohmann_json protobuf qt5.qtbase qt5.qtsvg qt5.qtwebsockets qt5.qtx11extras rclcpp zstd ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/point-cloud-transport-tutorial/default.nix
+++ b/distros/rolling/point-cloud-transport-tutorial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, point-cloud-transport, point-cloud-transport-plugins, rclcpp, rosbag2-cpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-transport-tutorial";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_tutorial-release/archive/release/rolling/point_cloud_transport_tutorial/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "0bb50fc2cdf7964c643b8b4b7b17e766f57fe3e73d1a562c04e040266b28e01e";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_tutorial-release/archive/release/rolling/point_cloud_transport_tutorial/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "5c66a3089f5f2855cb673a42160410614515d44d6988ebd3160b29c541238d47";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pymoveit2/default.nix
+++ b/distros/rolling/pymoveit2/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-python, control-msgs, geometry-msgs, moveit-msgs, rclpy, sensor-msgs, shape-msgs, std-srvs, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-pymoveit2";
+  version = "4.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/pymoveit2-release/archive/release/rolling/pymoveit2/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "5a2aac50fefdd0610185e3ba7ec80c568c5b0b72964cccb65250814a163d2200";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  propagatedBuildInputs = [ action-msgs control-msgs geometry-msgs moveit-msgs rclpy sensor-msgs shape-msgs std-srvs trajectory-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "Basic Python interface for MoveIt 2 built on top of ROS 2 actions and services";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/quality-of-service-demo-cpp/default.nix
+++ b/distros/rolling/quality-of-service-demo-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, rclcpp, rclcpp-components, rcutils, rmw, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-quality-of-service-demo-cpp";
-  version = "0.37.2-r1";
+  version = "0.37.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_cpp/0.37.2-1.tar.gz";
-    name = "0.37.2-1.tar.gz";
-    sha256 = "48b64ff8cea7fab02d817acd7c6bf59e502a3dc0a886a238fde4964b2a0bc729";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_cpp/0.37.3-1.tar.gz";
+    name = "0.37.3-1.tar.gz";
+    sha256 = "706c3919f1ce3675b5e81c0f956d52b85b5ebffa9289b4f352c0b6becfbbbec9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/quality-of-service-demo-py/default.nix
+++ b/distros/rolling/quality-of-service-demo-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-quality-of-service-demo-py";
-  version = "0.37.2-r1";
+  version = "0.37.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_py/0.37.2-1.tar.gz";
-    name = "0.37.2-1.tar.gz";
-    sha256 = "78b4d47e0ba64a3879898207b5e287027b2ea8b377be6ab2b853014a7e9048ff";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_py/0.37.3-1.tar.gz";
+    name = "0.37.3-1.tar.gz";
+    sha256 = "e9fe51134bd461a372fb845ed37cc47a4b0309ac6d6b3ab641a2732ab1e3c90b";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rcpputils/default.nix
+++ b/distros/rolling/rcpputils/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-ros-core, ament-cmake-uncrustify, ament-cmake-xmllint, rcutils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros-core, ament-cmake-uncrustify, ament-cmake-xmllint, rcutils }:
 buildRosPackage {
   pname = "ros-rolling-rcpputils";
-  version = "2.14.2-r1";
+  version = "2.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/rolling/rcpputils/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "79a12ca408a134317c25aa2a41a88c1aad4ebfeb5af545d2dbd6eefc1f29ef90";
+    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/rolling/rcpputils/2.14.3-1.tar.gz";
+    name = "2.14.3-1.tar.gz";
+    sha256 = "de217db76cbd02e5c1e91cfcf7fa8214d865c9fcc4e4cb22e643f420c5f8eea8";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gen-version-h ament-cmake-ros-core ];
-  checkInputs = [ ament-cmake-copyright ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-uncrustify ament-cmake-xmllint ];
   propagatedBuildInputs = [ rcutils ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ament-cmake-ros-core ];
 

--- a/distros/rolling/rcutils/default.nix
+++ b/distros/rolling/rcutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros-core, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture }:
 buildRosPackage {
   pname = "ros-rolling-rcutils";
-  version = "7.0.2-r1";
+  version = "7.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/rolling/rcutils/7.0.2-1.tar.gz";
-    name = "7.0.2-1.tar.gz";
-    sha256 = "84c1b24b7e498257875e31434fb37e1f3afae90c68f9247f4158718ebc5dd7e1";
+    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/rolling/rcutils/7.0.3-1.tar.gz";
+    name = "7.0.3-1.tar.gz";
+    sha256 = "929da65493f8694b0ee72636d1ee961a4125ebf94fef890d7d8e762112ae9493";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/realtime-tools/default.nix
+++ b/distros/rolling/realtime-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, boost, libcap, lifecycle-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2-control-cmake, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-realtime-tools";
-  version = "4.5.0-r1";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/rolling/realtime_tools/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "3376710a874418406dcbf9eac765fdb6a1e56b31675b86344499110a466edf5e";
+    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/rolling/realtime_tools/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "8d47d56a28ad94182b740855910618be26f132759247087ca4822cbef336f051";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sdformat-vendor/default.nix
+++ b/distros/rolling/sdformat-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, gz-math-vendor, gz-tools-vendor, gz-utils-vendor, libxml2, python3Packages, tinyxml-2, urdfdom }:
 buildRosPackage {
   pname = "ros-rolling-sdformat-vendor";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sdformat_vendor-release/archive/release/rolling/sdformat_vendor/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "1de225a392e414429d636d1e4eba33fe374b49edde94ff7f0c901380b77417a6";
+    url = "https://github.com/ros2-gbp/sdformat_vendor-release/archive/release/rolling/sdformat_vendor/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "0c490a9c32e04d224e6d9c209db4259d1f8c305d955b80bc0e37d42592b30058";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sdformat-vendor/vendored-source.json
+++ b/distros/rolling/sdformat-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "sdformat_vendor": {
     "url": "https://github.com/gazebosim/sdformat.git",
-    "rev": "sdformat16_16.0.0-pre1",
-    "hash": "sha256-hLpIXhteWNhUrk6zs9FLZF4ScmNpkvplwW9laF42tqs="
+    "rev": "sdformat16_16.0.0-pre2",
+    "hash": "sha256-ByR5wXQmfZaS7tR3YAcGtxt5Va1Pbqj4Zg9fBjMAwck="
   }
 }

--- a/distros/rolling/topic-monitor/default.nix
+++ b/distros/rolling/topic-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, python3Packages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-topic-monitor";
-  version = "0.37.2-r1";
+  version = "0.37.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_monitor/0.37.2-1.tar.gz";
-    name = "0.37.2-1.tar.gz";
-    sha256 = "20d82fce552305ccd8039801616a5ed9d4e57f6d9c607d09be8f8384a5567694";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_monitor/0.37.3-1.tar.gz";
+    name = "0.37.3-1.tar.gz";
+    sha256 = "c0996b4c4c78017d505e81214e7a573453e2293827de1dc1079098c37616b11d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/topic-statistics-demo/default.nix
+++ b/distros/rolling/topic-statistics-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rcutils, sensor-msgs, statistics-msgs }:
 buildRosPackage {
   pname = "ros-rolling-topic-statistics-demo";
-  version = "0.37.2-r1";
+  version = "0.37.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_statistics_demo/0.37.2-1.tar.gz";
-    name = "0.37.2-1.tar.gz";
-    sha256 = "3d1679e31ed278f3b5bc0f1da39632ad8535a20497b97db899139260eb3340ae";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_statistics_demo/0.37.3-1.tar.gz";
+    name = "0.37.3-1.tar.gz";
+    sha256 = "7dc3f2917dc3fad58fa555a7c004b07303a1b5e7c13bd4d61efa93a91456844b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-simulation-gz/default.nix
+++ b/distros/rolling/ur-simulation-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, gz-ros2-control, joint-state-publisher, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, ros-gz-bridge, ros-gz-sim, rviz2, ur-controllers, ur-description, ur-moveit-config, urdf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ur-simulation-gz";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_simulation_gz-release/archive/release/rolling/ur_simulation_gz/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "c6c2df533235c478024c460cffc0560c27767718563f2b3da5065ccca46a4524";
+    url = "https://github.com/ros2-gbp/ur_simulation_gz-release/archive/release/rolling/ur_simulation_gz/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "2a6966b34e7658404bc7a356ac833bdd3ff27ee47fc95b822bcc3e23f33d26cd";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'kilted', 'rolling'] from nix-ros-overlay commit f62e7db0a215043ccd199a131d06603354d67552.
This pull request was generated by running the following command:

```
superflore-gen-nix --dry-run --output-repository-path . --all --tar-archive-dir /home/runner/.ros/tar --upstream-branch develop
```

Changes:
========
Humble Changes:
---------------
* *action-tutorials-cpp 0.20.5-r1 --> 0.20.6-r1*
* *action-tutorials-interfaces 0.20.5-r1 --> 0.20.6-r1*
* *action-tutorials-py 0.20.5-r1 --> 0.20.6-r1*
* *bcr-arm 0.1.0-r1*
* *bcr-arm-description 0.1.0-r1*
* *bcr-arm-moveit-config 0.1.0-r1*
* *bcr-arm-ros2 0.1.0-r1*
* *clearpath-common 1.3.6-r1 --> 1.3.7-r1*
* *clearpath-config 1.3.2-r1 --> 1.3.3-r1*
* *clearpath-control 1.3.6-r1 --> 1.3.7-r1*
* *clearpath-customization 1.3.6-r1 --> 1.3.7-r1*
* *clearpath-description 1.3.6-r1 --> 1.3.7-r1*
* *clearpath-generator-common 1.3.6-r1 --> 1.3.7-r1*
* *clearpath-manipulators 1.3.6-r1 --> 1.3.7-r1*
* *clearpath-manipulators-description 1.3.6-r1 --> 1.3.7-r1*
* *clearpath-mounts-description 1.3.6-r1 --> 1.3.7-r1*
* *clearpath-platform-description 1.3.6-r1 --> 1.3.7-r1*
* *clearpath-sensors-description 1.3.6-r1 --> 1.3.7-r1*
* *composition 0.20.5-r1 --> 0.20.6-r1*
* *control-toolbox 3.6.1-r1 --> 3.6.2-r1*
* *costmap-queue 1.1.18-r1 --> 1.1.19-r1*
* *demo-nodes-cpp 0.20.5-r1 --> 0.20.6-r1*
* *demo-nodes-cpp-native 0.20.5-r1 --> 0.20.6-r1*
* *demo-nodes-py 0.20.5-r1 --> 0.20.6-r1*
* *dummy-map-server 0.20.5-r1 --> 0.20.6-r1*
* *dummy-robot-bringup 0.20.5-r1 --> 0.20.6-r1*
* *dummy-sensors 0.20.5-r1 --> 0.20.6-r1*
* *dwb-core 1.1.18-r1 --> 1.1.19-r1*
* *dwb-critics 1.1.18-r1 --> 1.1.19-r1*
* *dwb-msgs 1.1.18-r1 --> 1.1.19-r1*
* *dwb-plugins 1.1.18-r1 --> 1.1.19-r1*
* *dynamixel-hardware-interface 1.4.14-r1 --> 1.4.15-r1*
* *fastrtps-cmake-module 2.2.2-r2 --> 2.2.3-r1*
* *image-tools 0.20.5-r1 --> 0.20.6-r1*
* *intra-process-demo 0.20.5-r1 --> 0.20.6-r1*
* *lifecycle 0.20.5-r1 --> 0.20.6-r1*
* *lifecycle-py 0.20.5-r1 --> 0.20.6-r1*
* *logging-demo 0.20.5-r1 --> 0.20.6-r1*
* *message-filters 4.3.8-r1 --> 4.3.9-r1*
* *mqtt-client 2.4.1-r1 --> 2.4.1-r2*
* *mqtt-client-interfaces 2.4.1-r1 --> 2.4.1-r2*
* *nav-2d-msgs 1.1.18-r1 --> 1.1.19-r1*
* *nav-2d-utils 1.1.18-r1 --> 1.1.19-r1*
* *nav2-amcl 1.1.18-r1 --> 1.1.19-r1*
* *nav2-behavior-tree 1.1.18-r1 --> 1.1.19-r1*
* *nav2-behaviors 1.1.18-r1 --> 1.1.19-r1*
* *nav2-bringup 1.1.18-r1 --> 1.1.19-r1*
* *nav2-bt-navigator 1.1.18-r1 --> 1.1.19-r1*
* *nav2-collision-monitor 1.1.18-r1 --> 1.1.19-r1*
* *nav2-common 1.1.18-r1 --> 1.1.19-r1*
* *nav2-constrained-smoother 1.1.18-r1 --> 1.1.19-r1*
* *nav2-controller 1.1.18-r1 --> 1.1.19-r1*
* *nav2-core 1.1.18-r1 --> 1.1.19-r1*
* *nav2-costmap-2d 1.1.18-r1 --> 1.1.19-r1*
* *nav2-dwb-controller 1.1.18-r1 --> 1.1.19-r1*
* *nav2-graceful-controller 1.1.18-r1 --> 1.1.19-r1*
* *nav2-lifecycle-manager 1.1.18-r1 --> 1.1.19-r1*
* *nav2-map-server 1.1.18-r1 --> 1.1.19-r1*
* *nav2-mppi-controller 1.1.18-r1 --> 1.1.19-r1*
* *nav2-msgs 1.1.18-r1 --> 1.1.19-r1*
* *nav2-navfn-planner 1.1.18-r1 --> 1.1.19-r1*
* *nav2-planner 1.1.18-r1 --> 1.1.19-r1*
* *nav2-regulated-pure-pursuit-controller 1.1.18-r1 --> 1.1.19-r1*
* *nav2-rotation-shim-controller 1.1.18-r1 --> 1.1.19-r1*
* *nav2-route 1.1.19-r1*
* *nav2-rviz-plugins 1.1.18-r1 --> 1.1.19-r1*
* *nav2-simple-commander 1.1.18-r1 --> 1.1.19-r1*
* *nav2-smac-planner 1.1.18-r1 --> 1.1.19-r1*
* *nav2-smoother 1.1.18-r1 --> 1.1.19-r1*
* *nav2-system-tests 1.1.18-r1 --> 1.1.19-r1*
* *nav2-theta-star-planner 1.1.18-r1 --> 1.1.19-r1*
* *nav2-util 1.1.18-r1 --> 1.1.19-r1*
* *nav2-velocity-smoother 1.1.18-r1 --> 1.1.19-r1*
* *nav2-voxel-grid 1.1.18-r1 --> 1.1.19-r1*
* *nav2-waypoint-follower 1.1.18-r1 --> 1.1.19-r1*
* *navigation2 1.1.18-r1 --> 1.1.19-r1*
* *novatel-oem7-driver 20.7.0-r1 --> 20.8.0-r1*
* *novatel-oem7-msgs 20.7.0-r1 --> 20.8.0-r1*
* *ouster-ros 0.13.14-r2*
* *ouster-sensor-msgs 0.13.14-r2*
* *pal-gazebo-plugins 4.0.6-r1 --> 4.1.0-r1*
* *pal-statistics 2.6.4-r1 --> 2.7.0-r1*
* *pal-statistics-msgs 2.6.4-r1 --> 2.7.0-r1*
* *pendulum-control 0.20.5-r1 --> 0.20.6-r1*
* *pendulum-msgs 0.20.5-r1 --> 0.20.6-r1*
* *play-motion2 1.5.3-r1 --> 1.7.0-r1*
* *play-motion2-msgs 1.5.3-r1 --> 1.7.0-r1*
* *pymoveit2 4.0.0-r1*
* *quality-of-service-demo-cpp 0.20.5-r1 --> 0.20.6-r1*
* *quality-of-service-demo-py 0.20.5-r1 --> 0.20.6-r1*
* *rcpputils 2.4.5-r1 --> 2.4.6-r1*
* *rmw-fastrtps-cpp 6.2.8-r1 --> 6.2.9-r1*
* *rmw-fastrtps-dynamic-cpp 6.2.8-r1 --> 6.2.9-r1*
* *rmw-fastrtps-shared-cpp 6.2.8-r1 --> 6.2.9-r1*
* *rosidl-typesupport-fastrtps-c 2.2.2-r2 --> 2.2.3-r1*
* *rosidl-typesupport-fastrtps-cpp 2.2.2-r2 --> 2.2.3-r1*
* *rpyutils 0.2.1-r2 --> 0.2.2-r1*
* *rviz-assimp-vendor 11.2.20-r1 --> 11.2.21-r1*
* *rviz-common 11.2.20-r1 --> 11.2.21-r1*
* *rviz-default-plugins 11.2.20-r1 --> 11.2.21-r1*
* *rviz-ogre-vendor 11.2.20-r1 --> 11.2.21-r1*
* *rviz-rendering 11.2.20-r1 --> 11.2.21-r1*
* *rviz-rendering-tests 11.2.20-r1 --> 11.2.21-r1*
* *rviz-visual-testing-framework 11.2.20-r1 --> 11.2.21-r1*
* *rviz2 11.2.20-r1 --> 11.2.21-r1*
* *tecgihan-driver 0.1.2-r1*
* *topic-monitor 0.20.5-r1 --> 0.20.6-r1*
* *topic-statistics-demo 0.20.5-r1 --> 0.20.6-r1*
* *ur 2.8.1-r1 --> 2.9.0-r1*
* *ur-bringup 2.8.1-r1 --> 2.9.0-r1*
* *ur-calibration 2.8.1-r1 --> 2.9.0-r1*
* *ur-controllers 2.8.1-r1 --> 2.9.0-r1*
* *ur-dashboard-msgs 2.8.1-r1 --> 2.9.0-r1*
* *ur-moveit-config 2.8.1-r1 --> 2.9.0-r1*
* *ur-robot-driver 2.8.1-r1 --> 2.9.0-r1*
* *ur-simulation-gz 0.3.0-r1 --> 0.4.0-r1*

Jazzy Changes:
--------------
* *ackermann-nlmpc 1.0.2-r1 --> 1.0.3-r1*
* *ackermann-nlmpc-msgs 1.0.2-r1 --> 1.0.3-r1*
* *action-tutorials-cpp 0.33.6-r1 --> 0.33.7-r1*
* *action-tutorials-interfaces 0.33.6-r1 --> 0.33.7-r1*
* *action-tutorials-py 0.33.6-r1 --> 0.33.7-r1*
* *ads-vendor 1.0.2-r1*
* *angles 1.16.0-r5 --> 1.16.1-r1*
* *clearpath-bt-joy 2.7.3-r1 --> 2.7.4-r1*
* *clearpath-common 2.7.3-r1 --> 2.7.4-r1*
* *clearpath-config 2.7.2-r1 --> 2.7.3-r1*
* *clearpath-control 2.7.3-r1 --> 2.7.4-r1*
* *clearpath-customization 2.7.3-r1 --> 2.7.4-r1*
* *clearpath-description 2.7.3-r1 --> 2.7.4-r1*
* *clearpath-diagnostics 2.7.3-r1 --> 2.7.4-r1*
* *clearpath-generator-common 2.7.3-r1 --> 2.7.4-r1*
* *clearpath-manipulators 2.7.3-r1 --> 2.7.4-r1*
* *clearpath-manipulators-description 2.7.3-r1 --> 2.7.4-r1*
* *clearpath-mounts-description 2.7.3-r1 --> 2.7.4-r1*
* *clearpath-platform-description 2.7.3-r1 --> 2.7.4-r1*
* *clearpath-sensors-description 2.7.3-r1 --> 2.7.4-r1*
* *composition 0.33.6-r1 --> 0.33.7-r1*
* *control-toolbox 4.7.0-r1 --> 4.7.1-r1*
* *costmap-queue 1.3.8-r1 --> 1.3.9-r1*
* *demo-nodes-cpp 0.33.6-r1 --> 0.33.7-r1*
* *demo-nodes-cpp-native 0.33.6-r1 --> 0.33.7-r1*
* *demo-nodes-py 0.33.6-r1 --> 0.33.7-r1*
* *dummy-map-server 0.33.6-r1 --> 0.33.7-r1*
* *dummy-robot-bringup 0.33.6-r1 --> 0.33.7-r1*
* *dummy-sensors 0.33.6-r1 --> 0.33.7-r1*
* *dwb-core 1.3.8-r1 --> 1.3.9-r1*
* *dwb-critics 1.3.8-r1 --> 1.3.9-r1*
* *dwb-msgs 1.3.8-r1 --> 1.3.9-r1*
* *dwb-plugins 1.3.8-r1 --> 1.3.9-r1*
* *dynamixel-hardware-interface 1.4.14-r1 --> 1.4.15-r1*
* *ffw 1.1.11-r1 --> 1.1.12-r1*
* *ffw-bringup 1.1.11-r1 --> 1.1.12-r1*
* *ffw-description 1.1.11-r1 --> 1.1.12-r1*
* *ffw-joint-trajectory-command-broadcaster 1.1.11-r1 --> 1.1.12-r1*
* *ffw-joystick-controller 1.1.11-r1 --> 1.1.12-r1*
* *ffw-moveit-config 1.1.11-r1 --> 1.1.12-r1*
* *ffw-robot-manager 1.1.11-r1 --> 1.1.12-r1*
* *ffw-spring-actuator-controller 1.1.11-r1 --> 1.1.12-r1*
* *ffw-swerve-drive-controller 1.1.11-r1 --> 1.1.12-r1*
* *ffw-teleop 1.1.11-r1 --> 1.1.12-r1*
* *image-tools 0.33.6-r1 --> 0.33.7-r1*
* *insight-gui 0.1.1-r1 --> 0.1.2-r1*
* *intra-process-demo 0.33.6-r1 --> 0.33.7-r1*
* *lifecycle 0.33.6-r1 --> 0.33.7-r1*
* *lifecycle-py 0.33.6-r1 --> 0.33.7-r1*
* *logging-demo 0.33.6-r1 --> 0.33.7-r1*
* *mqtt-client 2.4.1-r1 --> 2.4.1-r2*
* *mqtt-client-interfaces 2.4.1-r1 --> 2.4.1-r2*
* *nav-2d-msgs 1.3.8-r1 --> 1.3.9-r1*
* *nav-2d-utils 1.3.8-r1 --> 1.3.9-r1*
* *nav2-amcl 1.3.8-r1 --> 1.3.9-r1*
* *nav2-behavior-tree 1.3.8-r1 --> 1.3.9-r1*
* *nav2-behaviors 1.3.8-r1 --> 1.3.9-r1*
* *nav2-bringup 1.3.8-r1 --> 1.3.9-r1*
* *nav2-bt-navigator 1.3.8-r1 --> 1.3.9-r1*
* *nav2-collision-monitor 1.3.8-r1 --> 1.3.9-r1*
* *nav2-common 1.3.8-r1 --> 1.3.9-r1*
* *nav2-constrained-smoother 1.3.8-r1 --> 1.3.9-r1*
* *nav2-controller 1.3.8-r1 --> 1.3.9-r1*
* *nav2-core 1.3.8-r1 --> 1.3.9-r1*
* *nav2-costmap-2d 1.3.8-r1 --> 1.3.9-r1*
* *nav2-dwb-controller 1.3.8-r1 --> 1.3.9-r1*
* *nav2-graceful-controller 1.3.8-r1 --> 1.3.9-r1*
* *nav2-lifecycle-manager 1.3.8-r1 --> 1.3.9-r1*
* *nav2-loopback-sim 1.3.8-r1 --> 1.3.9-r1*
* *nav2-map-server 1.3.8-r1 --> 1.3.9-r1*
* *nav2-mppi-controller 1.3.8-r1 --> 1.3.9-r1*
* *nav2-msgs 1.3.8-r1 --> 1.3.9-r1*
* *nav2-navfn-planner 1.3.8-r1 --> 1.3.9-r1*
* *nav2-planner 1.3.8-r1 --> 1.3.9-r1*
* *nav2-regulated-pure-pursuit-controller 1.3.8-r1 --> 1.3.9-r1*
* *nav2-rotation-shim-controller 1.3.8-r1 --> 1.3.9-r1*
* *nav2-route 1.3.9-r1*
* *nav2-rviz-plugins 1.3.8-r1 --> 1.3.9-r1*
* *nav2-simple-commander 1.3.8-r1 --> 1.3.9-r1*
* *nav2-smac-planner 1.3.8-r1 --> 1.3.9-r1*
* *nav2-smoother 1.3.8-r1 --> 1.3.9-r1*
* *nav2-system-tests 1.3.8-r1 --> 1.3.9-r1*
* *nav2-theta-star-planner 1.3.8-r1 --> 1.3.9-r1*
* *nav2-util 1.3.8-r1 --> 1.3.9-r1*
* *nav2-velocity-smoother 1.3.8-r1 --> 1.3.9-r1*
* *nav2-voxel-grid 1.3.8-r1 --> 1.3.9-r1*
* *nav2-waypoint-follower 1.3.8-r1 --> 1.3.9-r1*
* *navigation2 1.3.8-r1 --> 1.3.9-r1*
* *novatel-oem7-driver 24.1.0-r1 --> 24.2.0-r1*
* *novatel-oem7-msgs 24.1.0-r1 --> 24.2.0-r1*
* *off-highway-can 1.0.0-r1*
* *off-highway-general-purpose-radar 1.0.0-r1*
* *off-highway-general-purpose-radar-msgs 1.0.0-r1*
* *off-highway-premium-radar 1.0.0-r1*
* *off-highway-premium-radar-msgs 1.0.0-r1*
* *off-highway-premium-radar-sample 1.0.0-r1*
* *off-highway-premium-radar-sample-msgs 1.0.0-r1*
* *off-highway-radar 1.0.0-r1*
* *off-highway-radar-msgs 1.0.0-r1*
* *off-highway-sensor-drivers 1.0.0-r1*
* *off-highway-sensor-drivers-examples 1.0.0-r1*
* *off-highway-uss 1.0.0-r1*
* *off-highway-uss-msgs 1.0.0-r1*
* *opennav-docking 1.3.8-r1 --> 1.3.9-r1*
* *opennav-docking-bt 1.3.8-r1 --> 1.3.9-r1*
* *opennav-docking-core 1.3.8-r1 --> 1.3.9-r1*
* *pal-statistics 2.6.4-r1 --> 2.7.0-r1*
* *pal-statistics-msgs 2.6.4-r1 --> 2.7.0-r1*
* *pendulum-control 0.33.6-r1 --> 0.33.7-r1*
* *pendulum-msgs 0.33.6-r1 --> 0.33.7-r1*
* *pymoveit2 4.0.0-r1*
* *quality-of-service-demo-cpp 0.33.6-r1 --> 0.33.7-r1*
* *quality-of-service-demo-py 0.33.6-r1 --> 0.33.7-r1*
* *rdl 6.0.0-r1*
* *rdl-benchmark 6.0.0-r1*
* *rdl-dynamics 6.0.0-r1*
* *rdl-urdfreader 6.0.0-r1*
* *realtime-tools 3.8.0-r1 --> 3.9.0-r1*
* *rpyutils 0.4.1-r3 --> 0.4.2-r1*
* *rviz-assimp-vendor 14.1.14-r1 --> 14.1.15-r1*
* *rviz-common 14.1.14-r1 --> 14.1.15-r1*
* *rviz-default-plugins 14.1.14-r1 --> 14.1.15-r1*
* *rviz-ogre-vendor 14.1.14-r1 --> 14.1.15-r1*
* *rviz-rendering 14.1.14-r1 --> 14.1.15-r1*
* *rviz-rendering-tests 14.1.14-r1 --> 14.1.15-r1*
* *rviz-visual-testing-framework 14.1.14-r1 --> 14.1.15-r1*
* *rviz2 14.1.14-r1 --> 14.1.15-r1*
* *tecgihan-driver 0.1.2-r1*
* *topic-monitor 0.33.6-r1 --> 0.33.7-r1*
* *topic-statistics-demo 0.33.6-r1 --> 0.33.7-r1*
* *ur-simulation-gz 2.3.0-r2 --> 2.4.0-r1*

Kilted Changes:
---------------
* *ackermann-nlmpc 1.0.2-r1 --> 1.0.3-r1*
* *ackermann-nlmpc-msgs 1.0.2-r1 --> 1.0.3-r1*
* *action-tutorials-cpp 0.36.1-r1 --> 0.36.2-r1*
* *action-tutorials-py 0.36.1-r1 --> 0.36.2-r1*
* *ads-vendor 1.0.2-r1*
* *angles 1.16.0-r5 --> 1.16.1-r1*
* *composition 0.36.1-r1 --> 0.36.2-r1*
* *control-toolbox 5.6.0-r1 --> 5.7.0-r1*
* *costmap-queue 1.4.1-r1 --> 1.4.2-r1*
* *demo-nodes-cpp 0.36.1-r1 --> 0.36.2-r1*
* *demo-nodes-cpp-native 0.36.1-r1 --> 0.36.2-r1*
* *demo-nodes-py 0.36.1-r1 --> 0.36.2-r1*
* *dummy-map-server 0.36.1-r1 --> 0.36.2-r1*
* *dummy-robot-bringup 0.36.1-r1 --> 0.36.2-r1*
* *dummy-sensors 0.36.1-r1 --> 0.36.2-r1*
* *dwb-core 1.4.1-r1 --> 1.4.2-r1*
* *dwb-critics 1.4.1-r1 --> 1.4.2-r1*
* *dwb-msgs 1.4.1-r1 --> 1.4.2-r1*
* *dwb-plugins 1.4.1-r1 --> 1.4.2-r1*
* *dynamixel-hardware-interface 1.4.14-r1 --> 1.4.15-r1*
* *gz-msgs-vendor 0.2.2-r2 --> 0.2.4-r1*
* *gz-plugin-vendor 0.2.1-r2 --> 0.2.3-r1*
* *gz-rendering-vendor 0.2.4-r1 --> 0.2.5-r1*
* *gz-sim-vendor 0.2.1-r2 --> 0.2.2-r1*
* *gz-transport-vendor 0.2.1-r2 --> 0.2.3-r1*
* *image-tools 0.36.1-r1 --> 0.36.2-r1*
* *intra-process-demo 0.36.1-r1 --> 0.36.2-r1*
* *lifecycle 0.36.1-r1 --> 0.36.2-r1*
* *lifecycle-py 0.36.1-r1 --> 0.36.2-r1*
* *logging-demo 0.36.1-r1 --> 0.36.2-r1*
* *message-filters 7.1.1-r1 --> 7.1.2-r1*
* *mqtt-client 2.4.1-r1 --> 2.4.1-r2*
* *mqtt-client-interfaces 2.4.1-r1 --> 2.4.1-r2*
* *nav-2d-msgs 1.4.1-r1 --> 1.4.2-r1*
* *nav-2d-utils 1.4.1-r1 --> 1.4.2-r1*
* *nav2-amcl 1.4.1-r1 --> 1.4.2-r1*
* *nav2-behavior-tree 1.4.1-r1 --> 1.4.2-r1*
* *nav2-behaviors 1.4.1-r1 --> 1.4.2-r1*
* *nav2-bringup 1.4.1-r1 --> 1.4.2-r1*
* *nav2-bt-navigator 1.4.1-r1 --> 1.4.2-r1*
* *nav2-collision-monitor 1.4.1-r1 --> 1.4.2-r1*
* *nav2-constrained-smoother 1.4.1-r1 --> 1.4.2-r1*
* *nav2-controller 1.4.1-r1 --> 1.4.2-r1*
* *nav2-core 1.4.1-r1 --> 1.4.2-r1*
* *nav2-costmap-2d 1.4.1-r1 --> 1.4.2-r1*
* *nav2-dwb-controller 1.4.1-r1 --> 1.4.2-r1*
* *nav2-graceful-controller 1.4.1-r1 --> 1.4.2-r1*
* *nav2-lifecycle-manager 1.4.1-r1 --> 1.4.2-r1*
* *nav2-loopback-sim 1.4.1-r1 --> 1.4.2-r1*
* *nav2-map-server 1.4.1-r1 --> 1.4.2-r1*
* *nav2-mppi-controller 1.4.1-r1 --> 1.4.2-r1*
* *nav2-msgs 1.4.1-r1 --> 1.4.2-r1*
* *nav2-navfn-planner 1.4.1-r1 --> 1.4.2-r1*
* *nav2-planner 1.4.1-r1 --> 1.4.2-r1*
* *nav2-regulated-pure-pursuit-controller 1.4.1-r1 --> 1.4.2-r1*
* *nav2-rotation-shim-controller 1.4.1-r1 --> 1.4.2-r1*
* *nav2-route 1.4.1-r1 --> 1.4.2-r1*
* *nav2-rviz-plugins 1.4.1-r1 --> 1.4.2-r1*
* *nav2-simple-commander 1.4.1-r1 --> 1.4.2-r1*
* *nav2-smac-planner 1.4.1-r1 --> 1.4.2-r1*
* *nav2-smoother 1.4.1-r1 --> 1.4.2-r1*
* *nav2-system-tests 1.4.1-r1 --> 1.4.2-r1*
* *nav2-theta-star-planner 1.4.1-r1 --> 1.4.2-r1*
* *nav2-util 1.4.1-r1 --> 1.4.2-r1*
* *nav2-velocity-smoother 1.4.1-r1 --> 1.4.2-r1*
* *nav2-voxel-grid 1.4.1-r1 --> 1.4.2-r1*
* *nav2-waypoint-follower 1.4.1-r1 --> 1.4.2-r1*
* *navigation2 1.4.1-r1 --> 1.4.2-r1*
* *opennav-docking 1.4.1-r1 --> 1.4.2-r1*
* *opennav-docking-bt 1.4.1-r1 --> 1.4.2-r1*
* *opennav-docking-core 1.4.1-r1 --> 1.4.2-r1*
* *pal-statistics 2.6.3-r1 --> 2.7.0-r1*
* *pal-statistics-msgs 2.6.3-r1 --> 2.7.0-r1*
* *pendulum-control 0.36.1-r1 --> 0.36.2-r1*
* *pendulum-msgs 0.36.1-r1 --> 0.36.2-r1*
* *quality-of-service-demo-cpp 0.36.1-r1 --> 0.36.2-r1*
* *quality-of-service-demo-py 0.36.1-r1 --> 0.36.2-r1*
* *rcpputils 2.13.4-r2 --> 2.13.5-r1*
* *realtime-tools 4.5.0-r1 --> 4.6.0-r1*
* *rmw-dds-common 3.2.1-r2 --> 4.0.0-r1*
* *rmw-fastrtps-cpp 9.3.2-r2 --> 9.3.3-r1*
* *rmw-fastrtps-dynamic-cpp 9.3.2-r2 --> 9.3.3-r1*
* *rmw-fastrtps-shared-cpp 9.3.2-r2 --> 9.3.3-r1*
* *rosidl-typesupport-fastrtps-c 3.8.0-r2 --> 3.8.1-r1*
* *rosidl-typesupport-fastrtps-cpp 3.8.0-r2 --> 3.8.1-r1*
* *rpyutils 0.6.2-r2 --> 0.6.3-r1*
* *rviz-assimp-vendor 15.0.5-r1 --> 15.0.6-r1*
* *rviz-common 15.0.5-r1 --> 15.0.6-r1*
* *rviz-default-plugins 15.0.5-r1 --> 15.0.6-r1*
* *rviz-ogre-vendor 15.0.5-r1 --> 15.0.6-r1*
* *rviz-rendering 15.0.5-r1 --> 15.0.6-r1*
* *rviz-rendering-tests 15.0.5-r1 --> 15.0.6-r1*
* *rviz-resource-interfaces 15.0.5-r1 --> 15.0.6-r1*
* *rviz-visual-testing-framework 15.0.5-r1 --> 15.0.6-r1*
* *rviz2 15.0.5-r1 --> 15.0.6-r1*
* *topic-monitor 0.36.1-r1 --> 0.36.2-r1*
* *topic-statistics-demo 0.36.1-r1 --> 0.36.2-r1*
* *ur-simulation-gz 2.3.0-r1 --> 2.4.0-r1*

Rolling Changes:
----------------
* *ackermann-nlmpc 1.0.2-r2 --> 1.0.3-r1*
* *ackermann-nlmpc-msgs 1.0.2-r2 --> 1.0.3-r1*
* *action-tutorials-cpp 0.37.2-r1 --> 0.37.3-r1*
* *action-tutorials-py 0.37.2-r1 --> 0.37.3-r1*
* *ads-vendor 1.0.2-r1*
* *angles 1.16.0-r4 --> 1.16.1-r1*
* *composition 0.37.2-r1 --> 0.37.3-r1*
* *control-toolbox 5.6.0-r1 --> 5.7.0-r1*
* *demo-nodes-cpp 0.37.2-r1 --> 0.37.3-r1*
* *demo-nodes-cpp-native 0.37.2-r1 --> 0.37.3-r1*
* *demo-nodes-py 0.37.2-r1 --> 0.37.3-r1*
* *dummy-map-server 0.37.2-r1 --> 0.37.3-r1*
* *dummy-robot-bringup 0.37.2-r1 --> 0.37.3-r1*
* *dummy-sensors 0.37.2-r1 --> 0.37.3-r1*
* *dynamixel-hardware-interface 1.4.14-r1 --> 1.4.15-r1*
* *foxglove-bridge 0.8.5-r1 --> 3.2.0-r1*
* *foxglove-msgs 3.1.0-r1 --> 3.2.0-r1*
* *gz-common-vendor 0.3.0-r1 --> 0.3.1-r1*
* *gz-math-vendor 0.4.0-r1 --> 0.4.1-r1*
* *gz-msgs-vendor 0.3.0-r1 --> 0.3.1-r1*
* *gz-physics-vendor 0.4.0-r1 --> 0.4.1-r1*
* *gz-rendering-vendor 0.4.0-r1 --> 0.4.1-r1*
* *gz-transport-vendor 0.3.0-r1 --> 0.3.1-r1*
* *image-tools 0.37.2-r1 --> 0.37.3-r1*
* *intra-process-demo 0.37.2-r1 --> 0.37.3-r1*
* *lifecycle 0.37.2-r1 --> 0.37.3-r1*
* *lifecycle-py 0.37.2-r1 --> 0.37.3-r1*
* *logging-demo 0.37.2-r1 --> 0.37.3-r1*
* *message-filters 7.3.0-r1 --> 7.3.1-r1*
* *mqtt-client 2.4.1-r1 --> 2.4.1-r2*
* *mqtt-client-interfaces 2.4.1-r1 --> 2.4.1-r2*
* *open3d-vendor 0.19.0-r1*
* *pal-statistics 2.6.4-r1 --> 2.7.0-r1*
* *pal-statistics-msgs 2.6.4-r1 --> 2.7.0-r1*
* *parameter-expression 0.0.2-r1*
* *pendulum-control 0.37.2-r1 --> 0.37.3-r1*
* *pendulum-msgs 0.37.2-r1 --> 0.37.3-r1*
* *plotjuggler 3.10.11-r1 --> 3.12.0-r1*
* *point-cloud-transport-tutorial 0.0.4-r1 --> 0.0.5-r1*
* *pymoveit2 4.0.0-r1*
* *quality-of-service-demo-cpp 0.37.2-r1 --> 0.37.3-r1*
* *quality-of-service-demo-py 0.37.2-r1 --> 0.37.3-r1*
* *rcpputils 2.14.2-r1 --> 2.14.3-r1*
* *rcutils 7.0.2-r1 --> 7.0.3-r1*
* *realtime-tools 4.5.0-r1 --> 4.6.0-r1*
* *sdformat-vendor 0.3.0-r1 --> 0.3.1-r1*
* *topic-monitor 0.37.2-r1 --> 0.37.3-r1*
* *topic-statistics-demo 0.37.2-r1 --> 0.37.3-r1*
* *ur-simulation-gz 2.3.0-r1 --> 2.4.0-r1*


Missing Dependencies:
=====================
 * [ ] action_tutorials_interfaces
 * [ ] actionlib_msgs
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gripper_controllers
 * [ ] gurumdds-3.0
 * [ ] gurumdds-3.2
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] libcurl_vendor
 * [ ] libopen3d-dev
 * [ ] libqt6svg6
 * [ ] libserial-dev
 * [ ] mola_imu_preintegration
 * [ ] nanobind-dev
 * [ ] pybind11-json-dev
 * [ ] pybind11_json_vendor
 * [ ] python3-jsonpickle
 * [ ] python3-pymap3d
 * [ ] python3-pytorch-pip
 * [ ] python3-torch-geometric-pip
 * [ ] python3-typer
 * [ ] python3-types-pyyaml
 * [ ] qml6-module-qt-labs-folderlistmodel
 * [ ] qml6-module-qt-labs-platform
 * [ ] qml6-module-qt-labs-settings
 * [ ] qml6-module-qt5compat-graphicaleffects
 * [ ] qml6-module-qtcharts
 * [ ] qml6-module-qtcore
 * [ ] qml6-module-qtpositioning
 * [ ] qml6-module-qtqml
 * [ ] qml6-module-qtqml-models
 * [ ] qml6-module-qtqml-workerscript
 * [ ] qml6-module-qtquick-controls
 * [ ] qml6-module-qtquick-dialogs
 * [ ] qml6-module-qtquick-layouts
 * [ ] qml6-module-qtquick-templates
 * [ ] qml6-module-qtquick-window
 * [ ] qt6-5compat-dev
 * [ ] qt6-base-private-dev
 * [ ] qt6-declarative-private-dev
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo