### PR TITLE
moveit-ros-move-group: fix plugin loading

### DIFF
--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -225,6 +225,25 @@ rosSelf: rosSuper: with rosSelf.lib; {
     '';
   });
 
+
+  # Fix for loading the default plugins for the `move-group` executable.
+  #
+  # Essentially the executable tries to dynamically load the capabilites .so to
+  # allow users to hook into various functions, but this mechanism relies on
+  # specific linker flags that are absent in the Nix build. The actual solution
+  # is likely some upstream changes to moveit, but this is a practical solution
+  # until somebody can dig into it.
+  #
+  # See for more details: https://github.com/lopsided98/nix-ros-overlay/issues/264
+  moveit-ros-move-group = rosSuper.moveit-ros-move-group.overrideAttrs({
+    postFixup ? "", ...
+  }: {
+    postFixup = postFixup + ''
+      patchelf --add-needed libmoveit_move_group_default_capabilities.so $out/lib/moveit_ros_move_group/move_group
+      patchelf --add-needed libmoveit_move_group_default_capabilities.so $out/lib/moveit_ros_move_group/list_move_group_capabilities
+    '';
+  });
+
   plotjuggler = rosSuper.plotjuggler.override {
     lz4 = self.lz4.overrideAttrs ({
       cmakeFlags ? [], ...


### PR DESCRIPTION
Refresh of #516, since it seems like the author of that decided against reopening a PR.

The only changes I've made are moving it to the overall `ros2-overlay.nix` so it applies to all distros, and removing the obsolete (?) python comment.

Should close #264 if merged.