### PR TITLE
patchExternalProjectGit: Log correct revision in case of mismatch

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -61,10 +61,16 @@
           { print }
         $0 ~ "GIT_TAG[[:blank:]]+" {
           print
-          currentRev = gensub(/.*GIT_TAG[[:blank:]]+([^[:blank:]]*).*/, "\\1", 1)
+          if (! revVariable) {
+            currentRev = gensub(/.*GIT_TAG[[:blank:]]+([^[:blank:]]*).*/, "\\1", 1)
+            if (currentRev == originalRev) foundRev = 1
+          }
+        }
+        $0 ~ "set\\(" revVariable "[[:blank:]]+" && revVariable {
+          print
+          currentRev =  gensub(".*set\\(" revVariable "[[:blank:]]+\"?([^\"[:blank:]]+)\"?\\).*", "\\1", 1)
           if (currentRev == originalRev) foundRev = 1
         }
-        $0 ~ "set\\(" revVariable "[[:blank:]]+\"?" originalRev "\"?\\)" { print; foundRev=1 }
         END {
           if (!foundUrl) print "patchExternalProjectGit: did not find URL: " originalUrl > "/dev/stderr"
           if (!foundRev) print "patchExternalProjectGit: did not find revision: " originalRev " (found " currentRev ")" > "/dev/stderr"


### PR DESCRIPTION
Previously, if `patchExternalProjectGit` failed due to revision mismatch, one had to unpack the original source code and look into `CMakeLists.txt` file which revision is used there. With this change, the correct revision will be printed as a part of the error message in most cases.

An example of printed error message is:

    patchExternalProjectGit: did not find revision: b63a0b6f79d3ea91dc221724b42dae49894449fc (found fb735b79cab5f0cdda45bc5087414d405ef8f3ab)