### PR TITLE
Add new ROS 2 examples and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,35 @@ roslaunch turtlebot3_gazebo turtlebot3_world.launch
 roslaunch turtlebot3_teleop turtlebot3_teleop_key.launch
 ```
 
+ROS 2 Jazzy Desktop environment:
+
+```sh
+nix-shell \
+  -I nix-ros-overlay=https://github.com/lopsided98/nix-ros-overlay/archive/master.tar.gz \
+  --option extra-substituters 'https://ros.cachix.org' \
+  --option trusted-public-keys 'cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ros.cachix.org-1:dSyZxI8geDCJrwgvCOHDoAfOm5sV1wCPjBkKL+38Rvo=' \
+  '<nix-ros-overlay/examples/ros2-desktop.nix>' --argstr rosDistro jazzy
+# Run command-line talker/listener demo
+ros2 launch demo_nodes_cpp talker_listener_launch.xml
+```
+
+If you want to run graphical applications like `rviz2` on non-NixOS
+distribution, we recommend to use [nix-system-graphics][] or
+[nixGL][]. The latter is less convenient but doesn't need to change
+system-wide configuration.
+
+[nix-system-graphics]: https://github.com/soupglasses/nix-system-graphics
+[nixGL]: https://github.com/nix-community/nixGL
+
 ### Flakes
 
 With [Flakes enabled][flake], the equivalent of the above is:
 ```
 nix develop github:lopsided98/nix-ros-overlay#example-turtlebot3-gazebo
 # Then use roslaunch commands as above
