### PR TITLE
Remove flake version of ROS 1 example from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,9 @@ system-wide configuration.
 
 With [Flakes enabled][flake], the equivalent of the above is:
 ```
-nix develop github:lopsided98/nix-ros-overlay#example-turtlebot3-gazebo
-# Then use roslaunch commands as above
-```
-```sh
-nix develop github:lopsided98/nix-ros-overlay#example-ros2-desktop-jazzy
+nix develop github:lopsided98/nix-ros-overlay/master#example-ros2-desktop-jazzy
+# Run command-line talker/listener demo
+ros2 launch demo_nodes_cpp talker_listener_launch.xml
 ```
 
 Using the overlay in your `flake.nix`-based project could look like this:


### PR DESCRIPTION
This should have been done in commit 9fd143d597 ("Remove Noetic Ninjemys - the last ROS 1 release", 2025-10-08).

The ROS 2 example is updated to use the master branch and not develop, which is the default.