### PR TITLE
rosdistro sync, Fri Apr  3 13:28:34 2026

### DIFF
--- a/distros/humble/kitti-metrics-eval/default.nix
+++ b/distros/humble/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmath, mrpt-libposes, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-humble-kitti-metrics-eval";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/kitti_metrics_eval/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "0334839f2662febb34acb4b295976f777f64963648f9eb824bbbf6b38d8ff121";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/kitti_metrics_eval/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "00024ca7bd206046018d9d1f47ee5fa38bc5e88c3b3e35fc02727f3327cacd7c";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-bridge-ros2/default.nix
+++ b/distros/humble/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, geographic-msgs, geometry-msgs, gps-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-mola-bridge-ros2";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_bridge_ros2/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "6eeb99b944619c7d2e57f5733fb025a9c9bba0252f9b21f977c7eaaf275f961d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_bridge_ros2/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "3e5822b21857f74e645ae51b827c4eb7bde06c5fbd1c815dac7d8827e4b53d3b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-demos/default.nix
+++ b/distros/humble/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-demos";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_demos/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "ceb7efb38d36b4b15df76725b9543453c526198901b7d2984f167baee9b9e0b5";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_demos/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "b59b7878dabb04d9ce439df47dcc649e75897bb37e9106697e3bec45d9599549";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-input-euroc-dataset/default.nix
+++ b/distros/humble/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmath, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-input-euroc-dataset";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_euroc_dataset/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "d10e698242f75150e668bf41070757bb85bb62444e274c1cbc2dcf657077becf";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_euroc_dataset/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "c041073662bccafc532ca8895c74a1ff990bac772958853f88b9308c38e43737";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-kitti-dataset/default.nix
+++ b/distros/humble/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-humble-mola-input-kitti-dataset";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti_dataset/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "35d5994bb3a13888c7034ea33978c18b0cc4b622fbfaf566b5eea61547271ff2";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti_dataset/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "3bb83873a1f976825a5466bdaa8685f58c1de8d9bd350b4857069b9a0fb47bb1";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-kitti360-dataset/default.nix
+++ b/distros/humble/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-humble-mola-input-kitti360-dataset";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti360_dataset/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "0213218fd3350da3d80e190b1155f28872771a8bb51f9da19a7ce0617524463b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti360_dataset/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "81c9214276f79013577dd5d1913365ac98fbba8e97c53f8d04a9c679eda13a35";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-lidar-bin-dataset/default.nix
+++ b/distros/humble/mola-input-lidar-bin-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-humble-mola-input-lidar-bin-dataset";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_lidar_bin_dataset/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "243dcb4843d9dc66d6d95191e080a53397ecdc10c98669314fa5f83636c8c430";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_lidar_bin_dataset/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "aa394a029cd30e1ac59cf0ddcbef1a2b3ecb716c3568fa97b1d5064c2498be13";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-mulran-dataset/default.nix
+++ b/distros/humble/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-humble-mola-input-mulran-dataset";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_mulran_dataset/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "084bbc15b06161760a2ad59bcd461f14060a066a1200d30b041876621c000f62";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_mulran_dataset/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "da19681d19b1064c7afb47ea7afc9fb0ef6c3a286fba837a860fa27596d8888f";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-paris-luco-dataset/default.nix
+++ b/distros/humble/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-humble-mola-input-paris-luco-dataset";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_paris_luco_dataset/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "d29120b27d78716af55392f34e75af7d5fe86e88aa9bc68519117ced66005fe0";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_paris_luco_dataset/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "6434edc1bb6aa701134282aa4ef7a98915e04b9ab7595a57df9c8abe1b9908bb";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-rawlog/default.nix
+++ b/distros/humble/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-input-rawlog";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rawlog/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "af1982fc809e54dd9dff772274428aba8bb110e2d3d6d2fd471ad35b9b952972";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rawlog/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "113d84026b46619f52e0a88c5722909977522ec4fab912f8326890c9da0a04e6";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-rosbag2/default.nix
+++ b/distros/humble/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, gps-msgs, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-mola-input-rosbag2";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rosbag2/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "11fc0c13c74e62f13f8b454cd33be5ebd09d0bbfebfe5e0af1d5156f0de9d1d1";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rosbag2/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "5d418c3302a6f90eda60df54c10866e747eb604a997c6661ea4717c8305affb0";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-video/default.nix
+++ b/distros/humble/mola-input-video/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libhwdrivers, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-input-video";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_video/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "43f02eebca470d6fe5f6a1f9a5c18b675a30b4537ce20eb3e2cefd3afaecb459";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_video/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "93f3f77d896a70f727c121109ad6d54a8ae2c124b496c3dc85e2c8070c568177";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-kernel/default.nix
+++ b/distros/humble/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libgui, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-kernel";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_kernel/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "d4d8c07075aed064cd3213ff1b7d754598fb8710246d51188c1e2e903036ff3c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_kernel/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "00865ff634da30e9f152bb15567d6ac822754f7c4eab9195e3895e6ab73b4eae";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-launcher/default.nix
+++ b/distros/humble/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-xmllint, ament-lint-auto, cmake, mola-kernel, mrpt-libbase, mrpt-libtclap, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-launcher";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_launcher/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "e505f47f017c38ac4b6f4acb614908b5b4b6371f891081ffbabaeeddcf13b6ac";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_launcher/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "7dcb4e4047e1afa7565d10cce6ac370a2ca0399c2412d43beb65010a0dfa90cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-lidar-odometry/default.nix
+++ b/distros/humble/mola-lidar-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-imu-preintegration, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-humble-mola-lidar-odometry";
-  version = "1.3.1-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/humble/mola_lidar_odometry/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "87fa4c2eebcf4530c3858fa335a49966c2e1d0aae014ea4f3791523f5f6b4d66";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/humble/mola_lidar_odometry/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "e467ad4e1f5eea2d9896a5f9c2ad940f0aeef1ec2733d231ca52fa09c7721d6d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-metric-maps/default.nix
+++ b/distros/humble/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mp2p-icp, mrpt-libmaps, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-metric-maps";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_metric_maps/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "9669777725c9ed4577fc56c11c4aa486cb774bcaca89c6e5a2a7bab3f9f0b960";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_metric_maps/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "9b789a3c472016f106d89e0592c8009c2e4510070e79f7fbe9af342cadaed26a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-msgs/default.nix
+++ b/distros/humble/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-mola-msgs";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_msgs/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "a91e09a61789779ac603ceca24ac4a10d7d18a341a8b4ade61a4262da4aa040e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_msgs/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "cc495fde9f7d8206e8cffe197cfcd3dbf527a0c402a76f93913ef63142de6c65";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-pose-list/default.nix
+++ b/distros/humble/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-humble-mola-pose-list";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_pose_list/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "5369927ea89a06e4f9f882873298e8c1587365b92bef45f3a7ab163faf383cb1";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_pose_list/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "0adba1e89a00ca4d192677435464108126d38c80d443afb39aa16ae93ccae555";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-relocalization/default.nix
+++ b/distros/humble/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-humble-mola-relocalization";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_relocalization/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "608de84898093ae0e69ec8a1b949dbe4f9d00246ef8205c287ff8baf730c3897";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_relocalization/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "e222755cfe3bb14489c1608d08d2c991f45cde588d8bf53fc8c40109d03b466b";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-traj-tools/default.nix
+++ b/distros/humble/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-humble-mola-traj-tools";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_traj_tools/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "6f02cd8a80cf700a0d9ca4837d1542a8cc7ccd9ec271384ef9df7d1025b0f543";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_traj_tools/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "ff9fba9826d54f05a3be2b9b9de980818ebecc646ebdc78434e7c0183ec67165";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-viz/default.nix
+++ b/distros/humble/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-humble-mola-viz";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_viz/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "57461be797a2243a38a3828ba46f4edc6237c3875a86245d9a312bf3d8b8b9b2";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_viz/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "15c14b9aad22127938c378e148b76ddcf1d9c27f5ac44ba206ba03507aa59aa9";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-yaml/default.nix
+++ b/distros/humble/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-humble-mola-yaml";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_yaml/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "2b77d5ccf18e5fe5bdd69023cd30c3684809f4013e913d11d28d53a868a96fdc";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_yaml/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "83d3bcdba13cc31a5ac4f59c19becbfbc78e4d47bae1d0c532a90607df68abe9";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola/default.nix
+++ b/distros/humble/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-input-video, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-humble-mola";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "2e73554ccf97c1408bd2bab850dad9c331c81c8918888fd5d648ce3f5f688cb4";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "217fbe4bc683f0131675b3072eed849d098039d20c95f299fb5557de8b554e59";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/controller-interface/default.nix
+++ b/distros/jazzy/controller-interface/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, fmt, geometry-msgs, hardware-interface, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, fmt, geometry-msgs, hardware-interface, pal-statistics, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-controller-interface";
-  version = "4.43.0-r1";
+  version = "4.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_interface/4.43.0-1.tar.gz";
-    name = "4.43.0-1.tar.gz";
-    sha256 = "4b747f408efdfec9787b7c43f02b009e5fb7b7d7abd503746c76e27bfee08eec";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_interface/4.44.0-1.tar.gz";
+    name = "4.44.0-1.tar.gz";
+    sha256 = "5d81870c6105cf473ff9f9cb2e7a6921466161242c170c6becd76ff1fde2b41b";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-gen-version-h fmt ros2-control-cmake ];
+  buildInputs = [ ament-cmake ament-cmake-gen-version-h fmt pal-statistics ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock geometry-msgs sensor-msgs std-msgs ];
   propagatedBuildInputs = [ hardware-interface rclcpp-lifecycle realtime-tools ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ];

