### PR TITLE
Switch superflore to the upstream version and adapt to renamed dependencies in nixpkgs

### DIFF
--- a/pkgs/superflore/default.nix
+++ b/pkgs/superflore/default.nix
@@ -5,13 +5,13 @@
 
 buildPythonPackage rec {
   pname = "superflore";
-  version = "unstable-2025-03-03";
+  version = "0.3.3-unstable-2025-10-01";
 
   src = fetchFromGitHub {
-    owner = "lopsided98";
-    repo = pname;
-    rev = "62104b9ae54faf53991a7d94bf84c8ddfc8573df";
-    hash = "sha256-it6cje1nkG4pjakn5Vvwhw0NGyc23xblmhXMEwUpTbg=";
+    owner = "ros-infrastructure";
+    repo = "superflore";
+    rev = "b10efe80de4abec269f8e4bd7e18d8bb737984bd";
+    hash = "sha256-WMUIBgzp6FH2j/pl8f5rBeaVceZmvue3fC2d1T7V43I=";
   };
 
   pyproject = true;


### PR DESCRIPTION
All changes needed for this overlay are merged upstream now so switch to it. An added bonus of this switch is that we get rid of the following warning:

    python3.13/site-packages/superflore/__init__.py:2: UserWarning:
    pkg_resources is deprecated as an API. See
    https://setuptools.pypa.io/en/latest/pkg_resources.html. The
    pkg_resources package is slated for removal as early as
    2025-11-30. Refrain from using this package or pin to
    Setuptools<81.

If we need to do some changes in superflore (which is quite likely), we can switch any fork later.