### PR TITLE
rolling.python-qt-bindings-deps: init

### DIFF
--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -404,44 +404,6 @@ in {
     ];
   });
 
-  # Switch to Qt6
-  python-qt-binding = rosSuper.python-qt-binding.overrideAttrs ({
-    patches ? [], propagatedBuildInputs ? [], ...
-  }: {
-    patches = patches ++ [
-      # ref. https://github.com/ros-visualization/python_qt_binding/pull/143
-      (self.fetchpatch2 {
-        name = "support-qt6.patch";
-        url = "https://github.com/ros-visualization/python_qt_binding/commit/fa854d325ad4fa5f6e788d70b3ba9ccf9ee5c80f.patch?full_index=1";
-        hash = "sha256-bszIhxh1ThuUdDDiKoHi7eQA/KGb41XmPjMaGpuf658=";
-      })
-      (self.fetchpatch2 {
-        name = "make-linters-happy.patch";
-        url = "https://github.com/ros-visualization/python_qt_binding/commit/bd88c0d5d51add58e329c40bba20a7b04c3df063.patch?full_index=1";
-        hash = "sha256-b3aoTkzxn+ngxJXt7mIaqA3oFkiDelxy/b+QuKaQXIo=";
-      })
-      (self.fetchpatch2 {
-        name = "fixes.patch";
-        url = "https://github.com/ros-visualization/python_qt_binding/commit/d710e1afb2ac0effed1e8d6ab90eee53354366bb.patch?full_index=1";
-        hash = "sha256-+QQzU6FXa+69QG8JaB/miBC1QxsvS9v0mPMJznPHl+c=";
-      })
-    ];
-    propagatedBuildInputs = propagatedBuildInputs ++ (with rosSelf.pythonPackages; [
-      pyside6
-      pyqt6-sip
-    ]);
-
-    dontWrapQtApps = true;
-
-    setupHook = self.writeText "python-qt-binding-setup-hook" ''
-        _pythonQtBindingPreFixupHook() {
-          # Prevent /build RPATH references
-          rm -rf devel/lib
-        }
-        preFixupHooks+=(_pythonQtBindingPreFixupHook)
-      '';
-  });
-
   # This meta-package is referenced by the rosdep key python3-qt-bindings,
   # which is used by packages such as rqt. These packages depend on Qt5 in
   # older ROS distributions and Qt6 in Lyrical and newer releases.

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -442,6 +442,35 @@ in {
       '';
   });
 