--- a/distros/jazzy/controller-manager-msgs/default.nix
+++ b/distros/jazzy/controller-manager-msgs/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-controller-manager-msgs";
-  version = "4.43.0-r1";
+  version = "4.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager_msgs/4.43.0-1.tar.gz";
-    name = "4.43.0-1.tar.gz";
-    sha256 = "1209648af8181a252cc9898cdfb5419ce93a86d4bb9da46029ee7edaad8b1734";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager_msgs/4.44.0-1.tar.gz";
+    name = "4.44.0-1.tar.gz";
+    sha256 = "8f6038f05c26f68a34a8912e3e3da99b2ecb44464496018fcd814cec5e7d6a85";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
-  checkInputs = [ ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces lifecycle-msgs rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 

--- a/distros/jazzy/controller-manager/default.nix
+++ b/distros/jazzy/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, example-interfaces, fmt, generate-parameter-library, hardware-interface, hardware-interface-testing, launch, launch-ros, launch-testing, launch-testing-ros, libstatistics-collector, lifecycle-msgs, pluginlib, python3Packages, rcl-interfaces, rclcpp, rclpy, realtime-tools, robot-state-publisher, ros2-control-cmake, ros2-control-test-assets, ros2param, ros2pkg, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-controller-manager";
-  version = "4.43.0-r1";
+  version = "4.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager/4.43.0-1.tar.gz";
-    name = "4.43.0-1.tar.gz";
-    sha256 = "1be988c7026009025fb8083287576e29502249c3ea4b6191309c6c7dcfd5ca60";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager/4.44.0-1.tar.gz";
+    name = "4.44.0-1.tar.gz";
+    sha256 = "151d6996c0b4e88f942debdb4ab808e8e90c69cc732aaae5b679a8f184ed50ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/eventdispatch-python/default.nix
+++ b/distros/jazzy/eventdispatch-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-eventdispatch-python";
-  version = "0.2.26-r1";
+  version = "0.2.29-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_eventdispatch-release/archive/release/jazzy/eventdispatch_python/0.2.26-1.tar.gz";
-    name = "0.2.26-1.tar.gz";
-    sha256 = "ab688bf9d71998d7e956ca4634e3f54ae178ab715a0758f284fa37aa066accc9";
+    url = "https://github.com/ros2-gbp/ros2_eventdispatch-release/archive/release/jazzy/eventdispatch_python/0.2.29-1.tar.gz";
+    name = "0.2.29-1.tar.gz";
+    sha256 = "7bcafdbc061a90cd4353fbcadf2e0a5ba5e48127566e29812436fed1e7320e7b";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/eventdispatch-ros2-interfaces/default.nix
+++ b/distros/jazzy/eventdispatch-ros2-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-eventdispatch-ros2-interfaces";
-  version = "0.2.26-r1";
+  version = "0.2.29-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_eventdispatch-release/archive/release/jazzy/eventdispatch_ros2_interfaces/0.2.26-1.tar.gz";
-    name = "0.2.26-1.tar.gz";
-    sha256 = "23b6eb5ed841b4741bfd416b6725f5917daea27423b3bf3ed80469a4a06e0f26";
+    url = "https://github.com/ros2-gbp/ros2_eventdispatch-release/archive/release/jazzy/eventdispatch_ros2_interfaces/0.2.29-1.tar.gz";
+    name = "0.2.29-1.tar.gz";
+    sha256 = "4bbe9f47f24ff61600c2a8b2a935c1c061beb7f6ba164550dd7a197ef14128a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/eventdispatch-ros2/default.nix
+++ b/distros/jazzy/eventdispatch-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, eventdispatch-python, eventdispatch-ros2-interfaces, rclcpp, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-eventdispatch-ros2";
-  version = "0.2.26-r1";
+  version = "0.2.29-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_eventdispatch-release/archive/release/jazzy/eventdispatch_ros2/0.2.26-1.tar.gz";
-    name = "0.2.26-1.tar.gz";
-    sha256 = "f646a6f9637228b58fbaead78d9131cb32f37f6b9f94ca4fb80be293de73c326";
+    url = "https://github.com/ros2-gbp/ros2_eventdispatch-release/archive/release/jazzy/eventdispatch_ros2/0.2.29-1.tar.gz";
+    name = "0.2.29-1.tar.gz";
+    sha256 = "90e5a9219d9c1e6da5647bc09516f9ec0fa95e5ec4c42287f27b3a3ee3dd0a17";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/hardware-interface-testing/default.nix
+++ b/distros/jazzy/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, fmt, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-hardware-interface-testing";
-  version = "4.43.0-r1";
+  version = "4.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface_testing/4.43.0-1.tar.gz";
-    name = "4.43.0-1.tar.gz";
-    sha256 = "f66d2c78abd6bbdaf66cbe8c6f0e4f9177e0b79183c12c9ea9f0612c6acb0b89";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface_testing/4.44.0-1.tar.gz";
+    name = "4.44.0-1.tar.gz";
+    sha256 = "147aaf126e757bc3e80d73553c1b24f50a8f97a0aad344193b2ef813e42bcdf7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/hardware-interface/default.nix
+++ b/distros/jazzy/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, control-msgs, fmt, joint-limits, lifecycle-msgs, pal-statistics, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sdformat-urdf, tinyxml2-vendor, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-hardware-interface";
-  version = "4.43.0-r1";
+  version = "4.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface/4.43.0-1.tar.gz";
-    name = "4.43.0-1.tar.gz";
-    sha256 = "0056cb895205a19550661af8b4184ad40a1dbefc5de6f353b1946a7c751d20fe";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface/4.44.0-1.tar.gz";
+    name = "4.44.0-1.tar.gz";
+    sha256 = "5008de7090799b222e8accdcc73a71c998755993b279c18f631854d1bd15a4b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-limits/default.nix
+++ b/distros/jazzy/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, fmt, generate-parameter-library, launch-ros, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-limits";
-  version = "4.43.0-r1";
+  version = "4.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/joint_limits/4.43.0-1.tar.gz";
-    name = "4.43.0-1.tar.gz";
-    sha256 = "b6809ac2cb3239f82930a70cc6dec5068b8c60090aaa8c2658de303e7b466466";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/joint_limits/4.44.0-1.tar.gz";
+    name = "4.44.0-1.tar.gz";
+    sha256 = "b8ade561c8f354da26e5f4a7e0b9e5766e659916914b20f428f3d2eeb4c5e2d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/kitti-metrics-eval/default.nix
+++ b/distros/jazzy/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmath, mrpt-libposes, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-jazzy-kitti-metrics-eval";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/kitti_metrics_eval/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "3248fb3942a173b0e35d9b3fa6503634278380ea09fb3b01c9d5e564a22b2456";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/kitti_metrics_eval/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "c067e3e5d078491a43c4e79b27ab8f03dc3ba93761dc8f9befda2d7c60d4725a";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-bridge-ros2/default.nix
+++ b/distros/jazzy/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, geographic-msgs, geometry-msgs, gps-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-bridge-ros2";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_bridge_ros2/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "ece1a06efa3424ba5c8331d6ddf0e39df66b7c4c08e4718d698bd60d44d41ceb";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_bridge_ros2/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "b94ecaaf14322d9c1ecf762404b7f24d185e69326b9cca9ec5c3444e5f99d9e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-demos/default.nix
+++ b/distros/jazzy/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-demos";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_demos/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "ab7743997c4d244b117004afebd6d8ae4d94d5af81c5a97833ccd79b5f049cfc";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_demos/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "e1bb812cbb32242d0b056b0edc481a93b271c8e2ee23ffd5086638d5c561f0e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-input-euroc-dataset/default.nix
+++ b/distros/jazzy/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmath, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-euroc-dataset";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_euroc_dataset/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "4b3f9c19c76b0915c05b12dcb156fed8a81f07ab1a63098a0110f72cfaa0aeff";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_euroc_dataset/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "0ac13648eba963a9b864fa0487a3a0fb4d2140b874bf5c85b8b6c58fe0c3cc78";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-kitti-dataset/default.nix
+++ b/distros/jazzy/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-kitti-dataset";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti_dataset/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "e56aeb6802ef248e9e235c075ec68f23569f2dad2c5eff0e02a482ed95eb831a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti_dataset/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "ccf12a97b9b5342805b3fac5ea2cdcdedf655272edc8d73b27d551cf31e6ee10";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-kitti360-dataset/default.nix
+++ b/distros/jazzy/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-kitti360-dataset";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti360_dataset/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "54b665b0d371b9fbd05ac821d95fdf2f7ac08b7915bcca5107e81ef42637e3c3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti360_dataset/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "56bf443f8471250c0e9b868b8713781b1ed8584bf550a760503cfbef64cd76b8";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-lidar-bin-dataset/default.nix
+++ b/distros/jazzy/mola-input-lidar-bin-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-lidar-bin-dataset";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_lidar_bin_dataset/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "18b0eb98f979a8a36f73657ef9e9d2611ef230fe8e9bf4a2323721d5807011fa";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_lidar_bin_dataset/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "4c654196c500aadb096a536fe2f562c9b894a4642da5666cd75dd2e251f7d37a";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-mulran-dataset/default.nix
+++ b/distros/jazzy/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-mulran-dataset";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_mulran_dataset/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "1f0afc3be1ee608773eee9ba5bcfb19c514ffdf1a32bb44bd6a2c8d84a9712ed";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_mulran_dataset/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "9602a3193d5328cd32267c15e3aa4251630086177fd122bd36ae060d543d68e9";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-paris-luco-dataset/default.nix
+++ b/distros/jazzy/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-paris-luco-dataset";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_paris_luco_dataset/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "744f428ffc4058966ce1a1b0a81082a7db737891964dedc540d2babe655aa34f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_paris_luco_dataset/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "a9352a69be1316ac68b20c35b07439a037b06c47ea76a549caf475d44e7323c7";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-rawlog/default.nix
+++ b/distros/jazzy/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-rawlog";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rawlog/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "62a5c1f602a8ac00db381e561181b3c7119404aea751b6304f11ebf848706589";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rawlog/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "240bc12542fd6f27d8789f4606e682ad987c3a3433c3b15f0bb30131bfd3ec90";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-rosbag2/default.nix
+++ b/distros/jazzy/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, gps-msgs, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-rosbag2";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rosbag2/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "48a597f238079191a5aa2c9a0d5f0d82c0f549d7c9fbdd45679875cec290e4f2";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rosbag2/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "c6922531d17250ae1ae60d311c4d4f2b4c8d0ccfab1a67275309128bfc25d9d6";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-video/default.nix
+++ b/distros/jazzy/mola-input-video/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libhwdrivers, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-video";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_video/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "f70fc70d490244779efaa1f1c45190d55db639a5d43c1c3a77a19c3abd14cc5e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_video/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "98a6cf38b5cb84a59fcf87652ac33e8a6cb42a5e282deea170ec905027abd566";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-kernel/default.nix
+++ b/distros/jazzy/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libgui, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-kernel";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_kernel/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "88869c502d25199f5e927b13484d932d2dd5039a222a1579c841941435671c7b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_kernel/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "bd6a726b1831ef95992d3e7b372028c8ad5a64507c1304e8064cac7cfbeda13e";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-launcher/default.nix
+++ b/distros/jazzy/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-xmllint, ament-lint-auto, cmake, mola-kernel, mrpt-libbase, mrpt-libtclap, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-launcher";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_launcher/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "33038779021ae69a3d832e8e17448fbc510883a66401a72d844abf335c854dc4";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_launcher/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "69428ef1ebb6391aa3e7fdf439fffc77ded53dbd177339820af2b75f5b3f4d25";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-lidar-odometry/default.nix
+++ b/distros/jazzy/mola-lidar-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-imu-preintegration, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-jazzy-mola-lidar-odometry";
-  version = "1.3.1-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/jazzy/mola_lidar_odometry/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "86b3559696dbb36fac5df857c25267a70c8e40e0f4c7c092fe7103b45c924092";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/jazzy/mola_lidar_odometry/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "29551c6e17da8bfe22fc6ab5c93b54981f913297f99159abb23155863d795a21";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-metric-maps/default.nix
+++ b/distros/jazzy/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mp2p-icp, mrpt-libmaps, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-metric-maps";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_metric_maps/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "76b615cdce6b3b8c86dbe28aea7b31ca04cb43097b184f079c4c3b183ba3ddb3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_metric_maps/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "3b36ed9af2d5d115ae19eb79e117cf17cb896ef4ca964cfe80a6b795c80013b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-msgs/default.nix
+++ b/distros/jazzy/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-mola-msgs";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_msgs/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "9807543773f4dd9b4a8807d37ba4fb92ded1532fdd0b349b7f21e1c583940a92";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_msgs/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "294783c730600b9c5743dac10a50cc7c937f503569431ff4e564f1123afadd30";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-pose-list/default.nix
+++ b/distros/jazzy/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-jazzy-mola-pose-list";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_pose_list/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "c55981c97ab04d6d58f7910d66d38a7800e03dd3601da93fe0acbf46125ec39f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_pose_list/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "1acdacf06d3802321b30a54e1633bf797ce215dcb32b369c3c31ab2c58c59d09";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-relocalization/default.nix
+++ b/distros/jazzy/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-jazzy-mola-relocalization";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_relocalization/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "39fba915f6becef1a6063c76e439361472ff288644976b63e7a56b200953ded9";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_relocalization/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "eed5cbeaa861d1044c43b11a58241fe96db57437a4f5ac2cf0d49d88769c1d92";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-traj-tools/default.nix
+++ b/distros/jazzy/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-jazzy-mola-traj-tools";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_traj_tools/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "84ce3e9735d7b36584331c4614ad2c88ea9423bc42a20b8e9880c3a9e03a7656";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_traj_tools/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "e0b98e1d5bbcbab580b8f9e0580e2b22277d597a0a15a66ab97fdcbd4a5a8b91";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-viz/default.nix
+++ b/distros/jazzy/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-jazzy-mola-viz";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_viz/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "2e17bbcfab04195afb568bbab3142c566ff1b80efa83ce54d805ad5fdf1f9d55";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_viz/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "ace1c0e216252fcf80f334c075fed7052112e6b90a72499022ea24078ae0b99d";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-yaml/default.nix
+++ b/distros/jazzy/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-jazzy-mola-yaml";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_yaml/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "0579b8402dbf86e5f3dc4e2fbc0c22eb303f3fb58f154f762bac3eec07b1d7dc";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_yaml/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "fd9c9e523756f8b3b021734748c5c21074a21e37dcef9568f3f48bb0b2ae9ed1";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola/default.nix
+++ b/distros/jazzy/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-input-video, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-jazzy-mola";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "ffd5166863dd60a6b5b585596b6eb22cd0f5783d37391b875a28de5d55cca75c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "d3568d6201aff5f8fd839c131fdcc7d78985af0d36cf8d49a4869e93c080d998";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/ros2-control-test-assets/default.nix
+++ b/distros/jazzy/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-control-test-assets";
-  version = "4.43.0-r1";
+  version = "4.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control_test_assets/4.43.0-1.tar.gz";
-    name = "4.43.0-1.tar.gz";
-    sha256 = "ad0b9c7dca66259a787d49766d8d249d9de12ab96282b6733fbe74afab476084";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control_test_assets/4.44.0-1.tar.gz";
+    name = "4.44.0-1.tar.gz";
+    sha256 = "d39369f8eeaec0c31ee2df96f2a364a24e90730c1f43f1dfe1ccf9df2243661f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-control/default.nix
+++ b/distros/jazzy/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-control";
-  version = "4.43.0-r1";
+  version = "4.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control/4.43.0-1.tar.gz";
-    name = "4.43.0-1.tar.gz";
-    sha256 = "0564d8671bc57e2e2cd633f87fec18c451c846347baac41d9e572b5bc1927bd1";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control/4.44.0-1.tar.gz";
+    name = "4.44.0-1.tar.gz";
+    sha256 = "a09268d103b0cefeb27150221fbb93634ecf6f0e1fb4cbe3e6355cb1d9eff4f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2controlcli/default.nix
+++ b/distros/jazzy/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-jazzy-ros2controlcli";
-  version = "4.43.0-r1";
+  version = "4.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2controlcli/4.43.0-1.tar.gz";
-    name = "4.43.0-1.tar.gz";
-    sha256 = "76b2f21cfbceb0b9484898898e9f9b396dc5625791089d236f224101620139e2";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2controlcli/4.44.0-1.tar.gz";
+    name = "4.44.0-1.tar.gz";
+    sha256 = "8e7e526b18fd147fb8ebccad3b4ea5095551dcf6382087744b0b8fcf386b9ee9";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rqt-controller-manager/default.nix
+++ b/distros/jazzy/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-jazzy-rqt-controller-manager";
-  version = "4.43.0-r1";
+  version = "4.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/rqt_controller_manager/4.43.0-1.tar.gz";
-    name = "4.43.0-1.tar.gz";
-    sha256 = "1041372fffb0e298fad1b842daee22ea462e39be5f8537aa42c61798975b3c1d";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/rqt_controller_manager/4.44.0-1.tar.gz";
+    name = "4.44.0-1.tar.gz";
+    sha256 = "c6740f000f91a66538a5ed044d12f1785b052e405355d375d8cf8f46c793e28e";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/transmission-interface/default.nix
+++ b/distros/jazzy/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, fmt, hardware-interface, pluginlib, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-transmission-interface";
-  version = "4.43.0-r1";
+  version = "4.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/transmission_interface/4.43.0-1.tar.gz";
-    name = "4.43.0-1.tar.gz";
-    sha256 = "3c3154909ee082ad01423905c9645e84a783a88bfc7bb0e311b43b10cfe18abc";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/transmission_interface/4.44.0-1.tar.gz";
+    name = "4.44.0-1.tar.gz";
+    sha256 = "eb8510b266b0a6cfe3040040fff665ebf7a1a12f6e69d21f623f90f48d1bedc4";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/controller-interface/default.nix
+++ b/distros/kilted/controller-interface/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, fmt, geometry-msgs, hardware-interface, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, fmt, geometry-msgs, hardware-interface, pal-statistics, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-controller-interface";
-  version = "5.12.0-r1";
+  version = "5.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/controller_interface/5.12.0-1.tar.gz";
-    name = "5.12.0-1.tar.gz";
-    sha256 = "a6b7e7ce3020da6c17a26201d6b638b2c8eac6f46b39fbb784c1ee188a267d78";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/controller_interface/5.13.0-1.tar.gz";
+    name = "5.13.0-1.tar.gz";
+    sha256 = "ee400bc71d67bb4fe6f53e8ea88a09e007bdddacc71e81b8636593332e687ea6";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-gen-version-h fmt ros2-control-cmake ];
+  buildInputs = [ ament-cmake ament-cmake-gen-version-h fmt pal-statistics ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock geometry-msgs sensor-msgs std-msgs ];
   propagatedBuildInputs = [ hardware-interface rclcpp-lifecycle realtime-tools ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ];

