### PR TITLE
extend nixpkgs with some ros pkgs

### DIFF
--- a/distros/default.nix
+++ b/distros/default.nix
@@ -1,15 +1,21 @@
 # Define all supported ROS distros
 
 self: super: {
+  rosNixpkgs = {
+    humble = self.extend (_: _: { inherit (self.rosPackages.humble) octomap urdfdom urdfdom-headers; });
+    jazzy = self.extend (_: _: { inherit (self.rosPackages.jazzy) octomap urdfdom urdfdom-headers; });
+    kilted = self.extend (_: _: { inherit (self.rosPackages.kilted) urdfdom urdfdom-headers; });
+    rolling = self.extend (_: _: { inherit (self.rosPackages.rolling) urdfdom urdfdom-headers; });
+  };
   rosPackages = rec {
     recurseForDerivations = true;
     lib = super.lib // import ../lib { inherit lib self; };
 
     mkRosDistroOverlay = args: import ./distro-overlay.nix args;
 
-    humble = mkRosDistroOverlay { version = 2; distro = "humble"; } self super;
-    jazzy = mkRosDistroOverlay { version = 2; distro = "jazzy"; } self super;
-    kilted = mkRosDistroOverlay { version = 2; distro = "kilted"; } self super;
-    rolling = mkRosDistroOverlay { version = 2; distro = "rolling"; } self super;
+    humble = mkRosDistroOverlay { version = 2; distro = "humble"; } self.rosNixpkgs.humble super;
+    jazzy = mkRosDistroOverlay { version = 2; distro = "jazzy"; } self.rosNixpkgs.jazzy super;
+    kilted = mkRosDistroOverlay { version = 2; distro = "kilted"; } self.rosNixpkgs.kilted super;
+    rolling = mkRosDistroOverlay { version = 2; distro = "rolling"; } self.rosNixpkgs.rolling super;
   };
 }


### PR DESCRIPTION
Hi,

While debugging a double free on a ros2-control controller loading unittest, valgrind displayed hints about liboctomap.so, which was very unrelated.

It turns out I had moveit somewhere in the dependency tree, and moveit-core depend on 
1. fcl (from nixpkgs), which depend on octomap 1.10.0 (from nixpkgs)
2. octomap 1.9.8 (from humble)

This is easy to see with `nix-tree --derivation .#humble.moveit` 

So I guess we need to somehow override nixpkgs with some packages from nix-ros-overlay to avoid this kind of version issues.

I identified potential similar situations with ~~console-bridge &~~ urdfdom, there may be others.


Here is a simple fix which solve my use case.