### PR TITLE
rosdistro sync, Fri Dec 26 13:03:49 2025

### DIFF
--- a/distros/humble/depthai-bridge/default.nix
+++ b/distros/humble/depthai-bridge/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, composition-interfaces, cv-bridge, depthai, depthai-ros-msgs, ffmpeg-image-transport-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, vision-msgs, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, composition-interfaces, cv-bridge, depthai, depthai-ros-msgs, ffmpeg-image-transport-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-bridge";
-  version = "2.12.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "2d93635eb7bbdc7d2fd5721b5a582b6116dad50a8ff3801326a921fe81549f07";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "41081a02610a19914e23c7106d7616e4de209f0fe24a8a2163d0b424beca9f54";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ boost camera-info-manager composition-interfaces cv-bridge depthai depthai-ros-msgs ffmpeg-image-transport-msgs image-transport opencv opencv.cxxdev rclcpp robot-state-publisher ros-environment sensor-msgs std-msgs stereo-msgs tf2 tf2-geometry-msgs tf2-ros vision-msgs xacro ];
+  buildInputs = [ ament-cmake ros-environment ];
+  propagatedBuildInputs = [ camera-info-manager composition-interfaces cv-bridge depthai depthai-ros-msgs ffmpeg-image-transport-msgs image-transport opencv opencv.cxxdev rclcpp robot-state-publisher sensor-msgs std-msgs stereo-msgs tf2 tf2-geometry-msgs tf2-ros vision-msgs xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/depthai-descriptions/default.nix
+++ b/distros/humble/depthai-descriptions/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, ros-environment, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-descriptions";
-  version = "2.12.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_descriptions/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "0b9f4d6e0a09f7710f12e6081bf582ed47a157ae3ce48c6ea2ddaa326c2345b6";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_descriptions/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "8e3298069f44dbb1cb939ea4da73f65c36e826bec802ad1a1f6a0c26afbfef0a";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ros-environment ];
   propagatedBuildInputs = [ robot-state-publisher xacro ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/humble/depthai-examples/default.nix
+++ b/distros/humble/depthai-examples/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-examples";
-  version = "2.12.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "50ad2568795a63f7132bdf40c84335a675a732a930921bf8653313ccf1d4e736";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "6b62e7546e8173e6bf489450b0db2f0bdf71a0a814b54f32e5e5d1b85fdd128d";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ camera-info-manager cv-bridge depth-image-proc depthai depthai-bridge depthai-descriptions depthai-ros-msgs foxglove-msgs image-transport opencv opencv.cxxdev rclcpp robot-state-publisher ros-environment rviz-imu-plugin sensor-msgs std-msgs stereo-msgs vision-msgs xacro ];
+  buildInputs = [ ament-cmake ros-environment ];
+  propagatedBuildInputs = [ camera-info-manager cv-bridge depth-image-proc depthai depthai-bridge depthai-descriptions depthai-ros-msgs foxglove-msgs image-transport opencv opencv.cxxdev rclcpp robot-state-publisher rviz-imu-plugin sensor-msgs std-msgs stereo-msgs vision-msgs xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/depthai-filters/default.nix
+++ b/distros/humble/depthai-filters/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, depthai-ros-msgs, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, depthai-ros-msgs, image-transport, message-filters, opencv, rclcpp, rclcpp-components, ros-environment, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-filters";
-  version = "2.12.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_filters/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "2db75b80b9bd7222adf5982f2782aa0e745aa48edf8c314b97a6426ed75b2ebf";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_filters/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "f8d1782aba7971d76be2679a28f1600633fa0737094fd963dd513012aca98217";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-auto ];
+  buildInputs = [ ament-cmake-auto ros-environment ];
   propagatedBuildInputs = [ cv-bridge depthai-ros-msgs image-transport message-filters opencv opencv.cxxdev rclcpp rclcpp-components sensor-msgs vision-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake-auto ];
 

--- a/distros/humble/depthai-ros-driver/default.nix
+++ b/distros/humble/depthai-ros-driver/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, ffmpeg-image-transport-msgs, image-pipeline, image-transport, image-transport-plugins, opencv, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, ffmpeg-image-transport-msgs, image-pipeline, image-transport, image-transport-plugins, opencv, pluginlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-driver";
-  version = "2.12.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_driver/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "16aae7745d322610e4cfb1fd3776389a3211f2b5d5adc415202c23acb63d86e2";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_driver/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "300f897ca2a63541823f79e3cbc86ae035561a7cdf48701eb67f10363d1a8236";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ros-environment ];
   propagatedBuildInputs = [ ament-cmake-auto camera-calibration cv-bridge depthai depthai-bridge depthai-descriptions depthai-examples depthai-ros-msgs diagnostic-msgs diagnostic-updater ffmpeg-image-transport-msgs image-pipeline image-transport image-transport-plugins opencv opencv.cxxdev pluginlib rclcpp rclcpp-components sensor-msgs std-msgs std-srvs vision-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/humble/depthai-ros-msgs/default.nix
+++ b/distros/humble/depthai-ros-msgs/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, ros-environment, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-msgs";
-  version = "2.12.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "bde6941d4c3124a4f48de904913895ed4141ed016f95589ddf62db1cafea25f0";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "ba259ec94e0c9183ea6e382664200674ed5c00f205ddf891ae5501f9688c360f";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ros-environment ];
   propagatedBuildInputs = [ builtin-interfaces geometry-msgs rclcpp rosidl-default-generators sensor-msgs std-msgs vision-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/humble/depthai-ros/default.nix
+++ b/distros/humble/depthai-ros/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros";
-  version = "2.12.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "f34c2a59b927e18dcfcabfa130857b8c3653ec0e6edf22eb3ff6ada7c17103f3";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "75044eca3f8bcbf764a7e4ad7b35446e60083b604d784e8b2ed44a7d3f5f4287";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ros-environment ];
   propagatedBuildInputs = [ depthai depthai-bridge depthai-descriptions depthai-examples depthai-filters depthai-ros-driver depthai-ros-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/humble/libmavconn/default.nix
+++ b/distros/humble/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-libmavconn";
-  version = "2.13.0-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/libmavconn/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "20b55a11bfcd5938f0edbd50451a2f7e95d46a9b791be84196f99c08e4e09259";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/libmavconn/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "0fd8b9ef8ce79253a743bc328549fb6caeefd9ebe093bd710bb9d9bdd7da2ec5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mavros-examples/default.nix
+++ b/distros/humble/mavros-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, eigen3-cmake-module, geometry-msgs, mavros, mavros-msgs, rclpy, sensor-msgs, std-msgs, std-srvs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-mavros-examples";
-  version = "2.13.0-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros_examples/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "a7345d5764e2848cdb193cd300f2b17c037041cd8b9ca8a926fae31f66429c3c";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros_examples/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "f7941b31432984e2bd863d5564020e9b3445058f15eacd2fc5192093881df5a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mavros-extras/default.nix
+++ b/distros/humble/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-mavros-extras";
-  version = "2.13.0-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros_extras/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "2c3efa72cbe3a3ca1a3cf4c91c3ebc42265aabcb15e034a68083553f1ff8adb1";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros_extras/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "6871d284e4a692649702c34ce861f343ecde8129da354b55447536c0257dc56f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mavros-msgs/default.nix
+++ b/distros/humble/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-mavros-msgs";
-  version = "2.13.0-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros_msgs/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "d54f35895e7ccc30a319a3e1420803c9f04488814a3caec5204170e56a94bcee";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros_msgs/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "1a271d98da5d2fc36516b31a8b3dac7324ea308cb8d8c20b0ca6d6a98e46ef6e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mavros/default.nix
+++ b/distros/humble/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-mavros";
-  version = "2.13.0-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "19ac84fddaffe7b04fd37336db40d32da30d7f6875879adc10f2fa8d6e3f8efa";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "b277cc34c70f07c14571f85d8faaac7ac72a2b2174350f0770c7356cd92321cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mrpt-libros-bridge/default.nix
+++ b/distros/humble/mrpt-libros-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cmake, cv-bridge, geometry-msgs, mrpt-libmaps, mrpt-libobs, nav-msgs, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libros-bridge";
-  version = "3.0.2-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/humble/mrpt_libros_bridge/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "448bdc1e2c4d9d13590037297834ce30923df66497017e17b1dba061bf4a8935";
+    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/humble/mrpt_libros_bridge/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "c385920cb798163beea27826ab0d25c3de5e2dd6cc4c0905d87b3e5ce768f655";
   };
 
   buildType = "cmake";

--- a/distros/humble/mujoco-vendor/default.nix
+++ b/distros/humble/mujoco-vendor/default.nix
@@ -2,23 +2,23 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, git, glfw3, xorg }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, git, glfw3, libxkbcommon, pkg-config, wayland, xorg }:
 buildRosPackage {
   pname = "ros-humble-mujoco-vendor";
-  version = "0.0.5-r1";
+  version = "0.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mujoco_vendor-release/archive/release/humble/mujoco_vendor/0.0.5-1.tar.gz";
-    name = "0.0.5-1.tar.gz";
-    sha256 = "eb70e1d80630896ddbc38df8762fc61d98005a210637eb920ac663fe8061f3f1";
+    url = "https://github.com/ros2-gbp/mujoco_vendor-release/archive/release/humble/mujoco_vendor/0.0.6-1.tar.gz";
+    name = "0.0.6-1.tar.gz";
+    sha256 = "93660fa1e8d2696846ee243b7c26e0a0014c165e4b69e9b8c788927a35b14b28";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-vendor-package git glfw3 xorg.libXcursor xorg.libXi xorg.libXinerama xorg.libXrandr ];
+  buildInputs = [ ament-cmake ament-cmake-vendor-package git glfw3 libxkbcommon pkg-config wayland xorg.libX11 xorg.libXcursor xorg.libXi xorg.libXinerama xorg.libXrandr ];
   nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package git ];
 
   meta = {
-    description = "Vendor package for MuJoCo simulator";
+    description = "Vendor package for MuJoCo simulator of version 3.4.0";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/humble/rosbag2rawlog/default.nix
+++ b/distros/humble/rosbag2rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, cli11, cmake, cv-bridge, mrpt-libmaps, mrpt-libros-bridge, mrpt-msgs, nav-msgs, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-rosbag2rawlog";
-  version = "3.0.2-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/humble/rosbag2rawlog/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "5a6f139df2b5b17cad3c8a73b9a528fef22d012dcf33687c907e1d3da8aad6ac";
+    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/humble/rosbag2rawlog/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "b7f6b20b2b09b0dc1347b506b65df340c4450acb5b315f204e10457dd6068468";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tcb-span/default.nix
+++ b/distros/humble/tcb-span/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-humble-tcb-span";
-  version = "1.0.2-r2";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/humble/tcb_span/1.0.2-2.tar.gz";
-    name = "1.0.2-2.tar.gz";
-    sha256 = "2a506d5ed3e043fcd5e81ae931a53553c7583137cb5ca0de9fe63e3c5f85b5b1";
+    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/humble/tcb_span/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "e2508258caeb0d816042e354d6cd12fd1e71384fd871601d12a2791e11ca3b4c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tl-expected/default.nix
+++ b/distros/humble/tl-expected/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-tl-expected";
-  version = "1.0.2-r2";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/humble/tl_expected/1.0.2-2.tar.gz";
-    name = "1.0.2-2.tar.gz";
-    sha256 = "c7ee1c7e16aea04c2da0c93bf41f9a2570f0d2ff987b2a25ea423f0d702821f7";
+    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/humble/tl_expected/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "9bf4e6922dc936811063abc591035ed376a65779465f3dfd7e254982e12893e2";
   };
 
   buildType = "ament_cmake";
@@ -19,6 +19,6 @@ buildRosPackage {
 
   meta = {
     description = "C++11/14/17 std::expected with functional-style extensions";
-    license = with lib.licenses; [ "Creative-Commons-Zero-v1.0-Universal" ];
+    license = with lib.licenses; [ "CC0-1.0" ];
   };
 }

--- a/distros/jazzy/clearpath-bt-joy/default.nix
+++ b/distros/jazzy/clearpath-bt-joy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, bluez, joy-linux, python3Packages, twist-mux }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-bt-joy";
-  version = "2.8.3-r1";
+  version = "2.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bt_joy/2.8.3-1.tar.gz";
-    name = "2.8.3-1.tar.gz";
-    sha256 = "95b668592d5c12793eeff61ab71f4062b8ea558a99160bf0087f57133ed1569c";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bt_joy/2.8.4-1.tar.gz";
+    name = "2.8.4-1.tar.gz";
+    sha256 = "a1c63c13960f1a7aebd3f24ebf0a151734cb882475754e8cf10c0b57b1af4011";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/clearpath-common/default.nix
+++ b/distros/jazzy/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-common";
-  version = "2.8.3-r1";
+  version = "2.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_common/2.8.3-1.tar.gz";
-    name = "2.8.3-1.tar.gz";
-    sha256 = "ddd3e8881fb2d1532d6b470d81851336c8562d26d3a6b49d93459b332d6c96d9";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_common/2.8.4-1.tar.gz";
+    name = "2.8.4-1.tar.gz";
+    sha256 = "5a9cb6ef93637c5eb02845440426bd1d3126d3c52744194415f3ec315f6011aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-control/default.nix
+++ b/distros/jazzy/clearpath-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-bt-joy, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, mecanum-drive-controller, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-control";
-  version = "2.8.3-r1";
+  version = "2.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_control/2.8.3-1.tar.gz";
-    name = "2.8.3-1.tar.gz";
-    sha256 = "eee2eba33a81b81a4703c61c73b08479b3af163664ef421fa178f5770c39d9d0";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_control/2.8.4-1.tar.gz";
+    name = "2.8.4-1.tar.gz";
+    sha256 = "82c21db5a508dde2703e39ecb89d6887682afa6d9743032cbbe6e790be5936a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-customization/default.nix
+++ b/distros/jazzy/clearpath-customization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-customization";
-  version = "2.8.3-r1";
+  version = "2.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_customization/2.8.3-1.tar.gz";
-    name = "2.8.3-1.tar.gz";
-    sha256 = "a888859917fcaec864baaef0e29bd86b13498dc332924c87aa15847ea8eda531";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_customization/2.8.4-1.tar.gz";
+    name = "2.8.4-1.tar.gz";
+    sha256 = "7d29ab94c85e277b4735a6b193ebea463800dcd15924786a492f283a708a7c54";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-description/default.nix
+++ b/distros/jazzy/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-description";
-  version = "2.8.3-r1";
+  version = "2.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_description/2.8.3-1.tar.gz";
-    name = "2.8.3-1.tar.gz";
-    sha256 = "bca175b3f5a1ec0380d2305a3994dcfb25741e95da5494689f56cbe376203c55";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_description/2.8.4-1.tar.gz";
+    name = "2.8.4-1.tar.gz";
+    sha256 = "6038098d57196e0427c4e935b476b429c8c232526c54968fb35598d5bb410b54";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-diagnostics/default.nix
+++ b/distros/jazzy/clearpath-diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-platform-msgs, diagnostic-aggregator, diagnostic-updater, foxglove-bridge, rclcpp, ros2launch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-diagnostics";
-  version = "2.8.3-r1";
+  version = "2.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_diagnostics/2.8.3-1.tar.gz";
-    name = "2.8.3-1.tar.gz";
-    sha256 = "a0b2166be1a00c774466c71a3b076ca6a60098bab385bbd96f3769de78aa57a5";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_diagnostics/2.8.4-1.tar.gz";
+    name = "2.8.4-1.tar.gz";
+    sha256 = "126d3ca59eba36b5f87c1ac90a6c33a1dd1b3fe69d30c10608428a0c37dd76cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-generator-common/default.nix
+++ b/distros/jazzy/clearpath-generator-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, _unresolved_python3-apt, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-diagnostics, clearpath-manipulators, moveit-setup-srdf-plugins }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-generator-common";
-  version = "2.8.3-r1";
+  version = "2.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_generator_common/2.8.3-1.tar.gz";
-    name = "2.8.3-1.tar.gz";
-    sha256 = "9bc753ff34650d28d402bdc7932b73cbbccb28ed24a39b581eedd2cd8d660f34";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_generator_common/2.8.4-1.tar.gz";
+    name = "2.8.4-1.tar.gz";
+    sha256 = "1846271d05f899f4e0c60b5e90639ce87f08c4012cbc0c8b285d23fe153a450f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-manipulators-description/default.nix
+++ b/distros/jazzy/clearpath-manipulators-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ewellix-description, robot-state-publisher, robotiq-description, ur-description, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-manipulators-description";
-  version = "2.8.3-r1";
+  version = "2.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators_description/2.8.3-1.tar.gz";
-    name = "2.8.3-1.tar.gz";
-    sha256 = "2ce0185e050947eaeade56f1dc2fe1ae9055aaced6bccdc711bd0d00e33fd64b";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators_description/2.8.4-1.tar.gz";
+    name = "2.8.4-1.tar.gz";
+    sha256 = "21cf26ce171a7947ae6c0ace83bdf47ddecebee0f9e8dcf8cdccc63825102300";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-manipulators/default.nix
+++ b/distros/jazzy/clearpath-manipulators/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, gripper-controllers, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-warehouse, moveit-setup-srdf-plugins, moveit-simple-controller-manager, position-controllers, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-manipulators";
-  version = "2.8.3-r1";
+  version = "2.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators/2.8.3-1.tar.gz";
-    name = "2.8.3-1.tar.gz";
-    sha256 = "777f962bbbeb2c5a98415cbba05d3e7491bfe6d60967091ba8652e5002d201b6";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators/2.8.4-1.tar.gz";
+    name = "2.8.4-1.tar.gz";
+    sha256 = "4ff185185e24cb69484ecf93db485eeccf55d1a02a11769baf3ea13e4876ab7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-mounts-description/default.nix
+++ b/distros/jazzy/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-mounts-description";
-  version = "2.8.3-r1";
+  version = "2.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_mounts_description/2.8.3-1.tar.gz";
-    name = "2.8.3-1.tar.gz";
-    sha256 = "812f0a0968ff06bca4459596cee5d477a1a6404904a24b3b4ada71e4afb54f35";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_mounts_description/2.8.4-1.tar.gz";
+    name = "2.8.4-1.tar.gz";
+    sha256 = "37c4a691b7351bb5cdbf0ccc4ca4904e67101a397540f0ed41928adb0d101b16";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-platform-description/default.nix
+++ b/distros/jazzy/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-platform-description";
-  version = "2.8.3-r1";
+  version = "2.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_platform_description/2.8.3-1.tar.gz";
-    name = "2.8.3-1.tar.gz";
-    sha256 = "ddda8985456af8cac9672d295d7287f6351c3ba1767b0237db73a39cb092c944";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_platform_description/2.8.4-1.tar.gz";
+    name = "2.8.4-1.tar.gz";
+    sha256 = "ac513bfb22ea2225dadbca44071f9fbc9c8109112869dce7b94c0395e64270e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-sensors-description/default.nix
+++ b/distros/jazzy/clearpath-sensors-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, axis-description, microstrain-inertial-description, realsense2-description, velodyne-description }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-sensors-description";
-  version = "2.8.3-r1";
+  version = "2.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_sensors_description/2.8.3-1.tar.gz";
-    name = "2.8.3-1.tar.gz";
-    sha256 = "56197d6319f972b9d58755244f0ee60cd4a3a08d85890c463ab174d1c3275b43";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_sensors_description/2.8.4-1.tar.gz";
+    name = "2.8.4-1.tar.gz";
+    sha256 = "29282dc2de61dc54f279c4aa157ade17508376a1313723ff6d55861098e32aa0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/libmavconn/default.nix
+++ b/distros/jazzy/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-libmavconn";
-  version = "2.13.0-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/libmavconn/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "c09192f21883897d27ee90b0790e05b857b963247281e746e858a28e5b42b62a";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/libmavconn/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "ece9727e2b39c76403aa0417a3a715e2836bba4b729284c34e7eba575513a76f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mavros-examples/default.nix
+++ b/distros/jazzy/mavros-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, eigen3-cmake-module, geometry-msgs, mavros, mavros-msgs, rclpy, sensor-msgs, std-msgs, std-srvs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mavros-examples";
-  version = "2.13.0-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros_examples/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "a4023fbaf5aea62366b13de30fb44cd9e231b9dd2a95ebeb8d6ab77bfee07fe3";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros_examples/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "c5bf596e23792c0d67483aa33f8c9354135e4c9450b7d4e240e76bbf21182d12";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mavros-extras/default.nix
+++ b/distros/jazzy/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-mavros-extras";
-  version = "2.13.0-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros_extras/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "5878791cc45e1a9254ae5a0ea9f88d68a7bc41bb8e1c30f03dfb6725b180c089";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros_extras/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "d12d7168ff26035e9c57655cab1e8173e36e202a18d77dad71e569d8a2eae93e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mavros-msgs/default.nix
+++ b/distros/jazzy/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mavros-msgs";
-  version = "2.13.0-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros_msgs/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "c5da55a5d0bcd3d8d4091337350b6a0139355e7be61109133ee3bad480824d91";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros_msgs/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "5b823dc09a725da3e08db5c537fa1d8359c6106d3548e5a5a8a2797c3176cabd";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mavros/default.nix
+++ b/distros/jazzy/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mavros";
-  version = "2.13.0-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "4517357e09893c6fbb285e06abdc3000c701cd6e8cc0f634aa7ea5e61ec94eec";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "3d89d061558dd4462bcef9c605f3ac7670563f8f1f14b85d44ac9d4052e4d7ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mrpt-libros-bridge/default.nix
+++ b/distros/jazzy/mrpt-libros-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cmake, cv-bridge, geometry-msgs, mrpt-libmaps, mrpt-libobs, nav-msgs, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libros-bridge";
-  version = "3.0.2-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/jazzy/mrpt_libros_bridge/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "de47bf6bd09d8563a80ff8aa088c1e711eefcf795f381bd94d8e40b2d57ab7f8";
+    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/jazzy/mrpt_libros_bridge/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "079dd3e994e616fa2334f037ea6340a3ae9d09f3e99a76f80306bb8e8f008b24";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mujoco-vendor/default.nix
+++ b/distros/jazzy/mujoco-vendor/default.nix
@@ -2,23 +2,23 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, git, glfw3, xorg }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, git, glfw3, libxkbcommon, pkg-config, wayland, xorg }:
 buildRosPackage {
   pname = "ros-jazzy-mujoco-vendor";
-  version = "0.0.5-r1";
+  version = "0.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mujoco_vendor-release/archive/release/jazzy/mujoco_vendor/0.0.5-1.tar.gz";
-    name = "0.0.5-1.tar.gz";
-    sha256 = "e28992c776b1e381630047ab28fa8c04b1153001b2860926cf68e1a8e700b123";
+    url = "https://github.com/ros2-gbp/mujoco_vendor-release/archive/release/jazzy/mujoco_vendor/0.0.6-1.tar.gz";
+    name = "0.0.6-1.tar.gz";
+    sha256 = "9eaba24ceedde4a75853e4654fed59bfb3ffed5c6031c878522f086813371600";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-vendor-package git glfw3 xorg.libXcursor xorg.libXi xorg.libXinerama xorg.libXrandr ];
+  buildInputs = [ ament-cmake ament-cmake-vendor-package git glfw3 libxkbcommon pkg-config wayland xorg.libX11 xorg.libXcursor xorg.libXi xorg.libXinerama xorg.libXrandr ];
   nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package git ];
 
   meta = {
-    description = "Vendor package for MuJoCo simulator";
+    description = "Vendor package for MuJoCo simulator of version 3.4.0";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/jazzy/rosbag2rawlog/default.nix
+++ b/distros/jazzy/rosbag2rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, cli11, cmake, cv-bridge, mrpt-libmaps, mrpt-libros-bridge, mrpt-msgs, nav-msgs, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-rosbag2rawlog";
-  version = "3.0.2-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/jazzy/rosbag2rawlog/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "0ea88dccaa30b2598291b394abb98bd40928af51b1f3b8889450eaf57ba60dc2";
+    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/jazzy/rosbag2rawlog/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "a2e50feef44e26c254884e3153daaf3c1c9b5bd1ad06a5851559aa3fab792402";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tcb-span/default.nix
+++ b/distros/jazzy/tcb-span/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-jazzy-tcb-span";
-  version = "1.0.2-r5";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/jazzy/tcb_span/1.0.2-5.tar.gz";
-    name = "1.0.2-5.tar.gz";
-    sha256 = "a8ad59841a27e25761f00a67a33ebf5dcd472d8258ccbe55b55dfcac6c4d9d66";
+    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/jazzy/tcb_span/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "4d080d32255175c8ea63baa51b46eabf15cb6eb146cf57b61d1f01d552eba5d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tl-expected/default.nix
+++ b/distros/jazzy/tl-expected/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-tl-expected";
-  version = "1.0.2-r5";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/jazzy/tl_expected/1.0.2-5.tar.gz";
-    name = "1.0.2-5.tar.gz";
-    sha256 = "a9a4975e21e493f3c778ed0b4d7a2d4fe0d52a1876a96d59d569d20669806b1b";
+    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/jazzy/tl_expected/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "58d90458a2230ebfc8d19a95fd5f829da9967ecbfb3bd3c9258bb76f96efccaf";
   };
 
   buildType = "ament_cmake";