--- a/distros/kilted/controller-manager-msgs/default.nix
+++ b/distros/kilted/controller-manager-msgs/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-controller-manager-msgs";
-  version = "5.12.0-r1";
+  version = "5.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/controller_manager_msgs/5.12.0-1.tar.gz";
-    name = "5.12.0-1.tar.gz";
-    sha256 = "07f1ed482ab84681c23baac0494a797929819e758cbdf94880fd0d362bbb476c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/controller_manager_msgs/5.13.0-1.tar.gz";
+    name = "5.13.0-1.tar.gz";
+    sha256 = "512e6082c32f7f1cb32fd1deeba4a66f15d8ee762b48ab1bd6db2f6e7fa2667f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
-  checkInputs = [ ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces lifecycle-msgs rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 

--- a/distros/kilted/controller-manager/default.nix
+++ b/distros/kilted/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, example-interfaces, fmt, generate-parameter-library, hardware-interface, hardware-interface-testing, launch, launch-ros, launch-testing, launch-testing-ros, libstatistics-collector, lifecycle-msgs, pluginlib, python3Packages, rcl-interfaces, rclcpp, rclpy, realtime-tools, robot-state-publisher, ros2-control-cmake, ros2-control-test-assets, ros2param, ros2pkg, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-controller-manager";
-  version = "5.12.0-r1";
+  version = "5.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/controller_manager/5.12.0-1.tar.gz";
-    name = "5.12.0-1.tar.gz";
-    sha256 = "b06a23cd0c80047e3d6db1c848c318370ed99eed04586f248f65fb941ba35b26";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/controller_manager/5.13.0-1.tar.gz";
+    name = "5.13.0-1.tar.gz";
+    sha256 = "8b14014e80d29eac4f2ac9da7c61487ec26eeb74b0fa4174b75dd67007026abb";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/hardware-interface-testing/default.nix
+++ b/distros/kilted/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, fmt, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-hardware-interface-testing";
-  version = "5.12.0-r1";
+  version = "5.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/hardware_interface_testing/5.12.0-1.tar.gz";
-    name = "5.12.0-1.tar.gz";
-    sha256 = "b46751148e73721d50a191ec236581e39e04c46029f960ed60201d527f28f227";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/hardware_interface_testing/5.13.0-1.tar.gz";
+    name = "5.13.0-1.tar.gz";
+    sha256 = "ae0ffaf0d9c4516b59f49dbbe319ef2272610ae1ac681d9b9330af08fd2fd118";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/hardware-interface/default.nix
+++ b/distros/kilted/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, control-msgs, fmt, joint-limits, lifecycle-msgs, pal-statistics, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sdformat-urdf, tinyxml2-vendor, urdf }:
 buildRosPackage {
   pname = "ros-kilted-hardware-interface";
-  version = "5.12.0-r1";
+  version = "5.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/hardware_interface/5.12.0-1.tar.gz";
-    name = "5.12.0-1.tar.gz";
-    sha256 = "76b0fe32318f42ea52e195b965ec3e12ab269d889cb557a366eebe1ce62a2921";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/hardware_interface/5.13.0-1.tar.gz";
+    name = "5.13.0-1.tar.gz";
+    sha256 = "d054c0f68d5eb5363d2a8f8ee5f35afe7cf963302841471b6425e4dcc8c1f553";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/joint-limits/default.nix
+++ b/distros/kilted/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, fmt, generate-parameter-library, launch-ros, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-kilted-joint-limits";
-  version = "5.12.0-r1";
+  version = "5.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/joint_limits/5.12.0-1.tar.gz";
-    name = "5.12.0-1.tar.gz";
-    sha256 = "b85b3be6815190bc529b6cabe8db5d57fc16db034609223fe8eba0cdc845429e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/joint_limits/5.13.0-1.tar.gz";
+    name = "5.13.0-1.tar.gz";
+    sha256 = "626c62cd1d8cfe3706c26c4f8309e3de54eadfcebebd4b97f3b384c19ee9ba60";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/kitti-metrics-eval/default.nix
+++ b/distros/kilted/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmath, mrpt-libposes, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-kilted-kitti-metrics-eval";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/kitti_metrics_eval/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "c3d4acda122d112e8714d94209e9bef0b8ecb69b0ce44110d8250b0887d7aecf";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/kitti_metrics_eval/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "44f2d5634083a87ae4cbb2b84aec26446c1a4d43200775624587670323c1926c";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-bridge-ros2/default.nix
+++ b/distros/kilted/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, geographic-msgs, geometry-msgs, gps-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mola-bridge-ros2";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_bridge_ros2/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "486a37f00485635263445963c12e8b8fbf38f22bff1ed7ec165510149711fe73";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_bridge_ros2/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "9f607238c6df9a8b4da3a44f5a2d2540d70709ed754f236b5436984df1a753f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mola-demos/default.nix
+++ b/distros/kilted/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-kilted-mola-demos";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_demos/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "013c87c01d8e83ae6630da8c83106a4c78ec8c181f0d322606ea6e4b55dc2e20";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_demos/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "044a91aa8eefb45e4363fc1b650ce10632bf978081b9df81402566efc1b2cd38";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mola-input-euroc-dataset/default.nix
+++ b/distros/kilted/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmath, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-kilted-mola-input-euroc-dataset";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_euroc_dataset/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "c88e9262fc53aeed7eae7ddf9f03f35d982d7361c02e8ee1cef6b90e39618d9e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_euroc_dataset/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "b438d3e4f8ba2837c8fdde314f9d702d7fe244a96a22e301be3245327452e004";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-input-kitti-dataset/default.nix
+++ b/distros/kilted/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-kilted-mola-input-kitti-dataset";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_kitti_dataset/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "cb445d374ac56e0760abda08c3f02598fc1bcd60152d53974cbe2d5867c35fa5";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_kitti_dataset/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "c35b84af165914e2c66711c1ff9f8eec7eedb2e2d13bbd07306e2bc86b61ec28";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-input-kitti360-dataset/default.nix
+++ b/distros/kilted/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-kilted-mola-input-kitti360-dataset";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_kitti360_dataset/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "0ed54bf9dcc63405a086f7ca36a409814c9558e675d863ce967e0b14fbba71f8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_kitti360_dataset/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "0d2850ecef4cd9f0911f6f04e8f88a41a9788350add8e61a2964b13b9f116a11";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-input-lidar-bin-dataset/default.nix
+++ b/distros/kilted/mola-input-lidar-bin-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-kilted-mola-input-lidar-bin-dataset";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_lidar_bin_dataset/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "183225b78eade07c364e5f64902cd6cad9e4aca533650b532acb349bc937e37b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_lidar_bin_dataset/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "05a1aa07926d04c8293222e720f0486447385be62f1c022fefbba5066ca2f79b";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-input-mulran-dataset/default.nix
+++ b/distros/kilted/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-kilted-mola-input-mulran-dataset";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_mulran_dataset/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "1290ac40c687fc4c946e95fc4f48b963e8ea19e6466c06a286aed9d5ed649a9b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_mulran_dataset/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "7c686df5d328de52b4a4c5a3cddd3964b30999bbbb599212121eaf3952c5f9c8";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-input-paris-luco-dataset/default.nix
+++ b/distros/kilted/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-kilted-mola-input-paris-luco-dataset";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_paris_luco_dataset/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "eea945e11bbf57b800d2ce291da11f49bac60112e5efa4754ee2db1e2d9e7089";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_paris_luco_dataset/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "6169d912489dfcaf503c23a518c527f3abe53a81f1116d5786f6bc245c13b673";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-input-rawlog/default.nix
+++ b/distros/kilted/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-kilted-mola-input-rawlog";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_rawlog/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "efb219c926376fc3839a6e020344384180cd1a2cf71d085564571c78f13c8f31";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_rawlog/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "ccd5599abde2d8f5489b5c357654194268a51a7c12b04a7298a428b11d1ffd77";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-input-rosbag2/default.nix
+++ b/distros/kilted/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, gps-msgs, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-mola-input-rosbag2";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_rosbag2/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "7ea488e8e577b8e948ed9c469c0c9b31b73345f576fc16151fed248eeafe3df6";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_rosbag2/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "b5822206833d2747bd39ec0f51917effb0733aba82da5f1fcb146c8e31ed075a";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-input-video/default.nix
+++ b/distros/kilted/mola-input-video/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libhwdrivers, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-kilted-mola-input-video";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_video/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "9fc48a656bee4281b8d5a1f293e10559d467f3c9f94aa330cfc55e8c1cdb3ed7";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_video/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "c0ae9b4faf5e644042071d870658dd638f67265ebd28487be148750d873394ad";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-kernel/default.nix
+++ b/distros/kilted/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libgui, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-kilted-mola-kernel";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_kernel/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "7f00423300c7a98e5ae00199f8e47947b200fe94d072e22923c73ba81fbbb5b3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_kernel/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "76eb9d9b6281db2402002c64f9ba87e1deca12207d549e749eec57513ba25947";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-launcher/default.nix
+++ b/distros/kilted/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-xmllint, ament-lint-auto, cmake, mola-kernel, mrpt-libbase, mrpt-libtclap, ros-environment }:
 buildRosPackage {
   pname = "ros-kilted-mola-launcher";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_launcher/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "0ddd4d403d053fdf16c736e05c25bd41b1fd72b66af0716743f7c380467ae26a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_launcher/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "2e55d91efd6ab44f39fb60fdd729e45f48363fbf378dc409784e92b2388765e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mola-lidar-odometry/default.nix
+++ b/distros/kilted/mola-lidar-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-imu-preintegration, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-kilted-mola-lidar-odometry";
-  version = "1.3.1-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/kilted/mola_lidar_odometry/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "365fe96b301db6dc03e523e5ac2545a4682911e1e5fa09ae660a9a1fb98ea3f7";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/kilted/mola_lidar_odometry/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "9d7b9dad42168b58c5331ad446c5dd168795c2d751eb0c67677cc2584ddb7263";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mola-metric-maps/default.nix
+++ b/distros/kilted/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mp2p-icp, mrpt-libmaps, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-kilted-mola-metric-maps";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_metric_maps/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "8f42b646e0d5b2f1cbd3a506e78b31ea4729a0d3d4cc4edc1b02b6b0f6af508a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_metric_maps/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "e2acb4bcb25699d16083afa8416240637d09542527d60007ad1e5702cb756445";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mola-msgs/default.nix
+++ b/distros/kilted/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-kilted-mola-msgs";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_msgs/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "f2800ad690645684aeaad2752f0d2d7e69aac83142f402e6e196f9bf97c5203c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_msgs/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "6d3cb4afaa36a012dea9b0f75aa61a68efe3b7a72be59b3c317d8ff568b8f026";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mola-pose-list/default.nix
+++ b/distros/kilted/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-kilted-mola-pose-list";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_pose_list/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "0d16a1511295cadaef92896090719bcf3f68d17d3217623c9b45520094695aae";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_pose_list/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "770129e6da7c46a70f72d193e689cea78454226e9910a65ce54306cc7ca89189";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-relocalization/default.nix
+++ b/distros/kilted/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-kilted-mola-relocalization";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_relocalization/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "5ad1a84981f04cdafb23158e48c2396cfb8d9fc67bc5c3f221ac755ccb86cba7";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_relocalization/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "cd94c9a2f6ead345e2b13a99ac6abefbe61a36a3b80e5e4beda5e617e56c713e";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-traj-tools/default.nix
+++ b/distros/kilted/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-kilted-mola-traj-tools";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_traj_tools/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "04acd94d33c1b07e24bd0114184f0bd30958e9b3586113ff7ae6a73e4cc83b71";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_traj_tools/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "7ed434060bda8c4284889888b993f8845e355a29456d8bcd9522abc185b5d3b2";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-viz/default.nix
+++ b/distros/kilted/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-kilted-mola-viz";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_viz/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "cdd801a7ca4ed92c87728fde2b63b2d735ead2ccfc39d9274d03e0a9ec4d8807";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_viz/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "c87b8019f1b995155374c038c29baf55c0448def8024bee249384798c5c74271";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-yaml/default.nix
+++ b/distros/kilted/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-kilted-mola-yaml";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_yaml/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "29f436cdde97c4769d221970f7051bb115dc26bf2a7d27492f781442502fb4bf";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_yaml/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "d373d0b99e858025369560494baf5c60235c5af58c3117ab9a559990fd9353d0";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola/default.nix
+++ b/distros/kilted/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-input-video, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-kilted-mola";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "504bf8d3dfbe771d14ac3e63e04b4da93814374e3ccf6930eb2b2a202b7284fc";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "d7978c9c3fb8daab3a766a72c9f89083443c4f1208991ece2c2c3dcab9185bdf";
   };
 
   buildType = "cmake";