+```
+```sh
+nix develop github:lopsided98/nix-ros-overlay#example-ros2-desktop-jazzy
 ```
 
 Using the overlay in your `flake.nix`-based project could look like this:

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Want to use ROS, but don't want to run Ubuntu? This project uses the power of [N
 ## Examples
 
 Turtlebot 3 simulation in Gazebo:
-```
+```sh
 nix-shell \
   -I nix-ros-overlay=https://github.com/lopsided98/nix-ros-overlay/archive/master.tar.gz \
   --option extra-substituters 'https://ros.cachix.org' \
-  --option trusted-public-keys 'cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ros.cachix.org-1:dSyZxI8geDCJrwgvCOHDoAfOm5sV1wCPjBkKL+38Rvo=' \
+  --option extra-trusted-public-keys 'ros.cachix.org-1:dSyZxI8geDCJrwgvCOHDoAfOm5sV1wCPjBkKL+38Rvo=' \
   '<nix-ros-overlay/examples/turtlebot3-gazebo.nix>'
 # If not on NixOS, nixGL (https://github.com/guibou/nixGL) is needed for OpenGL support
 roslaunch turtlebot3_gazebo turtlebot3_world.launch
@@ -36,7 +36,7 @@ ROS 2 Jazzy Desktop environment:
 nix-shell \
   -I nix-ros-overlay=https://github.com/lopsided98/nix-ros-overlay/archive/master.tar.gz \
   --option extra-substituters 'https://ros.cachix.org' \
-  --option trusted-public-keys 'cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ros.cachix.org-1:dSyZxI8geDCJrwgvCOHDoAfOm5sV1wCPjBkKL+38Rvo=' \
+  --option extra-trusted-public-keys 'ros.cachix.org-1:dSyZxI8geDCJrwgvCOHDoAfOm5sV1wCPjBkKL+38Rvo=' \
   '<nix-ros-overlay/examples/ros2-desktop.nix>' --argstr rosDistro jazzy
 # Run command-line talker/listener demo
 ros2 launch demo_nodes_cpp talker_listener_launch.xml

--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -219,8 +219,14 @@ let
       dontWrapQtApps = false;
       nativeBuildInputs = nativeBuildInputs ++ [ self.qt5.wrapQtAppsHook ];
       postFixup = postFixup + ''
-        wrapQtApp "$out/bin/rqt_graph"
         wrapQtApp "$out/lib/rqt_graph/rqt_graph"
+        if [[ -e "$out/bin/rqt_graph" ]]; then
+          wrapQtApp "$out/bin/rqt_graph"
+        else
+          # Needed for kilted and later
+          mkdir -p $out/bin
+          ln -s "$out/lib/rqt_graph/rqt_graph" "$out/bin/rqt_graph"
+        fi
       '';
     });
 

--- a/examples/ros2-basic.nix
+++ b/examples/ros2-basic.nix
@@ -1,17 +1,28 @@
 # Environment containing basic ROS2 tools
-
-{ pkgs ? import ../. {} }:
-with pkgs;
-with rosPackages.humble;
-
-mkShell {
-  nativeBuildInputs = [
-    (buildEnv {
+{
+  pkgs ? import ../. { },
+  rosDistro ? "jazzy",
+  package ? "ros-core",
+}:
+pkgs.mkShell {
+  packages = [
+    (pkgs.rosPackages.${rosDistro}.buildEnv {
       paths = [
-        ros-core
-        colcon
-        geometry-msgs
-      ];
+        pkgs.colcon
+      ]
+      ++ (with pkgs.rosPackages.${rosDistro}; [
+        ament-cmake-core
+        python-cmake-module
+
+        pkgs.rosPackages.${rosDistro}.${package}
+      ]);
     })
   ];
+  shellHook = ''
+    # Setup ROS 2 shell completion. Doing it in direnv is useless.
+    if [[ ! $DIRENV_IN_ENVRC ]]; then
+        eval "$(${pkgs.python3Packages.argcomplete}/bin/register-python-argcomplete ros2)"
+        eval "$(${pkgs.python3Packages.argcomplete}/bin/register-python-argcomplete colcon)"
+    fi
+  '';
 }

--- a/examples/ros2-desktop-full.nix
+++ b/examples/ros2-desktop-full.nix
@@ -1,0 +1,14 @@
+# Environment containing ROS 2 desktop_full entry point
+# (https://www.ros.org/reps/rep-2001.html#end-user-entry-points)
+
+# Usage:
+# NIXPKGS_ALLOW_INSECURE=1 nix-shell ros2-desktop-full.nix
+# NIXPKGS_ALLOW_INSECURE=1 nix develop --impure .#example-ros2-desktop-full
+{
+  pkgs ? import ../. { },
+  rosDistro ? "jazzy",
+}:
+import ./ros2-basic.nix {
+  inherit pkgs rosDistro;
+  package = "desktop-full";
+}

--- a/examples/ros2-desktop.nix
+++ b/examples/ros2-desktop.nix
@@ -1,0 +1,14 @@
+# Environment containing ROS 2 desktop_full entry point
+# (https://www.ros.org/reps/rep-2001.html#end-user-entry-points)
+
+# Usage:
+# nix-shell ros2-desktop.nix
+# nix develop --impure .#example-ros2-desktop
+{
+  pkgs ? import ../. { },
+  rosDistro ? "jazzy",
+}:
+import ./ros2-basic.nix {
+  inherit pkgs rosDistro;
+  package = "desktop";
+}

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,8 @@
       devShells = {
         example-turtlebot3-gazebo = import ./examples/turtlebot3-gazebo.nix { inherit pkgs; };
         example-ros2-basic = import ./examples/ros2-basic.nix { inherit pkgs; };
+        example-ros2-desktop = import ./examples/ros2-desktop.nix { inherit pkgs; };
+        example-ros2-desktop-full = import ./examples/ros2-desktop-full.nix { inherit pkgs; };
         example-ros2-gz = self.devShells.${system}.example-ros2-gz-jazzy;
         example-ros2-turtlebot4-gz = import ./examples/ros2-turtlebot4-gz.nix { inherit pkgs; };
 

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,11 @@
         overlays = [ self.overlays.default ];
       };
       genAttrs' = xs: f: listToAttrs (map f xs); # TODO remove after we're at newer nixpkgs
+      exampleForDistro = exampleName: rosDistro:
+        nameValuePair "example-${exampleName}-${rosDistro}" (
+          import ./examples/${exampleName}.nix { inherit pkgs rosDistro; }
+        );
+      inherit (pkgs.rosPackages.lib) distroNames;
     in {
       legacyPackages = pkgs.rosPackages;
       packages.update-overlay = pkgs.callPackage ./maintainers/scripts/update-overlay.nix { };
@@ -30,12 +35,10 @@
         # Development environment for the custom GitHub action
         nix-ros-build-action = pkgs.callPackage ./.github/actions/nix-ros-build-action/shell.nix { };
       }
-        // (genAttrs' [ "jazzy" "kilted" "rolling" ] (
-          rosDistro:
-          nameValuePair "example-ros2-gz-${rosDistro}" (
-            import ./examples/ros2-gz.nix { inherit pkgs rosDistro; }
-          )
-        ));
+      // (genAttrs' [ "jazzy" "kilted" "rolling" ] (exampleForDistro "ros2-gz"))
+      // (genAttrs' distroNames (exampleForDistro "ros2-desktop"))
+      // (genAttrs' distroNames (exampleForDistro "ros2-desktop-full"))
+      ;
     }) // {
       overlays.default = import ./overlay.nix;
       nixosModules.default = ./modules;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -196,4 +196,7 @@
       sed -i '/find_package(Boost [^)]*/s/signals//g' CMakeLists.txt
     '' + postPatch;
   });
+
+  /** Names of ROS distributions present in this overlay. */
+  distroNames = builtins.attrNames (lib.filterAttrs (k: v: v ? overrideScope) self.rosPackages);
 }


### PR DESCRIPTION
The new examples will make it easier for new users to experiment with ROS. They provide basic environments for working with simpler ROS projects and official demos. The current examples are:
- `ros2-basic` corresponds to `ros-core`. We keep the example name for backward compatibility although the content changed a bit.
- `ros2-desktop` contains `desktop` metapackage.
- `ros2-desktop-full` contains `desktop-full` metapackage. Currently, it depends on insecure `freeimage` so we don't advertise it in README.

All examples have `rosDistro` parameter, which allows to switch distros easily. Also, our hydra builds variants for all distros, which will allow us to easily spot breakage in important packages [here](https://hydra.iid.ciirc.cvut.cz/jobset/nix-ros-overlay/develop-examples-x86_64).