@@ -19,6 +19,6 @@ buildRosPackage {
 
   meta = {
     description = "C++11/14/17 std::expected with functional-style extensions";
-    license = with lib.licenses; [ "Creative-Commons-Zero-v1.0-Universal" ];
+    license = with lib.licenses; [ "CC0-1.0" ];
   };
 }

--- a/distros/kilted/libmavconn/default.nix
+++ b/distros/kilted/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
 buildRosPackage {
   pname = "ros-kilted-libmavconn";
-  version = "2.13.0-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/libmavconn/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "d692aecbdd12f94e2d7a8ec1030d00dee8474215f8200df57a8afb87cc424d79";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/libmavconn/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "c661bf719f2ba48b73b25a94b856221f779f4be80355395e6141d493dba87fed";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mavros-examples/default.nix
+++ b/distros/kilted/mavros-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, eigen3-cmake-module, geometry-msgs, mavros, mavros-msgs, rclpy, sensor-msgs, std-msgs, std-srvs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mavros-examples";
-  version = "2.13.0-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/mavros_examples/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "e6634bbb1abb2d015c9ee876cd8e9c2962cda8aaf70c19052494bb2816747420";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/mavros_examples/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "40a883fd969dac5774dfd41cc0e6323611589317548baec93d2ad9249136bbcb";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mavros-extras/default.nix
+++ b/distros/kilted/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-kilted-mavros-extras";
-  version = "2.13.0-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/mavros_extras/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "2a556c6de7d664e000766cf0da6e57a20f6635139d5d6fa164fd55ebcf525082";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/mavros_extras/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "1ff74ba09c96d51a35902d60ea9c2d955a50b30f575163832dc216739bfc938d";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mavros-msgs/default.nix
+++ b/distros/kilted/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mavros-msgs";
-  version = "2.13.0-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/mavros_msgs/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "13df9bda838dba5a741477492d3119011534a55b13e65f0cd350ea6cb9f7cda9";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/mavros_msgs/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "9d32e6b6a65a31c0cce7a8b1fc077c593dda12963d6e3409307b2b4d759e9082";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mavros/default.nix
+++ b/distros/kilted/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mavros";
-  version = "2.13.0-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/mavros/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "0ae0fa204ba9ac48c9e318b1a790144ab97a8415e16523d2064d49065234bc4f";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/kilted/mavros/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "7288aa21c533ab8176ef11cb4141186b40032983108ff7957e4a4285f22bb523";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mrpt-libros-bridge/default.nix
+++ b/distros/kilted/mrpt-libros-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cmake, cv-bridge, geometry-msgs, mrpt-libmaps, mrpt-libobs, nav-msgs, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libros-bridge";
-  version = "3.0.2-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/kilted/mrpt_libros_bridge/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "77f8bf19309806c89a03e9628df0eb93663fb8ee6394ede9bbefbc2bdef9cfab";
+    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/kilted/mrpt_libros_bridge/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "38e6786647838ea0833aa053453ebe9d1c58aa52a22cb84e01601c4cb86f7ecf";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mujoco-vendor/default.nix
+++ b/distros/kilted/mujoco-vendor/default.nix
@@ -2,23 +2,23 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, git, glfw3, xorg }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, git, glfw3, libxkbcommon, pkg-config, wayland, xorg }:
 buildRosPackage {
   pname = "ros-kilted-mujoco-vendor";
-  version = "0.0.5-r1";
+  version = "0.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mujoco_vendor-release/archive/release/kilted/mujoco_vendor/0.0.5-1.tar.gz";
-    name = "0.0.5-1.tar.gz";
-    sha256 = "aba8612044231a7427db64d46fb65993ca8cd2ade1b936672eb8163459241721";
+    url = "https://github.com/ros2-gbp/mujoco_vendor-release/archive/release/kilted/mujoco_vendor/0.0.6-1.tar.gz";
+    name = "0.0.6-1.tar.gz";
+    sha256 = "7195c468e3c9b946f182c26b757b9c02d8e08c94a6198ba4a724e448de55b88c";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-vendor-package git glfw3 xorg.libXcursor xorg.libXi xorg.libXinerama xorg.libXrandr ];
+  buildInputs = [ ament-cmake ament-cmake-vendor-package git glfw3 libxkbcommon pkg-config wayland xorg.libX11 xorg.libXcursor xorg.libXi xorg.libXinerama xorg.libXrandr ];
   nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package git ];
 
   meta = {
-    description = "Vendor package for MuJoCo simulator";
+    description = "Vendor package for MuJoCo simulator of version 3.4.0";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/kilted/rosbag2rawlog/default.nix
+++ b/distros/kilted/rosbag2rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, cli11, cmake, cv-bridge, mrpt-libmaps, mrpt-libros-bridge, mrpt-msgs, nav-msgs, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-rosbag2rawlog";
-  version = "3.0.2-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/kilted/rosbag2rawlog/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "958683c55bba6eb63d40ed0e23e56938223cdd0496ce972533734c40fbc5e4bb";
+    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/kilted/rosbag2rawlog/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "56a37c033d2e42a535e2b386ea7aa144bce86d069d9ecbfcf86b5c8834f6eb2f";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/tcb-span/default.nix
+++ b/distros/kilted/tcb-span/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-kilted-tcb-span";
-  version = "1.0.2-r5";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/kilted/tcb_span/1.0.2-5.tar.gz";
-    name = "1.0.2-5.tar.gz";
-    sha256 = "4495f1e7438aa5d77c5f28e29d92e9f92bf9fec90f02728077de01f12926b448";
+    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/kilted/tcb_span/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "2e37ce3750b5380807d9b4ae43bb0debf6fbe2442417061ac3d3c14f2ae64c13";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/tl-expected/default.nix
+++ b/distros/kilted/tl-expected/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-kilted-tl-expected";
-  version = "1.0.2-r5";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/kilted/tl_expected/1.0.2-5.tar.gz";
-    name = "1.0.2-5.tar.gz";
-    sha256 = "f8e4a31c05c1f5c075d780d6a19c058aebdfe81a1e1f9726be3d63091cbcfcfa";
+    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/kilted/tl_expected/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "7f9bdde98825fe3e9431343895c1277c979f5265e0454903f8ee427a637744b7";
   };
 
   buildType = "ament_cmake";
