### PR TITLE
Use tbb_2022 if tbb_2021_11 doesn't exist in nixpkgs

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -361,6 +361,9 @@ let
       propagatedBuildInputs = propagatedBuildInputs ++ [ self.qt5.wrapQtAppsHook self.librealsense self.octomap ];
     });
 
+    # TODO: Remove once onetbb appears in rosdep and in the locked nixpkgs version.
+    tbb_2021_11 = self.tbb_2021_11 or self.tbb_2022;
+
     turtlesim = rosSuper.turtlesim.overrideAttrs ({
       nativeBuildInputs ? [], ...
     }: {


### PR DESCRIPTION
This is needed with currently used nixpkgs version. Later, this should be fixed in rosdep, where we will use the new version-indepenent name `onetbb` (https://github.com/ros/rosdistro/pull/48172).