### PR TITLE
fix: colcon-core build

### DIFF
--- a/pkgs/colcon/core.nix
+++ b/pkgs/colcon/core.nix
@@ -39,6 +39,8 @@ let
     pyproject = true;
     build-system = [ setuptools ];
 
+    pythonRelaxDeps = true;
+
     propagatedBuildInputs = [
       distlib
       empy_3


### PR DESCRIPTION
Mismatch between `setuptools` versions was causing the `colcon-core` build to fail:  
```shell
Successfully built colcon_core-0.20.1-py3-none-any.whl
Finished creating a wheel...
Finished executing pypaBuildPhase
Running phase: pythonRuntimeDepsCheckHook
@nix { "action": "setPhase", "phase": "pythonRuntimeDepsCheckHook" }
Executing pythonRuntimeDepsCheck
Checking runtime dependencies for colcon_core-0.20.1-py3-none-any.whl
  - setuptools<80,>=30.3.0 not satisfied by version 80.9.0.post0
```