### PR TITLE
workflows/build: Add external binary cache to speed up CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,6 +29,14 @@ jobs:
         name: ros
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
         skipPush: true
+    # Add second cache after cachix-action to prevent cachix-action
+    # from overriding substituters.
+    - name: "Configure @wentasah's binary cache"
+      run: |
+        cat >> ~/.config/nix/nix.conf <<EOF
+        extra-substituters = https://attic.iid.ciirc.cvut.cz/ros?priority=42
+        extra-trusted-public-keys = ros:JR95vUYsShSqfA1VTYoFt1Nz6uXasm5QrcOsGry9f6Q=
+        EOF
     - uses: ./.github/actions/nix-ros-build-action
       with:
         root-attribute: 'rosPackages.${{ matrix.distro }}'


### PR DESCRIPTION
The purpose of our build workflow is to build all ROS packages and push them to binary cache at https://ros.cachix.org. There are two problems with this:

1. Building all packages on GitHub-hosted runners takes long time, often longer than 6-hour time limit. If the build times out, I have to manually restart it for our users to have the packages cached.

2. Cachix cache size is limited. This often leads to rebuilding the same package over and over again, making the problem 1 more severe.

Since I'm always building bigger PRs (such as rosdistro syncs) on my Hydra (https://hydra.iid.ciirc.cvut.cz/) and since Hydra pushes the results to the publicly accessible binary cache at https://attic.iid.ciirc.cvut.cz/ros, we can avoid those "expensive" rebuilds by fetching the packages built by Hydra. This way, the build workflow would just copy the packages from my cache to Cachix.

This has the following consequences:

- Some binaries will be built on my servers, which will be less transparent to users.

- Build logs will not be visible in GitHub Action logs, because Attic binary cache cannot store and serve build logs (yet?). The build logs are, however, available from Hydra web interface/API.

+ Fault tolerance: Compared to other possible approaches, e.g., using remote Nix builders or self-hosted GitHub runners, this has the advantage that if the external infrastructure fails, the packages will still be built by GitHub as before.

> [!NOTE]
> Since some users might not be happy about reduced transparency caused by this PR, I'll leave it open for at least a week to give users a chance to change their configuration or complain. 