### PR TITLE
Build rqt-web without webkit-dependency

### DIFF
--- a/distros/noetic/rqt-web/default.nix
+++ b/distros/noetic/rqt-web/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-gui, rospy, rqt-gui, rqt-gui-py, webkit-dependency }:
+{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-gui, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-web";
   version = "0.4.11-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ catkin python3Packages.setuptools ];
-  propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg qt-gui rospy rqt-gui rqt-gui-py webkit-dependency ];
+  propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg qt-gui rospy rqt-gui rqt-gui-py ];
   nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {


### PR DESCRIPTION
This will probably make the package non-functional, but since webkit dependency is marked as insecure, and in addition to that it fails to build, we just remove it. This change allows building desktop-full without errors.

Related to #782