### PR TITLE
Fix MRPT

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -47,7 +47,7 @@ let
           url = "https://github.com/MRPT/mrpt.git";
           originalRev = "\${MRPT_VERSION_TO_DOWNLOAD}";
           inherit rev;
-          fetchgitArgs.hash = "sha256-w9LxOtbXw01B2i4aqbhAIjjDwHzC+OvZbcZG/Pyn71Q=";
+          fetchgitArgs.hash = "sha256-274iBA2XqykUhyamoKCLsfknGydOW+aomLH+oIRqKWc=";
         }).overrideAttrs ({ postPatch ? "", ... }: {
           postPatch = postPatch + ''
             src=$(awk '/^URL/ { print gensub(/"/, "", "g", $2) }' CMakeLists.txt)


### PR DESCRIPTION
The first commit adds automatic detection of stale hashes. The second one updates the hash to the correct version.