### PR TITLE
colcon: Downgrade setuptools dependency to version 79

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -79,7 +79,7 @@ self: super: with self.lib; {
 
       colcon-cmake = pyFinal.callPackage ./colcon/cmake.nix { };
 
-      colcon-core = pyFinal.callPackage ./colcon/core.nix { };
+      colcon-core = pyFinal.callPackage ./colcon/core.nix { setuptools = pyFinal.setuptools_79; };
 
       colcon-defaults = pyFinal.callPackage ./colcon/defaults.nix { };
 
@@ -105,7 +105,7 @@ self: super: with self.lib; {
 
       colcon-pkg-config = pyFinal.callPackage ./colcon/pkg-config.nix { };
 
-      colcon-python-setup-py = pyFinal.callPackage ./colcon/python-setup-py.nix { };
+      colcon-python-setup-py = pyFinal.callPackage ./colcon/python-setup-py.nix { setuptools = pyFinal.setuptools_79; };
 
       colcon-recursive-crawl = pyFinal.callPackage ./colcon/recursive-crawl.nix { };
 
@@ -136,6 +136,18 @@ self: super: with self.lib; {
       rosinstall-generator = pyFinal.callPackage ./rosinstall-generator { };
 
       rospkg = pyFinal.callPackage ./rospkg { };
+
+      setuptools_79 = pyPrev.setuptools.overrideAttrs ({
+        pname, src, ...
+      }: rec {
+        version = "79.0.1";
+        src = self.fetchFromGitHub {
+          owner = "pypa";
+          repo = "setuptools";
+          tag = "v${version}";
+          hash = "sha256-6Gv8R0nlSSz0IL8kD6uPU9MeheGTF1OpdzU7BoApRtk=";
+        };
+      });
 
       vcstools = pyFinal.callPackage ./vcstools { };
     })


### PR DESCRIPTION
colcon_core uses functionality of setuptools to implement `colcon build --symlink-install` for Python packages. Setuptools version 80 removes parts of this functionality [1][2]. More specifically, colcon invokes setup.py of the package to be installed as follows:

    setup.py develop --editable --build-directory build --no-deps

and with setuptools >= 80, this fails with `error: option --editable not recognized`. For this reason, colcon_core now requires setuptools < 80 [3].

AFAICT there is no easy way to replace this setuptools functionality with something else now. Eventually, colcon-python-project [3] could be the solution, but until it's mature, downgrading setuptools seems to be the way to go.

Invocation of setup.py happens in `colcon-core` [4] so we have to downgrade setuptools in this package. With it, `colcon-python-setup-py` complains about two different setuptools versions, so we downgrade there as well.

FYI @znaniye

[1]: https://setuptools.pypa.io/en/stable/history.html#v80-0-0
[2]: https://github.com/colcon/colcon-core/issues/696
[3]: https://github.com/colcon/colcon-python-project
[4]: https://github.com/colcon/colcon-core/blob/3310754d1eeb820368580d569901ba4d26166717/colcon_core/task/python/build.py#L154