--- a/distros/kilted/ros2-control-test-assets/default.nix
+++ b/distros/kilted/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-kilted-ros2-control-test-assets";
-  version = "5.12.0-r1";
+  version = "5.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/ros2_control_test_assets/5.12.0-1.tar.gz";
-    name = "5.12.0-1.tar.gz";
-    sha256 = "06abacb9eea27ac6dbcaefc081b865599495601d5715c872256c480cb49a76cc";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/ros2_control_test_assets/5.13.0-1.tar.gz";
+    name = "5.13.0-1.tar.gz";
+    sha256 = "655a947ea86048155f5ca91f2e391bed323fce17bb3f4534e563a9f7dd86fa8f";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros2-control/default.nix
+++ b/distros/kilted/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-kilted-ros2-control";
-  version = "5.12.0-r1";
+  version = "5.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/ros2_control/5.12.0-1.tar.gz";
-    name = "5.12.0-1.tar.gz";
-    sha256 = "174e86ee99a28cfda141afc810ff2ffe82172e727d0850f4276d3fd4e02ef776";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/ros2_control/5.13.0-1.tar.gz";
+    name = "5.13.0-1.tar.gz";
+    sha256 = "fe22aa4397134f9a7c0e6bf07625ad39c89fbde3d48554b826953aea18dd6fa8";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros2controlcli/default.nix
+++ b/distros/kilted/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-kilted-ros2controlcli";
-  version = "5.12.0-r1";
+  version = "5.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/ros2controlcli/5.12.0-1.tar.gz";
-    name = "5.12.0-1.tar.gz";
-    sha256 = "98d77a9b9a63acb06995baec1f8aad0f7b1dc7dfe98dcce4be8dc06e4468e4d0";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/ros2controlcli/5.13.0-1.tar.gz";
+    name = "5.13.0-1.tar.gz";
+    sha256 = "a58a75fdfabb09615cca00a617efd849d60576db45b47d5711957cced9977851";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/rqt-controller-manager/default.nix
+++ b/distros/kilted/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-kilted-rqt-controller-manager";
-  version = "5.12.0-r1";
+  version = "5.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/rqt_controller_manager/5.12.0-1.tar.gz";
-    name = "5.12.0-1.tar.gz";
-    sha256 = "054c1199599430e732a6de0686a37b21d532f86d60aab8e1241f8de41fc5d757";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/rqt_controller_manager/5.13.0-1.tar.gz";
+    name = "5.13.0-1.tar.gz";
+    sha256 = "d2fa07a162f5c51880aef19099a8db71388e2b87c0ef278b192bd3721f63c054";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/transmission-interface/default.nix
+++ b/distros/kilted/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, fmt, hardware-interface, pluginlib, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-transmission-interface";
-  version = "5.12.0-r1";
+  version = "5.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/transmission_interface/5.12.0-1.tar.gz";
-    name = "5.12.0-1.tar.gz";
-    sha256 = "f00a5c8121829265be268f72666658d2a805d9011ed78bccca4132362944f43d";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/transmission_interface/5.13.0-1.tar.gz";
+    name = "5.13.0-1.tar.gz";
+    sha256 = "2bb4339c5b9a70d7b54d587b9cabb95e4bc7a2bef9ab25ced8c9fd6f28f2684f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ackermann-steering-controller/default.nix
+++ b/distros/rolling/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-ackermann-steering-controller";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "5aaf84296f3e7c819f6877f9beec03308b6cb47a0daeb289bbbd7c694213fcdc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "16fa27f2c8e673b59185fe0d4a98e1177545ad927aefc5bbca21ee1aa5130397";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/admittance-controller/default.nix
+++ b/distros/rolling/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, tinyxml-2, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-admittance-controller";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "92d7ed915637c393386bc3e6df6370d1fef5fdecbeb6f0061fd499df76b8015f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "427a6edf21af948c0084028725f0e761ef3db447e880052349d7f3ad7e414bca";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/bicycle-steering-controller/default.nix
+++ b/distros/rolling/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-bicycle-steering-controller";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "4b8f0eac2a0bb9a1b01359def547adb6f522021f226d99e643fab925da3865c4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "6dc9da2f27e200b90b2c2d563b0e3bf693a3f3d9c69f598794720831695c70fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/chained-filter-controller/default.nix
+++ b/distros/rolling/chained-filter-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, filters, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-chained-filter-controller";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/chained_filter_controller/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "0cb8304f7bebaa52eae980e9fd0be77a502ccd8fc2fa73588c39d86aebcf6669";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/chained_filter_controller/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "3da046f1e3843afdfbb0bea1ebb8cdabb372d149fa09e6a918a05d84820dd5cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-interface/default.nix
+++ b/distros/rolling/controller-interface/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, fmt, geometry-msgs, hardware-interface, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, fmt, geometry-msgs, hardware-interface, pal-statistics, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-interface";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "010bb6ac08a562aab218882fcb3261c1be59defbba4f670922a23c658890f86a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "9cc6628f1fe6e56563abea39848df1820fccac338c9365129ecf1aa7d2322dc7";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-gen-version-h fmt ros2-control-cmake ];
+  buildInputs = [ ament-cmake ament-cmake-gen-version-h fmt pal-statistics ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock geometry-msgs sensor-msgs std-msgs ];
   propagatedBuildInputs = [ hardware-interface rclcpp-lifecycle realtime-tools ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ];

