### PR TITLE
rosdistro sync, Fri Oct  3 13:24:34 2025

### DIFF
--- a/distros/humble/ackermann-steering-controller/default.nix
+++ b/distros/humble/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-ackermann-steering-controller";
-  version = "2.50.0-r1";
+  version = "2.50.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.50.0-1.tar.gz";
-    name = "2.50.0-1.tar.gz";
-    sha256 = "7b14a5ec17a6777f002c4803fa49dd663a0b1c23d46cb94cf93e3472b973e63b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.50.1-1.tar.gz";
+    name = "2.50.1-1.tar.gz";
+    sha256 = "98e4404db00b1f6de32de58c4a81362ecd4387b414f13d2276e46b05913a93df";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/admittance-controller/default.nix
+++ b/distros/humble/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-admittance-controller";
-  version = "2.50.0-r1";
+  version = "2.50.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.50.0-1.tar.gz";
-    name = "2.50.0-1.tar.gz";
-    sha256 = "4be0e4ca1312af1ce43c41b4b394dd84fecdbfe7f2640028c8fb03487448100f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.50.1-1.tar.gz";
+    name = "2.50.1-1.tar.gz";
+    sha256 = "37f7dcf390a15916cf5ea338f6341efc6d3b008956a7e33489ee3a166dede809";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/bicycle-steering-controller/default.nix
+++ b/distros/humble/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-bicycle-steering-controller";
-  version = "2.50.0-r1";
+  version = "2.50.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.50.0-1.tar.gz";
-    name = "2.50.0-1.tar.gz";
-    sha256 = "a7df72aab3224510a7894fc4e059031d0891c019000d344292d09ef73da8b513";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.50.1-1.tar.gz";
+    name = "2.50.1-1.tar.gz";
+    sha256 = "67756dfbf7b2be6c7892217ac9bf36a37eaa37dde436c82410cc9f172ff61fbd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diff-drive-controller/default.nix
+++ b/distros/humble/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-diff-drive-controller";
-  version = "2.50.0-r1";
+  version = "2.50.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.50.0-1.tar.gz";
-    name = "2.50.0-1.tar.gz";
-    sha256 = "0843d264630f24390ea40e6ec7ec5b4816fb43bcd0d09426ac6f1128dac9f5e2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.50.1-1.tar.gz";
+    name = "2.50.1-1.tar.gz";
+    sha256 = "9e8605723c123b72e9ed81acb47b7bb9abd9e3614c8ffdaa4db8662c03a42514";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/effort-controllers/default.nix
+++ b/distros/humble/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-effort-controllers";
-  version = "2.50.0-r1";
+  version = "2.50.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.50.0-1.tar.gz";
-    name = "2.50.0-1.tar.gz";
-    sha256 = "31f646b22ac8dcda7a1bb02626a375727f8ed2816189cfbccc62587ea6294d06";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.50.1-1.tar.gz";
+    name = "2.50.1-1.tar.gz";
+    sha256 = "b5247f592a0c9dd0bf2198857f5bb73cb8ab3cdedf49376cfa2b949cbaca2f18";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/force-torque-sensor-broadcaster/default.nix
+++ b/distros/humble/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-force-torque-sensor-broadcaster";
-  version = "2.50.0-r1";
+  version = "2.50.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.50.0-1.tar.gz";
-    name = "2.50.0-1.tar.gz";
-    sha256 = "0bfe35acec4fa614d7263a9ad2f5cb31d6933fe1bde083c005e78ed0fbb747d9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.50.1-1.tar.gz";
+    name = "2.50.1-1.tar.gz";
+    sha256 = "d3d1e8d2067dce706940c068953578623960b99a86db181bb84ae288085c8b22";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/forward-command-controller/default.nix
+++ b/distros/humble/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-forward-command-controller";
-  version = "2.50.0-r1";
+  version = "2.50.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.50.0-1.tar.gz";
-    name = "2.50.0-1.tar.gz";
-    sha256 = "2b62323c4c4ec37de88703bfe0a25d98f8c2fa2b78632ce46bff5b2e0b3928cf";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.50.1-1.tar.gz";
+    name = "2.50.1-1.tar.gz";
+    sha256 = "0cd329b36f489c219aca19fb625d1bc812a252d4235e185a01d3aef1df22453f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/foxglove-bridge/default.nix
+++ b/distros/humble/foxglove-bridge/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, rosx-introspection, std-msgs, std-srvs, websocketpp, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, rosx-introspection, std-msgs, std-srvs, websocketpp }:
 buildRosPackage {
   pname = "ros-humble-foxglove-bridge";
-  version = "0.8.5-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_bridge/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "066c71cf652079b631e15c0fb64881beaf8be9bb2b6a2c2e10443012dc940d00";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_bridge/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "d9f192bc7951a07cfade8ee65796abe0566493e46e887d84178c4ae4bfd0ea42";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake asio nlohmann_json ros-environment websocketpp ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto std-msgs std-srvs ];
-  propagatedBuildInputs = [ ament-index-cpp openssl rclcpp rclcpp-components resource-retriever rosgraph-msgs rosx-introspection zlib ];
+  buildInputs = [ ament-cmake asio nlohmann_json ros-environment ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto openssl std-msgs std-srvs websocketpp ];
+  propagatedBuildInputs = [ ament-index-cpp rclcpp rclcpp-components resource-retriever rosgraph-msgs rosx-introspection ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/foxglove-msgs/default.nix
+++ b/distros/humble/foxglove-msgs/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-foxglove-msgs";
-  version = "2.3.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_foxglove_msgs-release/archive/release/humble/foxglove_msgs/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "72943b94ffe0bf7bda862b750338fcd061f30c2405f35275d4e34ab91f72b517";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_msgs/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "d1429565dec30aaa45fe14036ea77977947cb3329e4950223b3ecf05b054a145";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
   checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime visualization-msgs ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "foxglove_msgs provides visualization messages that are supported by Foxglove Studio.";
+    description = "foxglove_msgs provides visualization messages that are supported by Foxglove.";
     license = with lib.licenses; [ mit ];
   };
 }

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -1900,6 +1900,8 @@ self: super: {
 
  mola-gnss-to-markers = self.callPackage ./mola-gnss-to-markers {};
 
+ mola-imu-preintegration = self.callPackage ./mola-imu-preintegration {};
+
  mola-input-euroc-dataset = self.callPackage ./mola-input-euroc-dataset {};
 
  mola-input-kitti360-dataset = self.callPackage ./mola-input-kitti360-dataset {};
@@ -1929,6 +1931,12 @@ self: super: {
  mola-pose-list = self.callPackage ./mola-pose-list {};
 
  mola-relocalization = self.callPackage ./mola-relocalization {};
+
+ mola-state-estimation = self.callPackage ./mola-state-estimation {};
+
+ mola-state-estimation-simple = self.callPackage ./mola-state-estimation-simple {};
+
+ mola-state-estimation-smoother = self.callPackage ./mola-state-estimation-smoother {};
 
  mola-test-datasets = self.callPackage ./mola-test-datasets {};
 

--- a/distros/humble/gpio-controllers/default.nix
+++ b/distros/humble/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gpio-controllers";
-  version = "2.50.0-r1";
+  version = "2.50.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gpio_controllers/2.50.0-1.tar.gz";
-    name = "2.50.0-1.tar.gz";
-    sha256 = "d7192a272bedf5f60b690dbd356025587204bf301d0fb663bb532b0d768d6116";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gpio_controllers/2.50.1-1.tar.gz";
+    name = "2.50.1-1.tar.gz";
+    sha256 = "a95de413631efc67976f6a4fa2bbfce70c2a4f3b82431e0d3b0fde621731323e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gripper-controllers/default.nix
+++ b/distros/humble/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gripper-controllers";
-  version = "2.50.0-r1";
+  version = "2.50.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.50.0-1.tar.gz";
-    name = "2.50.0-1.tar.gz";
-    sha256 = "d99da0bd05b71f20069eb293b9cd48fe2ed97d1d5f0349b6b069492da3da73fb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.50.1-1.tar.gz";
+    name = "2.50.1-1.tar.gz";
+    sha256 = "967d10aff42736b426da16ca3c4d6bdf0c08b4c6a0a57b47fb9f4c55e3e1f02c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gz-ros2-control-demos/default.nix
+++ b/distros/humble/gz-ros2-control-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, geometry-msgs, gz-ros2-control, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, mecanum-drive-controller, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2controlcli, ros2launch, std-msgs, tricycle-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-gz-ros2-control-demos";
-  version = "0.7.16-r1";
+  version = "0.7.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/gz_ros2_control_demos/0.7.16-1.tar.gz";
-    name = "0.7.16-1.tar.gz";
-    sha256 = "e9e9344655b06e688447529ec3597810184065f71427270a7e19a1a71517088b";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/gz_ros2_control_demos/0.7.17-1.tar.gz";
+    name = "0.7.17-1.tar.gz";
+    sha256 = "7929ca56f282c3d333af666358cfedf1e245fc71201a62ba8dfa04843cc63b78";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gz-ros2-control-tests/default.nix
+++ b/distros/humble/gz-ros2-control-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, controller-manager, gz-ros2-control-demos, ign-ros2-control-demos, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, ros2launch, rosgraph-msgs }:
 buildRosPackage {
   pname = "ros-humble-gz-ros2-control-tests";
-  version = "0.7.16-r1";
+  version = "0.7.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/gz_ros2_control_tests/0.7.16-1.tar.gz";
-    name = "0.7.16-1.tar.gz";
-    sha256 = "0c9fa90fd55cb0c7fdfedd4a1ea1e01cbbda4a6e13bd314050942f7327a78ac0";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/gz_ros2_control_tests/0.7.17-1.tar.gz";
+    name = "0.7.17-1.tar.gz";
+    sha256 = "9fc3ac2c236b603f8743f30d70ebf93b8a205dc79a1b467447116074ec3fc45a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hebi-cpp-api/default.nix
+++ b/distros/humble/hebi-cpp-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen }:
 buildRosPackage {
   pname = "ros-humble-hebi-cpp-api";
-  version = "3.13.0-r1";
+  version = "3.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hebi_cpp_api-release/archive/release/humble/hebi_cpp_api/3.13.0-1.tar.gz";
-    name = "3.13.0-1.tar.gz";
-    sha256 = "fcc5ddd5fd76c50ebfe8c99122275d8ffad4eee6051f43b570cce104205ad9ba";
+    url = "https://github.com/ros2-gbp/hebi_cpp_api-release/archive/release/humble/hebi_cpp_api/3.15.0-1.tar.gz";
+    name = "3.15.0-1.tar.gz";
+    sha256 = "84e69fc71b856135e1b5753babbae1eca22d511fd633c9795b80dac0c5604a4b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ign-ros2-control-demos/default.nix
+++ b/distros/humble/ign-ros2-control-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, gz-ros2-control-demos, launch, launch-ros }:
 buildRosPackage {
   pname = "ros-humble-ign-ros2-control-demos";
-  version = "0.7.16-r1";
+  version = "0.7.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/ign_ros2_control_demos/0.7.16-1.tar.gz";
-    name = "0.7.16-1.tar.gz";
-    sha256 = "cf646fbcc852f1175c7de6c30d2f9cf82b5f7eec7c8ef22a37b32322cc8aa201";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/ign_ros2_control_demos/0.7.17-1.tar.gz";
+    name = "0.7.17-1.tar.gz";
+    sha256 = "f2f625372c6356bed2cd3f86f65f1c536ec5fdabf773e723c93a3851dc83e040";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ign-ros2-control/default.nix
+++ b/distros/humble/ign-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gz-ros2-control }:
 buildRosPackage {
   pname = "ros-humble-ign-ros2-control";
-  version = "0.7.16-r1";
+  version = "0.7.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/ign_ros2_control/0.7.16-1.tar.gz";
-    name = "0.7.16-1.tar.gz";
-    sha256 = "e016b1fa878e4f3d3df63043052c86e0d283dcd464cbf85d9b7c5da8ddb34c7a";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/ign_ros2_control/0.7.17-1.tar.gz";
+    name = "0.7.17-1.tar.gz";
+    sha256 = "dcff105b617b903d27c8b2101ca88d25a182171164c3fb3d302fce238f52190a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/imu-sensor-broadcaster/default.nix
+++ b/distros/humble/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-imu-sensor-broadcaster";
-  version = "2.50.0-r1";
+  version = "2.50.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.50.0-1.tar.gz";
-    name = "2.50.0-1.tar.gz";
-    sha256 = "f1ba70aff419080b9edcaddc8bd7091943927581d9b1ebb87a9cd60376d3bea8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.50.1-1.tar.gz";
+    name = "2.50.1-1.tar.gz";
+    sha256 = "750c166485da1067338eadc915eb63f8e317c9c26b5ce6b81efbb0634434d068";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-state-broadcaster/default.nix
+++ b/distros/humble/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-state-broadcaster";
-  version = "2.50.0-r1";
+  version = "2.50.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.50.0-1.tar.gz";
-    name = "2.50.0-1.tar.gz";
-    sha256 = "e21916d81b8d33f7fbab4fe031ac748ded72b2241b05804bd4febaf1fcef0a64";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.50.1-1.tar.gz";
+    name = "2.50.1-1.tar.gz";
+    sha256 = "1cf95ccbd939640a4311fb88a8501e86462f7b09e6315fb1216ec66e67af7cf4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-trajectory-controller/default.nix
+++ b/distros/humble/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-trajectory-controller";
-  version = "2.50.0-r1";
+  version = "2.50.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.50.0-1.tar.gz";
-    name = "2.50.0-1.tar.gz";
-    sha256 = "f93ea2a700d25f68882ed48864a7867819964755acc1de91e8a0e192a95aa89b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.50.1-1.tar.gz";
+    name = "2.50.1-1.tar.gz";
+    sha256 = "03f0895b6b645c9f3e1e006c56ddccf1d5afa8f5a27b36bc2b23937f9aaa6b37";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kinematics-interface-kdl/default.nix
+++ b/distros/humble/kinematics-interface-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, eigen, eigen3-cmake-module, kdl-parser, kinematics-interface, pluginlib, ros2-control-test-assets, tf2-eigen-kdl }:
 buildRosPackage {
   pname = "ros-humble-kinematics-interface-kdl";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/humble/kinematics_interface_kdl/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "8a28c1ba3ad8e937114d88ad87290503c8edde7f1e9cfd2c01f316600975c38c";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/humble/kinematics_interface_kdl/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "93151c4b6d3b2f5872d48a0aa4c764421c12d6adf32737ff44d75b3067c12153";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kinematics-interface/default.nix
+++ b/distros/humble/kinematics-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-humble-kinematics-interface";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/humble/kinematics_interface/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "30fd4b0fe79c612200a750e02b3ec8e5d7211426faa7cdf459b4f77bf617f39d";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/humble/kinematics_interface/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "1c2f8b624e90247ab22542868f48b358086946f686d24d5e596ec038501cbec9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mecanum-drive-controller/default.nix
+++ b/distros/humble/mecanum-drive-controller/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-mecanum-drive-controller";
-  version = "2.50.0-r1";
+  version = "2.50.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/mecanum_drive_controller/2.50.0-1.tar.gz";
-    name = "2.50.0-1.tar.gz";
-    sha256 = "fcf5ece6007f4c1402b7a441545c9b587a1f31c7d2e20609824330a79dbe730d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/mecanum_drive_controller/2.50.1-1.tar.gz";
+    name = "2.50.1-1.tar.gz";
+    sha256 = "09e9b2dfc7b21da0d8970ce475ef3ccf0c759a38c4aca9d1af1e2585569bf7a0";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake generate-parameter-library ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
-  propagatedBuildInputs = [ control-msgs controller-interface geometry-msgs hardware-interface nav-msgs pluginlib rclcpp rclcpp-lifecycle rcpputils realtime-tools std-srvs tf2 tf2-geometry-msgs tf2-msgs ];
+  propagatedBuildInputs = [ backward-ros control-msgs controller-interface geometry-msgs hardware-interface nav-msgs pluginlib rclcpp rclcpp-lifecycle rcpputils realtime-tools std-srvs tf2 tf2-geometry-msgs tf2-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/mola-imu-preintegration/default.nix
+++ b/distros/humble/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-imu-preintegration";
-  version = "1.10.0-r1";
+  version = "1.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_imu_preintegration/1.10.0-1.tar.gz";
-    name = "1.10.0-1.tar.gz";
-    sha256 = "d672fb6219649681acb4b59d910847ba2bccc71e17c6d5a4e6417bbc19fb97c4";
+    url = "https://github.com/ros2-gbp/mola_imu_preintegration-release/archive/release/humble/mola_imu_preintegration/1.11.0-1.tar.gz";
+    name = "1.11.0-1.tar.gz";
+    sha256 = "5c4f91fe37db5a4fa2eabad052a4c2b6f33825b7e61e37b9b0ce72ed3fe6dfe0";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-apps/default.nix
+++ b/distros/humble/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, openni2, pkg-config, python3Packages, ros-environment, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-apps";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_apps/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "eaee0c2af787be6bd932ece00deacf9ee646f8973366df4fb88e6fedf26bc189";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_apps/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "adbcac649897c1022238206fd64b2112abe3d40f630f9a4bb9f061d9f96ec24f";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libapps/default.nix
+++ b/distros/humble/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libapps";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libapps/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "443eca842d6363d2621430debeb7814fd7fe64fc4561cf2051ae048c35c2d3f9";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libapps/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "952bd82d4e1285ce9b551c0eda5d0018799c007e6b3a447a95a38abf390d4ac7";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libbase/default.nix
+++ b/distros/humble/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libbase";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libbase/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "9da512425f092573e358b781813def0e2e978f253ce10128a6d32cd3738d1a92";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libbase/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "1a21fcb3a433f39959ace2640987e17380e4ef1ba08b1eabb535b5ed9811b0a1";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libgui/default.nix
+++ b/distros/humble/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libgui";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libgui/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "c93da2f29cc73a18f5e0e4121bda265a7e276f83b316e9fc59a6d882af876534";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libgui/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "20f6024538cd003852d0ca3363cf30a24338036ef9d1d99678220e15d9b5dc5f";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libhwdrivers/default.nix
+++ b/distros/humble/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libhwdrivers";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libhwdrivers/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "8dcb3220ff229e924cc87172ed1f09ec28fab9dde266e13c8771dacecf66f2af";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libhwdrivers/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "0bd366ab9b2a62429d706bbe6af8a50a6998e55c9a80c3b9bbb9301001b4e2bf";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libmaps/default.nix
+++ b/distros/humble/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libmaps";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmaps/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "439900fd93b775db3f066a525a89182e97c3294891f2cdb2f7032782d552a9a8";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmaps/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "391a7cc1353c900df4c2259cafb8b62a00a2a100983a87f932f394b050dcd058";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libmath/default.nix
+++ b/distros/humble/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libmath";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmath/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "52bf84df6c4b4887ec2ce8b091746d35d0d29577866f04d2a22b459a694acd05";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmath/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "fedef15e462ce93418e356b6c4ff15a6ef6330d42722eaa5e0f57bcf93495de1";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libnav/default.nix
+++ b/distros/humble/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libnav";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libnav/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "54c6303681d8558e6700aa7d6e0d6e63f7d2d0732d46e6356e220b11d9a50347";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libnav/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "9ae527b707d22cb1042b0dae3402de4fc88f7f5d19438b7b1dfabe8973ac51c5";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libobs/default.nix
+++ b/distros/humble/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libobs";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libobs/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "363ffc1d82564a2845a2f7fe8ab4bd8721da3bc980f7fbc4b04da705efc40f72";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libobs/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "5804ee0e0656ce8da574aec7675125ec3303e172ec60f50dda6e016b34d90703";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libopengl/default.nix
+++ b/distros/humble/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libopengl";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libopengl/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "e059dbfeffb88b2352ad614845bc937e81fb3c543d32e3429c00a5227a889e5a";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libopengl/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "8cfaa1aeb33f53cbdbaddde998e13609ad2fbc75a10cfb31bb769a0c5c360bb8";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libposes/default.nix
+++ b/distros/humble/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libposes";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libposes/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "937ed4352141637ddb08a3970065c08365280b2e95de026d5d426b0ca9771b3d";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libposes/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "21a3f7bdac0aa050b847461f7db2c128213eb0e921d4e714bc5d911f5c3917ff";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libros-bridge/default.nix
+++ b/distros/humble/mrpt-libros-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, tf2, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libros-bridge";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libros_bridge/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "ef0ecb03c940837cab8da176f3b53232112d2935b9e92662c82ddfb95f7fb594";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libros_bridge/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "34632968ae466ffd1e258ac980860b790cd065c38231307af66625cac1aad211";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libslam/default.nix
+++ b/distros/humble/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libslam";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libslam/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "8c727a1c4482a0ed21190090c3b704f27f5dfe157a65807f1c0573018517d415";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libslam/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "a6ccdbce4000bb6f86c297296e79ea59d4f79f04514b89f2cc9aa017363a5770";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libtclap/default.nix
+++ b/distros/humble/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libtclap";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libtclap/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "16c71aa6eef963515987581a4ff95d1743a0f485d0a760169b122c38b1db87b5";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libtclap/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "ecd23e2b1107ec4406f50abcb65fefc5c816d606911692540ed41372c6356cff";
   };
 
   buildType = "cmake";

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -41,7 +41,7 @@ in with lib; {
   };
 
   foxglove-bridge = rosSuper.foxglove-bridge.overrideAttrs({
-    postPatch ? "", ...
+    postPatch ? "", cmakeFlags ? [], ...
   }: {
     postPatch = let
       # SDK version from CMakeLists.txt. If the version doesn't match,
@@ -67,6 +67,11 @@ in with lib; {
           'https://github.com/foxglove/foxglove-sdk/releases/download/sdk%2Fv''${FOXGLOVE_SDK_VERSION}/foxglove-v''${FOXGLOVE_SDK_VERSION}-cpp-''${FOXGLOVE_SDK_PLATFORM}.zip' \
           ${sdk}
       '';
+    cmakeFlags = cmakeFlags ++  [
+      # Prevent: stl_algobase.h:452:30: error: 'void* __builtin_memmove(void*, const void*, long unsigned int)' forming offset 8 is out of the bounds [0, 8] [-Werror=array-bounds=]
+      # TODO: Remove this after we move to newer libstdc++
+      "-DCMAKE_CXX_FLAGS=-Wno-error=array-bounds"
+    ];
   });
 
   gazebo = self.gazebo_11;

--- a/distros/humble/pid-controller/default.nix
+++ b/distros/humble/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-pid-controller";
-  version = "2.50.0-r1";
+  version = "2.50.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pid_controller/2.50.0-1.tar.gz";
-    name = "2.50.0-1.tar.gz";
-    sha256 = "802de74c647ba7264dfa6aba14966ad526d4e999f0b730c27febfe0910b9775a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pid_controller/2.50.1-1.tar.gz";
+    name = "2.50.1-1.tar.gz";
+    sha256 = "3561a68756c454b1c86b36882c7db80caabd98d383c0890c7447ed595ad9a164";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pose-broadcaster/default.nix
+++ b/distros/humble/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-pose-broadcaster";
-  version = "2.50.0-r1";
+  version = "2.50.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pose_broadcaster/2.50.0-1.tar.gz";
-    name = "2.50.0-1.tar.gz";
-    sha256 = "be57d3abf518b9566288bef9022f6850595da392c1a925a8cc1b4a9648c70a6a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pose_broadcaster/2.50.1-1.tar.gz";
+    name = "2.50.1-1.tar.gz";
+    sha256 = "1cd8ce558b9fcfb69d655de8f457cd614ba51cad500b66c227aad2b00d011ae3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/position-controllers/default.nix
+++ b/distros/humble/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-position-controllers";
-  version = "2.50.0-r1";
+  version = "2.50.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.50.0-1.tar.gz";
-    name = "2.50.0-1.tar.gz";
-    sha256 = "42759038d3aa0d00f5aca5708ea5b3e643f223810eaaf605c3c90b861aa8a5c7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.50.1-1.tar.gz";
+    name = "2.50.1-1.tar.gz";
+    sha256 = "9dcf5c4633d18cc9488955ff9533ca4e85e9c88624f16cb82d5d49e8c6f9cf1c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/range-sensor-broadcaster/default.nix
+++ b/distros/humble/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-range-sensor-broadcaster";
-  version = "2.50.0-r1";
+  version = "2.50.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/range_sensor_broadcaster/2.50.0-1.tar.gz";
-    name = "2.50.0-1.tar.gz";
-    sha256 = "4d0602b663538a08be99c0517d158c2a4b7f802f3be2cb0e506d78b0d8d2ee17";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/range_sensor_broadcaster/2.50.1-1.tar.gz";
+    name = "2.50.1-1.tar.gz";
+    sha256 = "0d76b2b2948f3b8d4077689c52a52e4de000f8ef6baede933a2257b321b0f474";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/realtime-tools/default.nix
+++ b/distros/humble/realtime-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, boost, libcap, lifecycle-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-realtime-tools";
-  version = "2.14.0-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/humble/realtime_tools/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "75cfa288d40b30bae7e94eeef3d14873c687ac2cf752f170303ddb5d107450cd";
+    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/humble/realtime_tools/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "0125618e1901a96dfabdbe4c763c66a2f5e27467b707657bfd176663ec00e321";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-controllers-test-nodes/default.nix
+++ b/distros/humble/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers-test-nodes";
-  version = "2.50.0-r1";
+  version = "2.50.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.50.0-1.tar.gz";
-    name = "2.50.0-1.tar.gz";
-    sha256 = "ba4a9da2e5ff15e40c2091ee0bb0892a8cc0dd97dced6acf0055f2e078251d3d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.50.1-1.tar.gz";
+    name = "2.50.1-1.tar.gz";
+    sha256 = "d1e971ac206a38b4741fb8ba83288df21db48fb1cb5aa7a9635908a42585df1d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2-controllers/default.nix
+++ b/distros/humble/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gripper-controllers, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers";
-  version = "2.50.0-r1";
+  version = "2.50.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.50.0-1.tar.gz";
-    name = "2.50.0-1.tar.gz";
-    sha256 = "551f110f43091d034b7473b875f6ca5fd7dcbaa833ac37b5d0327b9c1bc72bc0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.50.1-1.tar.gz";
+    name = "2.50.1-1.tar.gz";
+    sha256 = "439347f94e9a521ffabb493480f8003b428140203a2795c89c7a7a71008635cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rqt-joint-trajectory-controller/default.nix
+++ b/distros/humble/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-rqt-joint-trajectory-controller";
-  version = "2.50.0-r1";
+  version = "2.50.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.50.0-1.tar.gz";
-    name = "2.50.0-1.tar.gz";
-    sha256 = "bf7d445d109e31d007d3429c81813756beab0c2d80c92c2363efc934d139bcf4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.50.1-1.tar.gz";
+    name = "2.50.1-1.tar.gz";
+    sha256 = "19b7372d0998ce3d2682913b6ae72202ecdfca69012b129e62016483e8e238ae";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rviz-assimp-vendor/default.nix
+++ b/distros/humble/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-humble-rviz-assimp-vendor";
-  version = "11.2.21-r1";
+  version = "11.2.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_assimp_vendor/11.2.21-1.tar.gz";
-    name = "11.2.21-1.tar.gz";
-    sha256 = "e3359b4bdaebd91a5657434bdcc77647d8672a4a90fb6e8eb579ae1bde39e454";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_assimp_vendor/11.2.22-1.tar.gz";
+    name = "11.2.22-1.tar.gz";
+    sha256 = "f9e809fe5a55dbd209adcf76e9b1cce02ab63813ea1de54c0728acf6249f42c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-common/default.nix
+++ b/distros/humble/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, rcpputils, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rviz-common";
-  version = "11.2.21-r1";
+  version = "11.2.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_common/11.2.21-1.tar.gz";
-    name = "11.2.21-1.tar.gz";
-    sha256 = "187956270d000b68db8cdd2e5043263edb839a794e56fae9fdb2cadded9da397";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_common/11.2.22-1.tar.gz";
+    name = "11.2.22-1.tar.gz";
+    sha256 = "ba0e63154de447dde66833fb4bb451f797f33f58c59505e085d9b7719d7ec7a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-default-plugins/default.nix
+++ b/distros/humble/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rviz-default-plugins";
-  version = "11.2.21-r1";
+  version = "11.2.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_default_plugins/11.2.21-1.tar.gz";
-    name = "11.2.21-1.tar.gz";
-    sha256 = "3273a050e0a3596f14c67f910b105383a1e4ff65229c678e6631c6b02eed7e5a";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_default_plugins/11.2.22-1.tar.gz";
+    name = "11.2.22-1.tar.gz";
+    sha256 = "0e6b7afb680d633aca1da91cb87afdae1cc04da2db38ecd8d705916dca7b6e82";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-ogre-vendor/default.nix
+++ b/distros/humble/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, freetype, git, glew, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-humble-rviz-ogre-vendor";
-  version = "11.2.21-r1";
+  version = "11.2.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_ogre_vendor/11.2.21-1.tar.gz";
-    name = "11.2.21-1.tar.gz";
-    sha256 = "adc05ffd5d6e21e4e21e57ef12321bb9c900534cb36237129b36ad9fa727c6a9";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_ogre_vendor/11.2.22-1.tar.gz";
+    name = "11.2.22-1.tar.gz";
+    sha256 = "7c5344eaeac05a57455ab461ab3d28a8c5aad63251dc9d6606d449a239dfc81f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-rendering-tests/default.nix
+++ b/distros/humble/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-humble-rviz-rendering-tests";
-  version = "11.2.21-r1";
+  version = "11.2.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering_tests/11.2.21-1.tar.gz";
-    name = "11.2.21-1.tar.gz";
-    sha256 = "c8ce6893176242d03cacfc406acf544c4d31164796e57a65672f053455233274";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering_tests/11.2.22-1.tar.gz";
+    name = "11.2.22-1.tar.gz";
+    sha256 = "92e50079b10aa66a9b8f1140f2acf0eacb9cf1fda25c02e48092534f0d62e943";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-rendering/default.nix
+++ b/distros/humble/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-humble-rviz-rendering";
-  version = "11.2.21-r1";
+  version = "11.2.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering/11.2.21-1.tar.gz";
-    name = "11.2.21-1.tar.gz";
-    sha256 = "d87767737de0aa9327760da6f6f65cfaa08c52f8d94cec3438894cb1e3a17958";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering/11.2.22-1.tar.gz";
+    name = "11.2.22-1.tar.gz";
+    sha256 = "8c1ae06c65752dc3784e9183043cbaf5ca2422e2ff8510a89ed18672895da1e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-visual-testing-framework/default.nix
+++ b/distros/humble/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, qt5, rcutils, rviz-common }:
 buildRosPackage {
   pname = "ros-humble-rviz-visual-testing-framework";
-  version = "11.2.21-r1";
+  version = "11.2.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_visual_testing_framework/11.2.21-1.tar.gz";
-    name = "11.2.21-1.tar.gz";
-    sha256 = "929fc74ce207e1791818b0c09388f92a0ec7b108ec11c8f7d45d664a83951007";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_visual_testing_framework/11.2.22-1.tar.gz";
+    name = "11.2.22-1.tar.gz";
+    sha256 = "2187c8f971c5cb9d0ca96fa5f472ad7bce57964be654e3ff8f2cd87001fa172c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz2/default.nix
+++ b/distros/humble/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-rviz2";
-  version = "11.2.21-r1";
+  version = "11.2.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz2/11.2.21-1.tar.gz";
-    name = "11.2.21-1.tar.gz";
-    sha256 = "2ef7dad23e5a08ad3fbcea3a63c38e1085261c1ea1e42c4d366037c02e8764d9";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz2/11.2.22-1.tar.gz";
+    name = "11.2.22-1.tar.gz";
+    sha256 = "89c7a00612382cce59b48fe2788e7cae82636cc16a884e2ff43cc5f3b537ebbe";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/steering-controllers-library/default.nix
+++ b/distros/humble/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-steering-controllers-library";
-  version = "2.50.0-r1";
+  version = "2.50.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.50.0-1.tar.gz";
-    name = "2.50.0-1.tar.gz";
-    sha256 = "44e7d83f093852036fb185bc8ae9489029be8bd9444d547171327db2354b9598";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.50.1-1.tar.gz";
+    name = "2.50.1-1.tar.gz";
+    sha256 = "acae36738a472d420196a162557e08817886c35d6b1ef46b1daefa3139972eaa";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/teleop-twist-keyboard/default.nix
+++ b/distros/humble/teleop-twist-keyboard/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, rclpy }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, python3Packages, rcl-interfaces, rclpy }:
 buildRosPackage {
   pname = "ros-humble-teleop-twist-keyboard";
-  version = "2.4.0-r1";
+  version = "2.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_twist_keyboard-release/archive/release/humble/teleop_twist_keyboard/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "32c54e0b5e1c03d6ef24be8ed5f14e47fa17dbbdcc53ef80157734df61d11572";
+    url = "https://github.com/ros2-gbp/teleop_twist_keyboard-release/archive/release/humble/teleop_twist_keyboard/2.4.1-1.tar.gz";
+    name = "2.4.1-1.tar.gz";
+    sha256 = "609638e8144fa6d788bca38965bf7acf9ecefafbb1939431a24e71ae9098a2e6";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ];
-  propagatedBuildInputs = [ geometry-msgs rclpy ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest ];
+  propagatedBuildInputs = [ geometry-msgs rcl-interfaces rclpy ];
 
   meta = {
     description = "A robot-agnostic teleoperation node to convert keyboard commands to Twist

--- a/distros/humble/tricycle-controller/default.nix
+++ b/distros/humble/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-tricycle-controller";
-  version = "2.50.0-r1";
+  version = "2.50.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.50.0-1.tar.gz";
-    name = "2.50.0-1.tar.gz";
-    sha256 = "34d879fad240081180f283d6ecfeab22bb21b619e9eea4bfa2d8a39e6f03983a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.50.1-1.tar.gz";
+    name = "2.50.1-1.tar.gz";
+    sha256 = "8d51dc809389ac8da5327916904944fb1b5a64446436023c70adbc9e96d34ced";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-steering-controller/default.nix
+++ b/distros/humble/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-tricycle-steering-controller";
-  version = "2.50.0-r1";
+  version = "2.50.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.50.0-1.tar.gz";
-    name = "2.50.0-1.tar.gz";
-    sha256 = "8e4ee6d462e61fecafa3261725205e36215668ff5b87894e022db33a9988ee6e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.50.1-1.tar.gz";
+    name = "2.50.1-1.tar.gz";
+    sha256 = "54cdcf26d796b710a5a15a87770a7b357a089bfbabf0ebd1df251c73b7e8d76f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-description/default.nix
+++ b/distros/humble/ur-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, joint-state-publisher-gui, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, robot-state-publisher, rviz2, urdf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-description";
-  version = "2.7.0-r1";
+  version = "2.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/humble/ur_description/2.7.0-1.tar.gz";
-    name = "2.7.0-1.tar.gz";
-    sha256 = "fbb051d92b76df0b4b62706b83bb6ac7e2e5f5edeb65704a718ab27e243c1730";
+    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/humble/ur_description/2.7.1-1.tar.gz";
+    name = "2.7.1-1.tar.gz";
+    sha256 = "51d9693fd393323bcf0162ea1c814def2c4258265591173d593340392b803be1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/velocity-controllers/default.nix
+++ b/distros/humble/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-velocity-controllers";
-  version = "2.50.0-r1";
+  version = "2.50.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.50.0-1.tar.gz";
-    name = "2.50.0-1.tar.gz";
-    sha256 = "30997427ead08bd412bdbc782ffb306d74d8f1fd258959d6061b52021e56a5e8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.50.1-1.tar.gz";
+    name = "2.50.1-1.tar.gz";
+    sha256 = "19a38f4abb53d9bbadc58f47aab4b19fc2f5c4eae609f8d3c743cf19cdf0654a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/control-toolbox/default.nix
+++ b/distros/jazzy/control-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, eigen, filters, fmt, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-cmake, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-control-toolbox";
-  version = "4.7.1-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/jazzy/control_toolbox/4.7.1-1.tar.gz";
-    name = "4.7.1-1.tar.gz";
-    sha256 = "50d22c066b0c5f37853950be76cbf24039c0723983605cd077b5acce3966efc5";
+    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/jazzy/control_toolbox/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "a0d62f59ba74530f4ef02e1f179acafc52e9bf4e078180f6645de0b47d280909";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/foxglove-bridge/default.nix
+++ b/distros/jazzy/foxglove-bridge/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, rosx-introspection, std-msgs, std-srvs, websocketpp, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, rosx-introspection, std-msgs, std-srvs, websocketpp }:
 buildRosPackage {
   pname = "ros-jazzy-foxglove-bridge";
-  version = "0.8.5-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/jazzy/foxglove_bridge/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "b4610aace612c7490213c279c6f959dcf8bb1118dace2a0012508b68f97bb00a";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/jazzy/foxglove_bridge/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "9f05e297bd13c44188d160d934c4eb72148881c6dc9eb39a41c7676aa93971cd";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake asio nlohmann_json ros-environment websocketpp ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto std-msgs std-srvs ];
-  propagatedBuildInputs = [ ament-index-cpp openssl rclcpp rclcpp-components resource-retriever rosgraph-msgs rosx-introspection zlib ];
+  buildInputs = [ ament-cmake asio nlohmann_json ros-environment ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto openssl std-msgs std-srvs websocketpp ];
+  propagatedBuildInputs = [ ament-index-cpp rclcpp rclcpp-components resource-retriever rosgraph-msgs rosx-introspection ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/foxglove-msgs/default.nix
+++ b/distros/jazzy/foxglove-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-foxglove-msgs";
-  version = "3.1.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_foxglove_msgs-release/archive/release/jazzy/foxglove_msgs/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "e1c6c4f19466727fdd5e73b43034790ca0af844587dd222eb129f0f6d1195b33";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/jazzy/foxglove_msgs/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "ba1d39e9dd71d4f2487ec2818b097ee0701f8b2ae726158a0b8fcec83392cea6";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
   checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime visualization-msgs ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/frame-editor/default.nix
+++ b/distros/jazzy/frame-editor/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, builtin-interfaces, geometry-msgs, interactive-markers, qt-gui-py-common, rclpy, rosidl-default-generators, rosidl-default-runtime, rqt-gui, rqt-gui-py, std-msgs, tf-transformations, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-frame-editor";
+  version = "2.0.2-r5";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqt_frame_editor_plugin-release/archive/release/jazzy/frame_editor/2.0.2-5.tar.gz";
+    name = "2.0.2-5.tar.gz";
+    sha256 = "174f3172794766152b2caee5e26dc60f343c97c63925a1256abb60a051c76fa3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python rosidl-default-generators ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs interactive-markers qt-gui-py-common rclpy rosidl-default-runtime rqt-gui rqt-gui-py std-msgs tf-transformations tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python rosidl-default-generators ];
+
+  meta = {
+    description = "The frame_editor package";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -1006,6 +1006,8 @@ self: super: {
 
  foxglove-msgs = self.callPackage ./foxglove-msgs {};
 
+ frame-editor = self.callPackage ./frame-editor {};
+
  franka-inria-inverse-dynamics-solver = self.callPackage ./franka-inria-inverse-dynamics-solver {};
 
  fuse = self.callPackage ./fuse {};
@@ -1538,6 +1540,8 @@ self: super: {
 
  mola-gnss-to-markers = self.callPackage ./mola-gnss-to-markers {};
 
+ mola-imu-preintegration = self.callPackage ./mola-imu-preintegration {};
+
  mola-input-euroc-dataset = self.callPackage ./mola-input-euroc-dataset {};
 
  mola-input-kitti360-dataset = self.callPackage ./mola-input-kitti360-dataset {};
@@ -1567,6 +1571,12 @@ self: super: {
  mola-pose-list = self.callPackage ./mola-pose-list {};
 
  mola-relocalization = self.callPackage ./mola-relocalization {};
+
+ mola-state-estimation = self.callPackage ./mola-state-estimation {};
+
+ mola-state-estimation-simple = self.callPackage ./mola-state-estimation-simple {};
+
+ mola-state-estimation-smoother = self.callPackage ./mola-state-estimation-smoother {};
 
  mola-test-datasets = self.callPackage ./mola-test-datasets {};
 

--- a/distros/jazzy/gz-ros2-control-demos/default.nix
+++ b/distros/jazzy/gz-ros2-control-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, geometry-msgs, gz-ros2-control, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, mecanum-drive-controller, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2-control-cmake, ros2controlcli, ros2launch, std-msgs, tricycle-steering-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-gz-ros2-control-demos";
-  version = "1.2.15-r1";
+  version = "1.2.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/jazzy/gz_ros2_control_demos/1.2.15-1.tar.gz";
-    name = "1.2.15-1.tar.gz";
-    sha256 = "5f160db07357fbe95c5a7b1a01ed6470c5d473e7f330ecb32914e97b5c83be27";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/jazzy/gz_ros2_control_demos/1.2.16-1.tar.gz";
+    name = "1.2.16-1.tar.gz";
+    sha256 = "167d030108000c0ba07d5f72f04795d2b90f073fdc33ebb957bc65dc6aaa61f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gz-ros2-control/default.nix
+++ b/distros/jazzy/gz-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-manager, gz-plugin-vendor, gz-sim-vendor, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-gz-ros2-control";
-  version = "1.2.15-r1";
+  version = "1.2.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/jazzy/gz_ros2_control/1.2.15-1.tar.gz";
-    name = "1.2.15-1.tar.gz";
-    sha256 = "444366af98b41cd1899f64e2c8d2163bd7e3b1d60a5e7e8fafbecada71c984ab";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/jazzy/gz_ros2_control/1.2.16-1.tar.gz";
+    name = "1.2.16-1.tar.gz";
+    sha256 = "fe057d7764a1d9235f000c471bc3ae51238a25ca840de4f2e282589a2c47124f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/hebi-cpp-api/default.nix
+++ b/distros/jazzy/hebi-cpp-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen }:
 buildRosPackage {
   pname = "ros-jazzy-hebi-cpp-api";
-  version = "3.13.0-r3";
+  version = "3.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hebi_cpp_api-release/archive/release/jazzy/hebi_cpp_api/3.13.0-3.tar.gz";
-    name = "3.13.0-3.tar.gz";
-    sha256 = "db6a872352de82c05d7b96313056bfc2a0950f46a4e4d6db7864a9a731a1c371";
+    url = "https://github.com/ros2-gbp/hebi_cpp_api-release/archive/release/jazzy/hebi_cpp_api/3.15.0-1.tar.gz";
+    name = "3.15.0-1.tar.gz";
+    sha256 = "b34cf8ae404e46aa74913856cb4096cb05d1b66e748ef58b25eab7884d89d882";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-state-topic-hardware-interface/default.nix
+++ b/distros/jazzy/joint-state-topic-hardware-interface/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, angles, controller-manager, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, launch-testing, rclcpp, rclpy, robot-state-publisher, ros-testing, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, controller-manager, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, launch-testing, rclcpp, rclpy, robot-state-publisher, ros-testing, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-joint-state-topic-hardware-interface";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_based_hardware-release/archive/release/jazzy/joint_state_topic_hardware_interface/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "e92de99ea3b2a27756ec964a644c4b52f6a18aa5091f1367c0b4255671caace6";
+    url = "https://github.com/ros2-gbp/topic_based_hardware-release/archive/release/jazzy/joint_state_topic_hardware_interface/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "9269233fd5b3f8f12290758bc9dc3446aaf10dc7da7fbf8b28d58074f14b8381";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros2-control-cmake ];
-  checkInputs = [ controller-manager joint-state-broadcaster joint-trajectory-controller launch launch-ros launch-testing rclpy robot-state-publisher ros-testing ros2-control-test-assets xacro ];
+  checkInputs = [ ament-cmake-gmock controller-manager joint-state-broadcaster joint-trajectory-controller launch launch-ros launch-testing rclpy robot-state-publisher ros-testing ros2-control-test-assets xacro ];
   propagatedBuildInputs = [ angles hardware-interface rclcpp sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/jazzy/kinematics-interface-kdl/default.nix
+++ b/distros/jazzy/kinematics-interface-kdl/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, eigen, eigen3-cmake-module, kdl-parser, kinematics-interface, pluginlib, ros2-control-cmake, ros2-control-test-assets, tf2-eigen-kdl }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, eigen, eigen3-cmake-module, kdl-parser, kinematics-interface, pluginlib, ros2-control-cmake, ros2-control-test-assets, tf2-eigen-kdl }:
 buildRosPackage {
   pname = "ros-jazzy-kinematics-interface-kdl";
-  version = "1.5.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/jazzy/kinematics_interface_kdl/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "78cf82458f964d4ab56d8ef354445d00d3e08428174c55372a58777fafda8a2b";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/jazzy/kinematics_interface_kdl/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "a53fb8d0db2320f7ca723b3177ca386d930d5e89adb8f9df60cbd13d78460dfe";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake eigen3-cmake-module ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock ros2-control-test-assets ];
-  propagatedBuildInputs = [ eigen kdl-parser kinematics-interface pluginlib tf2-eigen-kdl ];
+  propagatedBuildInputs = [ backward-ros eigen kdl-parser kinematics-interface pluginlib tf2-eigen-kdl ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 
   meta = {

--- a/distros/jazzy/kinematics-interface/default.nix
+++ b/distros/jazzy/kinematics-interface/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, eigen, rclcpp-lifecycle, ros2-control-cmake }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, backward-ros, eigen, rclcpp-lifecycle, ros2-control-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-kinematics-interface";
-  version = "1.5.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/jazzy/kinematics_interface/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "4faeec43f7d067f1ffa6c8e8a757888db16abafee6e508ea01b703918b9470ca";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/jazzy/kinematics_interface/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "74654e360715e06c2939f18c519515c98d3b0412954c67b03b0da3f8a5cece46";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros2-control-cmake ];
-  propagatedBuildInputs = [ eigen rclcpp-lifecycle ];
+  propagatedBuildInputs = [ backward-ros eigen rclcpp-lifecycle ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/mola-imu-preintegration/default.nix
+++ b/distros/jazzy/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-imu-preintegration";
-  version = "1.10.0-r1";
+  version = "1.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_imu_preintegration/1.10.0-1.tar.gz";
-    name = "1.10.0-1.tar.gz";
-    sha256 = "be81ca748f10ba076d05e610da6dbe3c72bf644398d0c710f831d442b1f9c879";
+    url = "https://github.com/ros2-gbp/mola_imu_preintegration-release/archive/release/jazzy/mola_imu_preintegration/1.11.0-1.tar.gz";
+    name = "1.11.0-1.tar.gz";
+    sha256 = "b174ef3ede56a8f9cbd0f05720f9fab88a6a9fef6919178ef5be395012c3524b";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-apps/default.nix
+++ b/distros/jazzy/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, openni2, pkg-config, python3Packages, ros-environment, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-apps";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_apps/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "efc7d38e9f21a8836576e21674dcf6ae86e61be987ad23a3779f9c5000aa249d";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_apps/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "737257c90b848a2cdca6d2414cbcfb72ed88e3f959b9bcd7b4f61ba9796ee91d";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libapps/default.nix
+++ b/distros/jazzy/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libapps";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libapps/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "4c358d6505d40671585923428cb0602af7696b5e2425db83900a37c531100d85";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libapps/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "ce31afcf9c8a6c33c79468fdc6da3e87a0f832117533e0fe993805ad403602a9";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libbase/default.nix
+++ b/distros/jazzy/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libbase";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libbase/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "2a9cc45d6015796a63998c33301a10b4b20256f26d57c6bbcf5fb32d37267ff0";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libbase/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "10c316883bb2807d960bce0dc8343c3918f862b18839844e6e07f3482c3cb0ce";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libgui/default.nix
+++ b/distros/jazzy/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libgui";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libgui/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "5f521308860119ae22d332aae8db0aedb409fad6d997dc48983eb233b1ebd78f";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libgui/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "e0f0f6ec9f7427a3dcecea6b487428b5347649a630c1c39d7795b8404e5e58bc";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libhwdrivers/default.nix
+++ b/distros/jazzy/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libhwdrivers";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libhwdrivers/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "54f2893dd81cdad82d67d665e6408eb6d0ef641fcecb08939441cd8b866ee65c";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libhwdrivers/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "6ac2818ea1da5c9bf19a343e772e0b873602826b126686135380f3f3e49fff90";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libmaps/default.nix
+++ b/distros/jazzy/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libmaps";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libmaps/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "7f68e60facb14ae296b0a3cfe185b002d736e68f825a5e3a3128af44332f1821";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libmaps/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "f43ca2e733ec264d5008abaee9541dd364f3cf9638866e801d9acc6002991cb7";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libmath/default.nix
+++ b/distros/jazzy/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libmath";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libmath/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "a01aff5b47f9351cb3962e0fe00667135256f1574526f09713284d85c70a3f46";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libmath/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "4edae5287e613e8c6f5c7f3d8f811d177645810679a0cfaf13552611fe91cb80";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libnav/default.nix
+++ b/distros/jazzy/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libnav";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libnav/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "76839fcf90c3cd2a3895729753d4b09a5315601308bea068ee82210e6d51c0a3";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libnav/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "d79181b75e6fdc2f6e27ea3c5a51a4c6d937c126fb05cfa8741e2f61821d4ca4";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libobs/default.nix
+++ b/distros/jazzy/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libobs";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libobs/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "5f4d8e9e280eeef3d6f98c05d20610bb1e0ea48958b114f53c7c9a22332eb7da";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libobs/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "a2e85e64d1435dcb04dfec60a71f2304f2a8a7ea8f1ea4f0f2e3d5837074b249";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libopengl/default.nix
+++ b/distros/jazzy/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libopengl";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libopengl/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "af85176a1c9ea877cc13cc27b9e6735a8aba3ae921efb1f4456a2122dcacf5f0";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libopengl/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "dfe9d1e5b05594bdfb6a573d592734bc77c8d77755f9842d0c8727e9a7899082";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libposes/default.nix
+++ b/distros/jazzy/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libposes";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libposes/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "453336534f851fa276a54370d02b92cf3260a6d075f5f529cdab0b6b5370ebf5";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libposes/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "69404aa8d1a346100c5b276d9eae046463159e543e3cce5294dfd23853b47b14";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libros-bridge/default.nix
+++ b/distros/jazzy/mrpt-libros-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, tf2, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libros-bridge";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libros_bridge/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "6cfb983b7f3fcebeb7531eb2071493c3d72932b085f5222dfa8d06c26cee0aa6";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libros_bridge/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "536529b4411179b1705146699cbf0c4c99b9cc2e34c5eba5c329652cbfaee0d5";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libslam/default.nix
+++ b/distros/jazzy/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libslam";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libslam/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "1c9507771d95dfd7926be1c75c6698630c57ef0eb2860c1918674be44ff97d01";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libslam/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "d3cf286a8fb919d64a12280de8f166a81a6459025d184a39858a6da9303b3740";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libtclap/default.nix
+++ b/distros/jazzy/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libtclap";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libtclap/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "bcf07a24dda026733161412796f336f5c312ebe5581261daf2bee83b1a6f5acc";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libtclap/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "476d9c7acfe63685aa5b9b10a076035a73d8d62e8f48f125a5abfce547151f7a";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/multisensor-calibration-interface/default.nix
+++ b/distros/jazzy/multisensor-calibration-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-multisensor-calibration-interface";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/multisensor_calibration-release/archive/release/jazzy/multisensor_calibration_interface/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "e5eec64c7bbc094f2cb21a7b2b2d0c9190f9e1b2b6b3b81d82527130309b7535";
+    url = "https://github.com/ros2-gbp/multisensor_calibration-release/archive/release/jazzy/multisensor_calibration_interface/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "0ca6b38f1be95b2c2cf59b5bfe5876d1b523ea9b8d55cafeb89b6b5370619d5b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/multisensor-calibration/default.nix
+++ b/distros/jazzy/multisensor-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, image-transport, multisensor-calibration-interface, pcl-conversions, pcl-ros, qt5, rclcpp, rclcpp-components, rviz-common, sensor-msgs, small-gicp-vendor, std-msgs, tf2, tf2-ros, tinyxml-2, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-multisensor-calibration";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/multisensor_calibration-release/archive/release/jazzy/multisensor_calibration/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "72858873ef94b30986df813692b999ccc8142b6ed1dd9e410168f6f3111d2c8e";
+    url = "https://github.com/ros2-gbp/multisensor_calibration-release/archive/release/jazzy/multisensor_calibration/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "a7f26b61e3a95ff4cff04b2144a9840dc3e0029b6fd09b019c4c16333f824e1d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -23,6 +23,35 @@ in {
     fetchgitArgs.hash = "sha256-nLBnxPbPKiLCFF2TJgD/eJKJJfzktVBW3SRW2m3WK/s=";
   };
 
+  foxglove-bridge = rosSuper.foxglove-bridge.overrideAttrs({
+    postPatch ? "", ...
+  }: {
+    postPatch = let
+      # SDK version from CMakeLists.txt. If the version doesn't match,
+      # cmake fails with "Hash mismatch" and we can fix it here.
+      FOXGLOVE_SDK_VERSION = "0.14.2";
+      systemToPlatform = {
+        "x86_64-linux" = "x86_64-unknown-linux-gnu";
+        "aarch64-linux" = "aarch64-unknown-linux-gnu";
+      };
+      systemToHash = {
+        "x86_64-linux" = "sha256-V0w84AbWEx1lGbQW8l7zfFsqByHvSciUKGx5paXgtPw=";
+        "aarch64-linux" = "sha256-9U4+CJJqiIKpvIAxz7JKBAviY48e9OhyNvo63tGrKiM=";
+      };
+      FOXGLOVE_SDK_PLATFORM = systemToPlatform.${self.system};
+      sdk = self.fetchurl {
+        url = "https://github.com/foxglove/foxglove-sdk/releases/download/sdk%2Fv${FOXGLOVE_SDK_VERSION}/foxglove-v${FOXGLOVE_SDK_VERSION}-cpp-${FOXGLOVE_SDK_PLATFORM}.zip";
+        hash = systemToHash.${self.system};
+      };
+    in
+      # Does their CMakeLists.txt support cross compilation?
+      postPatch + ''
+        substituteInPlace CMakeLists.txt --replace-fail \
+          'https://github.com/foxglove/foxglove-sdk/releases/download/sdk%2Fv''${FOXGLOVE_SDK_VERSION}/foxglove-v''${FOXGLOVE_SDK_VERSION}-cpp-''${FOXGLOVE_SDK_PLATFORM}.zip' \
+          ${sdk}
+      '';
+  });
+
   gazebo = self.gazebo_11;
 
   geometric-shapes = rosSuper.geometric-shapes.overrideAttrs({

--- a/distros/jazzy/ros2-control-cmake/default.nix
+++ b/distros/jazzy/ros2-control-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-control-cmake";
-  version = "0.2.1-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control_cmake-release/archive/release/jazzy/ros2_control_cmake/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "76eaef4652e310794e534ce5344dce5ebcc563be0883818db74321edf264501d";
+    url = "https://github.com/ros2-gbp/ros2_control_cmake-release/archive/release/jazzy/ros2_control_cmake/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "1a981eeb0dec7517404c6d615bd57fba87ea48c2571b6cb4ca8891dbc6a198b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-assimp-vendor/default.nix
+++ b/distros/jazzy/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-assimp-vendor";
-  version = "14.1.15-r1";
+  version = "14.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_assimp_vendor/14.1.15-1.tar.gz";
-    name = "14.1.15-1.tar.gz";
-    sha256 = "bcdd3e9ed510f2ae68af05c42b886e710e63fe2501714b17f4c0229e8385fae1";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_assimp_vendor/14.1.16-1.tar.gz";
+    name = "14.1.16-1.tar.gz";
+    sha256 = "7b558718195d774256562ff7bb3546e71de455ab602a052475b1932e5662a1b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-common/default.nix
+++ b/distros/jazzy/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-common";
-  version = "14.1.15-r1";
+  version = "14.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_common/14.1.15-1.tar.gz";
-    name = "14.1.15-1.tar.gz";
-    sha256 = "6d164df586a39e003b7acca618e700f5eb36644ee38291a6cf9c5e99335cb5f8";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_common/14.1.16-1.tar.gz";
+    name = "14.1.16-1.tar.gz";
+    sha256 = "bd22a5ec0df696ed1f0075a2181874c565c3e0d6a8a65bb042c9949fbefda819";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-default-plugins/default.nix
+++ b/distros/jazzy/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, gz-math-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-default-plugins";
-  version = "14.1.15-r1";
+  version = "14.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_default_plugins/14.1.15-1.tar.gz";
-    name = "14.1.15-1.tar.gz";
-    sha256 = "ecf7d65da1f6e2ebe530f8ea8eba1b731445d2fefe5b4c4d0e52361df1a31974";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_default_plugins/14.1.16-1.tar.gz";
+    name = "14.1.16-1.tar.gz";
+    sha256 = "81fbe13674887da483ce6c398c4a5080a8cb79371eb406089ef6d9c59df04165";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-ogre-vendor/default.nix
+++ b/distros/jazzy/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, glew, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-ogre-vendor";
-  version = "14.1.15-r1";
+  version = "14.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_ogre_vendor/14.1.15-1.tar.gz";
-    name = "14.1.15-1.tar.gz";
-    sha256 = "990bb94c8f1ecbbd38eaaf7a36cf1f7fcf5e6ae48695e936c6fc8210d62b1e0c";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_ogre_vendor/14.1.16-1.tar.gz";
+    name = "14.1.16-1.tar.gz";
+    sha256 = "3efc5d04efa3974e17ccfcc33d0b883e4bc1c73719201327b39d2454ec0d993b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-rendering-tests/default.nix
+++ b/distros/jazzy/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-rendering-tests";
-  version = "14.1.15-r1";
+  version = "14.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_rendering_tests/14.1.15-1.tar.gz";
-    name = "14.1.15-1.tar.gz";
-    sha256 = "112d0489e0400c197cc71498a26becb50b86a6bff652aca062bcb32336276dec";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_rendering_tests/14.1.16-1.tar.gz";
+    name = "14.1.16-1.tar.gz";
+    sha256 = "b9c4c954a97b3763470c67f0040b7b96c1454eee3f2d7233b7c838bf78104280";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-rendering/default.nix
+++ b/distros/jazzy/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-rendering";
-  version = "14.1.15-r1";
+  version = "14.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_rendering/14.1.15-1.tar.gz";
-    name = "14.1.15-1.tar.gz";
-    sha256 = "937401ecb9b3f9599adf1cf495e8f000a620d95b784f81bd42e7a2dae6a9b5f0";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_rendering/14.1.16-1.tar.gz";
+    name = "14.1.16-1.tar.gz";
+    sha256 = "e8cdcb10b6fb705b157559c8dc22bf72d081c126c2015c5c1bfefc8efe547488";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-visual-testing-framework/default.nix
+++ b/distros/jazzy/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-visual-testing-framework";
-  version = "14.1.15-r1";
+  version = "14.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_visual_testing_framework/14.1.15-1.tar.gz";
-    name = "14.1.15-1.tar.gz";
-    sha256 = "057c8bb1808b0e0cabef98fa897d076c0d53661caa056f41cfb1727bdb255c44";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_visual_testing_framework/14.1.16-1.tar.gz";
+    name = "14.1.16-1.tar.gz";
+    sha256 = "f84fe4d3aa41d0db8795cf05035ac043d38cfc15a51b152aa1a42113719fd168";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz2/default.nix
+++ b/distros/jazzy/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rviz2";
-  version = "14.1.15-r1";
+  version = "14.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz2/14.1.15-1.tar.gz";
-    name = "14.1.15-1.tar.gz";
-    sha256 = "50e514b8b50f2e4f50f4bf63f09175a1c5e9fffbd1754361c385874c518dfcd9";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz2/14.1.16-1.tar.gz";
+    name = "14.1.16-1.tar.gz";
+    sha256 = "9dfcbe2d8300aaacc2e75add13093f2774bad6778ed5278ea8fecad4b2f8143d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/small-gicp-vendor/default.nix
+++ b/distros/jazzy/small-gicp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package }:
 buildRosPackage {
   pname = "ros-jazzy-small-gicp-vendor";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/multisensor_calibration-release/archive/release/jazzy/small_gicp_vendor/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "6ff742c649f1958b83f1a8635b87001e6040fb22dc737d9c17cd7f17624223ca";
+    url = "https://github.com/ros2-gbp/multisensor_calibration-release/archive/release/jazzy/small_gicp_vendor/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "536f7dd3af151643de8510c0cfa624adc199739419caf83b0803efc8e134d2a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/teleop-twist-keyboard/default.nix
+++ b/distros/jazzy/teleop-twist-keyboard/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, rclpy }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, python3Packages, rcl-interfaces, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-teleop-twist-keyboard";
-  version = "2.4.0-r2";
+  version = "2.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_twist_keyboard-release/archive/release/jazzy/teleop_twist_keyboard/2.4.0-2.tar.gz";
-    name = "2.4.0-2.tar.gz";
-    sha256 = "02a71382c9e966f06ee346dcb19b9f801264c5336dd1cbc6424d9850ca84d6c6";
+    url = "https://github.com/ros2-gbp/teleop_twist_keyboard-release/archive/release/jazzy/teleop_twist_keyboard/2.4.1-1.tar.gz";
+    name = "2.4.1-1.tar.gz";
+    sha256 = "8f187f965cdc9ef01dc782b58a974e6e3250e73040de664a899d25366d1ab129";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ];
-  propagatedBuildInputs = [ geometry-msgs rclpy ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest ];
+  propagatedBuildInputs = [ geometry-msgs rcl-interfaces rclpy ];
 
   meta = {
     description = "A robot-agnostic teleoperation node to convert keyboard commands to Twist

--- a/distros/jazzy/ur-description/default.nix
+++ b/distros/jazzy/ur-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, joint-state-publisher-gui, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, robot-state-publisher, rviz2, urdf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-ur-description";
-  version = "3.3.0-r1";
+  version = "3.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/jazzy/ur_description/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "7ff40b58a309a600280814df8751af6f7c4209d4dbe4226f310a8da5914ff8e0";
+    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/jazzy/ur_description/3.3.1-1.tar.gz";
+    name = "3.3.1-1.tar.gz";
+    sha256 = "a9ff6ca6c4b60469d3c31108bb0e5993e0679cb7ebf9fa05442618e245a7c91d";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ackermann-steering-controller/default.nix
+++ b/distros/kilted/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-kilted-ackermann-steering-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/ackermann_steering_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "e4e53801736a80dcd6aaa36889f487213c118031f6853ba3e5258c9ca2321734";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/ackermann_steering_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "2feb314bde093650cd8fdbd5be2ecd7dabe419a523c5d0c466f3ff2a1f33d846";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/actionlib-msgs/default.nix
+++ b/distros/kilted/actionlib-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-actionlib-msgs";
-  version = "5.5.0-r2";
+  version = "5.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/actionlib_msgs/5.5.0-2.tar.gz";
-    name = "5.5.0-2.tar.gz";
-    sha256 = "605f270d881e62d21b36ebdd219ba4055feed6a10db2321ac2a766807aa7d92c";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/actionlib_msgs/5.5.1-1.tar.gz";
+    name = "5.5.1-1.tar.gz";
+    sha256 = "0b14f1741d96dbabf9eee884cca6a8450632b76e1f62aee89eb915d6b1169487";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/admittance-controller/default.nix
+++ b/distros/kilted/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kilted-admittance-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/admittance_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "5f593f9ad6a7e3ce8b256d3a65235a7f1e8a418a446006c4e69d69c0371305fa";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/admittance_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "d8484b0ecfc99d6e8d777d75e30f2faa391893dc65f436597881159eeee94959";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/battery-state-broadcaster/default.nix
+++ b/distros/kilted/battery-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, pluginlib, realtime-tools, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-battery-state-broadcaster";
-  version = "1.0.2-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_battery_monitoring-release/archive/release/kilted/battery_state_broadcaster/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "9abaa58465a9688d689175d7ae2ca0d7bbf31f10d4ea9ea6d5d9aefcaaa22f6c";
+    url = "https://github.com/ros2-gbp/ros_battery_monitoring-release/archive/release/kilted/battery_state_broadcaster/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "991085afd00145a6c6f909528b9c9a04ecc9ffb86a3f483a70ac83430885e680";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/battery-state-rviz-overlay/default.nix
+++ b/distros/kilted/battery-state-rviz-overlay/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmt, rclcpp, rviz-2d-overlay-msgs, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-battery-state-rviz-overlay";
-  version = "1.0.2-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_battery_monitoring-release/archive/release/kilted/battery_state_rviz_overlay/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "1241ac78f9bd1708cededec6c29bcca92d07a7842efd4e5064c2cae8bf208ee5";
+    url = "https://github.com/ros2-gbp/ros_battery_monitoring-release/archive/release/kilted/battery_state_rviz_overlay/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "37f46ecc2e780992dfdcdf39bc46556a040140e960d6a65b1edfd8cc662c8e3d";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/bicycle-steering-controller/default.nix
+++ b/distros/kilted/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-kilted-bicycle-steering-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/bicycle_steering_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "18656390880042f80fee735c752715296f32b8560a12d9a2a1897a68fd72f7cc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/bicycle_steering_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "2d2715c45bfe8976d960550ec8a5ae95469af99a84e3ced2d7f7a9267fca4ad3";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/chained-filter-controller/default.nix
+++ b/distros/kilted/chained-filter-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, filters, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-chained-filter-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/chained_filter_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "dafde3ba34678d2565a4572763831705e00fc2cf987b089347e8fb86e8873397";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/chained_filter_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "d67da05d3195fd7ab5d87a7d3f77a2efb106e55fe1b8e9389330a09921a7254e";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/common-interfaces/default.nix
+++ b/distros/kilted/common-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, geometry-msgs, nav-msgs, sensor-msgs, shape-msgs, std-msgs, std-srvs, stereo-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-common-interfaces";
-  version = "5.5.0-r2";
+  version = "5.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/common_interfaces/5.5.0-2.tar.gz";
-    name = "5.5.0-2.tar.gz";
-    sha256 = "bc2f2c845f3d826ee37f80bf06ee321f89bb622b69907ebac8e1aee0f3f5062e";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/common_interfaces/5.5.1-1.tar.gz";
+    name = "5.5.1-1.tar.gz";
+    sha256 = "d048f560168f78a05366feef4efdfd1ccb3d4c84fe890b7d73e3dd44c47efe0b";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/control-toolbox/default.nix
+++ b/distros/kilted/control-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, eigen, filters, fmt, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-cmake, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-control-toolbox";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/kilted/control_toolbox/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "18ce82e0520f014da324fff69d137331cefb3972894f1b5e7738e2089da4e52f";
+    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/kilted/control_toolbox/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "8e48a2bd78954c4bff798ee150c16ab0f6eb9e1419f00c7339845429e0cca9dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/depthai/default.nix
+++ b/distros/kilted/depthai/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, curl, libtar, libusb1, nlohmann_json, opencv, ros-environment, udev, unzip, zip }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, curl, gfortran, libtar, libusb1, nlohmann_json, opencv, ros-environment, udev, unzip, zip }:
 buildRosPackage {
   pname = "ros-kilted-depthai";
-  version = "3.0.5-r1";
+  version = "3.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/kilted/depthai/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "93128bb2044eeb2ccf755a0b02e20e1dbef59b3eeffbb3a4bbbd63039396b001";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/kilted/depthai/3.0.6-1.tar.gz";
+    name = "3.0.6-1.tar.gz";
+    sha256 = "77617905aab8e25cee22145d67f1bc04bd4c14629e68bff31e1cce4110ed8b87";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ curl libtar libusb1 nlohmann_json opencv opencv.cxxdev udev unzip zip ];
+  propagatedBuildInputs = [ curl gfortran libtar libusb1 nlohmann_json opencv opencv.cxxdev udev unzip zip ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/diagnostic-msgs/default.nix
+++ b/distros/kilted/diagnostic-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-diagnostic-msgs";
-  version = "5.5.0-r2";
+  version = "5.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/diagnostic_msgs/5.5.0-2.tar.gz";
-    name = "5.5.0-2.tar.gz";
-    sha256 = "08a34ea299353df9f57954dbd4da420c2918805397c15759de9289cb6afa2926";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/diagnostic_msgs/5.5.1-1.tar.gz";
+    name = "5.5.1-1.tar.gz";
+    sha256 = "310176bef7500fdc94a8f3f047527d24c1601ef6af8950d21a8240125876a970";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/diff-drive-controller/default.nix
+++ b/distros/kilted/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-kilted-diff-drive-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/diff_drive_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "8d71d7ce06fe1f341eb0b9569c3ca0f19ccf3bdb18ddab17318b6e5451758be3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/diff_drive_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "96d089ced8f610b5061f65924ef183a4fc6a6ba40f01454c10b263d263fc0787";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/effort-controllers/default.nix
+++ b/distros/kilted/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-effort-controllers";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/effort_controllers/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "c0ad9f92eb2edc376d91b8147925a812b257c863911ec75f6b090ecfc70ae8b8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/effort_controllers/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "fd4427c43127384c284b4dd482840c558b496cc6fce87ea64c39f719c89eaa8b";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/fastcdr/default.nix
+++ b/distros/kilted/fastcdr/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cmake }:
 buildRosPackage {
   pname = "ros-kilted-fastcdr";
-  version = "2.3.0-r2";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastcdr-release/archive/release/kilted/fastcdr/2.3.0-2.tar.gz";
-    name = "2.3.0-2.tar.gz";
-    sha256 = "71bbc79240380314ae97878fa6511ae8e38f1d0e6ee17c1423035bb879a0736e";
+    url = "https://github.com/ros2-gbp/fastcdr-release/archive/release/kilted/fastcdr/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "69371bb0b9218df07a65794fb418ec5550c7c1e81e1a62250b629367c0541d4c";
   };
 
   buildType = "cmake";

--- a/distros/kilted/force-torque-sensor-broadcaster/default.nix
+++ b/distros/kilted/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-force-torque-sensor-broadcaster";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/force_torque_sensor_broadcaster/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "868516e1dfc6d6fe89f302259b2413e9f760bf8144f31ecf0125397f7c5d4b33";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/force_torque_sensor_broadcaster/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "e608d5085e4e1a7556381ab8fa3046607ff8e8adf087390fda26edac26322caa";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/forward-command-controller/default.nix
+++ b/distros/kilted/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-forward-command-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/forward_command_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "57453a4ac3a0075f2a9b623216e283bb9744ab5d9200350ddcad72cddfe7f8af";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/forward_command_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "2d023a33c58e53014f43cc9af87748710e6ad04965a60331f981106c5929442c";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/foxglove-bridge/default.nix
+++ b/distros/kilted/foxglove-bridge/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, rosx-introspection, std-msgs, std-srvs, websocketpp, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, rosx-introspection, std-msgs, std-srvs, websocketpp }:
 buildRosPackage {
   pname = "ros-kilted-foxglove-bridge";
-  version = "0.8.5-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/kilted/foxglove_bridge/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "398b2e31eadfe56525b45ae7105e05f21c9d83c1755b44caaf5b00338e0bc599";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/kilted/foxglove_bridge/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "9fd577c56a56493435c8581bfbd00cef85c038b7bf2e7073f985f76ac6037ba5";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake asio nlohmann_json ros-environment websocketpp ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto std-msgs std-srvs ];
-  propagatedBuildInputs = [ ament-index-cpp openssl rclcpp rclcpp-components resource-retriever rosgraph-msgs rosx-introspection zlib ];
+  buildInputs = [ ament-cmake asio nlohmann_json ros-environment ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto openssl std-msgs std-srvs websocketpp ];
+  propagatedBuildInputs = [ ament-index-cpp rclcpp rclcpp-components resource-retriever rosgraph-msgs rosx-introspection ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/foxglove-msgs/default.nix
+++ b/distros/kilted/foxglove-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-kilted-foxglove-msgs";
-  version = "3.1.0-r2";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_foxglove_msgs-release/archive/release/kilted/foxglove_msgs/3.1.0-2.tar.gz";
-    name = "3.1.0-2.tar.gz";
-    sha256 = "5f3224a97c4bfae2f85361603745db481aa294f11c29504bc32360768103b22a";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/kilted/foxglove_msgs/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "ffe12e74d00f6be02e845daa23c03f92ebbefc746779e2f0196962e02e4d5bce";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
   checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime visualization-msgs ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/generated.nix
+++ b/distros/kilted/generated.nix
@@ -1282,6 +1282,8 @@ self: super: {
 
  mola-gnss-to-markers = self.callPackage ./mola-gnss-to-markers {};
 
+ mola-imu-preintegration = self.callPackage ./mola-imu-preintegration {};
+
  mola-input-euroc-dataset = self.callPackage ./mola-input-euroc-dataset {};
 
  mola-input-kitti360-dataset = self.callPackage ./mola-input-kitti360-dataset {};
@@ -1311,6 +1313,12 @@ self: super: {
  mola-pose-list = self.callPackage ./mola-pose-list {};
 
  mola-relocalization = self.callPackage ./mola-relocalization {};
+
+ mola-state-estimation = self.callPackage ./mola-state-estimation {};
+
+ mola-state-estimation-simple = self.callPackage ./mola-state-estimation-simple {};
+
+ mola-state-estimation-smoother = self.callPackage ./mola-state-estimation-smoother {};
 
  mola-test-datasets = self.callPackage ./mola-test-datasets {};
 
@@ -1495,6 +1503,10 @@ self: super: {
  mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
 
  multires-image = self.callPackage ./multires-image {};
+
+ multisensor-calibration = self.callPackage ./multisensor-calibration {};
+
+ multisensor-calibration-interface = self.callPackage ./multisensor-calibration-interface {};
 
  mvsim = self.callPackage ./mvsim {};
 
@@ -2575,6 +2587,8 @@ self: super: {
  smach-msgs = self.callPackage ./smach-msgs {};
 
  smach-ros = self.callPackage ./smach-ros {};
+
+ small-gicp-vendor = self.callPackage ./small-gicp-vendor {};
 
  smclib = self.callPackage ./smclib {};
 

--- a/distros/kilted/geometry-msgs/default.nix
+++ b/distros/kilted/geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-geometry-msgs";
-  version = "5.5.0-r2";
+  version = "5.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/geometry_msgs/5.5.0-2.tar.gz";
-    name = "5.5.0-2.tar.gz";
-    sha256 = "50d6ba99a169ea9dc31d901504f94d19adc0844629bc22630cd45f150d2ea6b8";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/geometry_msgs/5.5.1-1.tar.gz";
+    name = "5.5.1-1.tar.gz";
+    sha256 = "cdb32fd1a34156f19781bb8a82865c6742498ac01a27d1d2dc4eec5098d4f5c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/gpio-controllers/default.nix
+++ b/distros/kilted/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-gpio-controllers";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/gpio_controllers/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "914115a04c68ba797e4c7e8c3b40526110828e3e7c61b89a66129147e9396c34";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/gpio_controllers/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "54f1cdad1221a9c357a115d1feda88677e4767c5709efe140e8f9c148003bc07";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/gps-sensor-broadcaster/default.nix
+++ b/distros/kilted/gps-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-gps-sensor-broadcaster";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/gps_sensor_broadcaster/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "7b434a858a8beccbde45abe9a9ba8513d104661a21987d609877a761cd37db84";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/gps_sensor_broadcaster/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "63f937b5497a9d9ccc53ab30ed21b35f21281c4cd019d6ae7a0295e68944a72a";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/gz-ros2-control-demos/default.nix
+++ b/distros/kilted/gz-ros2-control-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, geometry-msgs, gz-ros2-control, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, mecanum-drive-controller, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2-control-cmake, ros2controlcli, ros2launch, std-msgs, tricycle-steering-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-kilted-gz-ros2-control-demos";
-  version = "2.0.11-r2";
+  version = "2.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/kilted/gz_ros2_control_demos/2.0.11-2.tar.gz";
-    name = "2.0.11-2.tar.gz";
-    sha256 = "0bca941c3b3ddf139279eaba72739f55bcb970f02014b0235d928ea49a50e820";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/kilted/gz_ros2_control_demos/2.0.12-1.tar.gz";
+    name = "2.0.12-1.tar.gz";
+    sha256 = "eef128d6b1a6eda8703b5b7ae68eb28c01f8a87b00642a947306ca988a64cc89";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/gz-ros2-control/default.nix
+++ b/distros/kilted/gz-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-manager, gz-plugin-vendor, gz-sim-vendor, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-kilted-gz-ros2-control";
-  version = "2.0.11-r2";
+  version = "2.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/kilted/gz_ros2_control/2.0.11-2.tar.gz";
-    name = "2.0.11-2.tar.gz";
-    sha256 = "1e3cc79a73183ec5f04dc317aaeb28a2dba38daa6423e9e1e09daf87a9609d5e";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/kilted/gz_ros2_control/2.0.12-1.tar.gz";
+    name = "2.0.12-1.tar.gz";
+    sha256 = "b4d891c62eebff6a14b5f887f9a137b773a107dc9cf9e9c427930a3eee0731f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/hebi-cpp-api/default.nix
+++ b/distros/kilted/hebi-cpp-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen }:
 buildRosPackage {
   pname = "ros-kilted-hebi-cpp-api";
-  version = "3.13.1-r2";
+  version = "3.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hebi_cpp_api-release/archive/release/kilted/hebi_cpp_api/3.13.1-2.tar.gz";
-    name = "3.13.1-2.tar.gz";
-    sha256 = "1b3557c1c75ee6480658ac7cf3f5f71410e54e2b75a8adb00e202da49a7933fd";
+    url = "https://github.com/ros2-gbp/hebi_cpp_api-release/archive/release/kilted/hebi_cpp_api/3.15.0-1.tar.gz";
+    name = "3.15.0-1.tar.gz";
+    sha256 = "e5ff642c7f83ff2f1de6e8b9ff37392a5e1e96fae4fcd3b9a72901ede7da781c";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/imu-sensor-broadcaster/default.nix
+++ b/distros/kilted/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, eigen, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-kilted-imu-sensor-broadcaster";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/imu_sensor_broadcaster/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "8f9353599f7840385a16c7130d3ee62bf939db895d116ed1e6a61b5ffc8ab2d9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/imu_sensor_broadcaster/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "25aca7fcaef42c62dc55f93eff84343ba584b294cf82de9d37be3c46aad93f35";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/joint-state-broadcaster/default.nix
+++ b/distros/kilted/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, urdf }:
 buildRosPackage {
   pname = "ros-kilted-joint-state-broadcaster";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/joint_state_broadcaster/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "465133745778ec6fcd55e7fbaa2fab65a7ce5a61aa7ac33a65f0056032ee1fb9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/joint_state_broadcaster/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "1ff9148bd1ae4f6f8f3994c616af35f6cc969b5678f0de02bff318f453efe99d";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/joint-state-topic-hardware-interface/default.nix
+++ b/distros/kilted/joint-state-topic-hardware-interface/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, angles, controller-manager, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, launch-testing, rclcpp, rclpy, robot-state-publisher, ros-testing, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, controller-manager, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, launch-testing, rclcpp, rclpy, robot-state-publisher, ros-testing, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-kilted-joint-state-topic-hardware-interface";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_based_hardware-release/archive/release/kilted/joint_state_topic_hardware_interface/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "89b8b4c8a9f34afe664ee43b605cb163e5571698dbc275054c761f336b1126bc";
+    url = "https://github.com/ros2-gbp/topic_based_hardware-release/archive/release/kilted/joint_state_topic_hardware_interface/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "c0b87687b9c117985668d9567544d83d7ab9d2c46c5f5231de05a6ebf297be66";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros2-control-cmake ];
-  checkInputs = [ controller-manager joint-state-broadcaster joint-trajectory-controller launch launch-ros launch-testing rclpy robot-state-publisher ros-testing ros2-control-test-assets xacro ];
+  checkInputs = [ ament-cmake-gmock controller-manager joint-state-broadcaster joint-trajectory-controller launch launch-ros launch-testing rclpy robot-state-publisher ros-testing ros2-control-test-assets xacro ];
   propagatedBuildInputs = [ angles hardware-interface rclcpp sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/kilted/joint-trajectory-controller/default.nix
+++ b/distros/kilted/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-kilted-joint-trajectory-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/joint_trajectory_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "60e11a0eddd1cb1306ae57efbb0a961271536cfaf79d9fad22bf3b4e7bb0d967";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/joint_trajectory_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "bcd0c4fc3272786ced542f2475e9d16f8bff34305f9564900ff03ac11ac19e36";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/kinematics-interface-kdl/default.nix
+++ b/distros/kilted/kinematics-interface-kdl/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, eigen, eigen3-cmake-module, kdl-parser, kinematics-interface, pluginlib, ros2-control-cmake, ros2-control-test-assets, tf2-eigen-kdl }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, eigen, eigen3-cmake-module, kdl-parser, kinematics-interface, pluginlib, ros2-control-cmake, ros2-control-test-assets, tf2-eigen-kdl }:
 buildRosPackage {
   pname = "ros-kilted-kinematics-interface-kdl";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/kilted/kinematics_interface_kdl/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "9b7da2031e836b19c7e658eb92c76840efc72a2a47381176b7375d31485d4757";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/kilted/kinematics_interface_kdl/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "da2beb07883dcaafe900b9f39783ee1884688af1a8d37e2f9eb3c7294602f896";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake eigen3-cmake-module ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock ros2-control-test-assets ];
-  propagatedBuildInputs = [ eigen kdl-parser kinematics-interface pluginlib tf2-eigen-kdl ];
+  propagatedBuildInputs = [ backward-ros eigen kdl-parser kinematics-interface pluginlib tf2-eigen-kdl ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 
   meta = {

--- a/distros/kilted/kinematics-interface/default.nix
+++ b/distros/kilted/kinematics-interface/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, eigen, rclcpp-lifecycle, ros2-control-cmake }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, backward-ros, eigen, rclcpp-lifecycle, ros2-control-cmake }:
 buildRosPackage {
   pname = "ros-kilted-kinematics-interface";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/kilted/kinematics_interface/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "ddbd8d698a88b047fc366dd6a09c3b942dbca25ebc53b1b084253e8141f0a922";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/kilted/kinematics_interface/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "0187d6a1387f6aec0ee01e7fc33e543c04a7c638a87da47cfc5dd3d2c8b0d75f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros2-control-cmake ];
-  propagatedBuildInputs = [ eigen rclcpp-lifecycle ];
+  propagatedBuildInputs = [ backward-ros eigen rclcpp-lifecycle ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/mecanum-drive-controller/default.nix
+++ b/distros/kilted/mecanum-drive-controller/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mecanum-drive-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/mecanum_drive_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "b6129304704d8ba37bcc7a00e77e2f2f85f7dcb1216526c605cb337d4888679d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/mecanum_drive_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "dba361050ba38aceffefea3cea90a3782c01fc2cd592aeed4fdb809c17792f8f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake generate-parameter-library ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
-  propagatedBuildInputs = [ control-msgs controller-interface geometry-msgs hardware-interface nav-msgs pluginlib rclcpp rclcpp-lifecycle rcpputils realtime-tools std-srvs tf2 tf2-geometry-msgs tf2-msgs ];
+  propagatedBuildInputs = [ backward-ros control-msgs controller-interface geometry-msgs hardware-interface nav-msgs pluginlib rclcpp rclcpp-lifecycle rcpputils realtime-tools std-srvs tf2 tf2-geometry-msgs tf2-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/mola-imu-preintegration/default.nix
+++ b/distros/kilted/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-kilted-mola-imu-preintegration";
-  version = "1.10.0-r1";
+  version = "1.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/kilted/mola_imu_preintegration/1.10.0-1.tar.gz";
-    name = "1.10.0-1.tar.gz";
-    sha256 = "a84c915bfdd125d57cb99b5dc6fa6a7c48076232ceafb4d453f4112318a8bacb";
+    url = "https://github.com/ros2-gbp/mola_imu_preintegration-release/archive/release/kilted/mola_imu_preintegration/1.11.0-1.tar.gz";
+    name = "1.11.0-1.tar.gz";
+    sha256 = "0155ce876e51c82f0eb6578206e209f4906c0cdd004521b6c0bfa75e1078a062";
   };
 
   buildType = "cmake";

--- a/distros/kilted/motion-primitives-controllers/default.nix
+++ b/distros/kilted/motion-primitives-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-kilted-motion-primitives-controllers";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/motion_primitives_controllers/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "e470c6e3aa374d671d02da5682adfc49bd2731f4607d3084338f737262e0cf87";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/motion_primitives_controllers/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "f00e1fa51e02d83acdab837f430730a4c83c6223c343a41ac498a7a0d0906f66";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mrpt-apps/default.nix
+++ b/distros/kilted/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, openni2, pkg-config, python3Packages, ros-environment, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-apps";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_apps/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "c28522c1153305f30d793e603b1d09f3b13f61acfa85ab2a5d2a9566479f133a";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_apps/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "0406cb233ad150d708b4079c6915011aeb026a9e82c9661fbfa63ab128080499";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libapps/default.nix
+++ b/distros/kilted/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libapps";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libapps/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "7bf52aef08c670bebf8707e76e171acec766a57f9048856cfbe461ba5d9b25a2";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libapps/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "bb429b2a1ff6af48ab59ea795cf425a7394c2785dca8536c3b4b362075b8a4cd";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libbase/default.nix
+++ b/distros/kilted/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libbase";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libbase/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "d0dd29beb6de63a81fd0815d3ad420a1bd839dc78f028b937d27ddd58882d7e2";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libbase/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "46d2651f8a7a8c0b4b8ef08cdfec8bbc7ed33f0200d926efe60c0f96adc056fd";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libgui/default.nix
+++ b/distros/kilted/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libgui";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libgui/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "30849edc41e9903bb5af3963ff3b589c002aef6ab86f7ee39787ee495d6c51ed";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libgui/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "a101bf2eddba4c641c53073748c0662c1a2b66a305b41696c176824a75d57e64";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libhwdrivers/default.nix
+++ b/distros/kilted/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libhwdrivers";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libhwdrivers/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "6f35d98064ce4dbfbcc23281fbfe0e610dddd7819adc2cdc551e091ed98dd6e7";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libhwdrivers/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "d69dadeecb50d8de6a365559c17ee1fa9086553aecdaca7a40fe050d044086dc";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libmaps/default.nix
+++ b/distros/kilted/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libmaps";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libmaps/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "ad509e91d9f3645ef42c4613c0483e1c73d9dc4233c26128d26b017cc73efc81";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libmaps/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "03475a3a5120d091fde487e029278bf18dadc65b091b5be2a8786d94effb6d75";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libmath/default.nix
+++ b/distros/kilted/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libmath";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libmath/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "76d05588c967b0272b34ed065c2e3f4b3dbd2e093e8b449acb2853d9c9ae31b6";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libmath/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "aba9c8f2e910f18fc184d6363cabb3f7da30f5c911a1e83528b48b6cc146d2f4";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libnav/default.nix
+++ b/distros/kilted/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libnav";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libnav/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "2e46cd43a8a1f8e90164f337b1c305158e6655e8834860013303ad8a9db73ac1";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libnav/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "000367371257c57c5a0a9f9aa7949e3c192296d8aab2af381d9110761133ede9";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libobs/default.nix
+++ b/distros/kilted/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libobs";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libobs/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "df36da9e925109387f9c762e5f267bd28993aae951e5a3d295b99c8b00bb537e";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libobs/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "59e9c61829dcb9d03205a00c8227b110d5accdbae9ce2c22cb0bfff7280267b2";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libopengl/default.nix
+++ b/distros/kilted/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libopengl";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libopengl/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "e76e1db420fdc079d70f94cc0f034acce851aab0a31cd30c0e4ee041cb01fb2a";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libopengl/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "dbd98f87043a7511cdfd13a8d448fa00d4ab82ce6bbbd00956a8af5110716c54";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libposes/default.nix
+++ b/distros/kilted/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libposes";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libposes/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "fec058b9b19bfc52a932f00472e7cbdb24131bdcc8b418b729075cb31aaaafce";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libposes/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "af2c93068e4339731b012afc1ed95bcac142119518dbf63c33d7e6c7480da5eb";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libros-bridge/default.nix
+++ b/distros/kilted/mrpt-libros-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, tf2, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libros-bridge";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libros_bridge/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "c14389ac49c379691e483af8eba9358ea885c28e3367e6f0d4362b2818094f03";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libros_bridge/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "e41177d80dc3bbbff6753f4876e442188bb61b04de0ce600eb8cb3bfbf87c770";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libslam/default.nix
+++ b/distros/kilted/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libslam";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libslam/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "90ce7213ff8098423f7cc2d546cce45b37a2fc96e0b6a1b747b28b17a62c35f9";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libslam/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "8a0a40a65c4bb4287cbcdb588ecefa703167137bd626c58a6a2293f60d1d76fa";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libtclap/default.nix
+++ b/distros/kilted/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libtclap";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libtclap/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "2e64d843ae271d0ed88b90e5e0a8f74c0016200545ff2d5961a26db5dd2d36d5";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libtclap/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "565c48e2d5ffb6e2abef7b64b0b0430ec8237b903d03322f56021982325f0688";
   };
 
   buildType = "cmake";

--- a/distros/kilted/multisensor-calibration-interface/default.nix
+++ b/distros/kilted/multisensor-calibration-interface/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-multisensor-calibration-interface";
+  version = "2.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/multisensor_calibration-release/archive/release/kilted/multisensor_calibration_interface/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "140b44c3cc456e81bae8235ae141ce1fa5523dc19214f2d5d5a5cfa12123ebdd";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Messages and service definitions for the multisensor_calibration package.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/multisensor-calibration/default.nix
+++ b/distros/kilted/multisensor-calibration/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, image-transport, multisensor-calibration-interface, pcl-conversions, pcl-ros, qt5, rclcpp, rclcpp-components, rviz-common, sensor-msgs, small-gicp-vendor, std-msgs, tf2, tf2-ros, tinyxml-2, urdf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-multisensor-calibration";
+  version = "2.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/multisensor_calibration-release/archive/release/kilted/multisensor_calibration/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "71b446b1d92f49d80d9cbc9fc57472631c3708c5283b6f388cd9c051d1047bf5";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs image-transport multisensor-calibration-interface pcl-conversions pcl-ros qt5.qtbase rclcpp rclcpp-components rviz-common sensor-msgs small-gicp-vendor std-msgs tf2 tf2-ros tinyxml-2 urdf visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Collection of methods and applications to calibrate multi-sensor-systems, e.g.
+    camera to LiDAR, LiDAR to LiDAR, and LiDAR to vehicle.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/nav-msgs/default.nix
+++ b/distros/kilted/nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-nav-msgs";
-  version = "5.5.0-r2";
+  version = "5.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/nav_msgs/5.5.0-2.tar.gz";
-    name = "5.5.0-2.tar.gz";
-    sha256 = "b2974fd28e6b3bf3a13e4fbfaaae4897fda6865201042dadc55efa9554793a3d";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/nav_msgs/5.5.1-1.tar.gz";
+    name = "5.5.1-1.tar.gz";
+    sha256 = "28f47b28d9efe3ee81328bb48f5fd886517f519150d06689eb9d56046c720518";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/omni-wheel-drive-controller/default.nix
+++ b/distros/kilted/omni-wheel-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, eigen, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-kilted-omni-wheel-drive-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/omni_wheel_drive_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "141e6ea108ff92f46c056103cadc19349cafb1512cc4e6213f4afefe6740af9a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/omni_wheel_drive_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "4684bc4a94c6ef0f50639e2a2699ea7ea7a73ee3ad6577aeffb928615a1c33b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -23,6 +23,35 @@ in {
     fetchgitArgs.hash = "sha256-nLBnxPbPKiLCFF2TJgD/eJKJJfzktVBW3SRW2m3WK/s=";
   };
 
+  foxglove-bridge = rosSuper.foxglove-bridge.overrideAttrs({
+    postPatch ? "", ...
+  }: {
+    postPatch = let
+      # SDK version from CMakeLists.txt. If the version doesn't match,
+      # cmake fails with "Hash mismatch" and we can fix it here.
+      FOXGLOVE_SDK_VERSION = "0.14.2";
+      systemToPlatform = {
+        "x86_64-linux" = "x86_64-unknown-linux-gnu";
+        "aarch64-linux" = "aarch64-unknown-linux-gnu";
+      };
+      systemToHash = {
+        "x86_64-linux" = "sha256-V0w84AbWEx1lGbQW8l7zfFsqByHvSciUKGx5paXgtPw=";
+        "aarch64-linux" = "sha256-9U4+CJJqiIKpvIAxz7JKBAviY48e9OhyNvo63tGrKiM=";
+      };
+      FOXGLOVE_SDK_PLATFORM = systemToPlatform.${self.system};
+      sdk = self.fetchurl {
+        url = "https://github.com/foxglove/foxglove-sdk/releases/download/sdk%2Fv${FOXGLOVE_SDK_VERSION}/foxglove-v${FOXGLOVE_SDK_VERSION}-cpp-${FOXGLOVE_SDK_PLATFORM}.zip";
+        hash = systemToHash.${self.system};
+      };
+    in
+      # Does their CMakeLists.txt support cross compilation?
+      postPatch + ''
+        substituteInPlace CMakeLists.txt --replace-fail \
+          'https://github.com/foxglove/foxglove-sdk/releases/download/sdk%2Fv''${FOXGLOVE_SDK_VERSION}/foxglove-v''${FOXGLOVE_SDK_VERSION}-cpp-''${FOXGLOVE_SDK_PLATFORM}.zip' \
+          ${sdk}
+      '';
+  });
+
   gazebo = self.gazebo_11;
 
   geometric-shapes = rosSuper.geometric-shapes.overrideAttrs({

--- a/distros/kilted/parallel-gripper-controller/default.nix
+++ b/distros/kilted/parallel-gripper-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-parallel-gripper-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/parallel_gripper_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "d8cd547e5c32ed359b65b137ec26b8fb8dfb2d8b7be59cc9369c4cf7dbb1fe54";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/parallel_gripper_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "a7e9f0db6dbd139ae10ef7742d0c394a4bb69e85c730ce2aa50bfa0cfd7717d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/pid-controller/default.nix
+++ b/distros/kilted/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-kilted-pid-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/pid_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "aa7033c4c23d3bc75761e2ce41465549b993094c4d061b616c25deadc680af6b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/pid_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "4b2182d20fe48abe2e75d7df9784eb51923ca36707fc68f2f1a6b4bd9c5ceee1";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/pose-broadcaster/default.nix
+++ b/distros/kilted/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-kilted-pose-broadcaster";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/pose_broadcaster/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "0072da9fb92647d593679b7ff38bfd5dd086261d9ee42dcf6e838a0e46d64ac3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/pose_broadcaster/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "66100c08c83d31b097215ef0bc3de0ab1beb761a035abd27b102a3fd9990c063";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/position-controllers/default.nix
+++ b/distros/kilted/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-position-controllers";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/position_controllers/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "35d2f7bbd8d6ec613c74e51e065a627a9d88ffcf68c885c834668cede1c711cd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/position_controllers/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "072050fe33dbcd67ab0b8333a6178bc771f3c5a8ff9c4a00863f2cc84bf8642c";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/range-sensor-broadcaster/default.nix
+++ b/distros/kilted/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-range-sensor-broadcaster";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/range_sensor_broadcaster/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "59c87cf1c4c6070d63b460473815a1759d71fbc1d3598fc4cafdd4b9583f27ec";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/range_sensor_broadcaster/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "08dcc11d9e4444b800a12d9306d9eb4a3eac789f0189bf961d9d6376ce006c93";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rcl-action/default.nix
+++ b/distros/kilted/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-kilted-rcl-action";
-  version = "10.1.1-r1";
+  version = "10.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/kilted/rcl_action/10.1.1-1.tar.gz";
-    name = "10.1.1-1.tar.gz";
-    sha256 = "b08839e2a745623982acf951c9a6651631be3884d1de0e2c955f63a368bc04df";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/kilted/rcl_action/10.1.2-1.tar.gz";
+    name = "10.1.2-1.tar.gz";
+    sha256 = "46a4c4ebbbe1d360e0ca7b788c88f1d1f616a8102fe65d7a00bb65cd0ec4789b";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rcl-lifecycle/default.nix
+++ b/distros/kilted/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-kilted-rcl-lifecycle";
-  version = "10.1.1-r1";
+  version = "10.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/kilted/rcl_lifecycle/10.1.1-1.tar.gz";
-    name = "10.1.1-1.tar.gz";
-    sha256 = "6c358a6d45181a40f2db9e644128c9e4cd898fab2ba942393c478c2612fb880a";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/kilted/rcl_lifecycle/10.1.2-1.tar.gz";
+    name = "10.1.2-1.tar.gz";
+    sha256 = "80bfd9c031ee4a3ea7ad1ee3e8f347f7cb578653ffa32ff5a64afc8884667896";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rcl-yaml-param-parser/default.nix
+++ b/distros/kilted/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-kilted-rcl-yaml-param-parser";
-  version = "10.1.1-r1";
+  version = "10.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/kilted/rcl_yaml_param_parser/10.1.1-1.tar.gz";
-    name = "10.1.1-1.tar.gz";
-    sha256 = "fecbe345a7c3a1f87760aaea0e13cc42c79113f784e122e1189b6b7abf396c03";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/kilted/rcl_yaml_param_parser/10.1.2-1.tar.gz";
+    name = "10.1.2-1.tar.gz";
+    sha256 = "c6268c11da9826a9d5b26ccbbf9b0840070fb75a0c6ba5b7af2ed9e28df6f7f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rcl/default.nix
+++ b/distros/kilted/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, rosidl-runtime-cpp, service-msgs, test-msgs, tracetools, type-description-interfaces }:
 buildRosPackage {
   pname = "ros-kilted-rcl";
-  version = "10.1.1-r1";
+  version = "10.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/kilted/rcl/10.1.1-1.tar.gz";
-    name = "10.1.1-1.tar.gz";
-    sha256 = "a76ae52b04d7e43ded4a1a3fd7c16e7e24d14c21eb3628f9136642c7ae6ca761";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/kilted/rcl/10.1.2-1.tar.gz";
+    name = "10.1.2-1.tar.gz";
+    sha256 = "1f78593210f545ef84552132e74c3f803a7a42d09e05541b952d1a4ed44e1cac";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros-gz-bridge/default.nix
+++ b/distros/kilted/ros-gz-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actuator-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, gps-msgs, gz-msgs-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, nav-msgs, pkg-config, rclcpp, rclcpp-components, ros-gz-interfaces, rosgraph-msgs, rosidl-pycommon, sensor-msgs, std-msgs, tf2-msgs, trajectory-msgs, vision-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-kilted-ros-gz-bridge";
-  version = "2.1.10-r1";
+  version = "2.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/kilted/ros_gz_bridge/2.1.10-1.tar.gz";
-    name = "2.1.10-1.tar.gz";
-    sha256 = "11909664fe608f284bb8caeba01c14ecc9f441fa14484196ceafb55398f1601b";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/kilted/ros_gz_bridge/2.1.11-1.tar.gz";
+    name = "2.1.11-1.tar.gz";
+    sha256 = "630e72eda2811fbcdab78ed0241d9effe849fe873829a926f67330802fa98873";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros-gz-image/default.nix
+++ b/distros/kilted/ros-gz-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-msgs-vendor, gz-transport-vendor, image-transport, pkg-config, rclcpp, ros-gz-bridge, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ros-gz-image";
-  version = "2.1.10-r1";
+  version = "2.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/kilted/ros_gz_image/2.1.10-1.tar.gz";
-    name = "2.1.10-1.tar.gz";
-    sha256 = "dd05153c44e52607baaaeaa4559f4be5159506ad5dc53d7a6b547d18696e9666";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/kilted/ros_gz_image/2.1.11-1.tar.gz";
+    name = "2.1.11-1.tar.gz";
+    sha256 = "aec5b205816922657a54ef012d9a49cbb87bfcf8e71c901f69f221bd3718708f";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros-gz-interfaces/default.nix
+++ b/distros/kilted/ros-gz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ros-gz-interfaces";
-  version = "2.1.10-r1";
+  version = "2.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/kilted/ros_gz_interfaces/2.1.10-1.tar.gz";
-    name = "2.1.10-1.tar.gz";
-    sha256 = "9eeca83a6a884dc3af941305f37b8c5b15c40f3987871565a45d40ebd984f8fe";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/kilted/ros_gz_interfaces/2.1.11-1.tar.gz";
+    name = "2.1.11-1.tar.gz";
+    sha256 = "1683b71087c0ca61bb9bc96df075808dfa066cc6a8bc887f89ffd31767087f2e";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros-gz-sim-demos/default.nix
+++ b/distros/kilted/ros-gz-sim-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-sim-vendor, image-transport-plugins, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, rqt-image-view, rqt-plot, rqt-topic, rviz-imu-plugin, rviz2, sdformat-urdf, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-kilted-ros-gz-sim-demos";
-  version = "2.1.10-r1";
+  version = "2.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/kilted/ros_gz_sim_demos/2.1.10-1.tar.gz";
-    name = "2.1.10-1.tar.gz";
-    sha256 = "5917cb734d5e88e2071e8a6b423feee24d7c931a6178ede0492ddf7ef970f262";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/kilted/ros_gz_sim_demos/2.1.11-1.tar.gz";
+    name = "2.1.11-1.tar.gz";
+    sha256 = "b9c5d5259c5c081608b968047b93036ac0befeac9e5f10531fde6b172bf2aad9";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros-gz-sim/default.nix
+++ b/distros/kilted/ros-gz-sim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, cli11, geometry-msgs, gflags, gz-math-vendor, gz-msgs-vendor, gz-sim-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, pkg-config, rclcpp, rclcpp-components, rcpputils, ros-gz-interfaces, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-ros-gz-sim";
-  version = "2.1.10-r1";
+  version = "2.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/kilted/ros_gz_sim/2.1.10-1.tar.gz";
-    name = "2.1.10-1.tar.gz";
-    sha256 = "dcebaf357b35f6e66b47552cee9c10d50e4962a2173c6852418388e3d537ab93";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/kilted/ros_gz_sim/2.1.11-1.tar.gz";
+    name = "2.1.11-1.tar.gz";
+    sha256 = "2ace5f6771a594b6aa4abfb3b17f5669e8e15ae8207ad4e6d1b3bec12da3b824";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros-gz/default.nix
+++ b/distros/kilted/ros-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz-bridge, ros-gz-image, ros-gz-sim, ros-gz-sim-demos }:
 buildRosPackage {
   pname = "ros-kilted-ros-gz";
-  version = "2.1.10-r1";
+  version = "2.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/kilted/ros_gz/2.1.10-1.tar.gz";
-    name = "2.1.10-1.tar.gz";
-    sha256 = "32bbcf0a13cc15ed4a7a07fbca08eaec5d8fd47b81b337ee75464c57f26f5f94";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/kilted/ros_gz/2.1.11-1.tar.gz";
+    name = "2.1.11-1.tar.gz";
+    sha256 = "bed8c8098ade92f8e8b854c5cf0d87d964e8ede1cdec4cd21f4fcfaa3d6d4c95";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros2-control-cmake/default.nix
+++ b/distros/kilted/ros2-control-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-kilted-ros2-control-cmake";
-  version = "0.2.1-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control_cmake-release/archive/release/kilted/ros2_control_cmake/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "8ae543a6984f1d49cb74a34c706c74d266d9b3331c3ce20d09bbdc729d035cbd";
+    url = "https://github.com/ros2-gbp/ros2_control_cmake-release/archive/release/kilted/ros2_control_cmake/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "9a55e43b08cc37366628a73be3d66095ed3a73fee96f18d165dc82c44cc77e14";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros2-controllers-test-nodes/default.nix
+++ b/distros/kilted/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ros2-controllers-test-nodes";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/ros2_controllers_test_nodes/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "d88c060369f79a9057bd9b38b2ce9fcbfaef94c5f59fa16826845aac288a0921";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/ros2_controllers_test_nodes/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "f23b939ce216b090bec7f86639e65685488d43cc233634f8a6ba9367134e40f6";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/ros2-controllers/default.nix
+++ b/distros/kilted/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, chained-filter-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gps-sensor-broadcaster, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, motion-primitives-controllers, omni-wheel-drive-controller, parallel-gripper-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-kilted-ros2-controllers";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/ros2_controllers/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "997fdcb13c8f5326359587f107526ac3963a403f198121a035ff8489764079a7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/ros2_controllers/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "1fe0e26b77fde06eebad44bde858d6a7ec3816df2b5a0cb9ff5b9d8476589cde";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rqt-joint-trajectory-controller/default.nix
+++ b/distros/kilted/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kilted-rqt-joint-trajectory-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/rqt_joint_trajectory_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "b93922b386407d9250de5ee2d4113f4ea6acf89d039a6d109180c2293500debc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/rqt_joint_trajectory_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "0d734a2cdf46e7e08c09b35c12782d7a0a4af7c9491fb93bfae3eef6e9db6bc5";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/rviz-assimp-vendor/default.nix
+++ b/distros/kilted/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-kilted-rviz-assimp-vendor";
-  version = "15.0.6-r1";
+  version = "15.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_assimp_vendor/15.0.6-1.tar.gz";
-    name = "15.0.6-1.tar.gz";
-    sha256 = "ca149af595b47ac16bed07ca25423d1d2371c04e3566cf7669742695af2d9a86";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_assimp_vendor/15.0.7-1.tar.gz";
+    name = "15.0.7-1.tar.gz";
+    sha256 = "01f0c7b40530765ef4492434e717d14755795551e7c9a0b91636c7df10b00b71";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rviz-common/default.nix
+++ b/distros/kilted/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-kilted-rviz-common";
-  version = "15.0.6-r1";
+  version = "15.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_common/15.0.6-1.tar.gz";
-    name = "15.0.6-1.tar.gz";
-    sha256 = "3a25f712c9914935895946efa2874ea53ede10b3de4693940693a107cff10507";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_common/15.0.7-1.tar.gz";
+    name = "15.0.7-1.tar.gz";
+    sha256 = "ab132daeece1a1085126eabc4c5d87a3e1213064b100a8c324cd354492daaa99";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rviz-default-plugins/default.nix
+++ b/distros/kilted/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, gz-math-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-resource-interfaces, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-rviz-default-plugins";
-  version = "15.0.6-r1";
+  version = "15.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_default_plugins/15.0.6-1.tar.gz";
-    name = "15.0.6-1.tar.gz";
-    sha256 = "43182dda1efcefd97a6bc00e0fad3e31e83c0fbc7b5037a3ef1c51698ab67b7c";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_default_plugins/15.0.7-1.tar.gz";
+    name = "15.0.7-1.tar.gz";
+    sha256 = "a266c70edd59cac0cf5607a18daf30acbb35fc19c2ff97eebeebefaf1dc92479";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rviz-ogre-vendor/default.nix
+++ b/distros/kilted/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, glew, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-kilted-rviz-ogre-vendor";
-  version = "15.0.6-r1";
+  version = "15.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_ogre_vendor/15.0.6-1.tar.gz";
-    name = "15.0.6-1.tar.gz";
-    sha256 = "5049c8f178607683737c384d34c894c210a4925add309fc0752da684d479442b";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_ogre_vendor/15.0.7-1.tar.gz";
+    name = "15.0.7-1.tar.gz";
+    sha256 = "c06575b062ffd4fc43a3edb2bf21b9d29ef4731a4c655aeeca91f69900780ef6";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rviz-rendering-tests/default.nix
+++ b/distros/kilted/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-kilted-rviz-rendering-tests";
-  version = "15.0.6-r1";
+  version = "15.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_rendering_tests/15.0.6-1.tar.gz";
-    name = "15.0.6-1.tar.gz";
-    sha256 = "f689c8e74c0814a30f322bdd42af0c5dce2dbb9bd2cae0c487082a3529236095";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_rendering_tests/15.0.7-1.tar.gz";
+    name = "15.0.7-1.tar.gz";
+    sha256 = "7cc20a7d6613928df2ef972f80a7fa0e1d2aec6fcf90c2827656bc998e8f075d";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rviz-rendering/default.nix
+++ b/distros/kilted/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-kilted-rviz-rendering";
-  version = "15.0.6-r1";
+  version = "15.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_rendering/15.0.6-1.tar.gz";
-    name = "15.0.6-1.tar.gz";
-    sha256 = "5a3e2c7d8a9cd51927cfe45faef236d2557b64ee1cd89c51fb0150254fa528b1";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_rendering/15.0.7-1.tar.gz";
+    name = "15.0.7-1.tar.gz";
+    sha256 = "16dc4694bb0ac35436d090db2324700f06b2ebd4b509e3c0157969130a961364";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rviz-resource-interfaces/default.nix
+++ b/distros/kilted/rviz-resource-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-kilted-rviz-resource-interfaces";
-  version = "15.0.6-r1";
+  version = "15.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_resource_interfaces/15.0.6-1.tar.gz";
-    name = "15.0.6-1.tar.gz";
-    sha256 = "ec1d4e2d1be45b84e4d2db8413965792e86f5449e542cd79e779c0e3b5ca195a";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_resource_interfaces/15.0.7-1.tar.gz";
+    name = "15.0.7-1.tar.gz";
+    sha256 = "23e9386108768f393ffe8a62f9732a9f260d61257fdadc2cf3e8784d894e8645";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rviz-visual-testing-framework/default.nix
+++ b/distros/kilted/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-rviz-visual-testing-framework";
-  version = "15.0.6-r1";
+  version = "15.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_visual_testing_framework/15.0.6-1.tar.gz";
-    name = "15.0.6-1.tar.gz";
-    sha256 = "3737ab5734f605e88bc5d3463474210e9d0da8c7ede706f44d86ea7d6328bd30";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz_visual_testing_framework/15.0.7-1.tar.gz";
+    name = "15.0.7-1.tar.gz";
+    sha256 = "c541f22d971fded68d10f865e45f6557cb1a8a8e5c94f812475e8684fbf1d7af";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rviz2/default.nix
+++ b/distros/kilted/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-rviz2";
-  version = "15.0.6-r1";
+  version = "15.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz2/15.0.6-1.tar.gz";
-    name = "15.0.6-1.tar.gz";
-    sha256 = "7b51f626906d401e1762aea2453823d041507b27010f5bfee8f17a2364f1ffd0";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/kilted/rviz2/15.0.7-1.tar.gz";
+    name = "15.0.7-1.tar.gz";
+    sha256 = "da584e0f3c792d68d7757aa3da77eac4d7675966df8b1679884aa80522943ab7";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/sensor-msgs-py/default.nix
+++ b/distros/kilted/sensor-msgs-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-sensor-msgs-py";
-  version = "5.5.0-r2";
+  version = "5.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/sensor_msgs_py/5.5.0-2.tar.gz";
-    name = "5.5.0-2.tar.gz";
-    sha256 = "b52d20da3388ffc12e0eb78ba9e68107bb3c024442fa1c1f5b3c9c57e9732e72";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/sensor_msgs_py/5.5.1-1.tar.gz";
+    name = "5.5.1-1.tar.gz";
+    sha256 = "52ddf613d266aaae15b5c15e85e0f536caea2c6d80f3a4ae5763bc08e5971aab";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/sensor-msgs/default.nix
+++ b/distros/kilted/sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-sensor-msgs";
-  version = "5.5.0-r2";
+  version = "5.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/sensor_msgs/5.5.0-2.tar.gz";
-    name = "5.5.0-2.tar.gz";
-    sha256 = "c219d621fcfb003e22679b93f3d556a97f2858c49db7de49eee755047e98dabf";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/sensor_msgs/5.5.1-1.tar.gz";
+    name = "5.5.1-1.tar.gz";
+    sha256 = "2e8528157b9aaa7ba934696deb6feca7e7213b1aaccfbe55cfc0533eb2f7effe";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/shape-msgs/default.nix
+++ b/distros/kilted/shape-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-kilted-shape-msgs";
-  version = "5.5.0-r2";
+  version = "5.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/shape_msgs/5.5.0-2.tar.gz";
-    name = "5.5.0-2.tar.gz";
-    sha256 = "25d1b6a37ca8b78a9cc0db3c06fed09003eaff9488450846d0f68da89f72f14d";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/shape_msgs/5.5.1-1.tar.gz";
+    name = "5.5.1-1.tar.gz";
+    sha256 = "0f4652836586ff2cc630d4516b8b81b1db87c4ae257ccd6f4e8e8210502a7014";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/small-gicp-vendor/default.nix
+++ b/distros/kilted/small-gicp-vendor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package }:
+buildRosPackage {
+  pname = "ros-kilted-small-gicp-vendor";
+  version = "2.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/multisensor_calibration-release/archive/release/kilted/small_gicp_vendor/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "714ebfdb0c8f52308b164047ebeb10308dab4fb5071bbf6f09c2c397c66bc80c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-vendor-package ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package ];
+
+  meta = {
+    description = "Vendor package for small_gicp. This is just a wrapper to provide ExternalProject build";
+    license = with lib.licenses; [ mit bsdOriginal ];
+  };
+}

--- a/distros/kilted/std-msgs/default.nix
+++ b/distros/kilted/std-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-kilted-std-msgs";
-  version = "5.5.0-r2";
+  version = "5.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/std_msgs/5.5.0-2.tar.gz";
-    name = "5.5.0-2.tar.gz";
-    sha256 = "4d78fae09a0e5ef83a6c383062ecf81a2acf4ba564492f8cf1516415f4247e2f";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/std_msgs/5.5.1-1.tar.gz";
+    name = "5.5.1-1.tar.gz";
+    sha256 = "84a6849ae618c8dc7107e29cd124418f4223bab188a40abf18b9bc6f7c3c137e";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/std-srvs/default.nix
+++ b/distros/kilted/std-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-kilted-std-srvs";
-  version = "5.5.0-r2";
+  version = "5.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/std_srvs/5.5.0-2.tar.gz";
-    name = "5.5.0-2.tar.gz";
-    sha256 = "f973621cceeca8cd6224ad4485d07e0768fcc4863b8e68fe2b030e21ffa3eeef";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/std_srvs/5.5.1-1.tar.gz";
+    name = "5.5.1-1.tar.gz";
+    sha256 = "98d1f955baecfecc5c64763ab1d860e689620eaa502e6fc2194fec070086cbf3";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/steering-controllers-library/default.nix
+++ b/distros/kilted/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-kilted-steering-controllers-library";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/steering_controllers_library/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "19076466e46c3311665b2f2d060537221d17ce3e0a710b83dc42d514ec38f783";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/steering_controllers_library/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "4f92be6b33596c698151e1d985b358136f908d15234c537169b7c53ea4b3659d";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/stereo-msgs/default.nix
+++ b/distros/kilted/stereo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-stereo-msgs";
-  version = "5.5.0-r2";
+  version = "5.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/stereo_msgs/5.5.0-2.tar.gz";
-    name = "5.5.0-2.tar.gz";
-    sha256 = "d55a36e541160abee80e29c80a5a10dc9fb0aab00b4791320604c9fa39e45a1a";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/stereo_msgs/5.5.1-1.tar.gz";
+    name = "5.5.1-1.tar.gz";
+    sha256 = "a747433b0a8e4b6ed5d322a48b67fbf76965fda2d6b240c9336e3024766c586b";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/teleop-twist-keyboard/default.nix
+++ b/distros/kilted/teleop-twist-keyboard/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, rclpy }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, python3Packages, rcl-interfaces, rclpy }:
 buildRosPackage {
   pname = "ros-kilted-teleop-twist-keyboard";
-  version = "2.4.0-r2";
+  version = "2.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_twist_keyboard-release/archive/release/kilted/teleop_twist_keyboard/2.4.0-2.tar.gz";
-    name = "2.4.0-2.tar.gz";
-    sha256 = "4dda0692a4177c1bbea054c2c6f71accfb96e9d1bd004f1caafda4398ab487a7";
+    url = "https://github.com/ros2-gbp/teleop_twist_keyboard-release/archive/release/kilted/teleop_twist_keyboard/2.4.1-1.tar.gz";
+    name = "2.4.1-1.tar.gz";
+    sha256 = "77810aeee48d4c4961aa609509cf081ae7e9d4f023d04f268f5ae41896afdc7a";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ];
-  propagatedBuildInputs = [ geometry-msgs rclpy ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest ];
+  propagatedBuildInputs = [ geometry-msgs rcl-interfaces rclpy ];
 
   meta = {
     description = "A robot-agnostic teleoperation node to convert keyboard commands to Twist

--- a/distros/kilted/trajectory-msgs/default.nix
+++ b/distros/kilted/trajectory-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-trajectory-msgs";
-  version = "5.5.0-r2";
+  version = "5.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/trajectory_msgs/5.5.0-2.tar.gz";
-    name = "5.5.0-2.tar.gz";
-    sha256 = "ecfb95331a33b37d46c7663c13aa27385dc9b05dba1f424ba4b0637b045667d4";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/trajectory_msgs/5.5.1-1.tar.gz";
+    name = "5.5.1-1.tar.gz";
+    sha256 = "c2f604c3bab8812e50f3f7c50888534fc41e720c3c99498975428b30d8acf32b";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/tricycle-controller/default.nix
+++ b/distros/kilted/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-kilted-tricycle-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/tricycle_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "ed547214aeecf8a5958deb6e25caf399ef7ca37e10e80b8f6d88a84be6172cc2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/tricycle_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "31e0ace9adff2198652db93e931ec0788ee44f05aee9506d75b9aa5193d81a39";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/tricycle-steering-controller/default.nix
+++ b/distros/kilted/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-kilted-tricycle-steering-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/tricycle_steering_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "2343f3444b0bae635bde6a7230ad98d197d522005199eeee643fca5d49f769a4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/tricycle_steering_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "1bf3bc07f2b2b80e60ef861618d01a86ddf6c181e3173a9745e61604600096f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ur-description/default.nix
+++ b/distros/kilted/ur-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, joint-state-publisher-gui, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, robot-state-publisher, rviz2, urdf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-kilted-ur-description";
-  version = "4.1.0-r1";
+  version = "4.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/kilted/ur_description/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "8be8800a247ea3a38d70815e267f195907b09efb706f9bd4297530674e32c2c2";
+    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/kilted/ur_description/4.1.1-1.tar.gz";
+    name = "4.1.1-1.tar.gz";
+    sha256 = "751fbf932e9581ac6495680403eb332a974638589e8c3a8c7ded16106f01b23a";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/velocity-controllers/default.nix
+++ b/distros/kilted/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-velocity-controllers";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/velocity_controllers/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "d911431fbfebdbf37f26d58d07cd95a95039b50abb4876b9742a2aef58f15d41";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/velocity_controllers/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "2fdc1377678aad1d2f1f46314138cd0a898760a971d40dd857cb31bb3d481b6e";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/visualization-msgs/default.nix
+++ b/distros/kilted/visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-visualization-msgs";
-  version = "5.5.0-r2";
+  version = "5.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/visualization_msgs/5.5.0-2.tar.gz";
-    name = "5.5.0-2.tar.gz";
-    sha256 = "64cdc0ed7504c2751819595c769bfa9a265ba1a5e2b7063369ee8910eaa6db89";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/kilted/visualization_msgs/5.5.1-1.tar.gz";
+    name = "5.5.1-1.tar.gz";
+    sha256 = "543f4f4b28b944a6fed88ca06809d62a408c04655d26fd1bc3304f1949e28c19";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ackermann-steering-controller/default.nix
+++ b/distros/rolling/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-ackermann-steering-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "0f89c16dfc9b720f337e306762abfaca0c048fdf0c8ee38fe1a37726c180ccb8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "17e26d4d54290897feb5a190fd676bc939db937f5c8150340cb9b51d0d297996";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/admittance-controller/default.nix
+++ b/distros/rolling/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-admittance-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "c5ed98f460e2ffd9317587bbc1ce9b6646257a01dc6a53216caea7df93dff4cd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "ee4b234932ec4eb62c728dc184cdc7b22af1439dc05f5b25c05a4a82b0b7cf8e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/battery-state-broadcaster/default.nix
+++ b/distros/rolling/battery-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, pluginlib, realtime-tools, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-battery-state-broadcaster";
-  version = "1.0.2-r1";
+  version = "1.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_battery_monitoring-release/archive/release/rolling/battery_state_broadcaster/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "7ca31573b9dce4adb18edb6a2f4f30e20b1e50142162ef6841e3d82227574892";
+    url = "https://github.com/ros2-gbp/ros_battery_monitoring-release/archive/release/rolling/battery_state_broadcaster/1.1.0-2.tar.gz";
+    name = "1.1.0-2.tar.gz";
+    sha256 = "c1c6d9a0d8c3ffc845efe75fd568c56ac544c4c2c0ddf3f2e3d70a25fad5faf0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/battery-state-rviz-overlay/default.nix
+++ b/distros/rolling/battery-state-rviz-overlay/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmt, rclcpp, rviz-2d-overlay-msgs, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-battery-state-rviz-overlay";
-  version = "1.0.2-r1";
+  version = "1.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_battery_monitoring-release/archive/release/rolling/battery_state_rviz_overlay/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "7a5c8898f4ec34d501f17cc3450230ae0241dd6bd1dc64cf94eacd1dcbe765b7";
+    url = "https://github.com/ros2-gbp/ros_battery_monitoring-release/archive/release/rolling/battery_state_rviz_overlay/1.1.0-2.tar.gz";
+    name = "1.1.0-2.tar.gz";
+    sha256 = "2a8f631e1458d19149774fdd3637c76bbe438751f7636220b055f2ca05d1236d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/bicycle-steering-controller/default.nix
+++ b/distros/rolling/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-bicycle-steering-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "31664d17ae44536d1f87a3b381934aef081c0e606d30f45ce492a73d1f099e3e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "f6ee99e3dd60085349af49614f7dcb5d3de22efa74c1fe50abaafdb318f0aed4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/chained-filter-controller/default.nix
+++ b/distros/rolling/chained-filter-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, filters, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-chained-filter-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/chained_filter_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "708b43f1fcfb68bdca3bc26952d1e3ef9025b56c727408a54a2a3bf66640ba5c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/chained_filter_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "3efc21bb9790878c556599ac78f9de722d68c932f572f30f7a26f5763098f489";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/common-interfaces/default.nix
+++ b/distros/rolling/common-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, geometry-msgs, nav-msgs, sensor-msgs, shape-msgs, std-msgs, std-srvs, stereo-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-common-interfaces";
-  version = "5.8.2-r1";
+  version = "5.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/common_interfaces/5.8.2-1.tar.gz";
-    name = "5.8.2-1.tar.gz";
-    sha256 = "e24894eec9a884b26386c3e4edb52c863745589a54d6c36a75acc28ea39d7657";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/common_interfaces/5.9.0-1.tar.gz";
+    name = "5.9.0-1.tar.gz";
+    sha256 = "7549c1b9a768260f69f1da69ea907d47b786286c1c60a47987d0423449e0b063";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/control-toolbox/default.nix
+++ b/distros/rolling/control-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, eigen, filters, fmt, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-cmake, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-control-toolbox";
-  version = "5.7.0-r1";
+  version = "5.8.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/rolling/control_toolbox/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "a32e732ff65dffe307b092f838d941bc0e4806cea519e3cc4b87eb9727e25eaf";
+    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/rolling/control_toolbox/5.8.0-2.tar.gz";
+    name = "5.8.0-2.tar.gz";
+    sha256 = "534c8efaf5cc85ae0cee7e1f052e3f7b4fb543253d538e9e4edc8187d7998816";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/diagnostic-msgs/default.nix
+++ b/distros/rolling/diagnostic-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diagnostic-msgs";
-  version = "5.8.2-r1";
+  version = "5.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/diagnostic_msgs/5.8.2-1.tar.gz";
-    name = "5.8.2-1.tar.gz";
-    sha256 = "01b1c4a4ade3822aaf11e2c2ed4f769f6d95f6fc7093f05e3f20606392f32194";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/diagnostic_msgs/5.9.0-1.tar.gz";
+    name = "5.9.0-1.tar.gz";
+    sha256 = "0098b2e8f85e7c0a2e1124d3149bbe0c628fadeab644b0ad3d4e0513d3dfb10c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/diff-drive-controller/default.nix
+++ b/distros/rolling/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diff-drive-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "a6aa7ebd44a9e250ba2377c483fd52a26904b84c7fe774f22c13111198706ca8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "e1c55e8d9251247fd2f154ade4b7e6406a48ffc8aa079024dd07fad3b4063175";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/effort-controllers/default.nix
+++ b/distros/rolling/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-effort-controllers";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "0daa6dc0e265ec4786527bf41188b33e4bdc93cd9bc1f186ecb2d4c7046e2ed2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "09cdf686327f7a06fac89742b8612cd5751105370206df56f77dc6d1c8c303de";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fastcdr/default.nix
+++ b/distros/rolling/fastcdr/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cmake }:
 buildRosPackage {
   pname = "ros-rolling-fastcdr";
-  version = "2.3.0-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastcdr-release/archive/release/rolling/fastcdr/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "410fbcaf9b43e1a7b2f9254c4bab3d0f0fac9556bde1b39983099443048c4c60";
+    url = "https://github.com/ros2-gbp/fastcdr-release/archive/release/rolling/fastcdr/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "8f35bd4e0857af19d760240cd1b05db0a15b0d658319244de1c48277deaaa79f";
   };
 
   buildType = "cmake";

--- a/distros/rolling/force-torque-sensor-broadcaster/default.nix
+++ b/distros/rolling/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-force-torque-sensor-broadcaster";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "7ff4f90539a327ba548b7a770f67b369b0fb824e3de12507939a18a80a9c4d8a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "e8dfe847190c363de7a26d9af5a42ba274339442834a41a861da983ffeba7f18";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/forward-command-controller/default.nix
+++ b/distros/rolling/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-forward-command-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "d22b9e2eb13e6b777f2fd6dd29f355632d6f54c0caa9e8384ca90b0a887bb73d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "5baded481203d52507105f783fdce489b492ee9ce6e2db7d56d1726d53910848";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/foxglove-bridge/default.nix
+++ b/distros/rolling/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, rosx-introspection, std-msgs, std-srvs, websocketpp }:
 buildRosPackage {
   pname = "ros-rolling-foxglove-bridge";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "583779f28c2d1292db4745884effe94e41abddaf6fd8368876a01f1aecaddec2";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "98020659b66cc19b9f49e5fcff6f0e3cfe4c52ea9acfe05574c0d6ab9803be02";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/foxglove-msgs/default.nix
+++ b/distros/rolling/foxglove-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-foxglove-msgs";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_msgs/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "c532f77a4c0ce5b807b4bc3f729845b15c90782c6c8a42ac9d86d30e3aba3913";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_msgs/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "f4086d3064b4c45ea6a2e3bd66cadea7f1a9882265c2317bc466d22fd744a43f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -1202,6 +1202,8 @@ self: super: {
 
  mola-gnss-to-markers = self.callPackage ./mola-gnss-to-markers {};
 
+ mola-imu-preintegration = self.callPackage ./mola-imu-preintegration {};
+
  mola-input-euroc-dataset = self.callPackage ./mola-input-euroc-dataset {};
 
  mola-input-kitti360-dataset = self.callPackage ./mola-input-kitti360-dataset {};
@@ -1231,6 +1233,12 @@ self: super: {
  mola-pose-list = self.callPackage ./mola-pose-list {};
 
  mola-relocalization = self.callPackage ./mola-relocalization {};
+
+ mola-state-estimation = self.callPackage ./mola-state-estimation {};
+
+ mola-state-estimation-simple = self.callPackage ./mola-state-estimation-simple {};
+
+ mola-state-estimation-smoother = self.callPackage ./mola-state-estimation-smoother {};
 
  mola-test-datasets = self.callPackage ./mola-test-datasets {};
 
@@ -1815,6 +1823,8 @@ self: super: {
  resource-retriever = self.callPackage ./resource-retriever {};
 
  rig-reconfigure = self.callPackage ./rig-reconfigure {};
+
+ rko-lio = self.callPackage ./rko-lio {};
 
  rmf-api-msgs = self.callPackage ./rmf-api-msgs {};
 

--- a/distros/rolling/geometry-msgs/default.nix
+++ b/distros/rolling/geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-geometry-msgs";
-  version = "5.8.2-r1";
+  version = "5.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/geometry_msgs/5.8.2-1.tar.gz";
-    name = "5.8.2-1.tar.gz";
-    sha256 = "b379c70a91776360c1a27392c5a3e7269d0cadcd582d3467b9fe8b56d01f6ff8";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/geometry_msgs/5.9.0-1.tar.gz";
+    name = "5.9.0-1.tar.gz";
+    sha256 = "141fd93004f28dd407bada547215154f1a4413e11ecb5a214d5992c88cedb38d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gpio-controllers/default.nix
+++ b/distros/rolling/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-gpio-controllers";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gpio_controllers/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "dacbcae4f7e848df9df8b74b5614a9815eb6696cfc749352bebd65258de13f0e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gpio_controllers/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "7356ef6367396f592ac6ac9fea3747b46f58064dd7961fd047518fadf2ebd068";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gps-sensor-broadcaster/default.nix
+++ b/distros/rolling/gps-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-gps-sensor-broadcaster";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gps_sensor_broadcaster/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "87886e3fc1b9ecad1440c1c737b150550ef0f6f4f5d1be1884503dc9d5cca982";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gps_sensor_broadcaster/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "4b17b644c2322e96cd54e08dd3ddc489b41a0357f97fd469a513661fa4af1a6b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-cmake-vendor/default.nix
+++ b/distros/rolling/gz-cmake-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, pkg-config }:
 buildRosPackage {
   pname = "ros-rolling-gz-cmake-vendor";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_cmake_vendor-release/archive/release/rolling/gz_cmake_vendor/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "158a344618d09c6b251f8939d23c9ccfd9ebd5a2a26388db494d28ea31806e06";
+    url = "https://github.com/ros2-gbp/gz_cmake_vendor-release/archive/release/rolling/gz_cmake_vendor/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "bf4fcdb2ba640876b058b91efe5b30c6b6c623f1a2b1f9b297ebe2e083b76e4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-cmake-vendor/vendored-source.json
+++ b/distros/rolling/gz-cmake-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_cmake_vendor": {
     "url": "https://github.com/gazebosim/gz-cmake.git",
-    "rev": "gz-cmake5_5.0.0-pre1",
-    "hash": "sha256-EiEtnGqLDwGXFfcq/hidN2HI70OxLRi4HsacHf0WGT4="
+    "rev": "gz-cmake5_5.0.0",
+    "hash": "sha256-XF7oglj9Xr6F8a+6uowrY5a040yl4FZlFfW/Y0BJwOs="
   }
 }

--- a/distros/rolling/gz-common-vendor/default.nix
+++ b/distros/rolling/gz-common-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, assimp, cmake, ffmpeg, freeimage, gdal, gz-cmake-vendor, gz-math-vendor, gz-utils-vendor, pkg-config, spdlog-vendor, tinyxml-2, util-linux }:
 buildRosPackage {
   pname = "ros-rolling-gz-common-vendor";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_common_vendor-release/archive/release/rolling/gz_common_vendor/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "c6304e499c2e05f0f84a9252f92a4816e4446d9a0fe6cfd441a3d7f45daed765";
+    url = "https://github.com/ros2-gbp/gz_common_vendor-release/archive/release/rolling/gz_common_vendor/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "9373aa2b1d179c0190397c06e1d520f6170fda4c6c8095ad3423d89930d0ec4c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-common-vendor/vendored-source.json
+++ b/distros/rolling/gz-common-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_common_vendor": {
     "url": "https://github.com/gazebosim/gz-common.git",
-    "rev": "gz-common7_7.0.0-pre2",
-    "hash": "sha256-K5yGyLxy134lBtG9GAF3JyUzEYiNShUTSxoxUKZ/qvU="
+    "rev": "gz-common7_7.0.0",
+    "hash": "sha256-faoseEgvQmQzH0Ujb3GNavAEcJdxh6VSmCA4Uq9UgII="
   }
 }

--- a/distros/rolling/gz-fuel-tools-vendor/default.nix
+++ b/distros/rolling/gz-fuel-tools-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, curl, gflags, gz-cmake-vendor, gz-common-vendor, gz-math-vendor, gz-msgs-vendor, gz-tools-vendor, gz-utils-vendor, jsoncpp, libyaml, libzip, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-rolling-gz-fuel-tools-vendor";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_fuel_tools_vendor-release/archive/release/rolling/gz_fuel_tools_vendor/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "9066e408662e6cf94cb06fc10034716a6332c489872577db62c51008c33ee04f";
+    url = "https://github.com/ros2-gbp/gz_fuel_tools_vendor-release/archive/release/rolling/gz_fuel_tools_vendor/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "99b1a99a45a9822565561ba26a4bf520023e53794c4a2fdb105caa16b24951e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-fuel-tools-vendor/vendored-source.json
+++ b/distros/rolling/gz-fuel-tools-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_fuel_tools_vendor": {
     "url": "https://github.com/gazebosim/gz-fuel-tools.git",
-    "rev": "gz-fuel-tools11_11.0.0-pre1",
-    "hash": "sha256-XQG8nRB/YkxOGeRaAh0wmb+bEhh1GrF6Vsc+G8dCPpk="
+    "rev": "gz-fuel-tools11_11.0.0",
+    "hash": "sha256-IFnaXBURpN5xTCxFjlcZk9n0sCsUnPBr3NUZrf7Xde0="
   }
 }

--- a/distros/rolling/gz-launch-vendor/default.nix
+++ b/distros/rolling/gz-launch-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, binutils, cmake, gflags, gz-cmake-vendor, gz-common-vendor, gz-gui-vendor, gz-math-vendor, gz-msgs-vendor, gz-plugin-vendor, gz-sim-vendor, gz-tools-vendor, gz-transport-vendor, libwebsockets, libyaml, tinyxml-2, util-linux, xorg }:
 buildRosPackage {
   pname = "ros-rolling-gz-launch-vendor";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_launch_vendor-release/archive/release/rolling/gz_launch_vendor/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "3a9be17112b8c51867457f327e356784511892762d83083cc946ff5b20caad00";
+    url = "https://github.com/ros2-gbp/gz_launch_vendor-release/archive/release/rolling/gz_launch_vendor/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "fc00bbb9177e30a0ea71a2dcfbde71d50b466cdb3c7575a5a032540fdab73ac6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-math-vendor/default.nix
+++ b/distros/rolling/gz-math-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, eigen, gz-cmake-vendor, gz-utils-vendor, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-gz-math-vendor";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_math_vendor-release/archive/release/rolling/gz_math_vendor/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "f6589ebb2de0ef5f60939f3ac7367c6ea1b76ff921bda7277eea7152850cca30";
+    url = "https://github.com/ros2-gbp/gz_math_vendor-release/archive/release/rolling/gz_math_vendor/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "7e531185225ffc28be4680458c79561e53f5ebedb3dc6e13b327bf34ec249410";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-math-vendor/vendored-source.json
+++ b/distros/rolling/gz-math-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_math_vendor": {
     "url": "https://github.com/gazebosim/gz-math.git",
-    "rev": "gz-math9_9.0.0-pre2",
-    "hash": "sha256-cfo+t6GsktuLBA4vNRJg1VNqVgmT71nkqJIMsgUxu2I="
+    "rev": "gz-math9_9.0.0",
+    "hash": "sha256-5SGZtciJF+k0wjjU+O3I8CxAVnI8XpLLOuv4hsagb/4="
   }
 }

--- a/distros/rolling/gz-msgs-vendor/default.nix
+++ b/distros/rolling/gz-msgs-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, gz-math-vendor, gz-tools-vendor, protobuf, python3, python3Packages, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-rolling-gz-msgs-vendor";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_msgs_vendor-release/archive/release/rolling/gz_msgs_vendor/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "3df0e75a257a6011b598a92de5e14e9092bb72c09fe629486c1d8db8d9da98b5";
+    url = "https://github.com/ros2-gbp/gz_msgs_vendor-release/archive/release/rolling/gz_msgs_vendor/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "be769243acc26280d42ac5e1e6fac4dc78b6dad381016f7bd1d1a8b88414ef6a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-msgs-vendor/vendored-source.json
+++ b/distros/rolling/gz-msgs-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_msgs_vendor": {
     "url": "https://github.com/gazebosim/gz-msgs.git",
-    "rev": "gz-msgs12_12.0.0-pre2",
-    "hash": "sha256-yaPG8hzntlSQ/G8Wf0AOtq2F7ZqvdMQkFHlwTkTRTjY="
+    "rev": "gz-msgs12_12.0.0",
+    "hash": "sha256-RGF7yNwiUmfzrHcmrhyir4s0vBOfRpKbjEhLKrHecOk="
   }
 }

--- a/distros/rolling/gz-physics-vendor/default.nix
+++ b/distros/rolling/gz-physics-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, bullet, cmake, eigen, gbenchmark, gz-cmake-vendor, gz-common-vendor, gz-dartsim-vendor, gz-math-vendor, gz-plugin-vendor, gz-utils-vendor, sdformat-vendor }:
 buildRosPackage {
   pname = "ros-rolling-gz-physics-vendor";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_physics_vendor-release/archive/release/rolling/gz_physics_vendor/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "5694fd31a4351def384819c285e803bda736bb4f8c95609a9fb4b5f7dd91ff93";
+    url = "https://github.com/ros2-gbp/gz_physics_vendor-release/archive/release/rolling/gz_physics_vendor/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "9db9403c12a4d66e667bba2a1817e10b2c09a644bc93422976a3bc941cf5bc5a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-physics-vendor/vendored-source.json
+++ b/distros/rolling/gz-physics-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_physics_vendor": {
     "url": "https://github.com/gazebosim/gz-physics.git",
-    "rev": "gz-physics9_9.0.0-pre2",
-    "hash": "sha256-jwlMVK5Rkgfbv6MmruKAuckCegEpCyuCK4FgNmyfANs="
+    "rev": "gz-physics9_9.0.0",
+    "hash": "sha256-mW1PQAcHxNVXtBmjuwMhT1W8G+Mx2Hsc+1KmIDbzRqk="
   }
 }

--- a/distros/rolling/gz-plugin-vendor/default.nix
+++ b/distros/rolling/gz-plugin-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, gz-tools-vendor, gz-utils-vendor }:
 buildRosPackage {
   pname = "ros-rolling-gz-plugin-vendor";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_plugin_vendor-release/archive/release/rolling/gz_plugin_vendor/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "67759416e6ebc4a4cb369b810698c41a7d968483ccb9984284e9a4066e3e14e6";
+    url = "https://github.com/ros2-gbp/gz_plugin_vendor-release/archive/release/rolling/gz_plugin_vendor/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "6e5752b3e5af3b635bebc804acfac36caf4f75c8dbbaa90a3e958c65c03806c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-plugin-vendor/vendored-source.json
+++ b/distros/rolling/gz-plugin-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_plugin_vendor": {
     "url": "https://github.com/gazebosim/gz-plugin.git",
-    "rev": "gz-plugin4_4.0.0-pre1",
-    "hash": "sha256-/T0Gav0b9BG39qm8v8J7qnpYdLSwsRZVar4i5zUyF5M="
+    "rev": "gz-plugin4_4.0.0",
+    "hash": "sha256-cHpRXLKm3BHJJibL5VdLMHyRYAD3gLP7ageyFY13tZE="
   }
 }

