### PR TITLE
CI and caching improvements

### DIFF
--- a/.github/actions/nix-ros-build-action/action.yml
+++ b/.github/actions/nix-ros-build-action/action.yml
@@ -25,6 +25,9 @@ inputs:
     description: Name of the Cachix cache to use
     required: true
     default: ros
+  pin-name:
+    description: Name of the Cachix pin to pin the results
+    required: false
 
 runs:
   using: node20

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,3 +33,4 @@ jobs:
         system: '${{ matrix.system }}'
         eval-jobs: 4
         build-jobs: 2
+        pin-name: ${{ (github.ref_name == 'master' || github.ref_name == 'develop') && format('{0}-{1}-{2}', github.ref_name , matrix.distro, matrix.system) || null }}


### PR DESCRIPTION
CI runs too long and the binary cache seems to be too small to store all what's needed. These commits try to improve the situation and provide more insight into how is the cache used. See the individual commit messages for more information.