### PR TITLE
Revert "nix-ros-build-action: Don't push linkFarm separately, pin is sufficient"

### DIFF
--- a/.github/actions/nix-ros-build-action/dist/index.js
+++ b/.github/actions/nix-ros-build-action/dist/index.js
@@ -91562,6 +91562,7 @@ async function run() {
         ])`);
             (0,external_child_process_.execSync)(`
         linkFarm=$(nix-build --show-trace linkFarm.nix) &&
+        cachix push ${cachixCache} $linkFarm &&
         cachix pin ${cachixCache} ${pinName} $linkFarm &&
         nix-store --query --references $linkFarm | xargs du -shc | sort -h
       `, { stdio: "inherit" });

--- a/.github/actions/nix-ros-build-action/src/main.ts
+++ b/.github/actions/nix-ros-build-action/src/main.ts
@@ -472,6 +472,7 @@ async function run() {
         ])`)
       execSync(`
         linkFarm=$(nix-build --show-trace linkFarm.nix) &&
+        cachix push ${cachixCache} $linkFarm &&
         cachix pin ${cachixCache} ${pinName} $linkFarm &&
         nix-store --query --references $linkFarm | xargs du -shc | sort -h
       `, { stdio: "inherit" });


### PR DESCRIPTION
This reverts commit 0292bcdf07b53434e75a238caa1669d09b5e5bde.

The push is actually necessary. My testing didn't reveal this, because my testing cache already contained the pinned derivation.