--- a/distros/rolling/gz-rendering-vendor/default.nix
+++ b/distros/rolling/gz-rendering-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, freeglut, freeimage, glew, gz-cmake-vendor, gz-common-vendor, gz-math-vendor, gz-ogre-next-vendor, gz-plugin-vendor, gz-utils-vendor, ogre1_9, util-linux, vulkan-loader, xorg }:
 buildRosPackage {
   pname = "ros-rolling-gz-rendering-vendor";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_rendering_vendor-release/archive/release/rolling/gz_rendering_vendor/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "63f4ec4c4045421f5d6e91d1a1d8ce7d8037178e3fd0e2748f5aae9c630952d6";
+    url = "https://github.com/ros2-gbp/gz_rendering_vendor-release/archive/release/rolling/gz_rendering_vendor/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "9c9771846a7af0804599141571c0c9e842f012720eb8df20d6a1544ce2dbf86f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-rendering-vendor/vendored-source.json
+++ b/distros/rolling/gz-rendering-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_rendering_vendor": {
     "url": "https://github.com/gazebosim/gz-rendering.git",
-    "rev": "gz-rendering10_10.0.0-pre2",
-    "hash": "sha256-DBqamhfkQHiCkLPs6I9jwunLebRkVeK1QcQ6LouoCzg="
+    "rev": "gz-rendering10_10.0.0",
+    "hash": "sha256-Y6kGr4GmDDiQsoO/C2adhWdYhhvuEil+WXKdq3hPqfo="
   }
 }