--- a/distros/rolling/controller-manager-msgs/default.nix
+++ b/distros/rolling/controller-manager-msgs/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager-msgs";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "c974a022a8a031a4e61f9b99127cd20dd3a7b884ff7b90c6e975f48ea5e6b591";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "8c72bef20e6436b000edb61204e6ad9562f1a0b1eb1613076f386b13f3007d74";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
-  checkInputs = [ ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces lifecycle-msgs rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 

--- a/distros/rolling/controller-manager/default.nix
+++ b/distros/rolling/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, example-interfaces, fmt, generate-parameter-library, hardware-interface, hardware-interface-testing, launch, launch-ros, launch-testing, launch-testing-ros, libstatistics-collector, lifecycle-msgs, pluginlib, python3Packages, rcl-interfaces, rclcpp, rclpy, realtime-tools, robot-state-publisher, ros2-control-cmake, ros2-control-test-assets, ros2param, ros2pkg, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "5c24cad15fbdf2bd3a87d96a5fba3f80a371bd64997587967c61a8147b20e13e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "8f3848e2f0071616edbde6f26b908079d81ce29c4c2b7ac148f2cb16e0886c5c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/diff-drive-controller/default.nix
+++ b/distros/rolling/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diff-drive-controller";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "3609375dbee91ce20bcc2f7366f825763c09c79bbf8054a86e0e0f8034d242dd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "f7c497c7fa83b3800f7465fec2068dc9cec763cdda3cbfd1a1ee007319fc6ba0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/effort-controllers/default.nix
+++ b/distros/rolling/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-effort-controllers";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "68ac454a43ee1380496e66912fd503695e66b2c21b0ea8953d4fb05e0b3a25fe";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "a0b323758110a362cbc671414600c8f4cd6f00860f48e36e85f703d0c31c5db0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fastdds/default.nix
+++ b/distros/rolling/fastdds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, python3, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-rolling-fastdds";
-  version = "3.4.2-r1";
+  version = "3.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastdds-release/archive/release/rolling/fastdds/3.4.2-1.tar.gz";
-    name = "3.4.2-1.tar.gz";
-    sha256 = "e7bc727f325089fd6881e4838c72f46e81c0209a7a59e7e5dd8ff2364c276a08";
+    url = "https://github.com/ros2-gbp/fastdds-release/archive/release/rolling/fastdds/3.6.0-1.tar.gz";
+    name = "3.6.0-1.tar.gz";
+    sha256 = "3c58608585b274d49825947788ad5ce75acb814742fd45dd013d073bd4480b09";
   };
 
   buildType = "cmake";

