### PR TITLE
Revert "Remove dev outputs in ament-cmake-core and python-cmake-module"

### DIFF
--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -13,6 +13,7 @@ rosSelf: rosSuper: with rosSelf.lib; {
   in {
     propagatedBuildInputs = [ setupHook ] ++ propagatedBuildInputs;
     nativeBuildInputs = [ setupHook ] ++ nativeBuildInputs;
+    outputs = [ "out" "dev" ];
   });
 
   ament-cmake-vendor-package = rosSuper.ament-cmake-vendor-package.overrideAttrs ({
@@ -250,6 +251,7 @@ rosSelf: rosSuper: with rosSelf.lib; {
     pythonLibrary = "${python}/lib/lib${python.libPrefix}${libExt}";
     pythonIncludeDir = "${python}/include/${python.libPrefix}";
     setupHook = ./python-cmake-module-setup-hook.sh;
+    outputs = [ "out" "dev" ];
   });
 
   rig-reconfigure = patchExternalProjectGit rosSuper.rig-reconfigure {


### PR DESCRIPTION
Reverts lopsided98/nix-ros-overlay#624. See [this comment](https://github.com/lopsided98/nix-ros-overlay/pull/624#issuecomment-3395423655).