--- a/distros/rolling/gz-ros2-control-demos/default.nix
+++ b/distros/rolling/gz-ros2-control-demos/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, geometry-msgs, gz-ros2-control, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, mecanum-drive-controller, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2-control-cmake, ros2controlcli, ros2launch, std-msgs, tricycle-steering-controller, velocity-controllers, xacro }:
+{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, geometry-msgs, gz-ros2-control, gz-sim-vendor, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, mecanum-drive-controller, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2-control-cmake, ros2controlcli, ros2launch, std-msgs, tricycle-steering-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-rolling-gz-ros2-control-demos";
-  version = "3.0.3-r1";
+  version = "3.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/rolling/gz_ros2_control_demos/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "141bdb0134c57c2e420680b7ea3adbba5dd0abc6908974ed21c80cbae9ba776c";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/rolling/gz_ros2_control_demos/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "4540c8098954ca7c9e625cb97cece19cd419d1ffcf3e3a30714183f08cb9e7a9";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake rclcpp-action ];
+  buildInputs = [ ament-cmake pluginlib rclcpp-action ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ackermann-steering-controller ament-index-python control-msgs diff-drive-controller effort-controllers force-torque-sensor-broadcaster geometry-msgs gz-ros2-control hardware-interface imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller launch launch-ros mecanum-drive-controller rclcpp robot-state-publisher ros-gz-bridge ros-gz-sim ros2-control-cmake ros2controlcli ros2launch std-msgs tricycle-steering-controller velocity-controllers xacro ];
+  propagatedBuildInputs = [ ackermann-steering-controller ament-index-python control-msgs control-toolbox diff-drive-controller effort-controllers force-torque-sensor-broadcaster geometry-msgs gz-ros2-control gz-sim-vendor hardware-interface imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller launch launch-ros mecanum-drive-controller rclcpp rclcpp-lifecycle robot-state-publisher ros-gz-bridge ros-gz-sim ros2-control-cmake ros2controlcli ros2launch std-msgs tricycle-steering-controller velocity-controllers xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/gz-ros2-control/default.nix
+++ b/distros/rolling/gz-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-manager, gz-plugin-vendor, gz-sim-vendor, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-gz-ros2-control";
-  version = "3.0.3-r1";
+  version = "3.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/rolling/gz_ros2_control/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "411f4df93c6a0c3ebad38f12660531739bb1484f9dc51100ed2f5b9093843214";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/rolling/gz_ros2_control/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "75c02ac20de171d23fce2557dd9db773986701b345d93e74102af6996be0ef00";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-sensors-vendor/default.nix
+++ b/distros/rolling/gz-sensors-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, gz-common-vendor, gz-math-vendor, gz-msgs-vendor, gz-rendering-vendor, gz-tools-vendor, gz-transport-vendor, sdformat-vendor, xorg }:
 buildRosPackage {
   pname = "ros-rolling-gz-sensors-vendor";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_sensors_vendor-release/archive/release/rolling/gz_sensors_vendor/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "ebceacd777255c0a548be4e320dd61e52eaf2e9c6e06d659007203e5a6354085";
+    url = "https://github.com/ros2-gbp/gz_sensors_vendor-release/archive/release/rolling/gz_sensors_vendor/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "0cef788eb52992e06edffeaff68649f00a87651130e79efb3ff0677b5bb8f2e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-sensors-vendor/vendored-source.json
+++ b/distros/rolling/gz-sensors-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_sensors_vendor": {
     "url": "https://github.com/gazebosim/gz-sensors.git",
-    "rev": "gz-sensors10_10.0.0-pre1",
-    "hash": "sha256-xPpi0FQ0BaJU7MC+mx1KqVwp5cvdB1fEn+nKdoqJERE="
+    "rev": "gz-sensors10_10.0.0",
+    "hash": "sha256-UYI7Hw2W2W3+2c/NcNS+yxhli+5ERCqY6n2tSsPFbkE="
   }
 }