--- a/distros/rolling/force-torque-sensor-broadcaster/default.nix
+++ b/distros/rolling/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-force-torque-sensor-broadcaster";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "c974f1b797e6763a48eb9af9e5791800a5a3d33dbb9d5950a6fdd71ffd5dc201";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "0920da5ade3a752d8cf0ea80b6411c56889830cafa45122812d9a4962fd4e59e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/forward-command-controller/default.nix
+++ b/distros/rolling/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-forward-command-controller";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "7df2c92efe55629faee434f05798a21f613743b6682a49d6c038c02676664c40";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "72b7fa8ec7b23fc2deec3aea53d6f9cb78eb59f09f96dad4a68cec6348978199";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gpio-controllers/default.nix
+++ b/distros/rolling/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-gpio-controllers";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gpio_controllers/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "49c634ff089e25257691975fb12eb9a5ec5521af7b31a76a550173b07581f0af";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gpio_controllers/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "376b2c4adf30a8c171d09a3317f7fee857bc8a0cbaed580ef1d61252abb51f09";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gps-sensor-broadcaster/default.nix
+++ b/distros/rolling/gps-sensor-broadcaster/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-gps-sensor-broadcaster";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gps_sensor_broadcaster/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "b7e0875b69cf55385c46ccb66dde02e84b7194e2913ec3f8a85e9e36c2ae84b1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gps_sensor_broadcaster/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "e31d13f549cb3e8d08443e768ce32e6fa112a47832d5aec310b3573d008f7d73";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros2-control-cmake ];
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
   propagatedBuildInputs = [ controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/hardware-interface-testing/default.nix
+++ b/distros/rolling/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, fmt, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface-testing";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "ae035fa5847f5a986d432181b8c9c1fac4795b1e378a02436fe0807084d36a4f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "31902d6c24ced1330a384e430e6d72871ea714af850b902556a98c146e124ae2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/hardware-interface/default.nix
+++ b/distros/rolling/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, control-msgs, fmt, joint-limits, lifecycle-msgs, pal-statistics, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sdformat-urdf, tinyxml-2, urdf }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "e4e6fe87a7ef13ad9a44574b5d12659e86aae3d2f79e2be38816192c77a0a6b4";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "cb5e63de0d71b351bb9e0f33b286eb3ec05121b82e93b91825ff66ba536a1e21";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/imu-sensor-broadcaster/default.nix
+++ b/distros/rolling/imu-sensor-broadcaster/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, eigen, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, eigen, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-imu-sensor-broadcaster";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "e7492e9fc50e450df600dad896877d307065339a3d4c3fb25876f9207ac3a47b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "159f16d07bff16c7929780682ff67fede4599af7ce1d532940ce46a54fcf4086";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros2-control-cmake ];
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager hardware-interface-testing ros2-control-test-assets tf2 tf2-geometry-msgs ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets tf2 tf2-geometry-msgs ];
   propagatedBuildInputs = [ backward-ros controller-interface eigen generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/joint-limits/default.nix
+++ b/distros/rolling/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, fmt, generate-parameter-library, launch-ros, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-limits";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "8edbd603d2c4c3b6ca5a20af543449c5b702eaf16350da12f9fdb83b9dd280c8";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "1262b3a6f122bf8539510aa64c0bcd2e0354fb04d7fe9aaa2cd28bbe25a206f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-state-broadcaster/default.nix
+++ b/distros/rolling/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-state-broadcaster";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "2c01238fd40f33dfe6239d0564aad82c97775d3a999611e08a30a98527dd2839";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "49647d9105dee0ca94f7e209b66959f5371cee215ea3c9c820c0c754721bf0f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-trajectory-controller/default.nix
+++ b/distros/rolling/joint-trajectory-controller/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs, urdf }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, rsl, tl-expected-nixpkgs, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-trajectory-controller";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "8cb46a76c636a6f7407f7bb83df8c658fa231bc927d1dc686ecd627aa3067f9d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "c49759e1fe880e4260feb2bbc5dc6bd087389fb8a19c23454e9018a52779c7bb";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
-  propagatedBuildInputs = [ angles backward-ros control-msgs control-toolbox controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-action rclcpp-lifecycle realtime-tools rsl tl-expected trajectory-msgs urdf ];
+  propagatedBuildInputs = [ angles backward-ros control-msgs control-toolbox controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-action rclcpp-lifecycle realtime-tools rsl tl-expected-nixpkgs trajectory-msgs urdf ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/kitti-metrics-eval/default.nix
+++ b/distros/rolling/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmath, mrpt-libposes, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-rolling-kitti-metrics-eval";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/kitti_metrics_eval/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "f4d543e92db61e1ed7fc3150e156bffac76bbbd272479426e3c62cbd95ad4bc4";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/kitti_metrics_eval/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "00ed24e58d01edf4a37e4e426dd704170acb0d820efa730946878cc8ce5f10cc";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mecanum-drive-controller/default.nix
+++ b/distros/rolling/mecanum-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mecanum-drive-controller";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/mecanum_drive_controller/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "78581514abf323a23bf18eb6a3c1c6aa8eae9fbd48396556b2f8cd5194bcd1e0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/mecanum_drive_controller/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "99af797eb10e1a41feedae38b7c05f508379da36b49bc451fcd4b6ed0ec5d4f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-bridge-ros2/default.nix
+++ b/distros/rolling/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, geographic-msgs, geometry-msgs, gps-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mola-bridge-ros2";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_bridge_ros2/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "a0f124f222b79a36ff1deb6e99d63499968ddec262a66911f088a430883b6ef8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_bridge_ros2/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "6f402f06161b92ebf6e5c8600b10be0819bdbd6be7cc4d2ebc3d81445d10ca49";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-demos/default.nix
+++ b/distros/rolling/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-demos";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_demos/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "81a628ff9008f176a5713fc089ab38b41b5b41ba970133e4fa81ff600a3bad6c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_demos/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "a140c4014e9378eb9aae3a5627e95c0dbfed0de7742fb1e66df47d7d9480a2ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-input-euroc-dataset/default.nix
+++ b/distros/rolling/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmath, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-euroc-dataset";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_euroc_dataset/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "e0823b78dca49cab344888a395fcfae72398bea22cd6e5f571fc8fe2fdeec9a8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_euroc_dataset/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "2ad53fd686bc2a22e6d4e1857372b87b1d73ddee985f6b11dc3ea8bc045c27d2";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-kitti-dataset/default.nix
+++ b/distros/rolling/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-kitti-dataset";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti_dataset/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "b5830dbd0f6b8f7aeb6b88886ac92b7f1651e3abd6d0dc50066e5e17e0f3ef2b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti_dataset/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "6dc3a84125103af332244c92373c6294a7d3ac1fcb22513de4fde087e1e459c8";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-kitti360-dataset/default.nix
+++ b/distros/rolling/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-kitti360-dataset";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti360_dataset/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "113454f4df7dd78a0f4dcf8f68bbd031e49b3ab4bfd12a9b5c7364224a4447cf";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti360_dataset/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "cd537bf97dec4f8fb8be64d75cb96a33e7c7226fe9fbee3da22473ff23a75661";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-lidar-bin-dataset/default.nix
+++ b/distros/rolling/mola-input-lidar-bin-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-lidar-bin-dataset";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_lidar_bin_dataset/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "08d18cbd1e78ce0ca6b6f57acf5840e216ff7f2ac5d9ea9c8feaaeb49d712eec";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_lidar_bin_dataset/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "2dfff2232ca53bd02e8826554f2562d63acc186fb75a3f2a7ff16ea94b7bf3a5";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-mulran-dataset/default.nix
+++ b/distros/rolling/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-mulran-dataset";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_mulran_dataset/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "a8db6031be6c8f9fc588d3956d356bbc1a323c4aaf7a40ed8efae49bca6ae241";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_mulran_dataset/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "f6308524bd68cfbc766c2bb1ae9c72e4a42744a59c0acd9c4d5c24b6928fa73e";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-paris-luco-dataset/default.nix
+++ b/distros/rolling/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-paris-luco-dataset";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_paris_luco_dataset/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "ce9e7cdca3fa72d7fb77aa5e2d9ee7627a5e0cfe357634b84015a0e4e650c349";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_paris_luco_dataset/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "7176f81ef8bfc9a31db5572ee62fb206e29959610ad60c04777c1c1867b4fe0e";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-rawlog/default.nix
+++ b/distros/rolling/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-rawlog";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rawlog/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "d89d82df7c09a2c396aac892315e7a3d7ee9b81f03948c82edfe3889b8d41919";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rawlog/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "d6dbda0a6ccbc1eb743b01fc4112925e1be3e3316994f52dd957dc7970025ce8";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-rosbag2/default.nix
+++ b/distros/rolling/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, gps-msgs, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-rosbag2";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rosbag2/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "c87f875d21da63fcac3306a4f10ec1b7a54d9088334d92682d9c1014c8372bd6";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rosbag2/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "3a66c5319c5158b2030cfc5e566bdd79291e8af76a657adcbb84a765f8cfe0f9";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-video/default.nix
+++ b/distros/rolling/mola-input-video/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libhwdrivers, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-video";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_video/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "dddc695127cfbfa0faa9159870e76750a7fadf6d51593c482914f17b39badb40";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_video/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "e624f841849084887f3d5e622d2b767f7014b304d7ea5bf0c39c94171c5394af";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-kernel/default.nix
+++ b/distros/rolling/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libgui, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-kernel";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_kernel/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "8cc463447c8ee60150ffc770b3b5af40e58a8f2481aabbab1642d7c5abb61344";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_kernel/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "6dcfd3d8f6e69c7b6fa6dd2097419deb8bd0cfaa52413b168da396f070fd4e62";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-launcher/default.nix
+++ b/distros/rolling/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-xmllint, ament-lint-auto, cmake, mola-kernel, mrpt-libbase, mrpt-libtclap, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-launcher";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_launcher/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "7d492c1c1de4c4b4555505f56f96f3b8aeb57569b13b56b01c2f79b542cd0bbf";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_launcher/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "89cdcb006b9e470a7cd4fa38be7af406872ee427e63ed27ead7b1569122efc62";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-lidar-odometry/default.nix
+++ b/distros/rolling/mola-lidar-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-imu-preintegration, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-rolling-mola-lidar-odometry";
-  version = "1.3.1-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/rolling/mola_lidar_odometry/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "01df64478e99d51d3936413bd3598c5c2a340cfe1683d1c514034de74bd36583";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/rolling/mola_lidar_odometry/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "29d85b5c7c2795cfe825f83d20be8bb11860dd5cccc2bf874de3c29dc68c30c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-metric-maps/default.nix
+++ b/distros/rolling/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mp2p-icp, mrpt-libmaps, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-metric-maps";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_metric_maps/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "1227e361f4ab9d705fef5b988f9af4162a82a37e25f9c7d066a3bef7232d816b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_metric_maps/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "ed799f673eaa1f9ad34d74f61f6be54889fde4891f9444be4c4e3048abde0655";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-msgs/default.nix
+++ b/distros/rolling/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-mola-msgs";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_msgs/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "2c17d018de887c7a44dba3f39ca61c6936cd13c6db034bfb711990d92145d04b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_msgs/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "608562cf668a6e2cac9a569a032775bf3725bc792a395b6223ad4a04914f9b92";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-pose-list/default.nix
+++ b/distros/rolling/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-rolling-mola-pose-list";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_pose_list/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "1e8cb55336f6123d68d5b7bf2c9fd15d8f3322cb45574929ebfdc8c54f85f4c2";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_pose_list/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "206613c60b312d623cec4838887ba1b99c25f57fb3b225f39c848e7415486db3";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-relocalization/default.nix
+++ b/distros/rolling/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-rolling-mola-relocalization";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_relocalization/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "0e25e92ef34cf7850078417b860f9d55617a83b0d9618fefa78e9fe5bc1cb3ec";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_relocalization/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "c7caf3f5197bb5be82cf00512c41f67342803395b64b8adfb1cc45dae05f251c";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-traj-tools/default.nix
+++ b/distros/rolling/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-rolling-mola-traj-tools";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_traj_tools/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "cb3d4a9a5478e454b469f597c591ffd3ce41b2ff1b5712387b74785374408d13";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_traj_tools/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "5c629805fa2cea36e2a735cfa87d5a17967c1be917350cff519bd516044f735a";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-viz/default.nix
+++ b/distros/rolling/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-rolling-mola-viz";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "7f5bde4491b672e23e929833d94cbf0a0033fdce5a0b138106b5a4a033e85ed4";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "267abcceef54587d49f69d2215954249195e13d45a40ea8c5c691df02471c95e";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-yaml/default.nix
+++ b/distros/rolling/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-rolling-mola-yaml";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_yaml/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "d850586b3fcbb7775af79398b577564fd027166b3630a11a3d88be5b0d8a4d1b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_yaml/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "83434cc26b191f7ee6c90cd8e5827da10e6774d7a346ac0f1df3b4c110ee1573";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola/default.nix
+++ b/distros/rolling/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-input-video, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-rolling-mola";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "28dfa86f8bf48abd9d32b939cdf553654e46bf74a35201d31a31fd9659eaad83";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "c6b47bb780e7756b96c8b8237952f222aa4c3b021081e03c40b1e0727cfa430d";
   };
 
   buildType = "cmake";

