### PR TITLE
vtk, pcl, rtabmap: Switch to Qt6

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -360,6 +360,7 @@ let
       '';
     });
 
+    # Use rtabmap derivation from nixpkgs, but with the source from ROS.
     rtabmap = self.rtabmap.overrideAttrs ({
       propagatedBuildInputs ? [], ...
     }: {
@@ -367,7 +368,11 @@ let
         pname
         version
         src;
-      propagatedBuildInputs = propagatedBuildInputs ++ [ self.qt5.wrapQtAppsHook self.librealsense self.octomap ];
+      propagatedBuildInputs = propagatedBuildInputs ++ [
+        self.qt6.wrapQtAppsHook
+        self.librealsense
+        self.octomap
+      ];
     });
 
     # TODO: Remove once onetbb appears in the locked nixpkgs version.

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -65,6 +65,18 @@ self: super: with self.lib; {
 
   openni2 = self.callPackage ./openni2 { };
 
+  # For rtabmap-conversions
+  pcl = (super.pcl.override { vtk = self.vtkWithQt6; }).overrideAttrs ({
+    propagatedBuildInputs ? [], propagatedNativeBuildInputs ? [], ...
+  }:{
+    propagatedNativeBuildInputs = propagatedNativeBuildInputs ++ [
+      self.qt6.wrapQtAppsHook
+    ];
+    propagatedBuildInputs = propagatedBuildInputs ++ [
+      self.qt6.qtbase
+    ];
+  });
+
   pythonPackagesExtensions = super.pythonPackagesExtensions ++ [
     (pyFinal: pyPrev: {
       bloom = pyFinal.callPackage ./bloom { };
@@ -166,10 +178,4 @@ self: super: with self.lib; {
 
   superflore = self.python3Packages.callPackage ./superflore { };
 
-  vtk = super.vtk.overrideAttrs ({
-    cmakeFlags ? [], nativeBuildInputs ? [], ...
-  }: {
-    cmakeFlags = cmakeFlags ++ ["-DVTK_MODULE_ENABLE_VTK_GUISupportQt:STRING=YES"];
-    nativeBuildInputs = nativeBuildInputs ++ [ self.qt5.wrapQtAppsHook self.qt5.full ];
-  });
 }


### PR DESCRIPTION
In the past, vtk was overridden to use Qt5 to support rtabmap build (#639). However, by using qt5.full, it adds dependency on insecure qtwebengine to packages like pcl, which is used by many ROS packages including ros-desktop metapackages, which now fail to evaluate. Additionally, Qt5 is no longer supported [1], so we need to start switching everything to Qt6.

This is just a first step to get rid of most important evaluation failures. Many things now evaluate but still fail to build. This will need to be addressed later.

[1]: https://www.qt.io/blog/extended-security-maintenance-for-qt-5.15-begins-may-2025

Cc @muellerbernd