--- a/distros/rolling/gz-transport-vendor/default.nix
+++ b/distros/rolling/gz-transport-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, cppzmq, gz-cmake-vendor, gz-math-vendor, gz-msgs-vendor, gz-tools-vendor, gz-utils-vendor, pkg-config, protobuf, python3, python3Packages, sqlite, util-linux, zenoh-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-gz-transport-vendor";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_transport_vendor-release/archive/release/rolling/gz_transport_vendor/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "c1b027a1bae62291f0ce97f6160ba3610229aaf7d446705c5d1cef10f3313356";
+    url = "https://github.com/ros2-gbp/gz_transport_vendor-release/archive/release/rolling/gz_transport_vendor/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "54b2af3a39d289f77401f7a90e76a9599f118381a71344c2827dc46ef47c90f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-transport-vendor/vendored-source.json
+++ b/distros/rolling/gz-transport-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_transport_vendor": {
     "url": "https://github.com/gazebosim/gz-transport.git",
-    "rev": "gz-transport15_15.0.0-pre2",
-    "hash": "sha256-WgvuEeiFReqbB4L2T2CMI6SdJ2X8UlBiNIu+ZlY/IYU="
+    "rev": "gz-transport15_15.0.0",
+    "hash": "sha256-ruXgDCzQKwjUvLqqr4zSuV7Bv+gV+p4WY2UyONwoi4U="
   }
 }