--- a/distros/rolling/motion-primitives-controllers/default.nix
+++ b/distros/rolling/motion-primitives-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-motion-primitives-controllers";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/motion_primitives_controllers/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "8195358f2b2755d9d9e8da5c96be771c94d1ec12f5dd67c273d04edc5c1c9da3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/motion_primitives_controllers/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "4c2d6af7d2eb3871f488d157c00de6561493b1c9849d391e7942c389414647a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/omni-wheel-drive-controller/default.nix
+++ b/distros/rolling/omni-wheel-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, eigen, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-omni-wheel-drive-controller";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/omni_wheel_drive_controller/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "3acb1cef82a50b0bbf5de87f16d7a0bb2f0f4bae7d8dd983d22d42fc725ebb10";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/omni_wheel_drive_controller/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "300a23a32513ea90d2af013cb6cb5a29ca7dbac61899e2958bd39b83f4630955";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/parallel-gripper-controller/default.nix
+++ b/distros/rolling/parallel-gripper-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-parallel-gripper-controller";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/parallel_gripper_controller/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "04f2e8a044c022758d6c5d0de0151a2b1baedb51d7dc0876ee30d3b2a2c149b9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/parallel_gripper_controller/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "f83fc158c1c9dd627a7ba73812eaa9fd706d80b69cae0ea26f1fdc39632e3e32";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pid-controller/default.nix
+++ b/distros/rolling/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-pid-controller";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pid_controller/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "c4d27bd00e486f7f3879a5c608a495024cd946c29b430d6341d9054ecbaa7ac2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pid_controller/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "0894e4ac80d71607dbf289857312bbe6e8f870bd33e7f2b92d94295eb4afe654";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pose-broadcaster/default.nix
+++ b/distros/rolling/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-pose-broadcaster";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pose_broadcaster/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "ed459d4d3309aae4682811beafc8ea54f6021f15d090921185b8dff1dc7fd8ee";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pose_broadcaster/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "ca70ef6e45fc06b70667d71159b3703df1d1847a277749e090a73434f5e3c3a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/position-controllers/default.nix
+++ b/distros/rolling/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-position-controllers";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "a59926dff5ccb481bf19e6b403d6485449b3c2d5617c2f6b2527644c2eb8cf20";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "962552a4869d986bf3e2f9791ac1d643afd9087dc33a8bf68a99d808aa37e617";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/range-sensor-broadcaster/default.nix
+++ b/distros/rolling/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-range-sensor-broadcaster";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "afef03e13f0e8d66c588335f2e5a1aa213d480f66c6a4f8ab56e01af57392c9a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "28483a5a3ef4c7dc1201dff797d3075bac0e41019bb26b14bdb37894f97763ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control-test-assets/default.nix
+++ b/distros/rolling/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control-test-assets";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "84257ed12539e1760625161ac307fa7f2aca45ed3409207a364a0d69ff570940";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "b31ace5d085a327eb40fbaa5d85b95dd392be9a4723e9839111e090bf7a2de1c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control/default.nix
+++ b/distros/rolling/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "c24491de4f27a206bbb1d32ca26df963492f67ed18f3ded79bba2353b7a77463";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "df7f2096265cfa9ced2070c12ee1ccef75793a31766e401dd7e94b1d37519e3d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-controllers-test-nodes/default.nix
+++ b/distros/rolling/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers-test-nodes";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "84fb56f423703a9cce3c9e36430b25e1dfff49edf86635d8853c0392dfbb8d28";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "38a536c71a3d39544f437740ae1b450c89566d26d6ea60c3105c73b6eb5ff6e7";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2-controllers/default.nix
+++ b/distros/rolling/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, chained-filter-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gps-sensor-broadcaster, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, motion-primitives-controllers, omni-wheel-drive-controller, parallel-gripper-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, state-interfaces-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "af2c526cb9ab744c98480b6106b4fbc48faefc9a85683d4a2272ecd0498e4e9f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "7cfb4c8195aed2a26cb59f73c8196cc60d40a1a8343b51caef2f95178256dc10";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2controlcli/default.nix
+++ b/distros/rolling/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-rolling-ros2controlcli";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "8b913f41c35bbd0fde038603485d83637d4aaa00ac41013318f4586ac3d70332";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "e05d7d59e07c4b788c2f6ece91cf84be793c8e9cc99f88a61d8e8fb5698c43af";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-controller-manager/default.nix
+++ b/distros/rolling/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-controller-manager";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "a7f6ccfc33c4786e4cfa80ae0e89bf322199a4da5e6ea45e0635ef9e862bebfc";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "06ebcbe25170a084cf9f8f79e3a55900776c3043fc5eda3a120a6687a26611ed";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-joint-trajectory-controller/default.nix
+++ b/distros/rolling/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-joint-trajectory-controller";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "76fe77860648046c0476b16fc1d6bebba9059bc184c8a254eaa12ce0145c8c47";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "9ee0752d42fd7d7b9fbda35fa0d1fa8fb2b1ef71d935365373e6000e9bc2bb1e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/state-interfaces-broadcaster/default.nix
+++ b/distros/rolling/state-interfaces-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-state-interfaces-broadcaster";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/state_interfaces_broadcaster/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "96955ac94f5bd7f7bd4e0bb126d148c8ad1089ffa14ecdfaa0324537d65e4ff3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/state_interfaces_broadcaster/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "7efd1469ab27d505d89b76debfcf181e702673941985f37eca597e147f2d3edb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/steering-controllers-library/default.nix
+++ b/distros/rolling/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-steering-controllers-library";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "5c62348b2ff5150d196f1531e3a4200daefc8235e9664f9aa8a4dcc843d4f581";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "a8f4023b1915c99c3d924684b3001dd3728266337bb1feff21c755415f59fecd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/transmission-interface/default.nix
+++ b/distros/rolling/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, fmt, hardware-interface, pluginlib, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-transmission-interface";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "019f8775c9da77d59e1c63ce29d09af38f49da7e6cf6d40226533ef6130bd39e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "c7c6c1098c368e418a1ee3fe094aa44b4f807c0c4d3894fcc5b793a3ed4e8340";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-controller/default.nix
+++ b/distros/rolling/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-controller";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "469f54e374e68c3c0e04ab2882a596793b56f20e5213e6b3b95a33e3893c96f1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "b41b0bbde51a4f974823e9c6dfd99ff0b9d03c417e5dbd243fdf2bbef79e392a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-steering-controller/default.nix
+++ b/distros/rolling/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-steering-controller";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "2a218b45ee08e08ea6e3e446651151692d537d4f5b285764a10caf8e8566d409";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "0c0c5a8a380c4b0244d15410aa677171fb709f7f3fee09c8da5b585836ff3dbf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/velocity-controllers/default.nix
+++ b/distros/rolling/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-velocity-controllers";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "c7c87a2da362db8fc7181295977ef1683bcaaf631f3b93d964345f17776a043c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "dbf8469f42dd1c81533fd38e59779a839fbc2fca6293121eb1e635eb166aa409";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'kilted', 'rolling'] from nix-ros-overlay commit 197a2b55c4ed24f8b885a5b20b65f426fb6d57ca.
This pull request was generated by running the following command:

```
superflore-gen-nix --dry-run --output-repository-path . --all --tar-archive-dir /home/runner/.ros/tar --upstream-branch develop
```

Changes:
========
Humble Changes:
---------------
* *kitti-metrics-eval 2.6.0-r1 --> 2.6.1-r1*
* *mola 2.6.0-r1 --> 2.6.1-r1*
* *mola-bridge-ros2 2.6.0-r1 --> 2.6.1-r1*
* *mola-demos 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-euroc-dataset 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-kitti-dataset 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-kitti360-dataset 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-lidar-bin-dataset 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-mulran-dataset 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-paris-luco-dataset 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-rawlog 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-rosbag2 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-video 2.6.0-r1 --> 2.6.1-r1*
* *mola-kernel 2.6.0-r1 --> 2.6.1-r1*
* *mola-launcher 2.6.0-r1 --> 2.6.1-r1*
* *mola-lidar-odometry 1.3.1-r1 --> 2.0.0-r1*
* *mola-metric-maps 2.6.0-r1 --> 2.6.1-r1*
* *mola-msgs 2.6.0-r1 --> 2.6.1-r1*
* *mola-pose-list 2.6.0-r1 --> 2.6.1-r1*
* *mola-relocalization 2.6.0-r1 --> 2.6.1-r1*
* *mola-traj-tools 2.6.0-r1 --> 2.6.1-r1*
* *mola-viz 2.6.0-r1 --> 2.6.1-r1*
* *mola-yaml 2.6.0-r1 --> 2.6.1-r1*

