### PR TITLE
workflows/build: Add CACHIX_AUTH_TOKEN configuration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,7 @@ jobs:
     - uses: cachix/cachix-action@v15
       with:
         name: ros
+        authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
         skipPush: true
     - uses: ./.github/actions/nix-ros-build-action


### PR DESCRIPTION
This should make cache pinning work.