--- a/distros/rolling/gz-utils-vendor/default.nix
+++ b/distros/rolling/gz-utils-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cli11, cmake, gz-cmake-vendor, spdlog-vendor }:
 buildRosPackage {
   pname = "ros-rolling-gz-utils-vendor";
-  version = "0.4.0-r2";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_utils_vendor-release/archive/release/rolling/gz_utils_vendor/0.4.0-2.tar.gz";
-    name = "0.4.0-2.tar.gz";
-    sha256 = "40b9cc6699e0bcc2b3893c9bf03c6d2709f8e43f89c2658a63002fb9230f11ae";
+    url = "https://github.com/ros2-gbp/gz_utils_vendor-release/archive/release/rolling/gz_utils_vendor/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "3c3132a79e71acc35a6f4b1fb4782f186b8b1b9741b8e6ee9930e8d8a26d2be1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-utils-vendor/vendored-source.json
+++ b/distros/rolling/gz-utils-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_utils_vendor": {
     "url": "https://github.com/gazebosim/gz-utils.git",
-    "rev": "gz-utils4_4.0.0-pre1",
-    "hash": "sha256-UZh4d+WngOWFJepHGD3JLWtf1hz8yWJ5EaQ/1iXlZc0="
+    "rev": "gz-utils4_4.0.0",
+    "hash": "sha256-fZonC/o5CNHdK/R3IgEoo1llehy36MwvXPQCgFnP8Ls="
   }
 }