Jazzy Changes:
--------------
* *controller-interface 4.43.0-r1 --> 4.44.0-r1*
* *controller-manager 4.43.0-r1 --> 4.44.0-r1*
* *controller-manager-msgs 4.43.0-r1 --> 4.44.0-r1*
* *eventdispatch-python 0.2.26-r1 --> 0.2.29-r1*
* *eventdispatch-ros2 0.2.26-r1 --> 0.2.29-r1*
* *eventdispatch-ros2-interfaces 0.2.26-r1 --> 0.2.29-r1*
* *hardware-interface 4.43.0-r1 --> 4.44.0-r1*
* *hardware-interface-testing 4.43.0-r1 --> 4.44.0-r1*
* *joint-limits 4.43.0-r1 --> 4.44.0-r1*
* *kitti-metrics-eval 2.6.0-r1 --> 2.6.1-r1*
* *mola 2.6.0-r1 --> 2.6.1-r1*
* *mola-bridge-ros2 2.6.0-r1 --> 2.6.1-r1*
* *mola-demos 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-euroc-dataset 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-kitti-dataset 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-kitti360-dataset 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-lidar-bin-dataset 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-mulran-dataset 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-paris-luco-dataset 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-rawlog 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-rosbag2 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-video 2.6.0-r1 --> 2.6.1-r1*
* *mola-kernel 2.6.0-r1 --> 2.6.1-r1*
* *mola-launcher 2.6.0-r1 --> 2.6.1-r1*
* *mola-lidar-odometry 1.3.1-r1 --> 2.0.0-r1*
* *mola-metric-maps 2.6.0-r1 --> 2.6.1-r1*
* *mola-msgs 2.6.0-r1 --> 2.6.1-r1*
* *mola-pose-list 2.6.0-r1 --> 2.6.1-r1*
* *mola-relocalization 2.6.0-r1 --> 2.6.1-r1*
* *mola-traj-tools 2.6.0-r1 --> 2.6.1-r1*
* *mola-viz 2.6.0-r1 --> 2.6.1-r1*
* *mola-yaml 2.6.0-r1 --> 2.6.1-r1*
* *ros2-control 4.43.0-r1 --> 4.44.0-r1*
* *ros2-control-test-assets 4.43.0-r1 --> 4.44.0-r1*
* *ros2controlcli 4.43.0-r1 --> 4.44.0-r1*
* *rqt-controller-manager 4.43.0-r1 --> 4.44.0-r1*
* *transmission-interface 4.43.0-r1 --> 4.44.0-r1*

Kilted Changes:
---------------
* *controller-interface 5.12.0-r1 --> 5.13.0-r1*
* *controller-manager 5.12.0-r1 --> 5.13.0-r1*
* *controller-manager-msgs 5.12.0-r1 --> 5.13.0-r1*
* *hardware-interface 5.12.0-r1 --> 5.13.0-r1*
* *hardware-interface-testing 5.12.0-r1 --> 5.13.0-r1*
* *joint-limits 5.12.0-r1 --> 5.13.0-r1*
* *kitti-metrics-eval 2.6.0-r1 --> 2.6.1-r1*
* *mola 2.6.0-r1 --> 2.6.1-r1*
* *mola-bridge-ros2 2.6.0-r1 --> 2.6.1-r1*
* *mola-demos 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-euroc-dataset 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-kitti-dataset 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-kitti360-dataset 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-lidar-bin-dataset 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-mulran-dataset 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-paris-luco-dataset 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-rawlog 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-rosbag2 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-video 2.6.0-r1 --> 2.6.1-r1*
* *mola-kernel 2.6.0-r1 --> 2.6.1-r1*
* *mola-launcher 2.6.0-r1 --> 2.6.1-r1*
* *mola-lidar-odometry 1.3.1-r1 --> 2.0.0-r1*
* *mola-metric-maps 2.6.0-r1 --> 2.6.1-r1*
* *mola-msgs 2.6.0-r1 --> 2.6.1-r1*
* *mola-pose-list 2.6.0-r1 --> 2.6.1-r1*
* *mola-relocalization 2.6.0-r1 --> 2.6.1-r1*
* *mola-traj-tools 2.6.0-r1 --> 2.6.1-r1*
* *mola-viz 2.6.0-r1 --> 2.6.1-r1*
* *mola-yaml 2.6.0-r1 --> 2.6.1-r1*
* *ros2-control 5.12.0-r1 --> 5.13.0-r1*
* *ros2-control-test-assets 5.12.0-r1 --> 5.13.0-r1*
* *ros2controlcli 5.12.0-r1 --> 5.13.0-r1*
* *rqt-controller-manager 5.12.0-r1 --> 5.13.0-r1*
* *transmission-interface 5.12.0-r1 --> 5.13.0-r1*

Rolling Changes:
----------------
* *ackermann-steering-controller 6.4.0-r1 --> 6.5.0-r1*
* *admittance-controller 6.4.0-r1 --> 6.5.0-r1*
* *bicycle-steering-controller 6.4.0-r1 --> 6.5.0-r1*
* *chained-filter-controller 6.4.0-r1 --> 6.5.0-r1*
* *controller-interface 6.4.0-r1 --> 6.5.0-r1*
* *controller-manager 6.4.0-r1 --> 6.5.0-r1*
* *controller-manager-msgs 6.4.0-r1 --> 6.5.0-r1*
* *diff-drive-controller 6.4.0-r1 --> 6.5.0-r1*
* *effort-controllers 6.4.0-r1 --> 6.5.0-r1*
* *fastdds 3.4.2-r1 --> 3.6.0-r1*
* *force-torque-sensor-broadcaster 6.4.0-r1 --> 6.5.0-r1*
* *forward-command-controller 6.4.0-r1 --> 6.5.0-r1*
* *gpio-controllers 6.4.0-r1 --> 6.5.0-r1*
* *gps-sensor-broadcaster 6.4.0-r1 --> 6.5.0-r1*
* *hardware-interface 6.4.0-r1 --> 6.5.0-r1*
* *hardware-interface-testing 6.4.0-r1 --> 6.5.0-r1*
* *imu-sensor-broadcaster 6.4.0-r1 --> 6.5.0-r1*
* *joint-limits 6.4.0-r1 --> 6.5.0-r1*
* *joint-state-broadcaster 6.4.0-r1 --> 6.5.0-r1*
* *joint-trajectory-controller 6.4.0-r1 --> 6.5.0-r1*
* *kitti-metrics-eval 2.6.0-r1 --> 2.6.1-r1*
* *mecanum-drive-controller 6.4.0-r1 --> 6.5.0-r1*
* *mola 2.6.0-r1 --> 2.6.1-r1*
* *mola-bridge-ros2 2.6.0-r1 --> 2.6.1-r1*
* *mola-demos 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-euroc-dataset 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-kitti-dataset 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-kitti360-dataset 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-lidar-bin-dataset 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-mulran-dataset 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-paris-luco-dataset 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-rawlog 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-rosbag2 2.6.0-r1 --> 2.6.1-r1*
* *mola-input-video 2.6.0-r1 --> 2.6.1-r1*
* *mola-kernel 2.6.0-r1 --> 2.6.1-r1*
* *mola-launcher 2.6.0-r1 --> 2.6.1-r1*
* *mola-lidar-odometry 1.3.1-r1 --> 2.0.0-r1*
* *mola-metric-maps 2.6.0-r1 --> 2.6.1-r1*
* *mola-msgs 2.6.0-r1 --> 2.6.1-r1*
* *mola-pose-list 2.6.0-r1 --> 2.6.1-r1*
* *mola-relocalization 2.6.0-r1 --> 2.6.1-r1*
* *mola-traj-tools 2.6.0-r1 --> 2.6.1-r1*
* *mola-viz 2.6.0-r1 --> 2.6.1-r1*
* *mola-yaml 2.6.0-r1 --> 2.6.1-r1*
* *motion-primitives-controllers 6.4.0-r1 --> 6.5.0-r1*
* *omni-wheel-drive-controller 6.4.0-r1 --> 6.5.0-r1*
* *parallel-gripper-controller 6.4.0-r1 --> 6.5.0-r1*
* *pid-controller 6.4.0-r1 --> 6.5.0-r1*
* *pose-broadcaster 6.4.0-r1 --> 6.5.0-r1*
* *position-controllers 6.4.0-r1 --> 6.5.0-r1*
* *range-sensor-broadcaster 6.4.0-r1 --> 6.5.0-r1*
* *ros2-control 6.4.0-r1 --> 6.5.0-r1*
* *ros2-control-test-assets 6.4.0-r1 --> 6.5.0-r1*
* *ros2-controllers 6.4.0-r1 --> 6.5.0-r1*
* *ros2-controllers-test-nodes 6.4.0-r1 --> 6.5.0-r1*
* *ros2controlcli 6.4.0-r1 --> 6.5.0-r1*
* *rqt-controller-manager 6.4.0-r1 --> 6.5.0-r1*
* *rqt-joint-trajectory-controller 6.4.0-r1 --> 6.5.0-r1*
* *state-interfaces-broadcaster 6.4.0-r1 --> 6.5.0-r1*
* *steering-controllers-library 6.4.0-r1 --> 6.5.0-r1*
* *transmission-interface 6.4.0-r1 --> 6.5.0-r1*
* *tricycle-controller 6.4.0-r1 --> 6.5.0-r1*
* *tricycle-steering-controller 6.4.0-r1 --> 6.5.0-r1*
* *velocity-controllers 6.4.0-r1 --> 6.5.0-r1*


No missing dependencies.