### PR TITLE
examples/ros2-gz.nix: Add ros-gz-sim

### DIFF
--- a/examples/ros2-gz.nix
+++ b/examples/ros2-gz.nix
@@ -2,9 +2,12 @@
 # to run this dev shell use:
 # NIXPKGS_ALLOW_INSECURE=1 nix develop --impure .\#example-ros2-gz
 
-{pkgs ? import ../. {}}:
+{
+  pkgs ? import ../. {},
+  rosDistro ? "jazzy",
+}:
 with pkgs;
-with rosPackages.jazzy;
+with rosPackages.${rosDistro};
   mkShell {
     nativeBuildInputs = [
       (buildEnv {


### PR DESCRIPTION
Gazebo docs [1] refer to this package, so we should include it in the example.

[1]: https://gazebosim.org/docs/harmonic/ros2_launch_gazebo/#

@muellerbernd Do you agree?