--- a/distros/rolling/hebi-cpp-api/default.nix
+++ b/distros/rolling/hebi-cpp-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen }:
 buildRosPackage {
   pname = "ros-rolling-hebi-cpp-api";
-  version = "3.13.0-r1";
+  version = "3.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hebi_cpp_api-release/archive/release/rolling/hebi_cpp_api/3.13.0-1.tar.gz";
-    name = "3.13.0-1.tar.gz";
-    sha256 = "52f79ae0fc1ab05cd0cf6ef44004e1416cead7a49147e54cf1869211f6afb855";
+    url = "https://github.com/ros2-gbp/hebi_cpp_api-release/archive/release/rolling/hebi_cpp_api/3.15.0-1.tar.gz";
+    name = "3.15.0-1.tar.gz";
+    sha256 = "7c81f06f58569f3ae7c38b3b6952f73257e3b7235f8c49788f723d5a9564f41c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/imu-sensor-broadcaster/default.nix
+++ b/distros/rolling/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, eigen, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-imu-sensor-broadcaster";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "0e65611385b9de23d77ced3298e06daaad76c3230a45d3b8488e4b652ea27cab";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "846bb59ab3de368de6bf03a3a4e40b0812c77201a3e18efdb81be79c0f46432c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-state-broadcaster/default.nix
+++ b/distros/rolling/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-state-broadcaster";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "091ffc881586936dc7f5296a97c68f179671ae2bcfcf5a0f3ac3a134861b171e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "3e871e19ec54840f6a888485500d8d1d73fd2ac625c109267b53f81cd4521fa8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-state-topic-hardware-interface/default.nix
+++ b/distros/rolling/joint-state-topic-hardware-interface/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, angles, controller-manager, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, launch-testing, rclcpp, rclpy, robot-state-publisher, ros-testing, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, controller-manager, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, launch-testing, rclcpp, rclpy, robot-state-publisher, ros-testing, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-rolling-joint-state-topic-hardware-interface";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_based_hardware-release/archive/release/rolling/joint_state_topic_hardware_interface/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "f57cc7bad09bd88c59e22746fcb3284b6ef8555871f22230ad0e0406815e585e";
+    url = "https://github.com/ros2-gbp/topic_based_hardware-release/archive/release/rolling/joint_state_topic_hardware_interface/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "02359e29a5fad7fc1be406fd879a3798655bbbed6687e710d230a07ffd3f4051";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros2-control-cmake ];
-  checkInputs = [ controller-manager joint-state-broadcaster joint-trajectory-controller launch launch-ros launch-testing rclpy robot-state-publisher ros-testing ros2-control-test-assets xacro ];
+  checkInputs = [ ament-cmake-gmock controller-manager joint-state-broadcaster joint-trajectory-controller launch launch-ros launch-testing rclpy robot-state-publisher ros-testing ros2-control-test-assets xacro ];
   propagatedBuildInputs = [ angles hardware-interface rclcpp sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/joint-trajectory-controller/default.nix
+++ b/distros/rolling/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-trajectory-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "bc1008a86a52d045700835f020852cf000c69692202aa15b2574ac4884145170";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "a46732b1880278dc85a88fb91692d459992d80aac5cf8220f53481abe93f57fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/kinematics-interface-kdl/default.nix
+++ b/distros/rolling/kinematics-interface-kdl/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, eigen, eigen3-cmake-module, kdl-parser, kinematics-interface, pluginlib, ros2-control-cmake, ros2-control-test-assets, tf2-eigen-kdl }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, eigen, eigen3-cmake-module, kdl-parser, kinematics-interface, pluginlib, ros2-control-cmake, ros2-control-test-assets, tf2-eigen-kdl }:
 buildRosPackage {
   pname = "ros-rolling-kinematics-interface-kdl";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/rolling/kinematics_interface_kdl/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "c318debe323c095e640954e8c275e0b8f5de05cfd3446118959958ae82e5b64f";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/rolling/kinematics_interface_kdl/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "67227bc7b73cc67fb25364240c40bc374165c85ea3c2d815983a0dc3e3b7824c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake eigen3-cmake-module ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock ros2-control-test-assets ];
-  propagatedBuildInputs = [ eigen kdl-parser kinematics-interface pluginlib tf2-eigen-kdl ];
+  propagatedBuildInputs = [ backward-ros eigen kdl-parser kinematics-interface pluginlib tf2-eigen-kdl ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 
   meta = {

--- a/distros/rolling/kinematics-interface/default.nix
+++ b/distros/rolling/kinematics-interface/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, eigen, rclcpp-lifecycle, ros2-control-cmake }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, backward-ros, eigen, rclcpp-lifecycle, ros2-control-cmake }:
 buildRosPackage {
   pname = "ros-rolling-kinematics-interface";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/rolling/kinematics_interface/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "103f10238cf106c0f5e38ec0c80f655c35e1d601b7a72a54e9396dddac7bf9db";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/rolling/kinematics_interface/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "06e896b0ed02ef2ee503c06f74ced9aadd78f51c584756970aa24efc97236bcd";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros2-control-cmake ];
-  propagatedBuildInputs = [ eigen rclcpp-lifecycle ];
+  propagatedBuildInputs = [ backward-ros eigen rclcpp-lifecycle ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/mecanum-drive-controller/default.nix
+++ b/distros/rolling/mecanum-drive-controller/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mecanum-drive-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/mecanum_drive_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "eb6ed344643c2b5ac450642122cbf8f905f3c05f28e62e031f8e6ed8a94c5d23";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/mecanum_drive_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "ffc81eecf718e329e0ffde381727d9cde8007fbf268719a18788d58100c32eb7";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake generate-parameter-library ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
-  propagatedBuildInputs = [ control-msgs controller-interface geometry-msgs hardware-interface nav-msgs pluginlib rclcpp rclcpp-lifecycle rcpputils realtime-tools std-srvs tf2 tf2-geometry-msgs tf2-msgs ];
+  propagatedBuildInputs = [ backward-ros control-msgs controller-interface geometry-msgs hardware-interface nav-msgs pluginlib rclcpp rclcpp-lifecycle rcpputils realtime-tools std-srvs tf2 tf2-geometry-msgs tf2-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/mola-imu-preintegration/default.nix
+++ b/distros/rolling/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-imu-preintegration";
-  version = "1.10.0-r1";
+  version = "1.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_imu_preintegration/1.10.0-1.tar.gz";
-    name = "1.10.0-1.tar.gz";
-    sha256 = "2a428c71f70a2712691eb040c197ad92f7ea43c0541001c88aca444bc6e20e67";
+    url = "https://github.com/ros2-gbp/mola_imu_preintegration-release/archive/release/rolling/mola_imu_preintegration/1.11.0-1.tar.gz";
+    name = "1.11.0-1.tar.gz";
+    sha256 = "36e0660bb25ddfc6c01841c4f0547dc1fe72c0a7c96c4cb458b0159530dd0238";
   };
 
   buildType = "cmake";

--- a/distros/rolling/motion-primitives-controllers/default.nix
+++ b/distros/rolling/motion-primitives-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-motion-primitives-controllers";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/motion_primitives_controllers/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "6edbc234b433ee9d4a69e06f81f9f9b0b6afee19eae9863bd24bd962ca43df17";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/motion_primitives_controllers/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "56d7ca83476a020836aee05e4881301738e1e86a52f7d55a7a79fe63e7dc9ab2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mrpt-apps/default.nix
+++ b/distros/rolling/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, openni2, pkg-config, python3Packages, ros-environment, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-apps";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_apps/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "229003a2ff97ca8da6eb03356001ebe89bcf024802a629dad2a97866c529b5de";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_apps/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "d6e596a227e0213f66f5e9d8b69f5d867c172839920ff0e3cf43df7a3d7b918d";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libapps/default.nix
+++ b/distros/rolling/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libapps";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libapps/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "cbe2215f86804a7b610de5566b3647a10d993312e1c5323b66c037f89fc175a9";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libapps/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "2b6bc9e05e1df3f75935dc31a22b3477a2387225dd99c0e3a532e6c60fb8e199";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libbase/default.nix
+++ b/distros/rolling/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libbase";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libbase/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "9d9506b7e92509ec494476841617e5f5d3cd46fb2bdd73e58cf0100deec4a8d6";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libbase/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "f360596dadf2873bce83e02635b9f3cabdaf84b6e721381f164b5f4ff12263ff";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libgui/default.nix
+++ b/distros/rolling/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libgui";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libgui/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "89e9cf7b4f428695f49643774d324022b0630dde3039ff1cc5630adf856845c3";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libgui/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "645069f0362a9b037059df081f1a9d47dd3ea71443f8f0d4c887d531ac3635ff";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libhwdrivers/default.nix
+++ b/distros/rolling/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libhwdrivers";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libhwdrivers/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "227295284e6715311c04ce01204e072abf98185310ec0cbbe17b2f2542174311";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libhwdrivers/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "b38b1f47ce32c831c5fb79f5cce34cc12d7fd85c1c3182e8e2caaa8fb4b4a61c";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libmaps/default.nix
+++ b/distros/rolling/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libmaps";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmaps/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "9e118c7ed6eb6f1a4eb883f08f04ce49fe8fda24d63a2ac91505b86773c174c5";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmaps/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "2eb049c2d5dba8ea520da0fddf906617926c0a020ec84d1c5d6e348383864265";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libmath/default.nix
+++ b/distros/rolling/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libmath";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmath/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "bfe5a75f604134b9a2ebbcc6bdbd690d6de2258394882c85f1f7a470c73fb49c";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmath/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "ceb98e5b705aea56b9168479688cc1851af93477b7842897f53fb7d73f24e234";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libnav/default.nix
+++ b/distros/rolling/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libnav";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libnav/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "88e6f265aa41da3f3b9eb803d5092929438e0aeec24a92bd7ca33b0a68fabfaa";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libnav/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "8b58655e46aac4dbe7864378a6f0120f02daa52acb551a6f175805eacb440d2e";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libobs/default.nix
+++ b/distros/rolling/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libobs";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libobs/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "220be77885aa9d84538e23d1ffc9bb907c50bde94abf9c7b60c8741708a9bbc6";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libobs/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "c7a98b00044c2d1e31bbc4358deb498db229363efddf5e7045a076a7e14b24e1";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libopengl/default.nix
+++ b/distros/rolling/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libopengl";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libopengl/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "3906aec74f3e92b0766f988198a38375e8fd1d8e9596be6513b586170ba7882e";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libopengl/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "ea825f47d056e5c83b17183e6c17e4d2d16e16472c360cbd98da732b73ccb570";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libposes/default.nix
+++ b/distros/rolling/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libposes";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libposes/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "f7540854918f7cf520c15fae76d87ea8009e7580f0d86d8f64500c7e979a9f87";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libposes/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "9c7374fc2beb7d578be48a04c5fff116c5e6524c3d4b33f27346b82402b3a746";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libros-bridge/default.nix
+++ b/distros/rolling/mrpt-libros-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, tf2, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libros-bridge";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libros_bridge/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "70d817e4b1e676176cee43e9e7cab9100ce5f1ea592f6b0d20412469a68e07b9";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libros_bridge/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "472aeddea1573d756f1b59c4e58f0b0777d57ae0f1aaca6a36e7671b80fb68e5";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libslam/default.nix
+++ b/distros/rolling/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libslam";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libslam/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "7e778cd166c7500fac465f19c0ebcf1586bd2cbe7bf6b22204aaa98b0663b333";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libslam/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "ada733430ea3129ac8d3df32a9170cad8fd3dd033c31974bb628c9bf7b956102";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libtclap/default.nix
+++ b/distros/rolling/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libtclap";
-  version = "2.14.12-r1";
+  version = "2.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libtclap/2.14.12-1.tar.gz";
-    name = "2.14.12-1.tar.gz";
-    sha256 = "13b3efd51a7aaef6312e19fe9e101475b9c1252a6c3b044ce8dc9ff0191d13f3";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libtclap/2.14.15-1.tar.gz";
+    name = "2.14.15-1.tar.gz";
+    sha256 = "20e3575bbf9f2d14bc50618debd1101a25bb76c288bf864af0d2b847d73e07fd";
   };
 
   buildType = "cmake";

--- a/distros/rolling/nav-msgs/default.nix
+++ b/distros/rolling/nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-nav-msgs";
-  version = "5.8.2-r1";
+  version = "5.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/nav_msgs/5.8.2-1.tar.gz";
-    name = "5.8.2-1.tar.gz";
-    sha256 = "08c05b835c39a2a758c495b8a98da395a8b6a7ffe8cac8366c2db0e89e7668a1";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/nav_msgs/5.9.0-1.tar.gz";
+    name = "5.9.0-1.tar.gz";
+    sha256 = "dc966f286e39118c73a6afd27157883e861ed7d074814169d27b8f4ab0676732";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/omni-wheel-drive-controller/default.nix
+++ b/distros/rolling/omni-wheel-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, eigen, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-omni-wheel-drive-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/omni_wheel_drive_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "a021ec2d251e1fcda6d45824e16301d4d8ebe69f0ffbafa59851b53b7b263ba1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/omni_wheel_drive_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "ca25ea90fcecb4638beb4ac6c556cf6478ae8810b51a75abe6773c80559f7d03";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/parallel-gripper-controller/default.nix
+++ b/distros/rolling/parallel-gripper-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-parallel-gripper-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/parallel_gripper_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "d4f2309b7a126ff49c06e17848a618712f039a5b82f14a835edbd59d37d80304";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/parallel_gripper_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "2405399b568f4a50bcaa044a90ec7be99acb9c41bf7378701aacc855feb1ee0e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pid-controller/default.nix
+++ b/distros/rolling/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-pid-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pid_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "6885dec552855145303810a62e9b0f11b2ef15d67ba637d4b01fac42dd9101cc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pid_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "e9bbd387b31cba017445585ad272b6d548ca96701824b642de6db82f48098074";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/plotjuggler/default.nix
+++ b/distros/rolling/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, data-tamer-cpp, fmt, lua, lz4, nlohmann_json, protobuf, qt5, rclcpp, zstd }:
 buildRosPackage {
   pname = "ros-rolling-plotjuggler";
-  version = "3.12.0-r1";
+  version = "3.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/rolling/plotjuggler/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "b5e027d7d33e55dcc4540e957787ab289ec6b1aba2a8b106da55461312788273";
+    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/rolling/plotjuggler/3.13.1-1.tar.gz";
+    name = "3.13.1-1.tar.gz";
+    sha256 = "50d32e5eef22ec344056a6d2f1277c423d36ab1fa930f6bc100946c99574949a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pose-broadcaster/default.nix
+++ b/distros/rolling/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-pose-broadcaster";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pose_broadcaster/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "ed05741b797c0dce24d26aca804ecd422774a924286ba1cba98d7110f23acbff";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pose_broadcaster/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "8eba2e0941afd7dfe861457670f8ed30fc70176bf76e5bd0b29ba0bbca277daa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/position-controllers/default.nix
+++ b/distros/rolling/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-position-controllers";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "7f05a82f6b6847a5f77af987a4e54f39e351b0c6260103964159db0a6fba8b09";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "92a37db428c2d8e4c873fc12140a7fe1943bfdac87507ecca0bd84d0e268e005";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/range-sensor-broadcaster/default.nix
+++ b/distros/rolling/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-range-sensor-broadcaster";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "38d62208df5dbb19506936765ec998f9cc3c39df2873eafb1d379b53ae44d2e4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "05b0d586b97e505f1381fedec95d1e262c552e8e4db35b810829e4bfc5e7c8c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-action/default.nix
+++ b/distros/rolling/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rcl-action";
-  version = "10.2.3-r1";
+  version = "10.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/10.2.3-1.tar.gz";
-    name = "10.2.3-1.tar.gz";
-    sha256 = "8108f451d4fe95a4f301a0e81f09268e07cafce27ace741a2f3884d738d77151";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/10.2.4-1.tar.gz";
+    name = "10.2.4-1.tar.gz";
+    sha256 = "5a5f1923fbf8c176c983be6b8198ed2f2bb7b3e2b9279123438f34a0cde5dd94";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-lifecycle/default.nix
+++ b/distros/rolling/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rcl-lifecycle";
-  version = "10.2.3-r1";
+  version = "10.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/10.2.3-1.tar.gz";
-    name = "10.2.3-1.tar.gz";
-    sha256 = "d91696f415f5b6f4b0d486d162a88d1f81fa238b2e4ead97cfef073843e078d5";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/10.2.4-1.tar.gz";
+    name = "10.2.4-1.tar.gz";
+    sha256 = "33838397310c7346a5638bb512fae688c616f0774457d7cf932fba9a222594e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-yaml-param-parser/default.nix
+++ b/distros/rolling/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-rolling-rcl-yaml-param-parser";
-  version = "10.2.3-r1";
+  version = "10.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/10.2.3-1.tar.gz";
-    name = "10.2.3-1.tar.gz";
-    sha256 = "4a4f7097ac95d6e77694194163167c797f9d4e790125ddb88f49dff133b13395";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/10.2.4-1.tar.gz";
+    name = "10.2.4-1.tar.gz";
+    sha256 = "aac5ba099b2cc867d3e4975ada47af172899d14e4b19589278163fb3e13afc92";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl/default.nix
+++ b/distros/rolling/rcl/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, rosidl-runtime-cpp, service-msgs, test-msgs, tracetools, type-description-interfaces }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, rosidl-runtime-cpp, service-msgs, test-msgs, tracetools, type-description-interfaces }:
 buildRosPackage {
   pname = "ros-rolling-rcl";
-  version = "10.2.3-r1";
+  version = "10.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/10.2.3-1.tar.gz";
-    name = "10.2.3-1.tar.gz";
-    sha256 = "7f9bb4977834c3d82d46cae68bf07a6c6f1511196e638ca9081e3a0e90305c5c";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/10.2.4-1.tar.gz";
+    name = "10.2.4-1.tar.gz";
+    sha256 = "5b450208123d155da5b959f837228322304d1a9f191d336d4e6f2a89f3f7f2c4";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common launch launch-testing launch-testing-ament-cmake mimick-vendor osrf-testing-tools-cpp rmw rmw-implementation-cmake rosidl-runtime-cpp test-msgs ];
+  checkInputs = [ ament-lint-auto ament-lint-common launch launch-testing launch-testing-ament-cmake mimick-vendor osrf-testing-tools-cpp rmw rmw-implementation-cmake rosidl-runtime-cpp test-msgs ];
   propagatedBuildInputs = [ libyaml libyaml-vendor rcl-interfaces rcl-logging-interface rcl-logging-spdlog rcl-yaml-param-parser rcutils rmw rmw-implementation rosidl-runtime-c service-msgs tracetools type-description-interfaces ];
   nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
 

