### PR TITLE
update-colcon: Update only packages in this overlay

### DIFF
--- a/maintainers/scripts/update-colcon.sh
+++ b/maintainers/scripts/update-colcon.sh
@@ -10,7 +10,7 @@ nix eval --json --impure --expr '
 let
   pkgs = (import ./. {});
   lib = pkgs.lib;
-  colconPkgs = lib.filterAttrs (n: v: builtins.substring 0 7 n == "colcon-") pkgs.python3Packages;
+  colconPkgs = lib.filterAttrs (n: v: builtins.substring 0 7 n == "colcon-" && lib.hasPrefix "'"$PWD"'" v.meta.position ) pkgs.python3Packages;
 in
    lib.attrNames colconPkgs' \
     | jq  --raw-output '.[]' \


### PR DESCRIPTION
The update script started failing on packages, which are in nixpkgs and not in our overlay. Such packages cannot be updated here. One such package is `colcon-installed-package-information`.