@@ -19,6 +19,6 @@ buildRosPackage {
 
   meta = {
     description = "C++11/14/17 std::expected with functional-style extensions";
-    license = with lib.licenses; [ "Creative-Commons-Zero-v1.0-Universal" ];
+    license = with lib.licenses; [ "CC0-1.0" ];
   };
 }

--- a/distros/rolling/libmavconn/default.nix
+++ b/distros/rolling/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-libmavconn";
-  version = "2.13.0-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/libmavconn/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "afcfc4131138df4afea1dc1a45789a84b5394204e2686f8f72d590ad3176e6a8";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/libmavconn/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "810effb1b7adbea0b75ba0c1de22271c7cd7c007505b8e81c882c05a3a3e25bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mavros-examples/default.nix
+++ b/distros/rolling/mavros-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, eigen3-cmake-module, geometry-msgs, mavros, mavros-msgs, rclpy, sensor-msgs, std-msgs, std-srvs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mavros-examples";
-  version = "2.13.0-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros_examples/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "dbd0fc2b8d04516e8fb3bc2d553d798b8fb94d58f267cf891b9e717da40eca97";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros_examples/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "7f8b467471e11d43752edfa9c91c342448bc2d6306c8b97ce28f6bdacac5d72b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mavros-extras/default.nix
+++ b/distros/rolling/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-mavros-extras";
-  version = "2.13.0-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros_extras/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "3ff99beab10cf0f7d925852336a969fa29b3f710a61c6f8e19601705a486f621";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros_extras/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "34eac49cc65e2a190c2ae8891ae78d04d57e9f4401e9032b23a5f2e379be4fe6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mavros-msgs/default.nix
+++ b/distros/rolling/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mavros-msgs";
-  version = "2.13.0-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros_msgs/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "f388fb197a7cd656844987cbb2b418a1b6e906ac503febb5241663306721d48d";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros_msgs/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "aaadda36f64f47363f804624e58ddf98c92295a03c451e9b6fd45dcc9911ea64";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mavros/default.nix
+++ b/distros/rolling/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mavros";
-  version = "2.13.0-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "dd6d36ae76fc32f1e5bbe98f2e21111e4a8ca88d1d21dc9f245c1908cfae53ef";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "59b58b03eb7bbaf7b3f063e457ed306a54affe7b1c7f917754ebe6b2b00afcc8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mrpt-libros-bridge/default.nix
+++ b/distros/rolling/mrpt-libros-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cmake, cv-bridge, geometry-msgs, mrpt-libmaps, mrpt-libobs, nav-msgs, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libros-bridge";
-  version = "3.0.2-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/rolling/mrpt_libros_bridge/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "e6fff49ddfdd42b58ea5468dac93fb75a3c1db3602095eaa895b31ba9745c07b";
+    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/rolling/mrpt_libros_bridge/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "6880169571b9cfb49fbebfc81ea7230ba38fbac7de447fe7f0a4e56f178f5efa";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mujoco-vendor/default.nix
+++ b/distros/rolling/mujoco-vendor/default.nix
@@ -2,23 +2,23 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, git, glfw3, xorg }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, git, glfw3, libxkbcommon, pkg-config, wayland, xorg }:
 buildRosPackage {
   pname = "ros-rolling-mujoco-vendor";
-  version = "0.0.5-r1";
+  version = "0.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mujoco_vendor-release/archive/release/rolling/mujoco_vendor/0.0.5-1.tar.gz";
-    name = "0.0.5-1.tar.gz";
-    sha256 = "583fe413127387ed0d206455c87981a1c5c82b8d57303bf8fd06c6b91d5cfa73";
+    url = "https://github.com/ros2-gbp/mujoco_vendor-release/archive/release/rolling/mujoco_vendor/0.0.6-1.tar.gz";
+    name = "0.0.6-1.tar.gz";
+    sha256 = "4bb1ccc23eb8736f4fd5c9227f666bd38c88f4791d4d1dec5177a96ba8e5ba0b";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-vendor-package git glfw3 xorg.libXcursor xorg.libXi xorg.libXinerama xorg.libXrandr ];
+  buildInputs = [ ament-cmake ament-cmake-vendor-package git glfw3 libxkbcommon pkg-config wayland xorg.libX11 xorg.libXcursor xorg.libXi xorg.libXinerama xorg.libXrandr ];
   nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package git ];
 
   meta = {
-    description = "Vendor package for MuJoCo simulator";
+    description = "Vendor package for MuJoCo simulator of version 3.4.0";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/rolling/rosbag2rawlog/default.nix
+++ b/distros/rolling/rosbag2rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, cli11, cmake, cv-bridge, mrpt-libmaps, mrpt-libros-bridge, mrpt-msgs, nav-msgs, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2rawlog";
-  version = "3.0.2-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/rolling/rosbag2rawlog/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "e3dfbd0fbfdfd43e280ffe20b8fbcd011f70439cb23a80cecc621a4a0a5c464d";
+    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/rolling/rosbag2rawlog/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "5a09b5ed67057a7171946bc164091af1575d9f60c9c4b013657a666cb266fa7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tcb-span/default.nix
+++ b/distros/rolling/tcb-span/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-rolling-tcb-span";
-  version = "1.0.2-r4";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/rolling/tcb_span/1.0.2-4.tar.gz";
-    name = "1.0.2-4.tar.gz";
-    sha256 = "e665789a428a85da155f325c869f800c7846a844ea4cca883700a27e1cc2e826";
+    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/rolling/tcb_span/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "2d5ae26cd23005eb21b96b117a447b2e9bd21d585e9420401e6cf3a5c9cea007";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tl-expected/default.nix
+++ b/distros/rolling/tl-expected/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-tl-expected";
-  version = "1.0.2-r4";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/rolling/tl_expected/1.0.2-4.tar.gz";
-    name = "1.0.2-4.tar.gz";
-    sha256 = "302dc0a889107bc7d76f1fa05ee00055d670151a5cf85ab1572ac5acce13917e";
+    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/rolling/tl_expected/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "a39191e8e9cd087467597348ca22b4870ff8f7019c9fef6bac866f2903a70374";
   };
 
   buildType = "ament_cmake";
@@ -19,6 +19,6 @@ buildRosPackage {
 
   meta = {
     description = "C++11/14/17 std::expected with functional-style extensions";
-    license = with lib.licenses; [ "Creative-Commons-Zero-v1.0-Universal" ];
+    license = with lib.licenses; [ "CC0-1.0" ];
   };
 }


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'kilted', 'rolling'] from nix-ros-overlay commit 6c9921c5317aaab30a7456232c67875d501d5995.
This pull request was generated by running the following command:

```
superflore-gen-nix --dry-run --output-repository-path . --all --tar-archive-dir /home/runner/.ros/tar --upstream-branch develop
```

Changes:
========
Humble Changes:
---------------
* *depthai-bridge 2.12.0-r1 --> 2.12.1-r1*
* *depthai-descriptions 2.12.0-r1 --> 2.12.1-r1*
* *depthai-examples 2.12.0-r1 --> 2.12.1-r1*
* *depthai-filters 2.12.0-r1 --> 2.12.1-r1*
* *depthai-ros 2.12.0-r1 --> 2.12.1-r1*
* *depthai-ros-driver 2.12.0-r1 --> 2.12.1-r1*
* *depthai-ros-msgs 2.12.0-r1 --> 2.12.1-r1*
* *libmavconn 2.13.0-r1 --> 2.14.0-r1*
* *mavros 2.13.0-r1 --> 2.14.0-r1*
* *mavros-examples 2.13.0-r1 --> 2.14.0-r1*
* *mavros-extras 2.13.0-r1 --> 2.14.0-r1*
* *mavros-msgs 2.13.0-r1 --> 2.14.0-r1*
* *mrpt-libros-bridge 3.0.2-r1 --> 3.1.0-r1*
* *mujoco-vendor 0.0.5-r1 --> 0.0.6-r1*
* *rosbag2rawlog 3.0.2-r1 --> 3.1.0-r1*
* *tcb-span 1.0.2-r2 --> 1.2.0-r1*
* *tl-expected 1.0.2-r2 --> 1.2.0-r1*