--- a/distros/rolling/rko-lio/default.nix
+++ b/distros/rolling/rko-lio/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, eigen, geometry-msgs, nav-msgs, nlohmann_json, rclcpp, rclcpp-components, rosbag2-cpp, rosbag2-storage, sensor-msgs, sophus, std-msgs, tbb_2021_11, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-rolling-rko-lio";
+  version = "0.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rko_lio-release/archive/release/rolling/rko_lio/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "f2ad2d380a26c3079ad663ee7cc1262f74c58560aaa868e9cd565dd2b35dc061";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ eigen geometry-msgs nav-msgs nlohmann_json rclcpp rclcpp-components rosbag2-cpp rosbag2-storage sensor-msgs sophus std-msgs tbb_2021_11 tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A Robust Approach for LiDAR-Inertial Odometry Without Sensor-Specific Modelling";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/ros-gz-bridge/default.nix
+++ b/distros/rolling/ros-gz-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actuator-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, gps-msgs, gz-msgs-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, nav-msgs, pkg-config, rclcpp, rclcpp-components, ros-gz-interfaces, rosgraph-msgs, rosidl-pycommon, sensor-msgs, std-msgs, tf2-msgs, trajectory-msgs, vision-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-bridge";
-  version = "3.0.3-r1";
+  version = "3.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_bridge/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "874098d16db878fd3ad7106b722d28194f86267be78dc0d739e498064048fa93";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_bridge/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "0997936300cd12c09d20c4fdc4711434b50b20b711849d53e5d9a29ce6f0eb8a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-image/default.nix
+++ b/distros/rolling/ros-gz-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-msgs-vendor, gz-transport-vendor, image-transport, pkg-config, rclcpp, ros-gz-bridge, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-image";
-  version = "3.0.3-r1";
+  version = "3.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_image/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "f08ebb0648072020c46d9969b22c0a9e3c09ccdd7aca02be3b1bf60cdcbe20df";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_image/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "f01144332375db268a871dbe2867607bcf97d6ca5ef4e9c3fda0fd2f53f574d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-interfaces/default.nix
+++ b/distros/rolling/ros-gz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-interfaces";
-  version = "3.0.3-r1";
+  version = "3.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_interfaces/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "e1026da655fb8bb852fb075d6a831269021f3911071401b982271ed7d59ad09b";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_interfaces/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "65a1f922854e445613d80ab3e4dfff8f33296b62af1ff769b40727bab9234961";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-sim-demos/default.nix
+++ b/distros/rolling/ros-gz-sim-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-sim-vendor, image-transport-plugins, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, rqt-image-view, rqt-plot, rqt-topic, rviz-imu-plugin, rviz2, sdformat-urdf, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-sim-demos";
-  version = "3.0.3-r1";
+  version = "3.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim_demos/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "3bc43b14694c86a359d96f2ac58db2f09b789ba6656c6f36dda58ecb9587cb4c";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim_demos/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "75f7312df6a0be41fb090753ddccff786c14721d380ac1826bf8408e9f160222";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-sim/default.nix
+++ b/distros/rolling/ros-gz-sim/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, cli11, geometry-msgs, gflags, gz-math-vendor, gz-msgs-vendor, gz-sim-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, pkg-config, rclcpp, rclcpp-components, rcpputils, ros-gz-interfaces, std-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, cli11, geometry-msgs, gflags, gz-math-vendor, gz-msgs-vendor, gz-sim-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, pkg-config, rclcpp, rclcpp-action, rclcpp-components, rcpputils, ros-gz-bridge, ros-gz-interfaces, simulation-interfaces, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-sim";
-  version = "3.0.3-r1";
+  version = "3.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "8deea4fdbfb53de94ecbaa440d70b7d4f526ca8c15943c1c4cbfaf0da74ba680";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "eb4a7db6db191af0724a53615df7769928e63910e52d25e0b4f16fb80440b95d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python pkg-config ];
-  checkInputs = [ ament-lint-auto ament-lint-common launch-ros launch-testing launch-testing-ament-cmake ];
-  propagatedBuildInputs = [ ament-index-python builtin-interfaces cli11 geometry-msgs gflags gz-math-vendor gz-msgs-vendor gz-sim-vendor gz-transport-vendor launch launch-ros rclcpp rclcpp-components rcpputils ros-gz-interfaces std-msgs tf2 tf2-ros ];
+  checkInputs = [ ament-lint-auto ament-lint-common launch-ros launch-testing launch-testing-ament-cmake ros-gz-bridge ];
+  propagatedBuildInputs = [ ament-index-python builtin-interfaces cli11 geometry-msgs gflags gz-math-vendor gz-msgs-vendor gz-sim-vendor gz-transport-vendor launch launch-ros rclcpp rclcpp-action rclcpp-components rcpputils ros-gz-interfaces simulation-interfaces std-msgs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python pkg-config ];
 
   meta = {

--- a/distros/rolling/ros-gz/default.nix
+++ b/distros/rolling/ros-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz-bridge, ros-gz-image, ros-gz-sim, ros-gz-sim-demos }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz";
-  version = "3.0.3-r1";
+  version = "3.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "945cd388d20bdb5b625fa1cdf67cc947ef999f0855e57c93cde0ae741b86b82c";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "4af6be30baf196727be014da19f1d992ff33a4555d7c2c8710651ad1081d58c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control-cmake/default.nix
+++ b/distros/rolling/ros2-control-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control-cmake";
-  version = "0.2.1-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control_cmake-release/archive/release/rolling/ros2_control_cmake/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "56da8bb26897254ba434e7de0be40296d247b6743500efb3724aa49a9211a436";
+    url = "https://github.com/ros2-gbp/ros2_control_cmake-release/archive/release/rolling/ros2_control_cmake/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "4e985cd4e112aac3dc6098c7bc75b8d32231702f9876a0196e74b4d29cbd5444";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-controllers-test-nodes/default.nix
+++ b/distros/rolling/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers-test-nodes";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "c0fcfaf020a0dd033095bce7565893aed44bfe674b9e3c540559f60d1983ee81";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "7cb60b7930973b9876db3913b4a41e9ac360fa9ba8d9867000e85572400e19ee";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2-controllers/default.nix
+++ b/distros/rolling/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, chained-filter-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gps-sensor-broadcaster, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, motion-primitives-controllers, omni-wheel-drive-controller, parallel-gripper-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "5e5060bb00ac23b688d267d32554432a6aca918846beb579c8b03b4ce0bbb8f3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "6ca6817ccd6d246d45a6dfb5c461d44fae8219c93e08380d7381bd375e0c111e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-fastrtps-c/default.nix
+++ b/distros/rolling/rosidl-typesupport-fastrtps-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros-core, ament-index-python, ament-lint-auto, ament-lint-common, fastcdr, osrf-testing-tools-cpp, performance-test-fixture, python3, rcutils, rmw, rosidl-cli, rosidl-generator-c, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-fastrtps-c";
-  version = "3.9.1-r1";
+  version = "3.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/rosidl_typesupport_fastrtps_c/3.9.1-1.tar.gz";
-    name = "3.9.1-1.tar.gz";
-    sha256 = "ced9d7c7849f991d5046cb4e11c58ed324b948e1d0fad48a1336428642f8402f";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/rosidl_typesupport_fastrtps_c/3.9.2-1.tar.gz";
+    name = "3.9.2-1.tar.gz";
+    sha256 = "f67cbc4f07f5188a3a07bf2d2ffb3d15b2273eea394bcbc1a66d01f92c25ef1c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-fastrtps-cpp/default.nix
+++ b/distros/rolling/rosidl-typesupport-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros-core, ament-index-python, ament-lint-auto, ament-lint-common, fastcdr, osrf-testing-tools-cpp, performance-test-fixture, python3, rcutils, rmw, rosidl-cli, rosidl-generator-c, rosidl-generator-cpp, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-fastrtps-cpp";
-  version = "3.9.1-r1";
+  version = "3.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/rosidl_typesupport_fastrtps_cpp/3.9.1-1.tar.gz";
-    name = "3.9.1-1.tar.gz";
-    sha256 = "8beeb76f43e9f9775456c58bc82a5156fd29fe48eb9cd2ad5317beb21787e8bf";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/rosidl_typesupport_fastrtps_cpp/3.9.2-1.tar.gz";
+    name = "3.9.2-1.tar.gz";
+    sha256 = "1a45929ee02a926e75fe36cd6a9e31ba9e5d742b6c30ebd6ec17e9da935c0f37";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-joint-trajectory-controller/default.nix
+++ b/distros/rolling/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-joint-trajectory-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "ef8ebd1ad420e937420f58d763dc9c452bece5b28bb2ad5759de55cde880e835";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "e0a7a98034cf4bb066479fe39259358a4fe2728bc37a0913183121a5be0b66c1";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rviz-common/default.nix
+++ b/distros/rolling/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-common";
-  version = "15.1.9-r1";
+  version = "15.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/15.1.9-1.tar.gz";
-    name = "15.1.9-1.tar.gz";
-    sha256 = "04c5cba93451d01f5e9336ebf2c71181a4f1c71bbdc29f19860d2718aafc29aa";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/15.1.10-1.tar.gz";
+    name = "15.1.10-1.tar.gz";
+    sha256 = "7b98b0c372544f1724dcfcefae7fa5128705ff1d59daceb4758aaf6f2ea8d986";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-default-plugins/default.nix
+++ b/distros/rolling/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, gz-math-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-resource-interfaces, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz-default-plugins";
-  version = "15.1.9-r1";
+  version = "15.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/15.1.9-1.tar.gz";
-    name = "15.1.9-1.tar.gz";
-    sha256 = "47eade4f1b7ec7761b8f57e3da9f5a862c150f1adc4d9f6b2d13171f1f45dd78";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/15.1.10-1.tar.gz";
+    name = "15.1.10-1.tar.gz";
+    sha256 = "9f481b7d5cbec579b5cd72cc7830f3993ad35324d70e02fb69aec06646d7d438";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-ogre-vendor/default.nix
+++ b/distros/rolling/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, glew, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-rolling-rviz-ogre-vendor";
-  version = "15.1.9-r1";
+  version = "15.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/15.1.9-1.tar.gz";
-    name = "15.1.9-1.tar.gz";
-    sha256 = "7f4076255a5cd21650e5accaddbdcbf079309dffe8f85a70b821ca9fb35381a1";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/15.1.10-1.tar.gz";
+    name = "15.1.10-1.tar.gz";
+    sha256 = "d301cefcab668bf2d05f50423086bb5544b44883bca4a754cf0df0a5b06dcace";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering-tests/default.nix
+++ b/distros/rolling/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering-tests";
-  version = "15.1.9-r1";
+  version = "15.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/15.1.9-1.tar.gz";
-    name = "15.1.9-1.tar.gz";
-    sha256 = "44365463271b6711bb85031aa171c4cc71a2c496c436a4ccb5f7988b101df881";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/15.1.10-1.tar.gz";
+    name = "15.1.10-1.tar.gz";
+    sha256 = "a340b0d3a31ff72e06934e812322de968d5b768b8dd9f7102bd81322a63d9087";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering/default.nix
+++ b/distros/rolling/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, assimp, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering";
-  version = "15.1.9-r1";
+  version = "15.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/15.1.9-1.tar.gz";
-    name = "15.1.9-1.tar.gz";
-    sha256 = "79638fc233adbb0feb019ae4c5ddab64c4b3da27890e5cee185ee5f67448e9df";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/15.1.10-1.tar.gz";
+    name = "15.1.10-1.tar.gz";
+    sha256 = "c4ea9e978a4866fd574c055ce787346cf5036e49f33bd7d6d2e4790ebc1b0586";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-resource-interfaces/default.nix
+++ b/distros/rolling/rviz-resource-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rviz-resource-interfaces";
-  version = "15.1.9-r1";
+  version = "15.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_resource_interfaces/15.1.9-1.tar.gz";
-    name = "15.1.9-1.tar.gz";
-    sha256 = "de9c65a8386e0d59e2539b4d221a8c4185c18b8a1e4a27b34fc46e8dbc46cf8a";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_resource_interfaces/15.1.10-1.tar.gz";
+    name = "15.1.10-1.tar.gz";
+    sha256 = "4d7c2e22a5c2ef366c81636a540bb47048ab3b03dd68f20503ab74c370a4e02b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-visual-testing-framework/default.nix
+++ b/distros/rolling/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rviz-visual-testing-framework";
-  version = "15.1.9-r1";
+  version = "15.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/15.1.9-1.tar.gz";
-    name = "15.1.9-1.tar.gz";
-    sha256 = "895bda51ed4c61f573006abc4d35663e4595e7d871323871528d3681952238ce";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/15.1.10-1.tar.gz";
+    name = "15.1.10-1.tar.gz";
+    sha256 = "a515b49630a31dd159ca8fd5dcdfc2255cffe5efc7c9c1f7f460a8de86fbd132";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz2/default.nix
+++ b/distros/rolling/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz2";
-  version = "15.1.9-r1";
+  version = "15.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/15.1.9-1.tar.gz";
-    name = "15.1.9-1.tar.gz";
-    sha256 = "c336c69e8bd1963b357a71e75f54db916d5ce072a78d8fd19ff5d94b8c354db2";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/15.1.10-1.tar.gz";
+    name = "15.1.10-1.tar.gz";
+    sha256 = "87d36cf9757e0a65ce77be0e8d0b71e4a6d7a01231799514e4ee04c244406fb5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sensor-msgs-py/default.nix
+++ b/distros/rolling/sensor-msgs-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-sensor-msgs-py";
-  version = "5.8.2-r1";
+  version = "5.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs_py/5.8.2-1.tar.gz";
-    name = "5.8.2-1.tar.gz";
-    sha256 = "3a5afeb6cb27b3654eba0bada80dd40a9c99c8772e62f4978affa3f2584219a8";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs_py/5.9.0-1.tar.gz";
+    name = "5.9.0-1.tar.gz";
+    sha256 = "f3c92bf4d2f8776eece3b329d81d625a9c38f8ec437b3c9b66e113654d1816bf";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/sensor-msgs/default.nix
+++ b/distros/rolling/sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-sensor-msgs";
-  version = "5.8.2-r1";
+  version = "5.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs/5.8.2-1.tar.gz";
-    name = "5.8.2-1.tar.gz";
-    sha256 = "8ee52f68b55d4df408e83399d88df2ae20c0982bc34803cecd75a084eb5a5c32";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs/5.9.0-1.tar.gz";
+    name = "5.9.0-1.tar.gz";
+    sha256 = "b6cfe3148cf7b5c70a47287415f35d65eb5d36564937f78a3e0610e49c02239a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/shape-msgs/default.nix
+++ b/distros/rolling/shape-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-shape-msgs";
-  version = "5.8.2-r1";
+  version = "5.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/shape_msgs/5.8.2-1.tar.gz";
-    name = "5.8.2-1.tar.gz";
-    sha256 = "8ce0e553dc5ea521451baa1f0ab6951dc5f6fa01923f36093ecb21d37b79b72f";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/shape_msgs/5.9.0-1.tar.gz";
+    name = "5.9.0-1.tar.gz";
+    sha256 = "a83c70c85a5709cfe986cef2b9306d959de8a3f81cf8487c77920d1a05c418f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/std-msgs/default.nix
+++ b/distros/rolling/std-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-std-msgs";
-  version = "5.8.2-r1";
+  version = "5.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_msgs/5.8.2-1.tar.gz";
-    name = "5.8.2-1.tar.gz";
-    sha256 = "8527eff1ff81ba4598cb3f2b308b82afaa9c209cc21dea0d785e3f70112f76ff";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_msgs/5.9.0-1.tar.gz";
+    name = "5.9.0-1.tar.gz";
+    sha256 = "5ab52c8a59cc16a4223bd1646c8a23cd7521e384df88025d7ba50845acf9ec4d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/std-srvs/default.nix
+++ b/distros/rolling/std-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-std-srvs";
-  version = "5.8.2-r1";
+  version = "5.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_srvs/5.8.2-1.tar.gz";
-    name = "5.8.2-1.tar.gz";
-    sha256 = "96cc3cd20068eec34c52b52f2da2c9b2c90ae45b6c9b188627bead843543d462";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_srvs/5.9.0-1.tar.gz";
+    name = "5.9.0-1.tar.gz";
+    sha256 = "e5de368c79bce4767bb9d4da5436c310ceb481d1d7fefa090a94331779b27415";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/steering-controllers-library/default.nix
+++ b/distros/rolling/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-steering-controllers-library";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "f23a870071afe2d395f5f850013121bc80ae443c113b8c887bcf9152f452537f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "c5858c8311993ff17d6ec6e4f30bcd7c1cdfe6d5e7f0978c2922fbef2a9c929c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/stereo-msgs/default.nix
+++ b/distros/rolling/stereo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-stereo-msgs";
-  version = "5.8.2-r1";
+  version = "5.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/stereo_msgs/5.8.2-1.tar.gz";
-    name = "5.8.2-1.tar.gz";
-    sha256 = "a36e6545aac2d599b1c37cb76ce391c79f5761d9361441af6f549ca7148d84fd";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/stereo_msgs/5.9.0-1.tar.gz";
+    name = "5.9.0-1.tar.gz";
+    sha256 = "b9f51ac8efc55fd93ce0cf75fc08c4b736bc30265dce0280e4bb51dd09d342cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/teleop-twist-keyboard/default.nix
+++ b/distros/rolling/teleop-twist-keyboard/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, rclpy }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, python3Packages, rcl-interfaces, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-teleop-twist-keyboard";
-  version = "2.4.0-r1";
+  version = "2.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_twist_keyboard-release/archive/release/rolling/teleop_twist_keyboard/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "02d839a641a931d8428ff82970b408a5e0112f3bbe38872f91cbcc4978c3421b";
+    url = "https://github.com/ros2-gbp/teleop_twist_keyboard-release/archive/release/rolling/teleop_twist_keyboard/2.4.1-1.tar.gz";
+    name = "2.4.1-1.tar.gz";
+    sha256 = "ac85d7ec007da1bb149b9e751afc0356e47fda79e0f021b89cbbd4d659fe671b";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ];
-  propagatedBuildInputs = [ geometry-msgs rclpy ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest ];
+  propagatedBuildInputs = [ geometry-msgs rcl-interfaces rclpy ];
 
   meta = {
     description = "A robot-agnostic teleoperation node to convert keyboard commands to Twist

--- a/distros/rolling/trajectory-msgs/default.nix
+++ b/distros/rolling/trajectory-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-trajectory-msgs";
-  version = "5.8.2-r1";
+  version = "5.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/trajectory_msgs/5.8.2-1.tar.gz";
-    name = "5.8.2-1.tar.gz";
-    sha256 = "5c397f47e0d085ed95e72f8a64a986d9afa94f5bde143ce3d7408cc9f437929a";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/trajectory_msgs/5.9.0-1.tar.gz";
+    name = "5.9.0-1.tar.gz";
+    sha256 = "5847e8d7f37ba35c30e3989656b3ae6a97c4bac855a70353d9dd98b8c9c70525";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-controller/default.nix
+++ b/distros/rolling/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "17a4ab9c4402f66a0c1df5ce3cb76d6e14deaaf3ca37ccd3de587a6d017b18b3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "75799d86bdeb1b352e40eb2fe89006330af967873ccf776fa2fa39e42c052ff1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-steering-controller/default.nix
+++ b/distros/rolling/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-steering-controller";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "b1a7a0ba8cf61dd8e6b7762e8b6b7c289dc50cf1621a767d3b70a6dfe55a491a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "59a3f30a2c7ada6ca45a317c6fd3872cffc8a0c164dd284bf795b4c6c110a813";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-gps/default.nix
+++ b/distros/rolling/ublox-gps/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, asio, diagnostic-msgs, diagnostic-updater, geometry-msgs, rcl-interfaces, rclcpp, rclcpp-components, sensor-msgs, std-msgs, tf2, ublox-msgs, ublox-serialization }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, asio, diagnostic-msgs, diagnostic-updater, geometry-msgs, nmea-msgs, rcl-interfaces, rclcpp, rclcpp-components, rtcm-msgs, sensor-msgs, std-msgs, tf2, ublox-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-rolling-ublox-gps";
-  version = "2.3.0-r3";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox-release/archive/release/rolling/ublox_gps/2.3.0-3.tar.gz";
-    name = "2.3.0-3.tar.gz";
-    sha256 = "8134e0a04b7c37f5d12b0e729c50d9d3ca6f223bed6f39258d32e97465da8441";
+    url = "https://github.com/ros2-gbp/ublox-release/archive/release/rolling/ublox_gps/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "4f39376b4cdd33e5c18e503a9862d25d3b35fef3df7cdb278858f6bfd9e94069";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
-  propagatedBuildInputs = [ asio diagnostic-msgs diagnostic-updater geometry-msgs rcl-interfaces rclcpp rclcpp-components sensor-msgs std-msgs tf2 ublox-msgs ublox-serialization ];
+  propagatedBuildInputs = [ asio diagnostic-msgs diagnostic-updater geometry-msgs nmea-msgs rcl-interfaces rclcpp rclcpp-components rtcm-msgs sensor-msgs std-msgs tf2 ublox-msgs ublox-serialization ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/rolling/ublox-msgs/default.nix
+++ b/distros/rolling/ublox-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, rosidl-default-generators, sensor-msgs, std-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-rolling-ublox-msgs";
-  version = "2.3.0-r3";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox-release/archive/release/rolling/ublox_msgs/2.3.0-3.tar.gz";
-    name = "2.3.0-3.tar.gz";
-    sha256 = "594a79e11858621300775486cb224d50c5f531952a4a41d103954a660ec63af0";
+    url = "https://github.com/ros2-gbp/ublox-release/archive/release/rolling/ublox_msgs/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "d0b345e12c87c579b4a36d78ccfcef7e3b2436c0e4d8d77c7df7bc6cb7d3c685";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-serialization/default.nix
+++ b/distros/rolling/ublox-serialization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ublox-serialization";
-  version = "2.3.0-r3";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox-release/archive/release/rolling/ublox_serialization/2.3.0-3.tar.gz";
-    name = "2.3.0-3.tar.gz";
-    sha256 = "30418726bc8c96df1d129f6121f01b121a90573f15ad95f37eb8f575461fef60";
+    url = "https://github.com/ros2-gbp/ublox-release/archive/release/rolling/ublox_serialization/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "b98686583ba34e52e9d049c620d805392eb66a04a6898c8b6475e2733d768353";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox/default.nix
+++ b/distros/rolling/ublox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ublox-gps, ublox-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-rolling-ublox";
-  version = "2.3.0-r3";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox-release/archive/release/rolling/ublox/2.3.0-3.tar.gz";
-    name = "2.3.0-3.tar.gz";
-    sha256 = "2976021ed63ae46e7247d8224d9e4d56c1964726f7b37f1783b0e3bfa711c96a";
+    url = "https://github.com/ros2-gbp/ublox-release/archive/release/rolling/ublox/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "b1962b384cae2233a2d30b9710000b88f717c871fcf9fe0d29789297cc4f85f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-description/default.nix
+++ b/distros/rolling/ur-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, joint-state-publisher-gui, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, robot-state-publisher, rviz2, urdf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ur-description";
-  version = "4.1.0-r1";
+  version = "4.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/rolling/ur_description/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "a91cd638cd5ad713747de3ab8adec3598f96462d2710ae306e92ec3de7540fd4";
+    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/rolling/ur_description/4.1.1-1.tar.gz";
+    name = "4.1.1-1.tar.gz";
+    sha256 = "aefc51e57ee32639c0e5555bc14b0ccfce0edc5034e6841fc9b71e3ace478849";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/velocity-controllers/default.nix
+++ b/distros/rolling/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-velocity-controllers";
-  version = "5.7.0-r1";
+  version = "5.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/5.7.0-1.tar.gz";
-    name = "5.7.0-1.tar.gz";
-    sha256 = "01ffe96fccb9801d730d166cd96dc26f351baccd7d2f32dd29e843db29d25b60";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/5.8.0-1.tar.gz";
+    name = "5.8.0-1.tar.gz";
+    sha256 = "10c0b7f969cefbb8d2c76601c058b3c19b3ef223b7a605b6f6a0ebee587e4838";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/visualization-msgs/default.nix
+++ b/distros/rolling/visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-visualization-msgs";
-  version = "5.8.2-r1";
+  version = "5.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/visualization_msgs/5.8.2-1.tar.gz";
-    name = "5.8.2-1.tar.gz";
-    sha256 = "7559c3b66a412bd75dbb53196f304040f9f3cba614928ffa7a345eff7a31ba37";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/visualization_msgs/5.9.0-1.tar.gz";
+    name = "5.9.0-1.tar.gz";
+    sha256 = "823618a01ed6675ddf37e8bb21cf2f28b538d57834276e18e4a13236097e6856";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'kilted', 'rolling'] from nix-ros-overlay commit 42026cbc1be611736ca5c715e14f23a430a79088.
This pull request was generated by running the following command:

```
superflore-gen-nix --dry-run --output-repository-path . --all --tar-archive-dir /home/runner/.ros/tar --upstream-branch develop
```

Changes:
========
Humble Changes:
---------------
* *ackermann-steering-controller 2.50.0-r1 --> 2.50.1-r1*
* *admittance-controller 2.50.0-r1 --> 2.50.1-r1*
* *bicycle-steering-controller 2.50.0-r1 --> 2.50.1-r1*
* *diff-drive-controller 2.50.0-r1 --> 2.50.1-r1*
* *effort-controllers 2.50.0-r1 --> 2.50.1-r1*
* *force-torque-sensor-broadcaster 2.50.0-r1 --> 2.50.1-r1*
* *forward-command-controller 2.50.0-r1 --> 2.50.1-r1*
* *foxglove-bridge 0.8.5-r1 --> 3.2.1-r1*
* *foxglove-msgs 2.3.0-r1 --> 3.2.1-r1*
* *gpio-controllers 2.50.0-r1 --> 2.50.1-r1*
* *gripper-controllers 2.50.0-r1 --> 2.50.1-r1*
* *gz-ros2-control-demos 0.7.16-r1 --> 0.7.17-r1*
* *gz-ros2-control-tests 0.7.16-r1 --> 0.7.17-r1*
* *hebi-cpp-api 3.13.0-r1 --> 3.15.0-r1*
* *ign-ros2-control 0.7.16-r1 --> 0.7.17-r1*
* *ign-ros2-control-demos 0.7.16-r1 --> 0.7.17-r1*
* *imu-sensor-broadcaster 2.50.0-r1 --> 2.50.1-r1*
* *joint-state-broadcaster 2.50.0-r1 --> 2.50.1-r1*
* *joint-trajectory-controller 2.50.0-r1 --> 2.50.1-r1*
* *kinematics-interface 0.4.0-r1 --> 0.4.1-r1*
* *kinematics-interface-kdl 0.4.0-r1 --> 0.4.1-r1*
* *mecanum-drive-controller 2.50.0-r1 --> 2.50.1-r1*
* *mola-imu-preintegration 1.10.0-r1 --> 1.11.0-r1*
* *mrpt-apps 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libapps 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libbase 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libgui 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libhwdrivers 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libmaps 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libmath 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libnav 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libobs 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libopengl 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libposes 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libros-bridge 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libslam 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libtclap 2.14.12-r1 --> 2.14.15-r1*
* *pid-controller 2.50.0-r1 --> 2.50.1-r1*
* *pose-broadcaster 2.50.0-r1 --> 2.50.1-r1*
* *position-controllers 2.50.0-r1 --> 2.50.1-r1*
* *range-sensor-broadcaster 2.50.0-r1 --> 2.50.1-r1*
* *realtime-tools 2.14.0-r1 --> 2.14.1-r1*
* *ros2-controllers 2.50.0-r1 --> 2.50.1-r1*
* *ros2-controllers-test-nodes 2.50.0-r1 --> 2.50.1-r1*
* *rqt-joint-trajectory-controller 2.50.0-r1 --> 2.50.1-r1*
* *rviz-assimp-vendor 11.2.21-r1 --> 11.2.22-r1*
* *rviz-common 11.2.21-r1 --> 11.2.22-r1*
* *rviz-default-plugins 11.2.21-r1 --> 11.2.22-r1*
* *rviz-ogre-vendor 11.2.21-r1 --> 11.2.22-r1*
* *rviz-rendering 11.2.21-r1 --> 11.2.22-r1*
* *rviz-rendering-tests 11.2.21-r1 --> 11.2.22-r1*
* *rviz-visual-testing-framework 11.2.21-r1 --> 11.2.22-r1*
* *rviz2 11.2.21-r1 --> 11.2.22-r1*
* *steering-controllers-library 2.50.0-r1 --> 2.50.1-r1*
* *teleop-twist-keyboard 2.4.0-r1 --> 2.4.1-r1*
* *tricycle-controller 2.50.0-r1 --> 2.50.1-r1*
* *tricycle-steering-controller 2.50.0-r1 --> 2.50.1-r1*
* *ur-description 2.7.0-r1 --> 2.7.1-r1*
* *velocity-controllers 2.50.0-r1 --> 2.50.1-r1*

Jazzy Changes:
--------------
* *control-toolbox 4.7.1-r1 --> 4.8.0-r1*
* *foxglove-bridge 0.8.5-r1 --> 3.2.1-r1*
* *foxglove-msgs 3.1.0-r1 --> 3.2.1-r1*
* *frame-editor 2.0.2-r5*
* *gz-ros2-control 1.2.15-r1 --> 1.2.16-r1*
* *gz-ros2-control-demos 1.2.15-r1 --> 1.2.16-r1*
* *hebi-cpp-api 3.13.0-r3 --> 3.15.0-r1*
* *joint-state-topic-hardware-interface 0.2.0-r1 --> 0.2.1-r1*
* *kinematics-interface 1.5.0-r1 --> 1.6.0-r1*
* *kinematics-interface-kdl 1.5.0-r1 --> 1.6.0-r1*
* *mola-imu-preintegration 1.10.0-r1 --> 1.11.0-r1*
* *mrpt-apps 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libapps 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libbase 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libgui 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libhwdrivers 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libmaps 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libmath 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libnav 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libobs 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libopengl 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libposes 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libros-bridge 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libslam 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libtclap 2.14.12-r1 --> 2.14.15-r1*
* *multisensor-calibration 2.0.3-r1 --> 2.0.4-r1*
* *multisensor-calibration-interface 2.0.3-r1 --> 2.0.4-r1*
* *ros2-control-cmake 0.2.1-r1 --> 0.3.0-r1*
* *rviz-assimp-vendor 14.1.15-r1 --> 14.1.16-r1*
* *rviz-common 14.1.15-r1 --> 14.1.16-r1*
* *rviz-default-plugins 14.1.15-r1 --> 14.1.16-r1*
* *rviz-ogre-vendor 14.1.15-r1 --> 14.1.16-r1*
* *rviz-rendering 14.1.15-r1 --> 14.1.16-r1*
* *rviz-rendering-tests 14.1.15-r1 --> 14.1.16-r1*
* *rviz-visual-testing-framework 14.1.15-r1 --> 14.1.16-r1*
* *rviz2 14.1.15-r1 --> 14.1.16-r1*
* *small-gicp-vendor 2.0.3-r1 --> 2.0.4-r1*
* *teleop-twist-keyboard 2.4.0-r2 --> 2.4.1-r1*
* *ur-description 3.3.0-r1 --> 3.3.1-r1*

Kilted Changes:
---------------
* *ackermann-steering-controller 5.7.0-r1 --> 5.8.0-r1*
* *actionlib-msgs 5.5.0-r2 --> 5.5.1-r1*
* *admittance-controller 5.7.0-r1 --> 5.8.0-r1*
* *battery-state-broadcaster 1.0.2-r1 --> 1.1.0-r1*
* *battery-state-rviz-overlay 1.0.2-r1 --> 1.1.0-r1*
* *bicycle-steering-controller 5.7.0-r1 --> 5.8.0-r1*
* *chained-filter-controller 5.7.0-r1 --> 5.8.0-r1*
* *common-interfaces 5.5.0-r2 --> 5.5.1-r1*
* *control-toolbox 5.7.0-r1 --> 5.8.0-r1*
* *depthai 3.0.5-r1 --> 3.0.6-r1*
* *diagnostic-msgs 5.5.0-r2 --> 5.5.1-r1*
* *diff-drive-controller 5.7.0-r1 --> 5.8.0-r1*
* *effort-controllers 5.7.0-r1 --> 5.8.0-r1*
* *fastcdr 2.3.0-r2 --> 2.3.2-r1*
* *force-torque-sensor-broadcaster 5.7.0-r1 --> 5.8.0-r1*
* *forward-command-controller 5.7.0-r1 --> 5.8.0-r1*
* *foxglove-bridge 0.8.5-r1 --> 3.2.1-r1*
* *foxglove-msgs 3.1.0-r2 --> 3.2.1-r1*
* *geometry-msgs 5.5.0-r2 --> 5.5.1-r1*
* *gpio-controllers 5.7.0-r1 --> 5.8.0-r1*
* *gps-sensor-broadcaster 5.7.0-r1 --> 5.8.0-r1*
* *gz-ros2-control 2.0.11-r2 --> 2.0.12-r1*
* *gz-ros2-control-demos 2.0.11-r2 --> 2.0.12-r1*
* *hebi-cpp-api 3.13.1-r2 --> 3.15.0-r1*
* *imu-sensor-broadcaster 5.7.0-r1 --> 5.8.0-r1*
* *joint-state-broadcaster 5.7.0-r1 --> 5.8.0-r1*
* *joint-state-topic-hardware-interface 0.2.0-r1 --> 0.2.1-r1*
* *joint-trajectory-controller 5.7.0-r1 --> 5.8.0-r1*
* *kinematics-interface 2.2.0-r1 --> 2.3.0-r1*
* *kinematics-interface-kdl 2.2.0-r1 --> 2.3.0-r1*
* *mecanum-drive-controller 5.7.0-r1 --> 5.8.0-r1*
* *mola-imu-preintegration 1.10.0-r1 --> 1.11.0-r1*
* *motion-primitives-controllers 5.7.0-r1 --> 5.8.0-r1*
* *mrpt-apps 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libapps 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libbase 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libgui 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libhwdrivers 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libmaps 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libmath 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libnav 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libobs 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libopengl 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libposes 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libros-bridge 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libslam 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libtclap 2.14.12-r1 --> 2.14.15-r1*
* *multisensor-calibration 2.0.4-r1*
* *multisensor-calibration-interface 2.0.4-r1*
* *nav-msgs 5.5.0-r2 --> 5.5.1-r1*
* *omni-wheel-drive-controller 5.7.0-r1 --> 5.8.0-r1*
* *parallel-gripper-controller 5.7.0-r1 --> 5.8.0-r1*
* *pid-controller 5.7.0-r1 --> 5.8.0-r1*
* *pose-broadcaster 5.7.0-r1 --> 5.8.0-r1*
* *position-controllers 5.7.0-r1 --> 5.8.0-r1*
* *range-sensor-broadcaster 5.7.0-r1 --> 5.8.0-r1*
* *rcl 10.1.1-r1 --> 10.1.2-r1*
* *rcl-action 10.1.1-r1 --> 10.1.2-r1*
* *rcl-lifecycle 10.1.1-r1 --> 10.1.2-r1*
* *rcl-yaml-param-parser 10.1.1-r1 --> 10.1.2-r1*
* *ros-gz 2.1.10-r1 --> 2.1.11-r1*
* *ros-gz-bridge 2.1.10-r1 --> 2.1.11-r1*
* *ros-gz-image 2.1.10-r1 --> 2.1.11-r1*
* *ros-gz-interfaces 2.1.10-r1 --> 2.1.11-r1*
* *ros-gz-sim 2.1.10-r1 --> 2.1.11-r1*
* *ros-gz-sim-demos 2.1.10-r1 --> 2.1.11-r1*
* *ros2-control-cmake 0.2.1-r1 --> 0.3.0-r1*
* *ros2-controllers 5.7.0-r1 --> 5.8.0-r1*
* *ros2-controllers-test-nodes 5.7.0-r1 --> 5.8.0-r1*
* *rqt-joint-trajectory-controller 5.7.0-r1 --> 5.8.0-r1*
* *rviz-assimp-vendor 15.0.6-r1 --> 15.0.7-r1*
* *rviz-common 15.0.6-r1 --> 15.0.7-r1*
* *rviz-default-plugins 15.0.6-r1 --> 15.0.7-r1*
* *rviz-ogre-vendor 15.0.6-r1 --> 15.0.7-r1*
* *rviz-rendering 15.0.6-r1 --> 15.0.7-r1*
* *rviz-rendering-tests 15.0.6-r1 --> 15.0.7-r1*
* *rviz-resource-interfaces 15.0.6-r1 --> 15.0.7-r1*
* *rviz-visual-testing-framework 15.0.6-r1 --> 15.0.7-r1*
* *rviz2 15.0.6-r1 --> 15.0.7-r1*
* *sensor-msgs 5.5.0-r2 --> 5.5.1-r1*
* *sensor-msgs-py 5.5.0-r2 --> 5.5.1-r1*
* *shape-msgs 5.5.0-r2 --> 5.5.1-r1*
* *small-gicp-vendor 2.0.4-r1*
* *std-msgs 5.5.0-r2 --> 5.5.1-r1*
* *std-srvs 5.5.0-r2 --> 5.5.1-r1*
* *steering-controllers-library 5.7.0-r1 --> 5.8.0-r1*
* *stereo-msgs 5.5.0-r2 --> 5.5.1-r1*
* *teleop-twist-keyboard 2.4.0-r2 --> 2.4.1-r1*
* *trajectory-msgs 5.5.0-r2 --> 5.5.1-r1*
* *tricycle-controller 5.7.0-r1 --> 5.8.0-r1*
* *tricycle-steering-controller 5.7.0-r1 --> 5.8.0-r1*
* *ur-description 4.1.0-r1 --> 4.1.1-r1*
* *velocity-controllers 5.7.0-r1 --> 5.8.0-r1*
* *visualization-msgs 5.5.0-r2 --> 5.5.1-r1*

Rolling Changes:
----------------
* *ackermann-steering-controller 5.7.0-r1 --> 5.8.0-r1*
* *admittance-controller 5.7.0-r1 --> 5.8.0-r1*
* *battery-state-broadcaster 1.0.2-r1 --> 1.1.0-r2*
* *battery-state-rviz-overlay 1.0.2-r1 --> 1.1.0-r2*
* *bicycle-steering-controller 5.7.0-r1 --> 5.8.0-r1*
* *chained-filter-controller 5.7.0-r1 --> 5.8.0-r1*
* *common-interfaces 5.8.2-r1 --> 5.9.0-r1*
* *control-toolbox 5.7.0-r1 --> 5.8.0-r2*
* *diagnostic-msgs 5.8.2-r1 --> 5.9.0-r1*
* *diff-drive-controller 5.7.0-r1 --> 5.8.0-r1*
* *effort-controllers 5.7.0-r1 --> 5.8.0-r1*
* *fastcdr 2.3.0-r1 --> 2.3.2-r1*
* *force-torque-sensor-broadcaster 5.7.0-r1 --> 5.8.0-r1*
* *forward-command-controller 5.7.0-r1 --> 5.8.0-r1*
* *foxglove-bridge 3.2.0-r1 --> 3.2.1-r1*
* *foxglove-msgs 3.2.0-r1 --> 3.2.1-r1*
* *geometry-msgs 5.8.2-r1 --> 5.9.0-r1*
* *gpio-controllers 5.7.0-r1 --> 5.8.0-r1*
* *gps-sensor-broadcaster 5.7.0-r1 --> 5.8.0-r1*
* *gz-cmake-vendor 0.4.0-r1 --> 0.4.1-r1*
* *gz-common-vendor 0.3.1-r1 --> 0.3.2-r1*
* *gz-fuel-tools-vendor 0.3.0-r1 --> 0.3.1-r1*
* *gz-launch-vendor 0.3.0-r1 --> 0.3.1-r1*
* *gz-math-vendor 0.4.1-r1 --> 0.4.2-r1*
* *gz-msgs-vendor 0.3.1-r1 --> 0.3.2-r1*
* *gz-physics-vendor 0.4.1-r1 --> 0.4.2-r1*
* *gz-plugin-vendor 0.3.0-r1 --> 0.3.1-r1*
* *gz-rendering-vendor 0.4.1-r1 --> 0.4.2-r1*
* *gz-ros2-control 3.0.3-r1 --> 3.0.4-r1*
* *gz-ros2-control-demos 3.0.3-r1 --> 3.0.4-r1*
* *gz-sensors-vendor 0.3.0-r1 --> 0.3.1-r1*
* *gz-transport-vendor 0.3.1-r1 --> 0.3.2-r1*
* *gz-utils-vendor 0.4.0-r2 --> 0.4.1-r1*
* *hebi-cpp-api 3.13.0-r1 --> 3.15.0-r1*
* *imu-sensor-broadcaster 5.7.0-r1 --> 5.8.0-r1*
* *joint-state-broadcaster 5.7.0-r1 --> 5.8.0-r1*
* *joint-state-topic-hardware-interface 0.2.0-r1 --> 0.2.1-r1*
* *joint-trajectory-controller 5.7.0-r1 --> 5.8.0-r1*
* *kinematics-interface 2.2.0-r1 --> 2.3.0-r1*
* *kinematics-interface-kdl 2.2.0-r1 --> 2.3.0-r1*
* *mecanum-drive-controller 5.7.0-r1 --> 5.8.0-r1*
* *mola-imu-preintegration 1.10.0-r1 --> 1.11.0-r1*
* *motion-primitives-controllers 5.7.0-r1 --> 5.8.0-r1*
* *mrpt-apps 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libapps 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libbase 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libgui 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libhwdrivers 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libmaps 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libmath 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libnav 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libobs 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libopengl 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libposes 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libros-bridge 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libslam 2.14.12-r1 --> 2.14.15-r1*
* *mrpt-libtclap 2.14.12-r1 --> 2.14.15-r1*
* *nav-msgs 5.8.2-r1 --> 5.9.0-r1*
* *omni-wheel-drive-controller 5.7.0-r1 --> 5.8.0-r1*
* *parallel-gripper-controller 5.7.0-r1 --> 5.8.0-r1*
* *pid-controller 5.7.0-r1 --> 5.8.0-r1*
* *plotjuggler 3.12.0-r1 --> 3.13.1-r1*
* *pose-broadcaster 5.7.0-r1 --> 5.8.0-r1*
* *position-controllers 5.7.0-r1 --> 5.8.0-r1*
* *range-sensor-broadcaster 5.7.0-r1 --> 5.8.0-r1*
* *rcl 10.2.3-r1 --> 10.2.4-r1*
* *rcl-action 10.2.3-r1 --> 10.2.4-r1*
* *rcl-lifecycle 10.2.3-r1 --> 10.2.4-r1*
* *rcl-yaml-param-parser 10.2.3-r1 --> 10.2.4-r1*
* *rko-lio 0.1.3-r1*
* *ros-gz 3.0.3-r1 --> 3.0.4-r1*
* *ros-gz-bridge 3.0.3-r1 --> 3.0.4-r1*
* *ros-gz-image 3.0.3-r1 --> 3.0.4-r1*
* *ros-gz-interfaces 3.0.3-r1 --> 3.0.4-r1*
* *ros-gz-sim 3.0.3-r1 --> 3.0.4-r1*
* *ros-gz-sim-demos 3.0.3-r1 --> 3.0.4-r1*
* *ros2-control-cmake 0.2.1-r1 --> 0.3.0-r1*
* *ros2-controllers 5.7.0-r1 --> 5.8.0-r1*
* *ros2-controllers-test-nodes 5.7.0-r1 --> 5.8.0-r1*
* *rosidl-typesupport-fastrtps-c 3.9.1-r1 --> 3.9.2-r1*
* *rosidl-typesupport-fastrtps-cpp 3.9.1-r1 --> 3.9.2-r1*
* *rqt-joint-trajectory-controller 5.7.0-r1 --> 5.8.0-r1*
* *rviz-common 15.1.9-r1 --> 15.1.10-r1*
* *rviz-default-plugins 15.1.9-r1 --> 15.1.10-r1*
* *rviz-ogre-vendor 15.1.9-r1 --> 15.1.10-r1*
* *rviz-rendering 15.1.9-r1 --> 15.1.10-r1*
* *rviz-rendering-tests 15.1.9-r1 --> 15.1.10-r1*
* *rviz-resource-interfaces 15.1.9-r1 --> 15.1.10-r1*
* *rviz-visual-testing-framework 15.1.9-r1 --> 15.1.10-r1*
* *rviz2 15.1.9-r1 --> 15.1.10-r1*
* *sensor-msgs 5.8.2-r1 --> 5.9.0-r1*
* *sensor-msgs-py 5.8.2-r1 --> 5.9.0-r1*
* *shape-msgs 5.8.2-r1 --> 5.9.0-r1*
* *std-msgs 5.8.2-r1 --> 5.9.0-r1*
* *std-srvs 5.8.2-r1 --> 5.9.0-r1*
* *steering-controllers-library 5.7.0-r1 --> 5.8.0-r1*
* *stereo-msgs 5.8.2-r1 --> 5.9.0-r1*
* *teleop-twist-keyboard 2.4.0-r1 --> 2.4.1-r1*
* *trajectory-msgs 5.8.2-r1 --> 5.9.0-r1*
* *tricycle-controller 5.7.0-r1 --> 5.8.0-r1*
* *tricycle-steering-controller 5.7.0-r1 --> 5.8.0-r1*
* *ublox 2.3.0-r3 --> 3.0.0-r1*
* *ublox-gps 2.3.0-r3 --> 3.0.0-r1*
* *ublox-msgs 2.3.0-r3 --> 3.0.0-r1*
* *ublox-serialization 2.3.0-r3 --> 3.0.0-r1*
* *ur-description 4.1.0-r1 --> 4.1.1-r1*
* *velocity-controllers 5.7.0-r1 --> 5.8.0-r1*
* *visualization-msgs 5.8.2-r1 --> 5.9.0-r1*


Missing Dependencies:
=====================
 * [ ] action_tutorials_interfaces
 * [ ] actionlib_msgs
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gripper_controllers
 * [ ] gurumdds-3.0
 * [ ] gurumdds-3.2
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] libcurl_vendor
 * [ ] libopen3d-dev
 * [ ] libqt6svg6
 * [ ] libserial-dev
 * [ ] nanobind-dev
 * [ ] pybind11-json-dev
 * [ ] pybind11_json_vendor
 * [ ] python3-jsonpickle
 * [ ] python3-pymap3d
 * [ ] python3-pytorch-pip
 * [ ] python3-torch-geometric-pip
 * [ ] python3-typer
 * [ ] python3-types-pyyaml
 * [ ] qml6-module-qt-labs-folderlistmodel
 * [ ] qml6-module-qt-labs-platform
 * [ ] qml6-module-qt-labs-settings
 * [ ] qml6-module-qt5compat-graphicaleffects
 * [ ] qml6-module-qtcharts
 * [ ] qml6-module-qtcore
 * [ ] qml6-module-qtpositioning
 * [ ] qml6-module-qtqml
 * [ ] qml6-module-qtqml-models
 * [ ] qml6-module-qtqml-workerscript
 * [ ] qml6-module-qtquick-controls
 * [ ] qml6-module-qtquick-dialogs
 * [ ] qml6-module-qtquick-layouts
 * [ ] qml6-module-qtquick-templates
 * [ ] qml6-module-qtquick-window
 * [ ] qt6-5compat-dev
 * [ ] qt6-base-private-dev
 * [ ] qt6-declarative-private-dev
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo