### PR TITLE
python3Packages.colcon-cargo: 0.1.3 -> 0.2.0

### DIFF
--- a/pkgs/colcon/cargo.nix
+++ b/pkgs/colcon/cargo.nix
@@ -4,11 +4,12 @@
 
 buildPythonPackage rec {
   pname = "colcon-cargo";
-  version = "0.1.3";
+  version = "0.2.0";
 
   src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-FXp3Nso5NlvBqPA2Kv03mBNR8fwQELbDMU+mqmxTSWc=";
+    inherit version;
+    pname = "colcon_cargo";
+    hash = "sha256-E66G45eqB0056PrS3V4+QpfMvYHVe3E3vQgtFkb8eKA=";
   };
 
   pyproject = true;


### PR DESCRIPTION
This requires changing pname in the same way as was needed for colcon-meson recently. This is likely caused by some change on PyPI, since the same renames are needed in many nixpkgs packages. Many of those packages switch from fetchPypi to fetchFromGithub. Maybe, we should do the same (later).