### PR TITLE
rosdistro sync, Mon Dec 22 21:17:15 2025

### DIFF
--- a/distros/humble/ardrone-sdk/default.nix
+++ b/distros/humble/ardrone-sdk/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_libjson-c-dev, ament-cmake, avahi, ffmpeg, ncurses }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, avahi, ffmpeg, json-c, ncurses }:
 buildRosPackage {
   pname = "ros-humble-ardrone-sdk";
   version = "2.0.3-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ _unresolved_libjson-c-dev avahi ffmpeg ncurses ];
+  propagatedBuildInputs = [ avahi ffmpeg json-c ncurses ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/autoware-internal-debug-msgs/default.nix
+++ b/distros/humble/autoware-internal-debug-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-autoware-internal-debug-msgs";
-  version = "1.12.0-r2";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/humble/autoware_internal_debug_msgs/1.12.0-2.tar.gz";
-    name = "1.12.0-2.tar.gz";
-    sha256 = "fa40591d8885b1d50468c8527f6ad0f6908a75d2d8bf0cb00b0c5dfa6e723930";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/humble/autoware_internal_debug_msgs/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "a2f52856c702320da7ab196feb06cb6d0be719c9e06a993392afbf040cf4d7fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-internal-localization-msgs/default.nix
+++ b/distros/humble/autoware-internal-localization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-common-msgs, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-autoware-internal-localization-msgs";
-  version = "1.12.0-r2";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/humble/autoware_internal_localization_msgs/1.12.0-2.tar.gz";
-    name = "1.12.0-2.tar.gz";
-    sha256 = "e3ad337f46d9c1def22b39ac328c9b0bfa890f9b9e52e335878c07d676dda015";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/humble/autoware_internal_localization_msgs/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "b0f99e41a1f778e2227fa95e0eede77ff91afe226c71f935feda66c7e051f094";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-internal-metric-msgs/default.nix
+++ b/distros/humble/autoware-internal-metric-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-autoware-internal-metric-msgs";
-  version = "1.12.0-r2";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/humble/autoware_internal_metric_msgs/1.12.0-2.tar.gz";
-    name = "1.12.0-2.tar.gz";
-    sha256 = "f3c98c70b1ad88471b0c0e350535508d7e84cf44c85ec5d1dbcbe6425ad6f472";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/humble/autoware_internal_metric_msgs/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "de5b1580cb0f5aca7beca2be05ef0f39131d6f27ba7b1f799d317e780fa7f720";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-internal-msgs/default.nix
+++ b/distros/humble/autoware-internal-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-internal-debug-msgs, autoware-internal-metric-msgs, autoware-internal-perception-msgs, autoware-internal-planning-msgs, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-autoware-internal-msgs";
-  version = "1.12.0-r2";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/humble/autoware_internal_msgs/1.12.0-2.tar.gz";
-    name = "1.12.0-2.tar.gz";
-    sha256 = "48e60efb66f8c61a6c34d7780234d7813a959e2700bcfbda6a973dcd3c876b0d";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/humble/autoware_internal_msgs/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "164e6673afa9f5332ca1a48ed470aa5af8e6a06e66fb00db73fdd8e2e8a54758";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-internal-perception-msgs/default.nix
+++ b/distros/humble/autoware-internal-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-perception-msgs, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-autoware-internal-perception-msgs";
-  version = "1.12.0-r2";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/humble/autoware_internal_perception_msgs/1.12.0-2.tar.gz";
-    name = "1.12.0-2.tar.gz";
-    sha256 = "569ca07ca630d9e5a2ded6239a1c4847a5ef15ebbca988956e146b84f952a2eb";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/humble/autoware_internal_perception_msgs/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "6569af66fe00da252e01d7eaebd71aec63edec423cc222e9fc0a1354603e33fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-internal-planning-msgs/default.nix
+++ b/distros/humble/autoware-internal-planning-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-common-msgs, autoware-perception-msgs, autoware-planning-msgs, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-humble-autoware-internal-planning-msgs";
-  version = "1.12.0-r2";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/humble/autoware_internal_planning_msgs/1.12.0-2.tar.gz";
-    name = "1.12.0-2.tar.gz";
-    sha256 = "3969f748260527388415bd2033014986c5e1b946d906341dc6d67ec5ea6ae04b";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/humble/autoware_internal_planning_msgs/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "667aa24d76099ddf51a6ceccdb4dd5e1d1d7dd410bba290779a77496323fe950";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-bridge/default.nix
+++ b/distros/humble/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, composition-interfaces, cv-bridge, depthai, depthai-ros-msgs, ffmpeg-image-transport-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-bridge";
-  version = "2.11.2-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.11.2-1.tar.gz";
-    name = "2.11.2-1.tar.gz";
-    sha256 = "efe501f5829eee35f015d3ff82f61a92c3874a4f0b439d54391204c0fa44066b";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "2d93635eb7bbdc7d2fd5721b5a582b6116dad50a8ff3801326a921fe81549f07";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-descriptions/default.nix
+++ b/distros/humble/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-descriptions";
-  version = "2.11.2-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_descriptions/2.11.2-1.tar.gz";
-    name = "2.11.2-1.tar.gz";
-    sha256 = "d750d4508e24099172c8ad7a0d85dfe4bb9756322ecfbda924dc9bc4f5caf7f7";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_descriptions/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "0b9f4d6e0a09f7710f12e6081bf582ed47a157ae3ce48c6ea2ddaa326c2345b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-examples/default.nix
+++ b/distros/humble/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-examples";
-  version = "2.11.2-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.11.2-1.tar.gz";
-    name = "2.11.2-1.tar.gz";
-    sha256 = "92a51ffc70388ea352c0564e994b866a080c6ea72cd1a2d4f6eff458ae54dfde";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "50ad2568795a63f7132bdf40c84335a675a732a930921bf8653313ccf1d4e736";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-filters/default.nix
+++ b/distros/humble/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, depthai-ros-msgs, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-filters";
-  version = "2.11.2-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_filters/2.11.2-1.tar.gz";
-    name = "2.11.2-1.tar.gz";
-    sha256 = "7a535d6a2fe27e1c81f2afc892c08c7e78c7e515fa4eb813e38afb71d5b9a710";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_filters/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "2db75b80b9bd7222adf5982f2782aa0e745aa48edf8c314b97a6426ed75b2ebf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros-driver/default.nix
+++ b/distros/humble/depthai-ros-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, ffmpeg-image-transport-msgs, image-pipeline, image-transport, image-transport-plugins, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, ffmpeg-image-transport-msgs, image-pipeline, image-transport, image-transport-plugins, opencv, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-driver";
-  version = "2.11.2-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_driver/2.11.2-1.tar.gz";
-    name = "2.11.2-1.tar.gz";
-    sha256 = "f27f9ad17ab448352075fe1fe0ec6507d1ec77809f94b48b1488636b6a1f6a11";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_driver/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "16aae7745d322610e4cfb1fd3776389a3211f2b5d5adc415202c23acb63d86e2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-cmake-auto camera-calibration cv-bridge depthai depthai-bridge depthai-descriptions depthai-examples depthai-ros-msgs diagnostic-msgs diagnostic-updater ffmpeg-image-transport-msgs image-pipeline image-transport image-transport-plugins pluginlib rclcpp rclcpp-components sensor-msgs std-msgs std-srvs vision-msgs ];
+  propagatedBuildInputs = [ ament-cmake-auto camera-calibration cv-bridge depthai depthai-bridge depthai-descriptions depthai-examples depthai-ros-msgs diagnostic-msgs diagnostic-updater ffmpeg-image-transport-msgs image-pipeline image-transport image-transport-plugins opencv opencv.cxxdev pluginlib rclcpp rclcpp-components sensor-msgs std-msgs std-srvs vision-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/depthai-ros-msgs/default.nix
+++ b/distros/humble/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-msgs";
-  version = "2.11.2-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.11.2-1.tar.gz";
-    name = "2.11.2-1.tar.gz";
-    sha256 = "f21eab977509fc17e2c7281948052badcc1a777677ca4309af712a5dd8e036ed";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "bde6941d4c3124a4f48de904913895ed4141ed016f95589ddf62db1cafea25f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros/default.nix
+++ b/distros/humble/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros";
-  version = "2.11.2-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.11.2-1.tar.gz";
-    name = "2.11.2-1.tar.gz";
-    sha256 = "56f50b1f25b391e50ad4e757d94210c2c59cc9bbb121f48a067b8367034c6296";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "f34c2a59b927e18dcfcabfa130857b8c3653ec0e6edf22eb3ff6ada7c17103f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/fastrtps/default.nix
+++ b/distros/humble/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, python3, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-humble-fastrtps";
-  version = "2.6.10-r1";
+  version = "2.6.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastdds-release/archive/release/humble/fastrtps/2.6.10-1.tar.gz";
-    name = "2.6.10-1.tar.gz";
-    sha256 = "affd47aea9f765b702037b434fa50b591d35bac98671024c66e7d999433fb8cb";
+    url = "https://github.com/ros2-gbp/fastdds-release/archive/release/humble/fastrtps/2.6.11-1.tar.gz";
+    name = "2.6.11-1.tar.gz";
+    sha256 = "0724e19ebcb159d3be0eb38e41c43564b29b3da56391851ad7b19c848af4801c";
   };
 
   buildType = "cmake";

--- a/distros/humble/nanoeigenpy/default.nix
+++ b/distros/humble/nanoeigenpy/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_nanobind-dev, cmake, doxygen, eigen, git, python3, python3Packages }:
+{ lib, buildRosPackage, fetchurl, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-nanoeigenpy";
   version = "0.4.0-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "cmake";
   buildInputs = [ cmake doxygen git ];
-  propagatedBuildInputs = [ _unresolved_nanobind-dev eigen python3 python3Packages.numpy python3Packages.scipy ];
+  propagatedBuildInputs = [ eigen python3 python3Packages.nanobind python3Packages.numpy python3Packages.scipy ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/jazzy/ardrone-sdk/default.nix
+++ b/distros/jazzy/ardrone-sdk/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_libjson-c-dev, ament-cmake, avahi, ffmpeg, ncurses }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, avahi, ffmpeg, json-c, ncurses }:
 buildRosPackage {
   pname = "ros-jazzy-ardrone-sdk";
   version = "2.0.3-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ _unresolved_libjson-c-dev avahi ffmpeg ncurses ];
+  propagatedBuildInputs = [ avahi ffmpeg json-c ncurses ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/autoware-internal-debug-msgs/default.nix
+++ b/distros/jazzy/autoware-internal-debug-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-internal-debug-msgs";
-  version = "1.12.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/jazzy/autoware_internal_debug_msgs/1.12.0-1.tar.gz";
-    name = "1.12.0-1.tar.gz";
-    sha256 = "ddd7e030e7f8be50596a798a9b1e8b013a34ed6dcc3690dd7a2df8bc77af5679";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/jazzy/autoware_internal_debug_msgs/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "339cf456daacf8fa08e7fdb673cbc57f0563782ef7f8111bfca87dc02ffe77c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-internal-localization-msgs/default.nix
+++ b/distros/jazzy/autoware-internal-localization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-common-msgs, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-internal-localization-msgs";
-  version = "1.12.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/jazzy/autoware_internal_localization_msgs/1.12.0-1.tar.gz";
-    name = "1.12.0-1.tar.gz";
-    sha256 = "3b9b16c389a17b05436a06eaf002d9d3b4593ae59c9d2a38e174b7414623e2ad";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/jazzy/autoware_internal_localization_msgs/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "9a238c967e8220bd9ca5508ee2b56d91652732ab53a9a4bbdb87a1c5d84f6442";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-internal-metric-msgs/default.nix
+++ b/distros/jazzy/autoware-internal-metric-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-internal-metric-msgs";
-  version = "1.12.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/jazzy/autoware_internal_metric_msgs/1.12.0-1.tar.gz";
-    name = "1.12.0-1.tar.gz";
-    sha256 = "57cdd0148a3fcb736340df1c57c6f8a620c9e1bc328e88f74de3b231eb44c4aa";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/jazzy/autoware_internal_metric_msgs/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "c62a7f4b2f5656b73bd50fa222445780306a2e21492faf6672b65b1ab7aac266";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-internal-msgs/default.nix
+++ b/distros/jazzy/autoware-internal-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-internal-debug-msgs, autoware-internal-metric-msgs, autoware-internal-perception-msgs, autoware-internal-planning-msgs, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-internal-msgs";
-  version = "1.12.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/jazzy/autoware_internal_msgs/1.12.0-1.tar.gz";
-    name = "1.12.0-1.tar.gz";
-    sha256 = "13f764ef09434505016020e2d5bd0a4368814449727a178aae2b6a3cb492ace6";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/jazzy/autoware_internal_msgs/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "49c69a10be7edccb85bb1c1e60ee0cda02271fca527bfc9177bf200af6700c97";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-internal-perception-msgs/default.nix
+++ b/distros/jazzy/autoware-internal-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-perception-msgs, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-internal-perception-msgs";
-  version = "1.12.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/jazzy/autoware_internal_perception_msgs/1.12.0-1.tar.gz";
-    name = "1.12.0-1.tar.gz";
-    sha256 = "bbba1f6dc3051c67330a045da2a25abdbc511af2a5e6fd42ee10a287e40ea699";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/jazzy/autoware_internal_perception_msgs/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "871327647a5e5ce2a8c81f6b113d598c163ad33f774f781b6a4f9836ba3b7338";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-internal-planning-msgs/default.nix
+++ b/distros/jazzy/autoware-internal-planning-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-common-msgs, autoware-perception-msgs, autoware-planning-msgs, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-internal-planning-msgs";
-  version = "1.12.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/jazzy/autoware_internal_planning_msgs/1.12.0-1.tar.gz";
-    name = "1.12.0-1.tar.gz";
-    sha256 = "3f3df6ab7c146e2334b90b86eb081d27de2286cb41c28fa72ab58700757048c4";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/jazzy/autoware_internal_planning_msgs/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "fc16dac9cbc7ed99bb035d1efa0b4d631b52b746bb45b6185d83d8b3ce316976";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-bridge/default.nix
+++ b/distros/jazzy/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, composition-interfaces, cv-bridge, depthai, depthai-ros-msgs, ffmpeg-image-transport-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-bridge";
-  version = "2.11.2-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_bridge/2.11.2-1.tar.gz";
-    name = "2.11.2-1.tar.gz";
-    sha256 = "e53b8eb0104d7767a93d5de64b4764cc674d597c66ff06b20e901592e0a1396f";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_bridge/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "57c746deb86402e55117fb4434b0547a8af3517a744a7f05eec5b3a76d31e84a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-descriptions/default.nix
+++ b/distros/jazzy/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-descriptions";
-  version = "2.11.2-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_descriptions/2.11.2-1.tar.gz";
-    name = "2.11.2-1.tar.gz";
-    sha256 = "337eecacaee37b7fff055162d8c4415b66a506a59f8ddd90d539552cbd776ed7";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_descriptions/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "9e264d3a7b8d4a4f2d83aa1e218fc19f08d55080ffd261e2cf2e4cd12635f57e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-examples/default.nix
+++ b/distros/jazzy/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-examples";
-  version = "2.11.2-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_examples/2.11.2-1.tar.gz";
-    name = "2.11.2-1.tar.gz";
-    sha256 = "c02a25d94394c917421ffc08c44b4771115119d5ffbc44746573268c3ff05250";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_examples/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "88484e83ee35726d124d439342cbaadb10c05de4f156ce99d04e198f8f46f6e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-filters/default.nix
+++ b/distros/jazzy/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, depthai-ros-msgs, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-filters";
-  version = "2.11.2-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_filters/2.11.2-1.tar.gz";
-    name = "2.11.2-1.tar.gz";
-    sha256 = "86d51c2fecf4cb161331ddd7a9d07cb2bfc85baae14dea0461d2cfce9fa3fde8";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_filters/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "35c10f85bad9ef1a783a8e86149d0c2bff5dbdf894592e5dd074d90aee0bedc5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-ros-driver/default.nix
+++ b/distros/jazzy/depthai-ros-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, ffmpeg-image-transport-msgs, image-pipeline, image-transport, image-transport-plugins, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, ffmpeg-image-transport-msgs, image-pipeline, image-transport, image-transport-plugins, opencv, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-ros-driver";
-  version = "2.11.2-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_ros_driver/2.11.2-1.tar.gz";
-    name = "2.11.2-1.tar.gz";
-    sha256 = "ebe7cabee548192c848791a6051e3eed490e56aa2f677ab686f42cfc1fb35ccc";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_ros_driver/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "9b595e9176cdeeefc16333c315aa44f867779c6ab21f9bd53dcbdb3f4c2da6a9";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-cmake-auto camera-calibration cv-bridge depthai depthai-bridge depthai-descriptions depthai-examples depthai-ros-msgs diagnostic-msgs diagnostic-updater ffmpeg-image-transport-msgs image-pipeline image-transport image-transport-plugins pluginlib rclcpp rclcpp-components sensor-msgs std-msgs std-srvs vision-msgs ];
+  propagatedBuildInputs = [ ament-cmake-auto camera-calibration cv-bridge depthai depthai-bridge depthai-descriptions depthai-examples depthai-ros-msgs diagnostic-msgs diagnostic-updater ffmpeg-image-transport-msgs image-pipeline image-transport image-transport-plugins opencv opencv.cxxdev pluginlib rclcpp rclcpp-components sensor-msgs std-msgs std-srvs vision-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/depthai-ros-msgs/default.nix
+++ b/distros/jazzy/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-ros-msgs";
-  version = "2.11.2-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_ros_msgs/2.11.2-1.tar.gz";
-    name = "2.11.2-1.tar.gz";
-    sha256 = "c917510fe6b79d5be5ed837ee1ce6891db7b807ffef36cb4740c25aeb7691c4b";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_ros_msgs/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "cd5725c0d8c889ae137db028364b6da600f617f73c10438b5e3e7af032a41c6d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-ros/default.nix
+++ b/distros/jazzy/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-ros";
-  version = "2.11.2-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai-ros/2.11.2-1.tar.gz";
-    name = "2.11.2-1.tar.gz";
-    sha256 = "1de6f330b5a4227856c050759f9888e5c7e6830dcab2f81733be363cc582eb21";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai-ros/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "8672ac920dfded9a9587fb270b27c7579ff3a1b0b60a792e615f98b521429fc8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ds-dbw-can/default.nix
+++ b/distros/jazzy/ds-dbw-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, dataspeed-can-msg-filters, dataspeed-can-usb, ds-dbw-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ds-dbw-can";
-  version = "2.3.9-r1";
+  version = "2.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw_can/2.3.9-1.tar.gz";
-    name = "2.3.9-1.tar.gz";
-    sha256 = "d4b0592a980282e73b17f26500bfa1b4b60de8fc28b7c9b927e48e055e4bdf8e";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw_can/2.3.10-1.tar.gz";
+    name = "2.3.10-1.tar.gz";
+    sha256 = "3b78d318c8ab8b7867842794590d6cf6307c00bb079182defa95173f3dbdfd20";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ds-dbw-joystick-demo/default.nix
+++ b/distros/jazzy/ds-dbw-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ds-dbw-can, ds-dbw-msgs, joy, rclcpp, rclcpp-components, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ds-dbw-joystick-demo";
-  version = "2.3.9-r1";
+  version = "2.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw_joystick_demo/2.3.9-1.tar.gz";
-    name = "2.3.9-1.tar.gz";
-    sha256 = "840f0771be60a6be163ecbff1fd0df79a994efdfc939f31c3055490b422ffae2";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw_joystick_demo/2.3.10-1.tar.gz";
+    name = "2.3.10-1.tar.gz";
+    sha256 = "535be6f518bc5cc6dd3f86e19485c2171a69191a0c5ff33ad3c5f3472d81632b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ds-dbw-msgs/default.nix
+++ b/distros/jazzy/ds-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ds-dbw-msgs";
-  version = "2.3.9-r1";
+  version = "2.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw_msgs/2.3.9-1.tar.gz";
-    name = "2.3.9-1.tar.gz";
-    sha256 = "42e40d32b2cdbfacbd3656249f62f00f5b9735622069ab323dc2c08608e49abc";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw_msgs/2.3.10-1.tar.gz";
+    name = "2.3.10-1.tar.gz";
+    sha256 = "e1c41bbacee56502a8a9f93a63cd9d715160afa85c0b65cb7ba5414140b58d2b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ds-dbw/default.nix
+++ b/distros/jazzy/ds-dbw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ds-dbw-can, ds-dbw-joystick-demo, ds-dbw-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ds-dbw";
-  version = "2.3.9-r1";
+  version = "2.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw/2.3.9-1.tar.gz";
-    name = "2.3.9-1.tar.gz";
-    sha256 = "60441db0dc70d41dc952a3fa8a7052e80a326ab65cbf2fec1aad9845057d0f8b";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw/2.3.10-1.tar.gz";
+    name = "2.3.10-1.tar.gz";
+    sha256 = "b1b991fff7edd0c9689bcbb037643fb282c001287bdb33720ab0208559c69941";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nanoeigenpy/default.nix
+++ b/distros/jazzy/nanoeigenpy/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_nanobind-dev, cmake, doxygen, eigen, git, python3, python3Packages }:
+{ lib, buildRosPackage, fetchurl, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-nanoeigenpy";
   version = "0.4.0-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "cmake";
   buildInputs = [ cmake doxygen git ];
-  propagatedBuildInputs = [ _unresolved_nanobind-dev eigen python3 python3Packages.numpy python3Packages.scipy ];
+  propagatedBuildInputs = [ eigen python3 python3Packages.nanobind python3Packages.numpy python3Packages.scipy ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/kilted/nanoeigenpy/default.nix
+++ b/distros/kilted/nanoeigenpy/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_nanobind-dev, cmake, doxygen, eigen, git, python3, python3Packages }:
+{ lib, buildRosPackage, fetchurl, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-kilted-nanoeigenpy";
   version = "0.4.0-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "cmake";
   buildInputs = [ cmake doxygen git ];
-  propagatedBuildInputs = [ _unresolved_nanobind-dev eigen python3 python3Packages.numpy python3Packages.scipy ];
+  propagatedBuildInputs = [ eigen python3 python3Packages.nanobind python3Packages.numpy python3Packages.scipy ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/rolling/ardrone-sdk/default.nix
+++ b/distros/rolling/ardrone-sdk/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_libjson-c-dev, ament-cmake, avahi, ffmpeg, ncurses }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, avahi, ffmpeg, json-c, ncurses }:
 buildRosPackage {
   pname = "ros-rolling-ardrone-sdk";
   version = "2.0.3-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ _unresolved_libjson-c-dev avahi ffmpeg ncurses ];
+  propagatedBuildInputs = [ avahi ffmpeg json-c ncurses ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/autoware-internal-debug-msgs/default.nix
+++ b/distros/rolling/autoware-internal-debug-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-autoware-internal-debug-msgs";
-  version = "1.12.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/rolling/autoware_internal_debug_msgs/1.12.0-1.tar.gz";
-    name = "1.12.0-1.tar.gz";
-    sha256 = "16278a47f68e3fde653da8eaa34ab1be92031a85d7131ab537346a772d18c408";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/rolling/autoware_internal_debug_msgs/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "71faaebd26ff6f4c02645f6f60cb9c76fa94f1f8628ef3077be555b873c665f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/autoware-internal-localization-msgs/default.nix
+++ b/distros/rolling/autoware-internal-localization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-common-msgs, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-autoware-internal-localization-msgs";
-  version = "1.12.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/rolling/autoware_internal_localization_msgs/1.12.0-1.tar.gz";
-    name = "1.12.0-1.tar.gz";
-    sha256 = "c49cdb851f0872c8fd795ff025bd5cbad482027f73e56ce86abb249563867842";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/rolling/autoware_internal_localization_msgs/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "c16be6b26dfed8236abe985f7ac30a21e81493822324541658d976556f3e7458";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/autoware-internal-metric-msgs/default.nix
+++ b/distros/rolling/autoware-internal-metric-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-autoware-internal-metric-msgs";
-  version = "1.12.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/rolling/autoware_internal_metric_msgs/1.12.0-1.tar.gz";
-    name = "1.12.0-1.tar.gz";
-    sha256 = "fbc8f050bfc8468f8050257028d20b93be27f3c70b6fe6a270da2497803946f2";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/rolling/autoware_internal_metric_msgs/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "1718beebc08049905012642a95ba76a103da7235c7175d111b5be99aba5c1080";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/autoware-internal-msgs/default.nix
+++ b/distros/rolling/autoware-internal-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-internal-debug-msgs, autoware-internal-metric-msgs, autoware-internal-perception-msgs, autoware-internal-planning-msgs, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-autoware-internal-msgs";
-  version = "1.12.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/rolling/autoware_internal_msgs/1.12.0-1.tar.gz";
-    name = "1.12.0-1.tar.gz";
-    sha256 = "7a3e3516946853b57be63d8565c2a3b7e2f6f1b7494433b38e67e89ab433c26c";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/rolling/autoware_internal_msgs/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "b187d012e33e459fc00c357efc0e9d4c630fdf0a7550d8a72a82d2ef7350d784";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/autoware-internal-perception-msgs/default.nix
+++ b/distros/rolling/autoware-internal-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-perception-msgs, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-autoware-internal-perception-msgs";
-  version = "1.12.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/rolling/autoware_internal_perception_msgs/1.12.0-1.tar.gz";
-    name = "1.12.0-1.tar.gz";
-    sha256 = "507c596369e86b2dc9bf00483e6df3ffbe7da9b9d0435ef1f831b366a359f0cc";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/rolling/autoware_internal_perception_msgs/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "66cac676ffc0d80785f616b8d0c51dbb9227ca1443dd295bb623f085df0edef9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/autoware-internal-planning-msgs/default.nix
+++ b/distros/rolling/autoware-internal-planning-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-common-msgs, autoware-perception-msgs, autoware-planning-msgs, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-autoware-internal-planning-msgs";
-  version = "1.12.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/rolling/autoware_internal_planning_msgs/1.12.0-1.tar.gz";
-    name = "1.12.0-1.tar.gz";
-    sha256 = "043f215e5231a85813a85c47708ded69000117fe6f58da6b7ae496bfccf19699";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/rolling/autoware_internal_planning_msgs/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "fba9e9a97f72fcefc9d8133664490e7f4a2c984b3472806361a94a69feb79924";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/nanoeigenpy/default.nix
+++ b/distros/rolling/nanoeigenpy/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_nanobind-dev, cmake, doxygen, eigen, git, python3, python3Packages }:
+{ lib, buildRosPackage, fetchurl, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-nanoeigenpy";
   version = "0.4.0-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "cmake";
   buildInputs = [ cmake doxygen git ];
-  propagatedBuildInputs = [ _unresolved_nanobind-dev eigen python3 python3Packages.numpy python3Packages.scipy ];
+  propagatedBuildInputs = [ eigen python3 python3Packages.nanobind python3Packages.numpy python3Packages.scipy ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/rolling/rviz-common/default.nix
+++ b/distros/rolling/rviz-common/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_libqt6gui6t64, _unresolved_libqt6widgets6t64, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, message-filters, pluginlib, qt6, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml-2, urdf, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, message-filters, pluginlib, qt6, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml-2, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-common";
   version = "15.1.14-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ _unresolved_libqt6gui6t64 _unresolved_libqt6widgets6t64 geometry-msgs message-filters pluginlib qt6.qtbase qt6.qtsvg rclcpp resource-retriever rviz-ogre-vendor rviz-rendering sensor-msgs std-msgs std-srvs tf2 tf2-ros tinyxml-2 urdf yaml-cpp-vendor ];
+  propagatedBuildInputs = [ geometry-msgs message-filters pluginlib qt6.qtbase qt6.qtsvg rclcpp resource-retriever rviz-ogre-vendor rviz-rendering sensor-msgs std-msgs std-srvs tf2 tf2-ros tinyxml-2 urdf yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/rviz-default-plugins/default.nix
+++ b/distros/rolling/rviz-default-plugins/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_libqt6gui6t64, _unresolved_libqt6widgets6t64, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, gz-math-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt6, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-resource-interfaces, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, gz-math-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt6, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-resource-interfaces, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz-default-plugins";
   version = "15.1.14-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-cmake-lint-cmake ament-index-cpp ament-lint-auto ament-lint-common rviz-rendering-tests rviz-visual-testing-framework ];
-  propagatedBuildInputs = [ _unresolved_libqt6gui6t64 _unresolved_libqt6widgets6t64 geometry-msgs gz-math-vendor image-transport interactive-markers laser-geometry map-msgs nav-msgs pluginlib point-cloud-transport qt6.qtbase rclcpp resource-retriever rviz-common rviz-ogre-vendor rviz-rendering rviz-resource-interfaces tf2 tf2-geometry-msgs tf2-ros urdf visualization-msgs ];
+  propagatedBuildInputs = [ geometry-msgs gz-math-vendor image-transport interactive-markers laser-geometry map-msgs nav-msgs pluginlib point-cloud-transport qt6.qtbase rclcpp resource-retriever rviz-common rviz-ogre-vendor rviz-rendering rviz-resource-interfaces tf2 tf2-geometry-msgs tf2-ros urdf visualization-msgs ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/rolling/rviz-rendering/default.nix
+++ b/distros/rolling/rviz-rendering/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_libqt6gui6t64, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, assimp, eigen, eigen3-cmake-module, qt6, resource-retriever, rviz-ogre-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, assimp, eigen, eigen3-cmake-module, qt6, resource-retriever, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering";
   version = "15.1.14-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common assimp ];
-  propagatedBuildInputs = [ _unresolved_libqt6gui6t64 ament-index-cpp assimp eigen eigen3-cmake-module qt6.qtbase qt6.qtsvg resource-retriever rviz-ogre-vendor ];
+  propagatedBuildInputs = [ ament-index-cpp assimp eigen eigen3-cmake-module qt6.qtbase qt6.qtsvg resource-retriever rviz-ogre-vendor ];
   nativeBuildInputs = [ ament-cmake-ros eigen3-cmake-module ];
 
   meta = {


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'kilted', 'rolling'] from nix-ros-overlay commit 1b3d30c2b60d7af6c1f0f733674d711bc7a1c041.
This pull request was generated by running the following command:

```
superflore-gen-nix --dry-run --output-repository-path . --all --tar-archive-dir /home/runner/.ros/tar --upstream-branch develop
```

Changes:
========
Humble Changes:
---------------
* *autoware-internal-debug-msgs 1.12.0-r2 --> 1.12.1-r1*
* *autoware-internal-localization-msgs 1.12.0-r2 --> 1.12.1-r1*
* *autoware-internal-metric-msgs 1.12.0-r2 --> 1.12.1-r1*
* *autoware-internal-msgs 1.12.0-r2 --> 1.12.1-r1*
* *autoware-internal-perception-msgs 1.12.0-r2 --> 1.12.1-r1*
* *autoware-internal-planning-msgs 1.12.0-r2 --> 1.12.1-r1*
* *depthai-bridge 2.11.2-r1 --> 2.12.0-r1*
* *depthai-descriptions 2.11.2-r1 --> 2.12.0-r1*
* *depthai-examples 2.11.2-r1 --> 2.12.0-r1*
* *depthai-filters 2.11.2-r1 --> 2.12.0-r1*
* *depthai-ros 2.11.2-r1 --> 2.12.0-r1*
* *depthai-ros-driver 2.11.2-r1 --> 2.12.0-r1*
* *depthai-ros-msgs 2.11.2-r1 --> 2.12.0-r1*
* *fastrtps 2.6.10-r1 --> 2.6.11-r1*

Jazzy Changes:
--------------
* *autoware-internal-debug-msgs 1.12.0-r1 --> 1.12.1-r1*
* *autoware-internal-localization-msgs 1.12.0-r1 --> 1.12.1-r1*
* *autoware-internal-metric-msgs 1.12.0-r1 --> 1.12.1-r1*
* *autoware-internal-msgs 1.12.0-r1 --> 1.12.1-r1*
* *autoware-internal-perception-msgs 1.12.0-r1 --> 1.12.1-r1*
* *autoware-internal-planning-msgs 1.12.0-r1 --> 1.12.1-r1*
* *depthai-bridge 2.11.2-r1 --> 2.12.0-r1*
* *depthai-descriptions 2.11.2-r1 --> 2.12.0-r1*
* *depthai-examples 2.11.2-r1 --> 2.12.0-r1*
* *depthai-filters 2.11.2-r1 --> 2.12.0-r1*
* *depthai-ros 2.11.2-r1 --> 2.12.0-r1*
* *depthai-ros-driver 2.11.2-r1 --> 2.12.0-r1*
* *depthai-ros-msgs 2.11.2-r1 --> 2.12.0-r1*
* *ds-dbw 2.3.9-r1 --> 2.3.10-r1*
* *ds-dbw-can 2.3.9-r1 --> 2.3.10-r1*
* *ds-dbw-joystick-demo 2.3.9-r1 --> 2.3.10-r1*
* *ds-dbw-msgs 2.3.9-r1 --> 2.3.10-r1*

Rolling Changes:
----------------
* *autoware-internal-debug-msgs 1.12.0-r1 --> 1.12.1-r1*
* *autoware-internal-localization-msgs 1.12.0-r1 --> 1.12.1-r1*
* *autoware-internal-metric-msgs 1.12.0-r1 --> 1.12.1-r1*
* *autoware-internal-msgs 1.12.0-r1 --> 1.12.1-r1*
* *autoware-internal-perception-msgs 1.12.0-r1 --> 1.12.1-r1*
* *autoware-internal-planning-msgs 1.12.0-r1 --> 1.12.1-r1*


No missing dependencies.