Jazzy Changes:
--------------
* *clearpath-bt-joy 2.8.3-r1 --> 2.8.4-r1*
* *clearpath-common 2.8.3-r1 --> 2.8.4-r1*
* *clearpath-control 2.8.3-r1 --> 2.8.4-r1*
* *clearpath-customization 2.8.3-r1 --> 2.8.4-r1*
* *clearpath-description 2.8.3-r1 --> 2.8.4-r1*
* *clearpath-diagnostics 2.8.3-r1 --> 2.8.4-r1*
* *clearpath-generator-common 2.8.3-r1 --> 2.8.4-r1*
* *clearpath-manipulators 2.8.3-r1 --> 2.8.4-r1*
* *clearpath-manipulators-description 2.8.3-r1 --> 2.8.4-r1*
* *clearpath-mounts-description 2.8.3-r1 --> 2.8.4-r1*
* *clearpath-platform-description 2.8.3-r1 --> 2.8.4-r1*
* *clearpath-sensors-description 2.8.3-r1 --> 2.8.4-r1*
* *libmavconn 2.13.0-r1 --> 2.14.0-r1*
* *mavros 2.13.0-r1 --> 2.14.0-r1*
* *mavros-examples 2.13.0-r1 --> 2.14.0-r1*
* *mavros-extras 2.13.0-r1 --> 2.14.0-r1*
* *mavros-msgs 2.13.0-r1 --> 2.14.0-r1*
* *mrpt-libros-bridge 3.0.2-r1 --> 3.1.0-r1*
* *mujoco-vendor 0.0.5-r1 --> 0.0.6-r1*
* *rosbag2rawlog 3.0.2-r1 --> 3.1.0-r1*
* *tcb-span 1.0.2-r5 --> 1.2.0-r1*
* *tl-expected 1.0.2-r5 --> 1.2.0-r1*

