### PR TITLE
workflows/build: Don't fail fast

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         distro:
           - humble


### PR DESCRIPTION
The purpose of the build action is to populate our binary cache. If one distro fails and fail-fast is true (which it is by default), other distro builds are stopped and the cache will not be populated.

The hope is that switching fail-fast to off in this commit would build other distros and populate the cache even if one distro build fails for whatever reason. Currently, I have the impression that builds fail due to out-of-memory situations.