### PR TITLE
workflows: Update install-nix-action to v31.8.1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ (matrix.system == 'x86_64-linux') && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
     steps:
     - uses: actions/checkout@v4
-    - uses: cachix/install-nix-action@v30
+    - uses: cachix/install-nix-action@v31.8.1
       with:
         extra_nix_config: |
           max-jobs = 2

--- a/.github/workflows/update-colcon.yaml
+++ b/.github/workflows/update-colcon.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v27
+      - uses: cachix/install-nix-action@v31.8.1
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: develop
-      - uses: cachix/install-nix-action@v22
+      - uses: cachix/install-nix-action@v31.8.1
       - uses: cachix/cachix-action@v12
         with:
           name: ros


### PR DESCRIPTION
We used v22 for superflore updates and it started to fail due to too old nix version. Specifically, the error was:

    This version of Nixpkgs requires an implementation of Nix with the following features:
       - `builtins.nixVersion` reports at least 2.18

See https://github.com/lopsided98/nix-ros-overlay/actions/runs/18593237992/job/53012931785

When we're at it, let's update all other actions. The nix version there (2.32.1) should be a bit faster.