Kilted Changes:
---------------
* *libmavconn 2.13.0-r1 --> 2.14.0-r1*
* *mavros 2.13.0-r1 --> 2.14.0-r1*
* *mavros-examples 2.13.0-r1 --> 2.14.0-r1*
* *mavros-extras 2.13.0-r1 --> 2.14.0-r1*
* *mavros-msgs 2.13.0-r1 --> 2.14.0-r1*
* *mrpt-libros-bridge 3.0.2-r1 --> 3.1.0-r1*
* *mujoco-vendor 0.0.5-r1 --> 0.0.6-r1*
* *rosbag2rawlog 3.0.2-r1 --> 3.1.0-r1*
* *tcb-span 1.0.2-r5 --> 1.2.0-r1*
* *tl-expected 1.0.2-r5 --> 1.2.0-r1*

Rolling Changes:
----------------
* *libmavconn 2.13.0-r1 --> 2.14.0-r1*
* *mavros 2.13.0-r1 --> 2.14.0-r1*
* *mavros-examples 2.13.0-r1 --> 2.14.0-r1*
* *mavros-extras 2.13.0-r1 --> 2.14.0-r1*
* *mavros-msgs 2.13.0-r1 --> 2.14.0-r1*
* *mrpt-libros-bridge 3.0.2-r1 --> 3.1.0-r1*
* *mujoco-vendor 0.0.5-r1 --> 0.0.6-r1*
* *rosbag2rawlog 3.0.2-r1 --> 3.1.0-r1*
* *tcb-span 1.0.2-r4 --> 1.2.0-r1*
* *tl-expected 1.0.2-r4 --> 1.2.0-r1*


No missing dependencies.