+  # This meta-package is referenced by the rosdep key python3-qt-bindings,
+  # which is used by packages such as rqt. These packages depend on Qt5 in
+  # older ROS distributions and Qt6 in Lyrical and newer releases.
+  #
+  # On Ubuntu (and similar distributions), python3-qt-bindings
+  # resolves to different system packages depending on the OS version.
+  # In Nix, however, we do not use different nixpkgs versions for
+  # different ROS distros. Instead, we define the rosdep key to always
+  # resolve to python-qt-bindings-deps, and we define this package
+  # differently for each ROS distribution to depend on the appropriate
+  # Qt version.
+  python-qt-bindings-deps = self.stdenv.mkDerivation {
+    name = "python-qt-bindings-deps";
+    dontUnpack = true;
+    dontBuild = true;
+    dontInstall = true;
+    propagatedBuildInputs = with rosSelf.pythonPackages; [
+      pyqt-builder
+      pyqt6
+      pyqt6-sip
+      pyside6
+      self.pkg-config
+      self.qt6.qtbase
+      self.qt6.qtdeclarative
+      sip
+    ];
+    propagatedNativeBuildInputs = [ self.qt6.wrapQtAppsHook ];
+  };
+
   rcdiscover = rosSuper.rcdiscover.overrideAttrs ({
     postPatch ? "", ...
   }: {

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -428,6 +428,34 @@ in {
       '';
   });
 
+  # This meta-package is referenced by the rosdep key python3-qt-bindings,
+  # which is used by packages such as rqt. These packages depend on Qt5 in
+  # older ROS distributions and Qt6 in Lyrical and newer releases.
+  #
+  # On Ubuntu (and similar distributions), python3-qt-bindings resolves to
+  # different system packages depending on the OS version. In Nix, however, we
+  # do not rely on multiple nixpkgs versions, so we define the rosdep key to
+  # always resolve to python-qt-bindings-deps, and we define this package
+  # differently for each ROS distribution to depend on the appropriate Qt
+  # version.
+  python-qt-bindings-deps = self.stdenv.mkDerivation {
+    name = "python-qt-bindings-deps";
+    dontUnpack = true;
+    dontBuild = true;
+    dontInstall = true;
+    propagatedBuildInputs = with rosSelf.pythonPackages; [
+      pyqt-builder
+      pyqt6
+      pyqt6-sip
+      pyside6
+      self.pkg-config
+      self.qt6.qtbase
+      self.qt6.qtdeclarative
+      sip
+    ];
+    propagatedNativeBuildInputs = [ self.qt6.wrapQtAppsHook ];
+  };
+
   rcdiscover = rosSuper.rcdiscover.overrideAttrs ({
     postPatch ? "", ...
   }: {

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -390,44 +390,6 @@ in {
     ];
   });
 
-  # Switch to Qt6
-  python-qt-binding = rosSuper.python-qt-binding.overrideAttrs ({
-    patches ? [], propagatedBuildInputs ? [], ...
-  }: {
-    patches = patches ++ [
-      # ref. https://github.com/ros-visualization/python_qt_binding/pull/143
-      (self.fetchpatch2 {
-        name = "support-qt6.patch";
-        url = "https://github.com/ros-visualization/python_qt_binding/commit/fa854d325ad4fa5f6e788d70b3ba9ccf9ee5c80f.patch?full_index=1";
-        hash = "sha256-bszIhxh1ThuUdDDiKoHi7eQA/KGb41XmPjMaGpuf658=";
-      })
-      (self.fetchpatch2 {
-        name = "make-linters-happy.patch";
-        url = "https://github.com/ros-visualization/python_qt_binding/commit/bd88c0d5d51add58e329c40bba20a7b04c3df063.patch?full_index=1";
-        hash = "sha256-b3aoTkzxn+ngxJXt7mIaqA3oFkiDelxy/b+QuKaQXIo=";
-      })
-      (self.fetchpatch2 {
-        name = "fixes.patch";
-        url = "https://github.com/ros-visualization/python_qt_binding/commit/d710e1afb2ac0effed1e8d6ab90eee53354366bb.patch?full_index=1";
-        hash = "sha256-+QQzU6FXa+69QG8JaB/miBC1QxsvS9v0mPMJznPHl+c=";
-      })
-    ];
-    propagatedBuildInputs = propagatedBuildInputs ++ (with rosSelf.pythonPackages; [
-      pyside6
-      pyqt6-sip
-    ]);
-
-    dontWrapQtApps = true;
-
-    setupHook = self.writeText "python-qt-binding-setup-hook" ''
-        _pythonQtBindingPreFixupHook() {
-          # Prevent /build RPATH references
-          rm -rf devel/lib
-        }
-        preFixupHooks+=(_pythonQtBindingPreFixupHook)
-      '';
-  });
-
   # This meta-package is referenced by the rosdep key python3-qt-bindings,
   # which is used by packages such as rqt. These packages depend on Qt5 in
   # older ROS distributions and Qt6 in Lyrical and newer releases.


### PR DESCRIPTION
The introduced `python-qt-bindings-deps` meta-package is referenced by the rosdep key `python3-qt-bindings`, which is used by packages such as `rqt`. These packages depend on Qt5 in older ROS distributions and Qt6 in Lyrical and newer releases.

On Ubuntu (and similar distributions), `python3-qt-bindings` resolves to different system packages depending on the OS version. In Nix, however, we do not rely on multiple nixpkgs versions, so we define the rosdep key to always resolve to `python-qt-bindings-deps`, and we define this package differently for each ROS distribution to depend on the appropriate Qt version.

Currently, we introduce this package only for rolling and lyrical, because it is not used elsewhere. The plan is to add similar definitions to older distros as soon as some packages start depending on it.