### PR TITLE
nix-ros-build-action: Don't cache debug outputs

### DIFF
--- a/.github/actions/nix-ros-build-action/src/nix.ts
+++ b/.github/actions/nix-ros-build-action/src/nix.ts
@@ -139,8 +139,9 @@ export async function isDrvCachedOn(
 
 export async function isDrvCached(
   drvPath: string,
+  excludeOutputs: RegExp,
 ): Promise<boolean> {
-  const outputs = await getOutputs(drvPath)
+  const outputs = (await getOutputs(drvPath)).filter((output) => !excludeOutputs.test(output))
   const substituters = await getSubstituters();
 
   try {


### PR DESCRIPTION
Debug outputs of all packages consume a lot of cache capacity, and as such most of them are quickly garbage collected from the cache because they are over the quota. Missing debug outputs in the cache cause frequent rebuilds of almost all packages making CI painfully slow.

With this change, we ignore the debug outputs. The package is rebuilt only if all non-debug outputs (typically just `$out`) are missing from the cache and only those outputs are then pushed to the cache (and pinned).

With this change, all our builds for a single commit on the `develop` branch consume about 8 GB of the cache, which is below 10 GB capacity. Re-run of the CI then needs just between 4 to 8 minutes.

There are still some problems remaining:

- We also want to cache the `master` branch, which would result in cache consumption of ca. 16 GB, which is over the free 10 GB quota. Migration to nix-community with bigger cache would solve this.

- Limited disk capacity of GitHub runners: Creating the link farm for pinning the build in the cache requires downloading the full closure of all packages, which has about 13 GB. Since GitHub runners offer disk capacity of 14 GB, CI can easily run out of disk space. Especially when a bigger amount of packages needs to be built, and their build dependencies needs to be on disk. In that case, rerunning the build is sufficient, because the individual packages would already be cached and build dependencies would not be needed for the second time. If, however, ROS becomes bigger, we would always run out of disk space and something will need to be done. Either splitting the build jobs to smaller units or having bigger disk capacity.