### PR TITLE
rosdistro sync, Fri Apr 17 13:59:44 2026

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -48,7 +48,7 @@ let
           originalRev = "\${MRPT_VERSION_TO_DOWNLOAD}";
           inherit rev;
           fetchgitArgs.hash = {
-            "2.15.12" = "sha256-g/8gT1oN1oDK/pRuDbfnMaEQnxRWrcxYw7Nu/BtQl+o=";
+            "2.15.13" = "sha256-pSEE4hHVzwXkxlwX+0tDCRbKQVaaU9Wrw8sjp09KJJw=";
           }.${rev};
         }).overrideAttrs ({ postPatch ? "", buildInputs ? [], ... }: {
           postPatch = postPatch + ''

--- a/distros/humble/clearpath-common/default.nix
+++ b/distros/humble/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common }:
 buildRosPackage {
   pname = "ros-humble-clearpath-common";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "2c7725f6fae7ec0dc7f89d023e30f182748f4777520e1d083c558882c4399b7e";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "12edb46409104ea82960270d684eb9037b3c17c11c9a0d14c64c5893166a9fac";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-control/default.nix
+++ b/distros/humble/clearpath-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-mecanum-drive-controller, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-humble-clearpath-control";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "10af2fc97ed127a2bec93b2210362d07e1a7680cb67a423ccac9b6b95267f454";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "4bdc2c206c1191e3e7ad8bcc98c1f21a629a04c5782dfa54a9b0eb301a224331";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-customization/default.nix
+++ b/distros/humble/clearpath-customization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-clearpath-customization";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_customization/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "42ce3551f81411ebefc4501acf7b075c85bae662324274ab9531ee4566240323";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_customization/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "37489487efd3eec7acc15eb23026abf1d3402fd4d657f9ccc44224c514e25c11";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-description/default.nix
+++ b/distros/humble/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-description";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "3bf01e9e5b7ea06e31af6c3361115e7a4c2dcfe51cdb7d6297cf68079c7099e9";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "aa41a4fffd4b9d5a5ee19b864c6ab455fe4497839142f428415fe846704db478";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-generator-common/default.nix
+++ b/distros/humble/clearpath-generator-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-manipulators, moveit-setup-srdf-plugins }:
 buildRosPackage {
   pname = "ros-humble-clearpath-generator-common";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "0989215b489abb96369338aab58babf92aa583338e5577f87df064d8a856788a";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "81a20c0a910ed61179b9a2b2351e0ab806cb837322f85ba1949c13c296c8a3e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-manipulators-description/default.nix
+++ b/distros/humble/clearpath-manipulators-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ewellix-description, franka-description, kortex-description, robot-state-publisher, robotiq-description, ur-description, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-manipulators-description";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators_description/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "b031dd73a6db30a8b4752af37e0faf2da72c1d26672097f5bc29154b2d5a237a";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators_description/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "73d5bcb0eca16b8ecb5a700d2d2a102bb9a7305a2979c82650ca3e3bce2ac3c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-manipulators/default.nix
+++ b/distros/humble/clearpath-manipulators/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, gripper-controllers, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-warehouse, moveit-simple-controller-manager, position-controllers, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-manipulators";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "beed002442c57b7a8a37f2816a4b0f0c5e329b8f1f70e35e9367b55ae5fab66f";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "339409c48cf1caec31bee3e2146f56c14837d0256cd57fe3cd8cef3c1abc6191";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-mounts-description/default.nix
+++ b/distros/humble/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-clearpath-mounts-description";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "ab0796beb7abc7e01c50f49b3711e8b873733c0e95d0294234b821e99e53ee57";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "c35b77af3f4bafc348dc14f618d7b4f3eaa1941242277d2fe94e0001c8095c95";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform-description/default.nix
+++ b/distros/humble/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform-description";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "022ecd2fed1a615f15277d42c9580c5d75c98f45e32e6aefeb8c8c4679e1f471";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "f8abe3eaca1970636dc2556c3e633804486c5c0fbbde3f183e145c62d6b722af";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-sensors-description/default.nix
+++ b/distros/humble/clearpath-sensors-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-description, realsense2-description, velodyne-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-sensors-description";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "11e5e75b4c26eeef98c2fe55663d09457c04e4c52b1da8c203ae6d2c1dd8dd80";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "24432bda8452476733528aba341f0736ab2506375cdd0701bf7af137d9033ba6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -2066,6 +2066,8 @@ self: super: {
 
  mola-relocalization = self.callPackage ./mola-relocalization {};
 
+ mola-sm-loop-closure = self.callPackage ./mola-sm-loop-closure {};
+
  mola-state-estimation = self.callPackage ./mola-state-estimation {};
 
  mola-state-estimation-simple = self.callPackage ./mola-state-estimation-simple {};

--- a/distros/humble/gz-ros2-control-demos/default.nix
+++ b/distros/humble/gz-ros2-control-demos/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, geometry-msgs, gz-ros2-control, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, mecanum-drive-controller, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2controlcli, ros2launch, std-msgs, tricycle-controller, velocity-controllers, xacro }:
+{ lib, buildRosPackage, fetchurl, _unresolved_ignition-gazebo6, ackermann-steering-controller, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, geometry-msgs, gz-ros2-control, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, mecanum-drive-controller, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2controlcli, ros2launch, std-msgs, tricycle-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-gz-ros2-control-demos";
-  version = "0.7.18-r1";
+  version = "0.7.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/gz_ros2_control_demos/0.7.18-1.tar.gz";
-    name = "0.7.18-1.tar.gz";
-    sha256 = "7a45cf033859f5e268e196264f4f9cf8438c3deee0ab56e216ee1ab73fda48fa";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/gz_ros2_control_demos/0.7.19-1.tar.gz";
+    name = "0.7.19-1.tar.gz";
+    sha256 = "2811540f4569944f100a17662f94bc06ec80b46c09e238274fc5d1805ca52f9a";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake rclcpp-action ];
+  buildInputs = [ ament-cmake pluginlib rclcpp-action ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ackermann-steering-controller ament-index-python control-msgs diff-drive-controller effort-controllers force-torque-sensor-broadcaster geometry-msgs gz-ros2-control hardware-interface imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller launch launch-ros mecanum-drive-controller rclcpp robot-state-publisher ros-gz-bridge ros-gz-sim ros2controlcli ros2launch std-msgs tricycle-controller velocity-controllers xacro ];
+  propagatedBuildInputs = [ _unresolved_ignition-gazebo6 ackermann-steering-controller ament-index-python control-msgs control-toolbox diff-drive-controller effort-controllers force-torque-sensor-broadcaster geometry-msgs gz-ros2-control hardware-interface imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller launch launch-ros mecanum-drive-controller rclcpp rclcpp-lifecycle robot-state-publisher ros-gz-bridge ros-gz-sim ros2controlcli ros2launch std-msgs tricycle-controller velocity-controllers xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/gz-ros2-control-tests/default.nix
+++ b/distros/humble/gz-ros2-control-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, controller-manager, gz-ros2-control-demos, ign-ros2-control-demos, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, ros2launch, rosgraph-msgs }:
 buildRosPackage {
   pname = "ros-humble-gz-ros2-control-tests";
-  version = "0.7.18-r1";
+  version = "0.7.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/gz_ros2_control_tests/0.7.18-1.tar.gz";
-    name = "0.7.18-1.tar.gz";
-    sha256 = "fd67af73ac958725556d29266ad1e8a8ae35f52baf3b4b0c7c188b4f0a046d9e";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/gz_ros2_control_tests/0.7.19-1.tar.gz";
+    name = "0.7.19-1.tar.gz";
+    sha256 = "d3b9a48cc647931fab5bf0f7960a550a735f88290615404d11ae41c2116c7591";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gz-ros2-control/default.nix
+++ b/distros/humble/gz-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, _unresolved_ignition-gazebo6, _unresolved_ignition-plugin, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-gz-ros2-control";
-  version = "0.7.18-r1";
+  version = "0.7.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/gz_ros2_control/0.7.18-1.tar.gz";
-    name = "0.7.18-1.tar.gz";
-    sha256 = "dbe3dcf6f93cc66994f2354707483cc101262bdad8ef0684018a00ecc8be1f1c";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/gz_ros2_control/0.7.19-1.tar.gz";
+    name = "0.7.19-1.tar.gz";
+    sha256 = "91032e7ceb0dc6ce39400107dd3afa207d829a0ff270aa9bf1f277c6bb95fe40";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ign-ros2-control-demos/default.nix
+++ b/distros/humble/ign-ros2-control-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, gz-ros2-control-demos, launch, launch-ros }:
 buildRosPackage {
   pname = "ros-humble-ign-ros2-control-demos";
-  version = "0.7.18-r1";
+  version = "0.7.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/ign_ros2_control_demos/0.7.18-1.tar.gz";
-    name = "0.7.18-1.tar.gz";
-    sha256 = "109391463f139d5946518ee5e59d53d560a1dc433081874a7c4169dba32f7723";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/ign_ros2_control_demos/0.7.19-1.tar.gz";
+    name = "0.7.19-1.tar.gz";
+    sha256 = "137d7635a67b137d6e0e172823830fba533638887becc11d517f799f400dd43e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ign-ros2-control/default.nix
+++ b/distros/humble/ign-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gz-ros2-control }:
 buildRosPackage {
   pname = "ros-humble-ign-ros2-control";
-  version = "0.7.18-r1";
+  version = "0.7.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/ign_ros2_control/0.7.18-1.tar.gz";
-    name = "0.7.18-1.tar.gz";
-    sha256 = "5bd7f9c7f34f64195dbea5d325e0d928e3d51cc13c0cdd61f8e3ff4daa4287de";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/ign_ros2_control/0.7.19-1.tar.gz";
+    name = "0.7.19-1.tar.gz";
+    sha256 = "beed158bd45517fd5b3a8e8998c9f0f4a1f5f7098f4849809933a7605216a9c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/message-filters/default.nix
+++ b/distros/humble/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, builtin-interfaces, python-cmake-module, rclcpp, rclcpp-lifecycle, rclpy, rcutils, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-message-filters";
-  version = "4.3.15-r1";
+  version = "4.3.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/humble/message_filters/4.3.15-1.tar.gz";
-    name = "4.3.15-1.tar.gz";
-    sha256 = "db31714da1de722453234d8349882ca8b38bc7f95efc8c2c7bda2b33644f6ca5";
+    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/humble/message_filters/4.3.16-1.tar.gz";
+    name = "4.3.16-1.tar.gz";
+    sha256 = "0d45f77258bf3683b828a45a6067047882ab5f39f52f8e1bb4c89ebdda1023eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-sm-loop-closure/default.nix
+++ b/distros/humble/mola-sm-loop-closure/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, cmake, gtsam, mola-common, mola-georeferencing, mola-gtsam-factors, mola-metric-maps, mola-pose-list, mola-relocalization, mola-test-datasets, mola-yaml, mp2p-icp, mrpt-libgui, mrpt-libmaps, mrpt-libtclap, ros-environment }:
+buildRosPackage {
+  pname = "ros-humble-mola-sm-loop-closure";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_sm_loop_closure-release/archive/release/humble/mola_sm_loop_closure/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "b74e03ba438c77f8bef8d32d0be9cf82857c5bba071e88e81a71b68a54d2fe0e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-gtest cmake ros-environment ];
+  checkInputs = [ ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto mola-metric-maps mola-test-datasets ];
+  propagatedBuildInputs = [ gtsam mola-common mola-georeferencing mola-gtsam-factors mola-pose-list mola-relocalization mola-yaml mp2p-icp mrpt-libgui mrpt-libmaps mrpt-libtclap ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
+
+  meta = {
+    description = "Simplemap loop-closure postprocessing library and CLI tool";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/humble/mrpt-apps/default.nix
+++ b/distros/humble/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-apps";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_apps/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "d8a591c079269b5d86733929f2bdfcbe4a557613ebef00ff4250ae1fd2b47677";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_apps/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "336472662ccd6fde8df43f37fa5785b638d23cc9df7bee2e0784460d49f3f978";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libapps/default.nix
+++ b/distros/humble/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libapps";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libapps/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "1ed3a44313f31aa2630c1be6ed8df2389beb49d2d334237de7f66fc8727df5a0";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libapps/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "cc232bca831404b8a59b52602bcb53a404bab8c16f9a435076431c448171190f";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libbase/default.nix
+++ b/distros/humble/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, onetbb, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib, zstd }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libbase";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libbase/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "94f0ded534478d0898bae9565d308952324ec3b356a820fa3bd697b032db747c";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libbase/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "a7640b784de3cdadfef0252b8868c8b251b0fb82b93f471f404cbc060caa877e";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libgui/default.nix
+++ b/distros/humble/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libgui";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libgui/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "345def8279964edeb57d3c0a8b5d7077a655063e4762022bbb698eece3e6d81c";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libgui/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "de142c6baacfe79253b507cd98710257fe94fa3fa1e95c05db170d308750c1bb";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libhwdrivers/default.nix
+++ b/distros/humble/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libhwdrivers";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libhwdrivers/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "66721340e400a1721732a457192a2bb35bf447795280c6429193ae219d04ecaa";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libhwdrivers/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "7bbda58614b8d574f89b99942c2f3ac64f51f5a082d28b841b5bb163f7cd4038";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libmaps/default.nix
+++ b/distros/humble/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libmaps";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmaps/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "38c59163b257c513d36accb462d4c4322db044019e78a31535bd065c0e0596fc";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmaps/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "9b1226005c44956cbd6cb70a6b6cb7f494bd580ce33b544bf92fc1dd7fbe1d5e";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libmath/default.nix
+++ b/distros/humble/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libmath";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmath/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "6ade649df1e34e9f24df2c7214ce3a7554218964b38101fdab15296b6eda3d3c";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmath/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "6dbdbad72a0e32194ea76baea4c3b2106da123655c24a15ece8d1929c191366d";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libnav/default.nix
+++ b/distros/humble/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libnav";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libnav/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "8df969c413536f613ec10df583841c952d45269706020c39d9a06b5f5240ff81";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libnav/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "56ba4c9e38328d09fc71d0b0c4b89e3cf385ba144c59576b8ea869deaf23edde";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libobs/default.nix
+++ b/distros/humble/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libobs";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libobs/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "d7ca6635e9c74a29331ce0ffa844ec168c22bb329f526c7b1b09d8fc71a66a8f";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libobs/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "b3049e2537c9ad2233473e7b362ac602a5a9698ff7f9a6c42e342a5993634da3";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libopengl/default.nix
+++ b/distros/humble/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libopengl";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libopengl/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "21b49b84ca6b49b117e4dbaa3fd7091baf2ddb7336f9ba77a092eb4e6c8e4d54";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libopengl/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "f54f1511c44fb8f1dd72ef26dab78a169b2878f72fd97348cf3d2f0f7119fa1c";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libposes/default.nix
+++ b/distros/humble/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libposes";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libposes/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "c42558cc792be31e52408ac262e36cedc3636cdaf8104464e9dd51118a6c3e05";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libposes/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "9461b0294cf22d3f8915c0a42ad37559c892237395dcb5702c6a5db5742fe758";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libslam/default.nix
+++ b/distros/humble/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, onetbb, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libslam";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libslam/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "cd4c75b52536a9e9f9afa0ac3a5a1c72cc3c70d3cc4ee94539465dd63bb2e803";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libslam/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "dcd1f348dacc52e65d71d674856aa76a578e8e7c41e73ac1ad8cf021c2e0441d";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libtclap/default.nix
+++ b/distros/humble/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libtclap";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libtclap/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "343d4fe50ab197f5ff726bc43759ae864e15558b01ae339774d4d4b2ef69773f";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libtclap/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "b2a400c13d1610bb6c1710501bb0d21f44e97cfa8a66974c6c99edb5e54f240d";
   };
 
   buildType = "cmake";

--- a/distros/humble/ntrip-client-node/default.nix
+++ b/distros/humble/ntrip-client-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, curl, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ntrip-client-node";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ntrip_client_node/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "f543b2897fe35c8343a805bca5eb5f3517545bce994a38d1e195a32a765c6fac";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ntrip_client_node/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "243929b094ff69ffd00ae71f63172fd118b20d2a3b8aa1656a3327e14cbdfd96";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/toppra/default.nix
+++ b/distros/humble/toppra/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, eigen, python3, python3Packages }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, eigen, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-toppra";
-  version = "0.6.6-r1";
+  version = "0.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/toppra-release/archive/release/humble/toppra/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "19f34f035c7c09be8acc8a049498ee9596deea359e932150c503d0d59680de4c";
+    url = "https://github.com/ros2-gbp/toppra-release/archive/release/humble/toppra/0.6.7-1.tar.gz";
+    name = "0.6.7-1.tar.gz";
+    sha256 = "1ffb8223d507666dfd18d432db5301d5a8da713c9950265626129ec404407e36";
   };
 
   buildType = "catkin";
   buildInputs = [ ament-cmake ament-cmake-python python3 python3Packages.pybind11 ];
+  checkInputs = [ ament-cmake-gtest ];
   propagatedBuildInputs = [ eigen ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 

--- a/distros/humble/ublox-dgnss-node/default.nix
+++ b/distros/humble/ublox-dgnss-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-index-cpp, ament-lint-auto, ament-lint-common, libusb1, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-humble-ublox-dgnss-node";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_dgnss_node/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "46072d6f917c4f599b5e839806b6c6eef590bcb16ca8dcd6a272f21be2803801";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_dgnss_node/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "c31c9628270653ba8a65a2a58297cdc9ae0ef601ffc0c44e205223ab2fcf1ffb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ublox-dgnss/default.nix
+++ b/distros/humble/ublox-dgnss/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ntrip-client-node, ublox-dgnss-node, ublox-nav-sat-fix-hp-node, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-humble-ublox-dgnss";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_dgnss/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "4e24db385b30de4c3ca224a3617f2c0e0bc7781a7f9816ab02b608e11310cec3";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_dgnss/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "3bf9b72b25c3d8b8d0a7adf3d24c23b0f9f455cca46731c26093db16eb07a54b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ublox-nav-sat-fix-hp-node/default.nix
+++ b/distros/humble/ublox-nav-sat-fix-hp-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-humble-ublox-nav-sat-fix-hp-node";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_nav_sat_fix_hp_node/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "6d03b2423f351d0fb80061a253e6cfc3684efc3596e7e6fd15e9262c65414d45";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_nav_sat_fix_hp_node/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "15eb155e35538b0274d6b7304c9a1d84b533f976b4a02e578ddf8688b7ca7704";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ublox-ubx-interfaces/default.nix
+++ b/distros/humble/ublox-ubx-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-humble-ublox-ubx-interfaces";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_ubx_interfaces/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "fd88568e1a497bec22afdb299356bdd8d4552152abcf82ae44f7a3e0840a3c90";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_ubx_interfaces/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "444e62b9fd1bc4461e3a605dc119ae1ba382132709f0153c305793e67e73adac";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ublox-ubx-msgs/default.nix
+++ b/distros/humble/ublox-ubx-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ublox-ubx-msgs";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_ubx_msgs/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "1e5492d13c84b652314337854608b6b0a061fb2ba8a4d9e7213466cd82e44a79";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_ubx_msgs/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "5267c885656892ef6be2ce4d45b9fc98ac248ce66aca873e9ae8a54339bbd174";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-bms-broadcaster/default.nix
+++ b/distros/jazzy/clearpath-bms-broadcaster/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, rosidl-default-runtime, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-clearpath-bms-broadcaster";
+  version = "2.9.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bms_broadcaster/2.9.6-1.tar.gz";
+    name = "2.9.6-1.tar.gz";
+    sha256 = "570f689ead6e9ff9bd0e4adc5c53fc4983af5c500cc21d0bb698d6ce8a4f1ad8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake generate-parameter-library ros2-control-cmake ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
+  propagatedBuildInputs = [ backward-ros controller-interface hardware-interface pluginlib rclcpp rclcpp-lifecycle rosidl-default-runtime sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ros2_control battery state broadcaster controller";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/clearpath-bt-joy/default.nix
+++ b/distros/jazzy/clearpath-bt-joy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, bluez, joy-linux, python3Packages, twist-mux }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-bt-joy";
-  version = "2.9.5-r1";
+  version = "2.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bt_joy/2.9.5-1.tar.gz";
-    name = "2.9.5-1.tar.gz";
-    sha256 = "667e58bba383b4f14dec85b59f6d878260b56f7521d9f298d5ea8fcd07e08514";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bt_joy/2.9.6-1.tar.gz";
+    name = "2.9.6-1.tar.gz";
+    sha256 = "87797582c5268cd30c7f7d58c42e532b8ba3486266c1f5a8a1e9e4a1a3e11231";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/clearpath-common/default.nix
+++ b/distros/jazzy/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, rmw-zenoh-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-common";
-  version = "2.9.5-r1";
+  version = "2.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_common/2.9.5-1.tar.gz";
-    name = "2.9.5-1.tar.gz";
-    sha256 = "4a8f626c4f0d4d62b8b7ea3d685155ba12482f5c6954b088a3c5ea437646c305";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_common/2.9.6-1.tar.gz";
+    name = "2.9.6-1.tar.gz";
+    sha256 = "917f3fcf999554dbb2a16196fed5cf2bbe46d4f58b71667507c8ba123b0c88d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-control/default.nix
+++ b/distros/jazzy/clearpath-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-bt-joy, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, mecanum-drive-controller, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-control";
-  version = "2.9.5-r1";
+  version = "2.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_control/2.9.5-1.tar.gz";
-    name = "2.9.5-1.tar.gz";
-    sha256 = "acd5b26afd6ad7460a55027f61b6ceb4de73c25a8ed54d54b1bc23e1d93e48fe";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_control/2.9.6-1.tar.gz";
+    name = "2.9.6-1.tar.gz";
+    sha256 = "2f73fa031ed092cec0cf674568134a402568b4c42a3b4487bc48cf7571a57459";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-customization/default.nix
+++ b/distros/jazzy/clearpath-customization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-customization";
-  version = "2.9.5-r1";
+  version = "2.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_customization/2.9.5-1.tar.gz";
-    name = "2.9.5-1.tar.gz";
-    sha256 = "8db062d168a2488eb8527e8dea1b000d1f3e9a715a0b6e3701e008e8a0debebc";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_customization/2.9.6-1.tar.gz";
+    name = "2.9.6-1.tar.gz";
+    sha256 = "072e23a36e032569f6d3a73b6a40f076754d8dbd0852e42010907c2dd5a88db0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-description/default.nix
+++ b/distros/jazzy/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-description";
-  version = "2.9.5-r1";
+  version = "2.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_description/2.9.5-1.tar.gz";
-    name = "2.9.5-1.tar.gz";
-    sha256 = "c293db7e805835bd0d64ba00fa478cdd2ce47062623ad6ee231b868766cd46af";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_description/2.9.6-1.tar.gz";
+    name = "2.9.6-1.tar.gz";
+    sha256 = "5ad05fe7a9444fe416c8957376c24b3eecde974d7cbc5b215a6fe95b68ce0bf5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-diagnostics/default.nix
+++ b/distros/jazzy/clearpath-diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-platform-msgs, diagnostic-aggregator, diagnostic-updater, foxglove-bridge, rclcpp, ros2launch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-diagnostics";
-  version = "2.9.5-r1";
+  version = "2.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_diagnostics/2.9.5-1.tar.gz";
-    name = "2.9.5-1.tar.gz";
-    sha256 = "9d3eb6c6b528b5b206b4d1e47598f1a18bdcdec352e8743f8e0c573807921e78";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_diagnostics/2.9.6-1.tar.gz";
+    name = "2.9.6-1.tar.gz";
+    sha256 = "6fddf66b8d6437a97a59665a824615817d96948b9a2d207d8359fc4e65295f6d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-generator-common/default.nix
+++ b/distros/jazzy/clearpath-generator-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, _unresolved_python3-apt, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-diagnostics, clearpath-manipulators, moveit-setup-srdf-plugins }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-generator-common";
-  version = "2.9.5-r1";
+  version = "2.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_generator_common/2.9.5-1.tar.gz";
-    name = "2.9.5-1.tar.gz";
-    sha256 = "d4495dbb17e134e3fd99c2d99622d64823ee3d2bc590c7d41b02d77731035b52";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_generator_common/2.9.6-1.tar.gz";
+    name = "2.9.6-1.tar.gz";
+    sha256 = "3032b6efd266fdf0c5cb1da67fad2040c7e2ec6f519da1d24b49993e3e12ae5e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-manipulators-description/default.nix
+++ b/distros/jazzy/clearpath-manipulators-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ewellix-description, robot-state-publisher, robotiq-description, ur-description, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-manipulators-description";
-  version = "2.9.5-r1";
+  version = "2.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators_description/2.9.5-1.tar.gz";
-    name = "2.9.5-1.tar.gz";
-    sha256 = "4dbed610588f4875fa9246158ecfcff73b4c2279ba8a45a6274625b7a441b00b";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators_description/2.9.6-1.tar.gz";
+    name = "2.9.6-1.tar.gz";
+    sha256 = "9b99bebe5f3836060636d24b7c71a642a13b2fbf972fff6b96fe1d023e74deaa";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-manipulators/default.nix
+++ b/distros/jazzy/clearpath-manipulators/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, gripper-controllers, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-warehouse, moveit-setup-srdf-plugins, moveit-simple-controller-manager, position-controllers, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-manipulators";
-  version = "2.9.5-r1";
+  version = "2.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators/2.9.5-1.tar.gz";
-    name = "2.9.5-1.tar.gz";
-    sha256 = "60b39a3d8d9f332c32cd289a383802e6e814506a306406c6d6d8194569653aff";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators/2.9.6-1.tar.gz";
+    name = "2.9.6-1.tar.gz";
+    sha256 = "9147a84dc2f0f040d590755efd1d8c6792caa449e9078a53034a4ba2f148c4e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-mounts-description/default.nix
+++ b/distros/jazzy/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-mounts-description";
-  version = "2.9.5-r1";
+  version = "2.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_mounts_description/2.9.5-1.tar.gz";
-    name = "2.9.5-1.tar.gz";
-    sha256 = "df779e8cd7defe3abf87ff7438ac0e136dd0848b00ad5f41b1eb4033f3ee6f57";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_mounts_description/2.9.6-1.tar.gz";
+    name = "2.9.6-1.tar.gz";
+    sha256 = "c5283c90e71dfb59779bad2c5d7e5605f90d09f08083cabd8ee7f08da5c7bb42";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-platform-description/default.nix
+++ b/distros/jazzy/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-platform-description";
-  version = "2.9.5-r1";
+  version = "2.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_platform_description/2.9.5-1.tar.gz";
-    name = "2.9.5-1.tar.gz";
-    sha256 = "7bb7cf68bb1dbc67afe095892f78a84637a9495e6b2d56fcf5c76f9c310b976e";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_platform_description/2.9.6-1.tar.gz";
+    name = "2.9.6-1.tar.gz";
+    sha256 = "18a90a1d91edcef8ecd2757e02f0df656f82406f083945399e116945084d9def";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-sensors-description/default.nix
+++ b/distros/jazzy/clearpath-sensors-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, axis-description, microstrain-inertial-description, realsense2-description, velodyne-description }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-sensors-description";
-  version = "2.9.5-r1";
+  version = "2.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_sensors_description/2.9.5-1.tar.gz";
-    name = "2.9.5-1.tar.gz";
-    sha256 = "172554b1ca68b9a6f03d05655d60e5d1baf88a3aada83b30a055fac64b68dc38";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_sensors_description/2.9.6-1.tar.gz";
+    name = "2.9.6-1.tar.gz";
+    sha256 = "dab3397ae0a168e55d3abe808a83644a0ea50e389c543e4fd16118101ac10cb8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -452,6 +452,8 @@ self: super: {
 
  classic-bags = self.callPackage ./classic-bags {};
 
+ clearpath-bms-broadcaster = self.callPackage ./clearpath-bms-broadcaster {};
+
  clearpath-bt-joy = self.callPackage ./clearpath-bt-joy {};
 
  clearpath-common = self.callPackage ./clearpath-common {};
@@ -1851,6 +1853,8 @@ self: super: {
  mola-pose-list = self.callPackage ./mola-pose-list {};
 
  mola-relocalization = self.callPackage ./mola-relocalization {};
+
+ mola-sm-loop-closure = self.callPackage ./mola-sm-loop-closure {};
 
  mola-state-estimation = self.callPackage ./mola-state-estimation {};
 

--- a/distros/jazzy/gz-ros2-control-demos/default.nix
+++ b/distros/jazzy/gz-ros2-control-demos/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, geometry-msgs, gz-ros2-control, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, mecanum-drive-controller, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2-control-cmake, ros2controlcli, ros2launch, std-msgs, tricycle-steering-controller, velocity-controllers, xacro }:
+{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, geometry-msgs, gz-ros2-control, gz-sim-vendor, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, mecanum-drive-controller, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2-control-cmake, ros2controlcli, ros2launch, std-msgs, tricycle-steering-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-gz-ros2-control-demos";
-  version = "1.2.17-r1";
+  version = "1.2.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/jazzy/gz_ros2_control_demos/1.2.17-1.tar.gz";
-    name = "1.2.17-1.tar.gz";
-    sha256 = "3d79c36fdb0f287d34eafade92fc48b7ae3da89c9ae17945175b8332effdac05";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/jazzy/gz_ros2_control_demos/1.2.18-1.tar.gz";
+    name = "1.2.18-1.tar.gz";
+    sha256 = "616142311a39fc8c63d98b4bfa72050be7352b10cefa8ad5016a42ce3ca36704";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake rclcpp-action ];
+  buildInputs = [ ament-cmake pluginlib rclcpp-action ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ackermann-steering-controller ament-index-python control-msgs diff-drive-controller effort-controllers force-torque-sensor-broadcaster geometry-msgs gz-ros2-control hardware-interface imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller launch launch-ros mecanum-drive-controller rclcpp robot-state-publisher ros-gz-bridge ros-gz-sim ros2-control-cmake ros2controlcli ros2launch std-msgs tricycle-steering-controller velocity-controllers xacro ];
+  propagatedBuildInputs = [ ackermann-steering-controller ament-index-python control-msgs control-toolbox diff-drive-controller effort-controllers force-torque-sensor-broadcaster geometry-msgs gz-ros2-control gz-sim-vendor hardware-interface imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller launch launch-ros mecanum-drive-controller rclcpp rclcpp-lifecycle robot-state-publisher ros-gz-bridge ros-gz-sim ros2-control-cmake ros2controlcli ros2launch std-msgs tricycle-steering-controller velocity-controllers xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/gz-ros2-control/default.nix
+++ b/distros/jazzy/gz-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, gz-plugin-vendor, gz-sim-vendor, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-gz-ros2-control";
-  version = "1.2.17-r1";
+  version = "1.2.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/jazzy/gz_ros2_control/1.2.17-1.tar.gz";
-    name = "1.2.17-1.tar.gz";
-    sha256 = "5c1a720a78acd354aeabdb06f595c3bfd4c43cc7491d207b226dbfc4585219e0";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/jazzy/gz_ros2_control/1.2.18-1.tar.gz";
+    name = "1.2.18-1.tar.gz";
+    sha256 = "cf98a1c91465b9887c745e4a5f81a40c2aec532fb63c554ca8b673071ab9690f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/message-filters/default.nix
+++ b/distros/jazzy/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, builtin-interfaces, python-cmake-module, rclcpp, rclcpp-lifecycle, rclpy, rcutils, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-message-filters";
-  version = "4.11.12-r1";
+  version = "4.11.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/jazzy/message_filters/4.11.12-1.tar.gz";
-    name = "4.11.12-1.tar.gz";
-    sha256 = "5a7891504fd3410c33f84a8dae8f1eeebdd2c8087fa3ade118e8f46d7c4bbdca";
+    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/jazzy/message_filters/4.11.13-1.tar.gz";
+    name = "4.11.13-1.tar.gz";
+    sha256 = "c0bf7d10422da499fbab6162b2e943ffba965a4d0fe8202bc31a33610605616c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-sm-loop-closure/default.nix
+++ b/distros/jazzy/mola-sm-loop-closure/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, cmake, gtsam, mola-common, mola-georeferencing, mola-gtsam-factors, mola-metric-maps, mola-pose-list, mola-relocalization, mola-test-datasets, mola-yaml, mp2p-icp, mrpt-libgui, mrpt-libmaps, mrpt-libtclap, ros-environment }:
+buildRosPackage {
+  pname = "ros-jazzy-mola-sm-loop-closure";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_sm_loop_closure-release/archive/release/jazzy/mola_sm_loop_closure/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "c4227fd74295b586741fa2a20621d5dd08ae685d7fb39a7a63c729cbbfc21593";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-gtest cmake ros-environment ];
+  checkInputs = [ ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto mola-metric-maps mola-test-datasets ];
+  propagatedBuildInputs = [ gtsam mola-common mola-georeferencing mola-gtsam-factors mola-pose-list mola-relocalization mola-yaml mp2p-icp mrpt-libgui mrpt-libmaps mrpt-libtclap ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
+
+  meta = {
+    description = "Simplemap loop-closure postprocessing library and CLI tool";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/jazzy/mrpt-apps/default.nix
+++ b/distros/jazzy/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-apps";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_apps/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "a0904fb03a04c2ec29d00132dd1a7306396eb6bead1241a82531903c9f0cef25";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_apps/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "f3285406a701130ea38e5f9cf9952ae902834099ce900321fa62056344b7c3f4";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libapps/default.nix
+++ b/distros/jazzy/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libapps";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libapps/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "0183df9bfcfdfc6b92cda33c5d5e692f83310391e890d4d9d505a40e5a98d23c";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libapps/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "a44578dd2fd45c4cd3c64e79adce5a52ab88c941b9ef462f1bc62ba818d40b34";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libbase/default.nix
+++ b/distros/jazzy/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, onetbb, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib, zstd }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libbase";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libbase/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "e2a6fca41d8737d0b68a6253c7f1171d4456914b6267ee3a1f45923801a7c8e5";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libbase/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "d6688e6dbb8833769ba0cb1ebf83af7419ac729cc8cce1550c437cb2e8043ea5";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libgui/default.nix
+++ b/distros/jazzy/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libgui";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libgui/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "1e8b335fc62b8b767af09bd096d9cf5af5e2f06f36fe0b27e010cc0be5dcfaff";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libgui/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "2cf6d38260cef07d30b7b528e9af50717ceafb963c4258f9307ad0d91de31ede";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libhwdrivers/default.nix
+++ b/distros/jazzy/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libhwdrivers";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libhwdrivers/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "c28102c41d761133477bba3262b2ab5794168d7acae5470ccf9c0d4ddc43408b";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libhwdrivers/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "4ade780071bdb6d514ff94157cdf6024110d8469c854364fd7bb4bda92eb3464";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libmaps/default.nix
+++ b/distros/jazzy/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libmaps";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libmaps/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "c77dfe529669cff68aa7f076fbe2cb9f5773d12ea0db794119b3d3ab1cbbd3a5";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libmaps/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "b8111b1cf91fe50fa6dc79a1e5e63026c3d65fcd71747e6992903aadb7fe8686";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libmath/default.nix
+++ b/distros/jazzy/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libmath";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libmath/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "b274512074041031503ff121a50820d5f4415b851fbfdf40530b2dc6798bb72e";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libmath/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "d500cd2ac05cb9a4d4f39367462190ad0638ae0b93b86187abecf020446b2abe";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libnav/default.nix
+++ b/distros/jazzy/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libnav";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libnav/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "54bb9dcfe846557ee1d64f7623e7a84c93841a52bbe627c727dca38c466c2056";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libnav/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "dcf8140158f73e712a1af74c37daecb9f4a7aeaa3cf0566b2c2ff5f9e2d0b0fb";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libobs/default.nix
+++ b/distros/jazzy/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libobs";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libobs/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "2eadfda3fc6b1a4e50bb4292abdaec61a155815e85bc0dc76647f18534c5639a";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libobs/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "7ddece6812bcf8be4ec11e9676827382d2acc4d17aa4ddd50f9d2278f94b48a9";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libopengl/default.nix
+++ b/distros/jazzy/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libopengl";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libopengl/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "7950b4060c617418e53940e6f4a633de1bb75170dd9dd11cfc543ab4796d81b0";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libopengl/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "fd10d52acc8d4ab2cf6bf8ec250c7009686bda068ff1d3d463b722eb26b2b656";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libposes/default.nix
+++ b/distros/jazzy/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libposes";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libposes/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "4873a8052fab69485bcee5d8542d70d93ca40ceec8447d509e281fb078394319";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libposes/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "48a5dd191316af04f44e04377463b031d1d73a20ae1ac2c02e3f5c0242e1743c";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libslam/default.nix
+++ b/distros/jazzy/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, onetbb, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libslam";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libslam/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "f4f8a70f6b3c76610be43a977557d9c151b1e8c9c0467311a578528716357c5f";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libslam/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "3c1cd50837d9aa4bab1e4c27f47e9696edac095e6cc199a372529f51eb4fabb5";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libtclap/default.nix
+++ b/distros/jazzy/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libtclap";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libtclap/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "92fe113d5bd6ec7c1fc33a2cfa2d1b3ac4b64a50ae625e51b86cdb246fdc581a";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libtclap/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "7b829ac3318f16f47dcea6ac127d2ba945f3c7bffcb33402efc762693b6bdd27";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/ntrip-client-node/default.nix
+++ b/distros/jazzy/ntrip-client-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, curl, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ntrip-client-node";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/jazzy/ntrip_client_node/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "7fe92a1b3880517e05c9f67b892653499cabe80feb2cde1b75da43db7163c230";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/jazzy/ntrip_client_node/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "091c9e721bf9e63b22930cac5a45a4003e390eca9db1ea8f3f7fac07bf5a0578";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/toppra/default.nix
+++ b/distros/jazzy/toppra/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, eigen, python3, python3Packages }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, eigen, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-toppra";
-  version = "0.6.6-r1";
+  version = "0.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/toppra-release/archive/release/jazzy/toppra/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "7e8ec9b64f059ec6b7f238bed61034c584cb1674d7f4cf4915460a11e9abae13";
+    url = "https://github.com/ros2-gbp/toppra-release/archive/release/jazzy/toppra/0.6.7-1.tar.gz";
+    name = "0.6.7-1.tar.gz";
+    sha256 = "afbe3ea6eec448bdd310bf4c2f0d6d3406e328c6970dc80d21e4edd135aad54c";
   };
 
   buildType = "catkin";
   buildInputs = [ ament-cmake ament-cmake-python python3 python3Packages.pybind11 ];
+  checkInputs = [ ament-cmake-gtest ];
   propagatedBuildInputs = [ eigen ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 

--- a/distros/jazzy/ublox-dgnss-node/default.nix
+++ b/distros/jazzy/ublox-dgnss-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-index-cpp, ament-lint-auto, ament-lint-common, libusb1, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ublox-dgnss-node";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/jazzy/ublox_dgnss_node/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "e735ab74f0ca3be55d0ae0458b7f42df42f0cf815f7773c260d091336432d45d";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/jazzy/ublox_dgnss_node/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "838bd7d11b30ecec3772c6f7b6b816b05f5a1264da659fa718e0bd83d31859d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ublox-dgnss/default.nix
+++ b/distros/jazzy/ublox-dgnss/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ntrip-client-node, ublox-dgnss-node, ublox-nav-sat-fix-hp-node, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ublox-dgnss";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/jazzy/ublox_dgnss/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "494223f4a4c2e94ef37a09a8d4fce73ab06b05f33c7bef1d3ee584c664139775";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/jazzy/ublox_dgnss/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "e72d29f2506032886c6b7ee39f1c46dcdfa581b814b1630ecae74d3e9b8eb6ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ublox-nav-sat-fix-hp-node/default.nix
+++ b/distros/jazzy/ublox-nav-sat-fix-hp-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ublox-nav-sat-fix-hp-node";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/jazzy/ublox_nav_sat_fix_hp_node/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "53896024e0fb84d198bc37681e001a8676a9758e2d2409005ba0c16266a46ff7";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/jazzy/ublox_nav_sat_fix_hp_node/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "fe5a93c592e63a19391e2449f75631385d69c95882a9cd2cd0e8af1399c55e59";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ublox-ubx-interfaces/default.nix
+++ b/distros/jazzy/ublox-ubx-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-jazzy-ublox-ubx-interfaces";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/jazzy/ublox_ubx_interfaces/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "708aa30b234adfb815f1161ae97e7a5e40e4ceee0acbb2e48193e311a596ad77";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/jazzy/ublox_ubx_interfaces/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "5232c574cadd6f8402bc87026c0dd657d4a207edb87a4e9a9faf44ac532f1ba8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ublox-ubx-msgs/default.nix
+++ b/distros/jazzy/ublox-ubx-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ublox-ubx-msgs";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/jazzy/ublox_ubx_msgs/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "82e65ba14ca043a038ac5d113d5538348338f60b396d3a911ed784487cd9e932";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/jazzy/ublox_ubx_msgs/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "951f3e6aea3cc5fa02449eb1cf5bd93839e7c591bd4984e593368b4b704024c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/generated.nix
+++ b/distros/kilted/generated.nix
@@ -1466,6 +1466,8 @@ self: super: {
 
  mola-relocalization = self.callPackage ./mola-relocalization {};
 
+ mola-sm-loop-closure = self.callPackage ./mola-sm-loop-closure {};
+
  mola-state-estimation = self.callPackage ./mola-state-estimation {};
 
  mola-state-estimation-simple = self.callPackage ./mola-state-estimation-simple {};

--- a/distros/kilted/gz-ros2-control-demos/default.nix
+++ b/distros/kilted/gz-ros2-control-demos/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, geometry-msgs, gz-ros2-control, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, mecanum-drive-controller, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2-control-cmake, ros2controlcli, ros2launch, std-msgs, tricycle-steering-controller, velocity-controllers, xacro }:
+{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, geometry-msgs, gz-ros2-control, gz-sim-vendor, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, mecanum-drive-controller, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2-control-cmake, ros2controlcli, ros2launch, std-msgs, tricycle-steering-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-kilted-gz-ros2-control-demos";
-  version = "2.0.14-r1";
+  version = "2.0.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/kilted/gz_ros2_control_demos/2.0.14-1.tar.gz";
-    name = "2.0.14-1.tar.gz";
-    sha256 = "9332ccefbdd4aec0a2d4cd1a8783c5d2692192824bd32d3e1d3271d3ce5f10b8";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/kilted/gz_ros2_control_demos/2.0.15-1.tar.gz";
+    name = "2.0.15-1.tar.gz";
+    sha256 = "65d2185770b580186c684e1f63efd9cc3324bcdad5a425c5618a9f4801ba0de0";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake rclcpp-action ];
+  buildInputs = [ ament-cmake pluginlib rclcpp-action ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ackermann-steering-controller ament-index-python control-msgs diff-drive-controller effort-controllers force-torque-sensor-broadcaster geometry-msgs gz-ros2-control hardware-interface imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller launch launch-ros mecanum-drive-controller rclcpp robot-state-publisher ros-gz-bridge ros-gz-sim ros2-control-cmake ros2controlcli ros2launch std-msgs tricycle-steering-controller velocity-controllers xacro ];
+  propagatedBuildInputs = [ ackermann-steering-controller ament-index-python control-msgs control-toolbox diff-drive-controller effort-controllers force-torque-sensor-broadcaster geometry-msgs gz-ros2-control gz-sim-vendor hardware-interface imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller launch launch-ros mecanum-drive-controller rclcpp rclcpp-lifecycle robot-state-publisher ros-gz-bridge ros-gz-sim ros2-control-cmake ros2controlcli ros2launch std-msgs tricycle-steering-controller velocity-controllers xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/gz-ros2-control/default.nix
+++ b/distros/kilted/gz-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, gz-plugin-vendor, gz-sim-vendor, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-kilted-gz-ros2-control";
-  version = "2.0.14-r1";
+  version = "2.0.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/kilted/gz_ros2_control/2.0.14-1.tar.gz";
-    name = "2.0.14-1.tar.gz";
-    sha256 = "9a7bada6e41a3d5a33f5b759b8ad8a66c2891cf148196245efd916faf1a4a049";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/kilted/gz_ros2_control/2.0.15-1.tar.gz";
+    name = "2.0.15-1.tar.gz";
+    sha256 = "4ee8c8d772e779a73930220c079a0451947636a2688199db506904b12d3dce21";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mola-sm-loop-closure/default.nix
+++ b/distros/kilted/mola-sm-loop-closure/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, cmake, gtsam, mola-common, mola-georeferencing, mola-gtsam-factors, mola-metric-maps, mola-pose-list, mola-relocalization, mola-test-datasets, mola-yaml, mp2p-icp, mrpt-libgui, mrpt-libmaps, mrpt-libtclap, ros-environment }:
+buildRosPackage {
+  pname = "ros-kilted-mola-sm-loop-closure";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_sm_loop_closure-release/archive/release/kilted/mola_sm_loop_closure/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "673d3f17984322a3d907b902d009a19c30fa1a6b29e83a5b30636419521b1edf";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-gtest cmake ros-environment ];
+  checkInputs = [ ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto mola-metric-maps mola-test-datasets ];
+  propagatedBuildInputs = [ gtsam mola-common mola-georeferencing mola-gtsam-factors mola-pose-list mola-relocalization mola-yaml mp2p-icp mrpt-libgui mrpt-libmaps mrpt-libtclap ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
+
+  meta = {
+    description = "Simplemap loop-closure postprocessing library and CLI tool";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/kilted/mrpt-apps/default.nix
+++ b/distros/kilted/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-apps";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_apps/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "a642eee75bdcfce6b9d1b4655f489811b2a457a74846fde1f950c516827c2226";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_apps/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "52aa97138c2eece451047a5eed8b47990ca903bb339140f64312b6f04b5d72d8";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libapps/default.nix
+++ b/distros/kilted/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libapps";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libapps/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "461899b7142f0dd648a3db674528b897c90fa7c9973acc0137f857767f7d8970";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libapps/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "3071cf28145974ee0f4ea748ae518f64bbc0320300a4921a3c3b1aa6e1fe6d54";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libbase/default.nix
+++ b/distros/kilted/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, onetbb, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib, zstd }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libbase";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libbase/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "75e2b22899450ebb8639f4592ccbad09aaaff3eeaa8c8f15634fbe6dc9749aa0";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libbase/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "9deff76d2a504d6ccf58dbc35c08e08132acfe814c50642993478658f8b1a34c";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libgui/default.nix
+++ b/distros/kilted/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libgui";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libgui/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "464e4f98f9d959e45d9771e5aabde4e82bd2745f6b1d483e182e3c94bf5ffdeb";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libgui/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "21bce185f623aa3823ed42b54c27bd4f07410def70e70f7012c53b09b22c5d09";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libhwdrivers/default.nix
+++ b/distros/kilted/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libhwdrivers";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libhwdrivers/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "45c5d1ee82454b8407faac46172468fae69e34fe8f787dd65704ba460b8cad7c";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libhwdrivers/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "af1516cb3f214e7e021c94d4738e37242682f0f4602aa2689f376c433a3356c5";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libmaps/default.nix
+++ b/distros/kilted/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libmaps";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libmaps/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "160c3debe4b2b4f174eba241af90c8e1e87514bbf9bedf032a5f6e79c5bd9ebe";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libmaps/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "94f1637f11417385bf7089dc79c49e0f89bdb31fa31148c48dec22f3750e189d";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libmath/default.nix
+++ b/distros/kilted/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libmath";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libmath/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "5879246f6bb36ad64dd76293fdabbb6529211e807457452699abc49a696f4315";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libmath/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "dcfaa6f5921394a44ba4b8dcbf9aafa193dc68b96ffffdacff29d7d309a1b7f8";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libnav/default.nix
+++ b/distros/kilted/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libnav";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libnav/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "ce963a531416868578e135df1e46daa78e83ad0af96cbf8e7703b85186ef387e";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libnav/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "a7d63eb80f3c0d698977aa44122be4df67f3422caf7417db5c03c4a286b1393a";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libobs/default.nix
+++ b/distros/kilted/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libobs";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libobs/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "99ffd8bb7eea6e2cbd3953ab3e39b39f174589326a93acdd44f85853e454ebfc";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libobs/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "f64250a23bb6a8395e1cb97f1e9f0a7f154e2aa1e06f196aa45e97a4ad5d88f6";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libopengl/default.nix
+++ b/distros/kilted/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libopengl";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libopengl/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "8f607cc3bb09e40c02323648e7eeb2512dd5292e6653f3e70c035a1d022859c0";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libopengl/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "88d83c3d9674057a73106159dcca29feaeaacbe2faccda377d8a0c76959e3ec9";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libposes/default.nix
+++ b/distros/kilted/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libposes";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libposes/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "76c5eb3e2d586eb431bd669bc9d07dbed0e570c6877807aef4c1dff69a2e4e83";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libposes/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "e6810660ec8bef62d81255bdd7290d478304c6aa8d0f52fc23583c02d9df2bdb";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libslam/default.nix
+++ b/distros/kilted/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, onetbb, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libslam";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libslam/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "885aa6f452ed565f7224afa192424a09075d7521323b685cfbad39cf5a2c1b03";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libslam/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "491adc15845fe26d23d853d8e5494dc99744aa7f76dd445aeb4abced365cec4e";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libtclap/default.nix
+++ b/distros/kilted/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libtclap";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libtclap/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "5baf86428c0f255d59e86957f358b3f4b0af52ec5fc9cdb41469fa7ab41f6269";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libtclap/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "7f61d19cae7247bf1e60bfac263bd9665b3bf519cc41417a9432eb1657205622";
   };
 
   buildType = "cmake";

--- a/distros/kilted/ntrip-client-node/default.nix
+++ b/distros/kilted/ntrip-client-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, curl, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ntrip-client-node";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/kilted/ntrip_client_node/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "1ae828ed3fd96c652220938bd38a9dcd4ba294b6d6b20443549de9735b3ea8be";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/kilted/ntrip_client_node/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "9af7d6fe92cd4c0b2b0ccaaf9b7eea82a34d875072ba29be3583fa5c5b0d9934";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rqt-bag-plugins/default.nix
+++ b/distros/kilted/rqt-bag-plugins/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, geometry-msgs, python3Packages, rclpy, rosbag2, rqt-bag, rqt-gui, rqt-gui-py, rqt-plot, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, builtin-interfaces, geometry-msgs, python3Packages, rclpy, rosbag2, rqt-bag, rqt-gui, rqt-gui-py, rqt-plot, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-rqt-bag-plugins";
-  version = "2.0.2-r2";
+  version = "2.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/kilted/rqt_bag_plugins/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "ea617221a1f705eba4025437553e869a419d1e38e0d08af357a2237bb639b56b";
+    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/kilted/rqt_bag_plugins/2.0.3-2.tar.gz";
+    name = "2.0.3-2.tar.gz";
+    sha256 = "f501eb21c1011df20cc6656ac8ab83a8dda9d05e32d459b2cb35de5134b92f00";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest ];
-  propagatedBuildInputs = [ ament-index-python geometry-msgs python3Packages.pillow python3Packages.pycairo rclpy rosbag2 rqt-bag rqt-gui rqt-gui-py rqt-plot sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ ament-index-python builtin-interfaces geometry-msgs python3Packages.numpy python3Packages.pillow python3Packages.pycairo rclpy rosbag2 rqt-bag rqt-gui rqt-gui-py rqt-plot sensor-msgs std-msgs ];
 
   meta = {
     description = "rqt_bag provides a GUI plugin for displaying and replaying ROS bag files.";

--- a/distros/kilted/rqt-bag/default.nix
+++ b/distros/kilted/rqt-bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, builtin-interfaces, python-qt-binding, python3Packages, rclpy, rosbag2-py, rosidl-runtime-py, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-kilted-rqt-bag";
-  version = "2.0.2-r2";
+  version = "2.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/kilted/rqt_bag/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "5faef312882b8f254692a6ac5f9201e969fabdbcf1ad590ffc67f304977f7376";
+    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/kilted/rqt_bag/2.0.3-2.tar.gz";
+    name = "2.0.3-2.tar.gz";
+    sha256 = "ff6ef9babbc1cbe9726ee7217321f3ea25fcc2d0aa958d4f6022ec1693a41c57";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/rqt-msg/default.nix
+++ b/distros/kilted/rqt-msg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-index-python, ament-xmllint, python-qt-binding, python3Packages, rclpy, rosidl-runtime-py, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-kilted-rqt-msg";
-  version = "1.6.0-r2";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_msg-release/archive/release/kilted/rqt_msg/1.6.0-2.tar.gz";
-    name = "1.6.0-2.tar.gz";
-    sha256 = "1d3568826584c9bb300df3f873bf5950edb23f2dc6e692da441580211863b8ce";
+    url = "https://github.com/ros2-gbp/rqt_msg-release/archive/release/kilted/rqt_msg/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "88afaf72aae6478f4f34a153b8d04e85949aba5d63fd1becc40f731d1fd74124";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/rqt-plot/default.nix
+++ b/distros/kilted/rqt-plot/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rosidl-parser, rosidl-runtime-py, rqt-gui, rqt-gui-py, rqt-py-common, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rosidl-parser, rosidl-runtime-py, rqt-gui, rqt-gui-py, rqt-py-common, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-kilted-rqt-plot";
-  version = "1.6.3-r1";
+  version = "1.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_plot-release/archive/release/kilted/rqt_plot/1.6.3-1.tar.gz";
-    name = "1.6.3-1.tar.gz";
-    sha256 = "22bff291cff5298f0735d5c0fc81f1ab0be54a3f1ccb2cd3217e5f806528f6b2";
+    url = "https://github.com/ros2-gbp/rqt_plot-release/archive/release/kilted/rqt_plot/1.6.4-1.tar.gz";
+    name = "1.6.4-1.tar.gz";
+    sha256 = "ab025fb586fb1a6e4dc2ae0a754f53dc29befb7729c83f1e541bc44309261287";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest test-msgs ];
   propagatedBuildInputs = [ ament-index-python python-qt-binding python3Packages.matplotlib python3Packages.numpy qt-gui-py-common rclpy rosidl-parser rosidl-runtime-py rqt-gui rqt-gui-py rqt-py-common std-msgs ];
 
   meta = {

--- a/distros/kilted/rqt-publisher/default.nix
+++ b/distros/kilted/rqt-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rosidl-runtime-py, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-kilted-rqt-publisher";
-  version = "1.9.0-r2";
+  version = "1.9.1-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_publisher-release/archive/release/kilted/rqt_publisher/1.9.0-2.tar.gz";
-    name = "1.9.0-2.tar.gz";
-    sha256 = "31f2072b77ce6910347f547e0ba5f5a5a3e110d695fd768d462d52b58c65cf01";
+    url = "https://github.com/ros2-gbp/rqt_publisher-release/archive/release/kilted/rqt_publisher/1.9.1-4.tar.gz";
+    name = "1.9.1-4.tar.gz";
+    sha256 = "f7ad4f3715b90c1e448ffa7d44ea64af1cf75dcad21319010f3a54ebfdc5c0f5";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/rqt-service-caller/default.nix
+++ b/distros/kilted/rqt-service-caller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, python-qt-binding, python3Packages, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-kilted-rqt-service-caller";
-  version = "1.4.0-r2";
+  version = "1.4.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_service_caller-release/archive/release/kilted/rqt_service_caller/1.4.0-2.tar.gz";
-    name = "1.4.0-2.tar.gz";
-    sha256 = "afac12d54e85b66ab68f3cccff4dc4a52022a8fe2be59d9ae2b03a4990c32ef5";
+    url = "https://github.com/ros2-gbp/rqt_service_caller-release/archive/release/kilted/rqt_service_caller/1.4.1-2.tar.gz";
+    name = "1.4.1-2.tar.gz";
+    sha256 = "532ad906523dd31bd956b8171ecc33dfd2bf400e9c7b56df302eb7a66b64c537";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/toppra/default.nix
+++ b/distros/kilted/toppra/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, eigen, python3, python3Packages }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, eigen, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-kilted-toppra";
-  version = "0.6.6-r1";
+  version = "0.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/toppra-release/archive/release/kilted/toppra/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "66ad0c92d47b29f0acac1d73a08c75e23dd871bc3c3ebe02124bf7a2d86e914f";
+    url = "https://github.com/ros2-gbp/toppra-release/archive/release/kilted/toppra/0.6.7-1.tar.gz";
+    name = "0.6.7-1.tar.gz";
+    sha256 = "42da4ef39df13b822b43ada1622be495ab3c0b9ab2508aecd3ab283eff38ea26";
   };
 
   buildType = "catkin";
   buildInputs = [ ament-cmake ament-cmake-python python3 python3Packages.pybind11 ];
+  checkInputs = [ ament-cmake-gtest ];
   propagatedBuildInputs = [ eigen ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 

--- a/distros/kilted/ublox-dgnss-node/default.nix
+++ b/distros/kilted/ublox-dgnss-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-index-cpp, ament-lint-auto, ament-lint-common, libusb1, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ublox-dgnss-node";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/kilted/ublox_dgnss_node/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "51a1936458927f7c53d830b8397781fb898f0db33509d4f12186de716035a382";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/kilted/ublox_dgnss_node/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "d662fe034fbd43b3542a782980b5384ae17cc8d5c5b8cd34e5a38917eebd27dd";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ublox-dgnss/default.nix
+++ b/distros/kilted/ublox-dgnss/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ntrip-client-node, ublox-dgnss-node, ublox-nav-sat-fix-hp-node, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ublox-dgnss";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/kilted/ublox_dgnss/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "940816e3513b110ebfff64a5153e5dc02cab40bc7796c8121d1a65017392527b";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/kilted/ublox_dgnss/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "0c3ad7eefc5b53a1a49a46cf56fd2e63e6064a6aec127efd0ffcc400505e04c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ublox-nav-sat-fix-hp-node/default.nix
+++ b/distros/kilted/ublox-nav-sat-fix-hp-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ublox-nav-sat-fix-hp-node";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/kilted/ublox_nav_sat_fix_hp_node/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "45c8293cabd0a656878c7b852fea3c2cd99a9f06fb2e692c615a84c5816d0fff";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/kilted/ublox_nav_sat_fix_hp_node/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "816a250b640560ddbf74e1f8654197666bb1ac347bd74b472404b6ce3d59b2b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ublox-ubx-interfaces/default.nix
+++ b/distros/kilted/ublox-ubx-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-kilted-ublox-ubx-interfaces";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/kilted/ublox_ubx_interfaces/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "ea6277ca928930266bc69fc590d0678e2c62f9b6e076787f418d939d7febafcb";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/kilted/ublox_ubx_interfaces/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "b29042b6717bef4b598ffca3c3efa212e4a7836dff6e0f16a3d484840e942c06";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ublox-ubx-msgs/default.nix
+++ b/distros/kilted/ublox-ubx-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ublox-ubx-msgs";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/kilted/ublox_ubx_msgs/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "b9e79b4f09c1c8ff2137eeec824765b3ab1617ddb14abed4445f15b15023e441";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/kilted/ublox_ubx_msgs/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "5c489c8904814dec64f177e4855473c569bb4a421d4304373f54025f00cfe122";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/action-msgs/default.nix
+++ b/distros/rolling/action-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-core-generators, rosidl-core-runtime, service-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-action-msgs";
-  version = "2.4.3-r1";
+  version = "2.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/action_msgs/2.4.3-1.tar.gz";
-    name = "2.4.3-1.tar.gz";
-    sha256 = "f4fc7e22180fb636e9a5d0d352b7960693845bb72e8e0d1dda1c4c7f39c19f24";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/action_msgs/2.4.4-1.tar.gz";
+    name = "2.4.4-1.tar.gz";
+    sha256 = "b6ad06548e404c61770db7319d0c531207ed0e2dec890457f488e47c09d0816f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/action-tutorials-cpp/default.nix
+++ b/distros/rolling/action-tutorials-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rclcpp-action, rclcpp-components }:
 buildRosPackage {
   pname = "ros-rolling-action-tutorials-cpp";
-  version = "0.37.7-r1";
+  version = "0.37.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_cpp/0.37.7-1.tar.gz";
-    name = "0.37.7-1.tar.gz";
-    sha256 = "9345dd4c8e5a08bcfd66599a6adc118514f8e8933615abe0a5201a6b3965b24d";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_cpp/0.37.8-1.tar.gz";
+    name = "0.37.8-1.tar.gz";
+    sha256 = "6fa6a5473a93d493be712488b78c2ad721bbd95a23885bdfa6c79d3f0e2e6b43";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/action-tutorials-py/default.nix
+++ b/distros/rolling/action-tutorials-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, example-interfaces, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-action-tutorials-py";
-  version = "0.37.7-r1";
+  version = "0.37.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_py/0.37.7-1.tar.gz";
-    name = "0.37.7-1.tar.gz";
-    sha256 = "e2926e982b6699c3c5067926c53cbe35a05ecd052b7f3cb1fad897a6795c4ae4";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_py/0.37.8-1.tar.gz";
+    name = "0.37.8-1.tar.gz";
+    sha256 = "3430007241ccf44af2098f6662a76317d1bdddb8d5a7d1ce2e70ace8b61526c3";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/builtin-interfaces/default.nix
+++ b/distros/rolling/builtin-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-core-generators, rosidl-core-runtime }:
 buildRosPackage {
   pname = "ros-rolling-builtin-interfaces";
-  version = "2.4.3-r1";
+  version = "2.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/builtin_interfaces/2.4.3-1.tar.gz";
-    name = "2.4.3-1.tar.gz";
-    sha256 = "9594df2d15a67d7f122355085c867a4a108b17ed14d1fad7641cade54ac6b268";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/builtin_interfaces/2.4.4-1.tar.gz";
+    name = "2.4.4-1.tar.gz";
+    sha256 = "e12f3a0a809737686a81fa1e7d8f219daa6a47de5363e818de780a9a1f1af87f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/class-loader/default.nix
+++ b/distros/rolling/class-loader/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, console-bridge, console-bridge-vendor, rcpputils }:
 buildRosPackage {
   pname = "ros-rolling-class-loader";
-  version = "2.9.3-r1";
+  version = "2.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/class_loader-release/archive/release/rolling/class_loader/2.9.3-1.tar.gz";
-    name = "2.9.3-1.tar.gz";
-    sha256 = "9aca2b6409c53d67da46326f358a4d0bd1f1e1e1fd3e634f20d428d8a13484b0";
+    url = "https://github.com/ros2-gbp/class_loader-release/archive/release/rolling/class_loader/2.9.4-1.tar.gz";
+    name = "2.9.4-1.tar.gz";
+    sha256 = "cf01fb606562e1bba730fa99a26eb8f8ea329b301f6aa2d2cdb535d4cf5efba6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/common-interfaces/default.nix
+++ b/distros/rolling/common-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, geometry-msgs, nav-msgs, sensor-msgs, shape-msgs, std-msgs, std-srvs, stereo-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-common-interfaces";
-  version = "5.9.1-r1";
+  version = "5.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/common_interfaces/5.9.1-1.tar.gz";
-    name = "5.9.1-1.tar.gz";
-    sha256 = "af31aec61f86da5cd4af2735241d5ded8f2d08bf356b80ee7c2fec7f8a1e3af5";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/common_interfaces/5.9.2-1.tar.gz";
+    name = "5.9.2-1.tar.gz";
+    sha256 = "cfff36735bad83951c101540b2511a82f649bea718afea7d68e09b5fd18d76c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/composition-interfaces/default.nix
+++ b/distros/rolling/composition-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-composition-interfaces";
-  version = "2.4.3-r1";
+  version = "2.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/composition_interfaces/2.4.3-1.tar.gz";
-    name = "2.4.3-1.tar.gz";
-    sha256 = "83fa66b91bfb2be69cb2674495a8af3b052137f026c0f4028625a95228e8879b";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/composition_interfaces/2.4.4-1.tar.gz";
+    name = "2.4.4-1.tar.gz";
+    sha256 = "94d1a1ff532a2785c61b971078bde1630662923f1212c5ee351ca1630305d72c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/composition/default.nix
+++ b/distros/rolling/composition/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake }:
 buildRosPackage {
   pname = "ros-rolling-composition";
-  version = "0.37.7-r1";
+  version = "0.37.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/composition/0.37.7-1.tar.gz";
-    name = "0.37.7-1.tar.gz";
-    sha256 = "7ff87b276c9d86835f734d581e73ae54b6fd04a1849da752fe8cb4e66d611c37";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/composition/0.37.8-1.tar.gz";
+    name = "0.37.8-1.tar.gz";
+    sha256 = "320e90c306abfcd5d8cabfdf5627c1092b82c1925b75a70a2cd108888b87fb63";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/demo-nodes-cpp-native/default.nix
+++ b/distros/rolling/demo-nodes-cpp-native/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rmw-fastrtps-cpp }:
 buildRosPackage {
   pname = "ros-rolling-demo-nodes-cpp-native";
-  version = "0.37.7-r1";
+  version = "0.37.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp_native/0.37.7-1.tar.gz";
-    name = "0.37.7-1.tar.gz";
-    sha256 = "3167c0da2f886b7af22ee8006ccda9fb886b8544b1c7092e2a247d999ff109d0";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp_native/0.37.8-1.tar.gz";
+    name = "0.37.8-1.tar.gz";
+    sha256 = "cec326b40808a8a0e59bf9fe8b3a98cc06f6f32a28d9c87bc786a83076608ae5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/demo-nodes-cpp/default.nix
+++ b/distros/rolling/demo-nodes-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, launch-xml, rcl, rcl-interfaces, rclcpp, rclcpp-components, rcpputils, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-rolling-demo-nodes-cpp";
-  version = "0.37.7-r1";
+  version = "0.37.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp/0.37.7-1.tar.gz";
-    name = "0.37.7-1.tar.gz";
-    sha256 = "e9b705ee4b3887305d801ddd9b406bd36c05606da0396e3121548a0400e8b08b";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp/0.37.8-1.tar.gz";
+    name = "0.37.8-1.tar.gz";
+    sha256 = "ba4f19093e5599336205762a537d42a1b11a8e8517c3ff316ab4a1456baac2fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/demo-nodes-py/default.nix
+++ b/distros/rolling/demo-nodes-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, example-interfaces, python3Packages, rcl-interfaces, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-demo-nodes-py";
-  version = "0.37.7-r1";
+  version = "0.37.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_py/0.37.7-1.tar.gz";
-    name = "0.37.7-1.tar.gz";
-    sha256 = "55cfe175d6d6e22955440615f00d28a088149d273b8647ef024e68cd97a78350";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_py/0.37.8-1.tar.gz";
+    name = "0.37.8-1.tar.gz";
+    sha256 = "e0c15689e57499ecf76029e3d395c214996da66a5a22bd4af1646a9e9b9161e5";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/diagnostic-msgs/default.nix
+++ b/distros/rolling/diagnostic-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diagnostic-msgs";
-  version = "5.9.1-r1";
+  version = "5.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/diagnostic_msgs/5.9.1-1.tar.gz";
-    name = "5.9.1-1.tar.gz";
-    sha256 = "f8a03e7ac5baab1f7748abb7ea1b0326f50f6f5e9481e3815217b2f39e4beda9";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/diagnostic_msgs/5.9.2-1.tar.gz";
+    name = "5.9.2-1.tar.gz";
+    sha256 = "16044d097bfce5e172d45156247807b29e7c22498b788ee532be90db9706bcd6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/domain-bridge/default.nix
+++ b/distros/rolling/domain-bridge/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-testing, launch-testing-ament-cmake, rclcpp, rclcpp-components, rcutils, rmw-connextdds, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, rmw-implementation-cmake, rosbag2-cpp, rosgraph-msgs, rosidl-default-generators, rosidl-default-runtime, rosidl-typesupport-cpp, test-msgs, yaml-cpp, zstd-vendor }:
+{ lib, buildRosPackage, fetchurl, _unresolved_zstd_vendor, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-testing, launch-testing-ament-cmake, rclcpp, rclcpp-components, rcutils, rmw-connextdds, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, rmw-implementation-cmake, rosbag2-cpp, rosgraph-msgs, rosidl-default-generators, rosidl-default-runtime, rosidl-typesupport-cpp, test-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-domain-bridge";
   version = "0.5.0-r4";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common example-interfaces launch launch-testing launch-testing-ament-cmake rmw-connextdds rmw-cyclonedds-cpp rmw-fastrtps-cpp rmw-implementation-cmake rosgraph-msgs test-msgs ];
-  propagatedBuildInputs = [ rclcpp rclcpp-components rcutils rosbag2-cpp rosidl-default-runtime rosidl-typesupport-cpp yaml-cpp zstd-vendor ];
+  propagatedBuildInputs = [ _unresolved_zstd_vendor rclcpp rclcpp-components rcutils rosbag2-cpp rosidl-default-runtime rosidl-typesupport-cpp yaml-cpp ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/rolling/dummy-map-server/default.nix
+++ b/distros/rolling/dummy-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-dummy-map-server";
-  version = "0.37.7-r1";
+  version = "0.37.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_map_server/0.37.7-1.tar.gz";
-    name = "0.37.7-1.tar.gz";
-    sha256 = "8b87e270f87ff9238b46c32972cfdfd28fe247e83915a184fdbe99f8c3f92a88";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_map_server/0.37.8-1.tar.gz";
+    name = "0.37.8-1.tar.gz";
+    sha256 = "fedfeae3d6291fa2b0cdc5e89eb956431487ad293c12859d05a3444488c3e021";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dummy-robot-bringup/default.nix
+++ b/distros/rolling/dummy-robot-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, dummy-map-server, dummy-sensors, launch, launch-ros, robot-state-publisher, rviz2 }:
 buildRosPackage {
   pname = "ros-rolling-dummy-robot-bringup";
-  version = "0.37.7-r1";
+  version = "0.37.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_robot_bringup/0.37.7-1.tar.gz";
-    name = "0.37.7-1.tar.gz";
-    sha256 = "65da2cea8a01b6be161c60bdc772904654bafbc6e826ec8e4bfa19f466e5e659";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_robot_bringup/0.37.8-1.tar.gz";
+    name = "0.37.8-1.tar.gz";
+    sha256 = "900836f60e875510347ff5f73b6199b0cb0eb7cd25db868f64a31bb73b919365";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dummy-sensors/default.nix
+++ b/distros/rolling/dummy-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-dummy-sensors";
-  version = "0.37.7-r1";
+  version = "0.37.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_sensors/0.37.7-1.tar.gz";
-    name = "0.37.7-1.tar.gz";
-    sha256 = "963b9cc48d8e79de789024eb21fe3c7fcfa6461963590aa1fa0b11e6e3b228b7";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_sensors/0.37.8-1.tar.gz";
+    name = "0.37.8-1.tar.gz";
+    sha256 = "e86ec7c122ed0cc14dde743801eebdb0da1f09435b5a742004a13c1868b34b13";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -1198,8 +1198,6 @@ self: super: {
 
  libg2o = self.callPackage ./libg2o {};
 
- liblz4-vendor = self.callPackage ./liblz4-vendor {};
-
  libmavconn = self.callPackage ./libmavconn {};
 
  libnabo = self.callPackage ./libnabo {};
@@ -1233,6 +1231,8 @@ self: super: {
  logging-demo = self.callPackage ./logging-demo {};
 
  lttngpy = self.callPackage ./lttngpy {};
+
+ lz4-cmake-module = self.callPackage ./lz4-cmake-module {};
 
  magic-enum = self.callPackage ./magic-enum {};
 
@@ -1363,6 +1363,8 @@ self: super: {
  mola-pose-list = self.callPackage ./mola-pose-list {};
 
  mola-relocalization = self.callPackage ./mola-relocalization {};
+
+ mola-sm-loop-closure = self.callPackage ./mola-sm-loop-closure {};
 
  mola-state-estimation = self.callPackage ./mola-state-estimation {};
 
@@ -2002,6 +2004,12 @@ self: super: {
 
  resource-retriever = self.callPackage ./resource-retriever {};
 
+ resource-retriever-interfaces = self.callPackage ./resource-retriever-interfaces {};
+
+ resource-retriever-service = self.callPackage ./resource-retriever-service {};
+
+ resource-retriever-service-plugin = self.callPackage ./resource-retriever-service-plugin {};
+
  rig-reconfigure = self.callPackage ./rig-reconfigure {};
 
  rko-lio = self.callPackage ./rko-lio {};
@@ -2560,8 +2568,6 @@ self: super: {
 
  rviz-rendering-tests = self.callPackage ./rviz-rendering-tests {};
 
- rviz-resource-interfaces = self.callPackage ./rviz-resource-interfaces {};
-
  rviz-satellite = self.callPackage ./rviz-satellite {};
 
  rviz-visual-testing-framework = self.callPackage ./rviz-visual-testing-framework {};
@@ -2661,8 +2667,6 @@ self: super: {
  splsm-7 = self.callPackage ./splsm-7 {};
 
  splsm-7-conversion = self.callPackage ./splsm-7-conversion {};
-
- sqlite3-vendor = self.callPackage ./sqlite3-vendor {};
 
  srdfdom = self.callPackage ./srdfdom {};
 
@@ -3084,10 +3088,10 @@ self: super: {
 
  zmqpp-vendor = self.callPackage ./zmqpp-vendor {};
 
+ zstd-cmake-module = self.callPackage ./zstd-cmake-module {};
+
  zstd-image-transport = self.callPackage ./zstd-image-transport {};
 
  zstd-point-cloud-transport = self.callPackage ./zstd-point-cloud-transport {};
-
- zstd-vendor = self.callPackage ./zstd-vendor {};
 
 }

--- a/distros/rolling/geometry-msgs/default.nix
+++ b/distros/rolling/geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-geometry-msgs";
-  version = "5.9.1-r1";
+  version = "5.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/geometry_msgs/5.9.1-1.tar.gz";
-    name = "5.9.1-1.tar.gz";
-    sha256 = "90d3dfb0d31220cf85020d1094a21dcdb0131fdc129f2f193bcc4f3ab04ad5a8";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/geometry_msgs/5.9.2-1.tar.gz";
+    name = "5.9.2-1.tar.gz";
+    sha256 = "864d990382e9abf95a4684e3d79fc04f1b548d2c5cdd1439e2f88328ddeba0b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-ros2-control-demos/default.nix
+++ b/distros/rolling/gz-ros2-control-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, geometry-msgs, gz-ros2-control, gz-sim-vendor, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, mecanum-drive-controller, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2-control-cmake, ros2controlcli, ros2launch, std-msgs, tricycle-steering-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-rolling-gz-ros2-control-demos";
-  version = "3.0.6-r1";
+  version = "3.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/rolling/gz_ros2_control_demos/3.0.6-1.tar.gz";
-    name = "3.0.6-1.tar.gz";
-    sha256 = "6cff8c13a1af7f601edc8d8cc104de3e981d4622b41c8602095a4236ff3f133c";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/rolling/gz_ros2_control_demos/3.0.7-1.tar.gz";
+    name = "3.0.7-1.tar.gz";
+    sha256 = "3f255a137efe78cd3287c8fe85095bbdb55eef086fa4152cb3c795898ad359a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-ros2-control/default.nix
+++ b/distros/rolling/gz-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, gz-plugin-vendor, gz-sim-vendor, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-gz-ros2-control";
-  version = "3.0.6-r1";
+  version = "3.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/rolling/gz_ros2_control/3.0.6-1.tar.gz";
-    name = "3.0.6-1.tar.gz";
-    sha256 = "2a09eb21a4b8ca10a0815bac0954ad962ee140813c795f5509349bfd1a830b7b";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/rolling/gz_ros2_control/3.0.7-1.tar.gz";
+    name = "3.0.7-1.tar.gz";
+    sha256 = "91c5f7d29b41b8f651a4ef7cadd86d62366431896dafbfdcf0215d8376de35b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-tools/default.nix
+++ b/distros/rolling/image-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, opencv, rclcpp, rclcpp-components, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-image-tools";
-  version = "0.37.7-r1";
+  version = "0.37.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/image_tools/0.37.7-1.tar.gz";
-    name = "0.37.7-1.tar.gz";
-    sha256 = "b02c1c2be67d5df3d52c4318f732e91ecf3787095178e647e35e59457853940b";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/image_tools/0.37.8-1.tar.gz";
+    name = "0.37.8-1.tar.gz";
+    sha256 = "e641a6722ef7370463e1b6ace1c683013f263fa0d8639d97b7b04658fa1c24cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/intra-process-demo/default.nix
+++ b/distros/rolling/intra-process-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, opencv, rclcpp, rmw-implementation-cmake, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-intra-process-demo";
-  version = "0.37.7-r1";
+  version = "0.37.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/intra_process_demo/0.37.7-1.tar.gz";
-    name = "0.37.7-1.tar.gz";
-    sha256 = "65beea8c8d8c1038ce2c02e22419d7c26b2eddcd76b2cca25699372b9d3905b3";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/intra_process_demo/0.37.8-1.tar.gz";
+    name = "0.37.8-1.tar.gz";
+    sha256 = "251a3b8c9acc10099c33f4cec07ca02e0ee797e7d74681dc1f42712752014eb1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/libyaml-vendor/default.nix
+++ b/distros/rolling/libyaml-vendor/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-vendor-package, ament-lint-auto, ament-lint-common, libyaml, performance-test-fixture, pkg-config }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, libyaml, performance-test-fixture, pkg-config }:
 buildRosPackage {
   pname = "ros-rolling-libyaml-vendor";
-  version = "1.8.0-r1";
+  version = "1.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libyaml_vendor-release/archive/release/rolling/libyaml_vendor/1.8.0-1.tar.gz";
-    name = "1.8.0-1.tar.gz";
-    sha256 = "1a431f9c0029925b51711018f4e50d0d76234ab848df179d23e41671d4d2fe23";
+    url = "https://github.com/ros2-gbp/libyaml_vendor-release/archive/release/rolling/libyaml_vendor/1.8.1-1.tar.gz";
+    name = "1.8.1-1.tar.gz";
+    sha256 = "edf637ec3beef4d25c3303fb14de935c8060ab5c9830a43572e48c04095d2741";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-vendor-package ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common performance-test-fixture ];
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common libyaml performance-test-fixture ];
   propagatedBuildInputs = [ libyaml pkg-config ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package pkg-config ];
+  nativeBuildInputs = [ ament-cmake pkg-config ];
 
   meta = {
-    description = "Vendored version of libyaml.";
+    description = "Exports a custom CMake module to find libyaml.";
     license = with lib.licenses; [ asl20 mit ];
   };
 }

--- a/distros/rolling/lifecycle-msgs/default.nix
+++ b/distros/rolling/lifecycle-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-lifecycle-msgs";
-  version = "2.4.3-r1";
+  version = "2.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/lifecycle_msgs/2.4.3-1.tar.gz";
-    name = "2.4.3-1.tar.gz";
-    sha256 = "952ccbff6fa1c7c4f012a19bfde7b7b63f9703a9114f67859e9e16e93d16d48c";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/lifecycle_msgs/2.4.4-1.tar.gz";
+    name = "2.4.4-1.tar.gz";
+    sha256 = "e0b1ffb4af861343465f1b40b7d3b53cf4a6dd0c362812b98206c178fc26cbed";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/lifecycle-py/default.nix
+++ b/distros/rolling/lifecycle-py/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, example-interfaces, lifecycle, lifecycle-msgs, rclpy, ros-testing }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, example-interfaces, lifecycle, lifecycle-msgs, rclpy, ros-testing }:
 buildRosPackage {
   pname = "ros-rolling-lifecycle-py";
-  version = "0.37.7-r1";
+  version = "0.37.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle_py/0.37.7-1.tar.gz";
-    name = "0.37.7-1.tar.gz";
-    sha256 = "63c30823e186ba84c92b9a9562234d20f35e46eeacd0a45cdfd5a0f1068edc15";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle_py/0.37.8-1.tar.gz";
+    name = "0.37.8-1.tar.gz";
+    sha256 = "031da9ca37c62a8e90f1fa21120f4b6c61bc2b24fe92cd45da4be46abd0a9e67";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint lifecycle ros-testing ];
+  checkInputs = [ ament-copyright ament-flake8 ament-mypy ament-pep257 ament-xmllint lifecycle ros-testing ];
   propagatedBuildInputs = [ example-interfaces lifecycle-msgs rclpy ];
 
   meta = {

--- a/distros/rolling/lifecycle/default.nix
+++ b/distros/rolling/lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, lifecycle-msgs, rclcpp, rclcpp-lifecycle, ros-testing }:
 buildRosPackage {
   pname = "ros-rolling-lifecycle";
-  version = "0.37.7-r1";
+  version = "0.37.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle/0.37.7-1.tar.gz";
-    name = "0.37.7-1.tar.gz";
-    sha256 = "4ae0ac87bf46add1f0062f7429c0a1f139890d8dc00a4d7e3fe37d7e4867dc91";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle/0.37.8-1.tar.gz";
+    name = "0.37.8-1.tar.gz";
+    sha256 = "52d8a44954de6fa699c63df10ac39d05f46aba39f46e4340e887b3e20fd4b681";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/logging-demo/default.nix
+++ b/distros/rolling/logging-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-logging-demo";
-  version = "0.37.7-r1";
+  version = "0.37.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/logging_demo/0.37.7-1.tar.gz";
-    name = "0.37.7-1.tar.gz";
-    sha256 = "443c97ed58054dfdc6860220b4df20e18fdab930f3a391bb6ad071d70dff9cb9";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/logging_demo/0.37.8-1.tar.gz";
+    name = "0.37.8-1.tar.gz";
+    sha256 = "c63187bcb5799d6befdaa2aeedc242b20868f1c30237664bc9f0da419905d21c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/lz4-cmake-module/default.nix
+++ b/distros/rolling/lz4-cmake-module/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, lz4 }:
+buildRosPackage {
+  pname = "ros-rolling-lz4-cmake-module";
+  version = "0.33.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/lz4_cmake_module/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "6f6b9eaa38b53d771af4aa3db258155344a04c6042e48a8284916b46fb847692";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ lz4 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "LZ4 compression cmake module package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/mcap-vendor/default.nix
+++ b/distros/rolling/mcap-vendor/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, git, liblz4-vendor, zstd-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, git, lz4-cmake-module, zstd-cmake-module }:
 buildRosPackage {
   pname = "ros-rolling-mcap-vendor";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/mcap_vendor/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "b938a6408ccc724612bdebc3f2337d8a200af9bc19cc4426e7a84131f258a783";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/mcap_vendor/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "d184edec062a8d16b47a4d6b334d641471a5eb73d19eb76474d96e9a52c48ac5";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake git ];
-  propagatedBuildInputs = [ liblz4-vendor zstd-vendor ];
+  propagatedBuildInputs = [ lz4-cmake-module zstd-cmake-module ];
   nativeBuildInputs = [ ament-cmake git ];
 
   meta = {

--- a/distros/rolling/mola-sm-loop-closure/default.nix
+++ b/distros/rolling/mola-sm-loop-closure/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, cmake, gtsam, mola-common, mola-georeferencing, mola-gtsam-factors, mola-metric-maps, mola-pose-list, mola-relocalization, mola-test-datasets, mola-yaml, mp2p-icp, mrpt-libgui, mrpt-libmaps, mrpt-libtclap, ros-environment }:
+buildRosPackage {
+  pname = "ros-rolling-mola-sm-loop-closure";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_sm_loop_closure-release/archive/release/rolling/mola_sm_loop_closure/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "585b505f3fac990a77496efe479eb2b66b9c42197c8cbc528a18e59b5938f372";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-gtest cmake ros-environment ];
+  checkInputs = [ ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto mola-metric-maps mola-test-datasets ];
+  propagatedBuildInputs = [ gtsam mola-common mola-georeferencing mola-gtsam-factors mola-pose-list mola-relocalization mola-yaml mp2p-icp mrpt-libgui mrpt-libmaps mrpt-libtclap ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
+
+  meta = {
+    description = "Simplemap loop-closure postprocessing library and CLI tool";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/rolling/mrpt-apps/default.nix
+++ b/distros/rolling/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-apps";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_apps/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "65ef7f4d85e67861ef1fec3659bd373da8fb52d6fa3f9006f488b0c30a43a023";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_apps/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "9f4753c87b0c70317139bcc64162fe77c87cfd65b1cf7d240be32e797c99483e";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libapps/default.nix
+++ b/distros/rolling/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libapps";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libapps/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "8c94b617fc2c557c50564bdb04dce947e1878a90c8ee09a5616d2bd90d84247a";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libapps/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "47ba86143117399df76f3a198188427d654d7e0682aedfe11eac5c33dc7ed0cc";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libbase/default.nix
+++ b/distros/rolling/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, onetbb, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib, zstd }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libbase";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libbase/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "ee3646a9b09738b98290f6fe389eab20cb0ce7ad51333f74862e0c0888f117f1";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libbase/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "766aae44d61500e65c885dbef74670c6501c756c439e7ccd8d385d982ce27bad";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libgui/default.nix
+++ b/distros/rolling/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libgui";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libgui/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "a880329c011ea5597e0eb32d023d1daa3da7b5fe1c3e3e86623cf2a17840fce7";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libgui/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "7771b39e2b2edb0c2d72413ad98063adc50ea3aae00e9c4e8e47a5590ef7acce";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libhwdrivers/default.nix
+++ b/distros/rolling/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libhwdrivers";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libhwdrivers/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "93654a41db2ea162f8499c60168cd407e6290ed019c656626440997317fc24f5";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libhwdrivers/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "86ddbe28b309be7dfad4cb4ad896bb2bbed38c8b889ab46d2778b6ca3a540749";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libmaps/default.nix
+++ b/distros/rolling/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libmaps";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmaps/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "69e75af6c53ddff6196b0cd07430dbd345a2edef3f94ff922897faaa0a8ef100";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmaps/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "131df8f9d1878cbed1646f60dfbfcef59ec910f0cd1681e498e94bb1e515813f";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libmath/default.nix
+++ b/distros/rolling/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libmath";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmath/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "0085a73c899f321b5d488e42b5dc3c216221d306c6ca1450f2104b23df1df776";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmath/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "3ee596b699edf373f477b7ee0c8913cbc64d2b91723ffdd71a3288ba341d5fb2";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libnav/default.nix
+++ b/distros/rolling/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libnav";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libnav/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "3d920470dce80a96385971e7e00c3159be33b23e2285e361ae45b60fad25c236";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libnav/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "b203aff0c737e27a94d88cef82eb45278d2ee1d824d0b94d4b525235b9eec41b";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libobs/default.nix
+++ b/distros/rolling/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libobs";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libobs/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "fcb159644152ddba336cb04c876dba466c8e074561d62d32ef50b4b2454f991f";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libobs/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "1bbce4932deceaa46e2a4a095f0df2ab2db38deebbbe92ffee976082a85516f0";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libopengl/default.nix
+++ b/distros/rolling/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libopengl";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libopengl/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "5f776135d5ae1dc17760d44adc4879cd04c0e0bd303abefa57879ccb00ec4d9b";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libopengl/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "28cc54cba2bcefd17ddcd2ce38a1193163b3791705786cad9fe6f911bc0a9e74";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libposes/default.nix
+++ b/distros/rolling/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libposes";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libposes/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "33bca07d6d8d71fac6ebddaf8ca703fe9b505ccf2aec9d7519428b1dbd521202";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libposes/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "d4b8c2b0bde64de18a8fb31be90c91a716e571868115415e94e320b066bd47ad";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libslam/default.nix
+++ b/distros/rolling/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, onetbb, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libslam";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libslam/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "2c850b6541535cd592f03c6206de2ee42798a52f0fc74f1596de5c137aeb4b3f";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libslam/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "490d29b14a7f5b88095113a0ef388576809f83b6352d6b19520b3af80db6d0e9";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libtclap/default.nix
+++ b/distros/rolling/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libtclap";
-  version = "2.15.12-r1";
+  version = "2.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libtclap/2.15.12-1.tar.gz";
-    name = "2.15.12-1.tar.gz";
-    sha256 = "be990daa886b8a9ae8ca6bd79adc5836af609e6eff3cdf7b6c355af9084adf20";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libtclap/2.15.13-1.tar.gz";
+    name = "2.15.13-1.tar.gz";
+    sha256 = "acbc50cdd7090ad8090cf9fe4dd5c5a8f6445f237faac87ace41391d4b807a3d";
   };
 
   buildType = "cmake";

--- a/distros/rolling/nav-msgs/default.nix
+++ b/distros/rolling/nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-nav-msgs";
-  version = "5.9.1-r1";
+  version = "5.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/nav_msgs/5.9.1-1.tar.gz";
-    name = "5.9.1-1.tar.gz";
-    sha256 = "898c1ceb0ad9e11d68119d21515c8fdc57d4d435ea2042532350c148fee35057";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/nav_msgs/5.9.2-1.tar.gz";
+    name = "5.9.2-1.tar.gz";
+    sha256 = "234044ba04bea697c783fa232350b97ea0ff363680ad49c880f6c0227b9c9e86";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ntrip-client-node/default.nix
+++ b/distros/rolling/ntrip-client-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, curl, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ntrip-client-node";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ntrip_client_node/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "b5e535688a2894054a99a9118fa5ceb6f5b0f24dd054605205ecf1239a54b79a";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ntrip_client_node/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "6e3beffe6a97680d7f6f520d63776761f4833a9b39dbfa6d439aff538ae26bf7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -307,20 +307,10 @@ in {
     hash = "sha256-GpzGMpQ02s/X/XEcGoozzMjigrbqvAu81bcb7QG+36E=";
   };
 
-  mcap-vendor = (lib.patchVendorUrl rosSuper.mcap-vendor {
-    url = "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v1.4.0.tar.gz";
-    hash = "sha256-ZP8+URGfN//Pr53uy9mHp8tNTZA110o/03czlaRw/aE=";
-  }).overrideAttrs ( {
-    postPatch ? "", ...
-  }: {
-    # ref. https://github.com/foxglove/mcap/pull/1371
-    postPatch = postPatch + ''
-      substituteInPlace CMakeLists.txt --replace-fail \
-        "URL_HASH SHA1=354d894efb6a0c3968885c0e6d43224ff61fa762 # v1.4.0" \
-        "URL_HASH SHA1=354d894efb6a0c3968885c0e6d43224ff61fa762 # v1.4.0
-        PATCH_COMMAND sed -i \"1i #include <cstdint>\" cpp/mcap/include/mcap/types.hpp"
-    '';
-  });
+  mcap-vendor = lib.patchVendorUrl rosSuper.mcap-vendor {
+    url = "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v2.1.3.tar.gz";
+    hash = "sha256-GBp8UsyYJETN71Mwh7MhU4sCX8xe7CWOBInWi5zlPe0=";
+  };
 
   mimick-vendor = (lib.patchAmentVendorGit rosSuper.mimick-vendor { }).overrideAttrs({ ... }: {
     # Remove once https://github.com/Snaipe/Mimick/commit/321fcc74c1828e73af72cd75460857e1a3a549b9

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -705,7 +705,7 @@ in {
     nativeBuildInputs ? [], postPatch ? "", passthru ? {}, ...
   }: let
     outputHashes = {
-      "zenoh-1.6.2" = "sha256-uHm75MxW7ifmYOB3EPVjsPDWKYmk9nk9BLAOt7tvDzo=";
+      "zenoh-1.8.0" = "sha256-W0mVplCanR1zAoG/rExjD0h01altk0gC9wWeu3DNOqI=";
     };
     zenoh-c-source = finalAttrs.passthru.amentVendorSrcs.zenoh_c_vendor;
   in {

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -486,50 +486,6 @@ in {
     ];
   });
 
-  rmw-cyclonedds-cpp = rosSuper.rmw-cyclonedds-cpp.overrideAttrs ({
-    patches ? [], ...
-  }: {
-    patches = patches ++ [
-      # We need the patch from #575, but for it to apply cleanly, we need also the preceding commits.
-      (self.fetchpatch2 {
-        url = "https://github.com/ros2/rmw_cyclonedds/commit/b4963be0c79f5d78ed475cc63ba4215587a85068.patch";
-        hash = "sha256-GHgnjBF7w7/sx8PWCpRkTYFKCeIJ1BqpvHFPtgv0M40=";
-        stripLen = 1;
-      })
-      (self.fetchpatch2 {
-        url = "https://github.com/ros2/rmw_cyclonedds/commit/5147e01a012103d9cd650faa83ca18257136a362.patch";
-        hash = "sha256-JxFECv9jTFLAGYe6gSpdRDXqOBw4WMn410f2NyDAuo8=";
-        stripLen = 1;
-      })
-      (self.fetchpatch2 {
-        url = "https://github.com/ros2/rmw_cyclonedds/commit/fd48d5854a2b6f9278258121334d9fb97c454e34.patch";
-        hash = "sha256-X21nN2hKl+wqeMkNLYg4FXrQ98plGCfJudXov8ls0P8=";
-        stripLen = 1;
-      })
-      (self.fetchpatch2 {
-        url = "https://github.com/ros2/rmw_cyclonedds/commit/e7f44399fbadb474f0136370c232ed7eaf5be581.patch";
-        hash = "sha256-CzN8UuaX3l58sGVTD7qlZEkLvyqREVmq6fm9uR6dJQE=";
-        stripLen = 1;
-      })
-      (self.fetchpatch2 {
-        url = "https://github.com/ros2/rmw_cyclonedds/commit/1cf18c066e5c9cc6c4069b68c4b242155d606d2f.patch";
-        hash = "sha256-g2R8/CYnDcTqQt3UwQ6V4M54JcMUjCgTDyMgvytWIng=";
-        stripLen = 1;
-      })
-      (self.fetchpatch2 {
-        url = "https://github.com/ros2/rmw_cyclonedds/commit/ceb2eca8edead7d98d30bcbab80099a92a4c5015.patch";
-        hash = "sha256-yQg21wgYW3HsLb3L4fRDJxcG97BYWquYSVouDXPS3vg=";
-        stripLen = 1;
-      })
-      # Key support (#575)
-      (self.fetchpatch2 {
-        url = "https://github.com/ros2/rmw_cyclonedds/commit/92f6d89676326e14e4fdd89bee047cdd8c0fbbd5.patch";
-        hash = "sha256-dbWT7NVL7JXAJGWS7nBof6at7KXBOQgFbonMLy/UmH8=";
-        stripLen = 1;
-      })
-    ];
-  });
-
   # rqt is broken in rolling due to unfinished qt6 migration.
   # TODO: Remove this once rqt works in rolling.
   ros-gz-sim-demos = rosSuper.ros-gz-sim-demos.override {

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -625,12 +625,6 @@ in {
         url = "https://github.com/ros/urdfdom/commit/229c3ae867ba770dcade50b3ee520d81ff3b0413.patch";
         hash = "sha256-cfPnSux7qmTDngzwPYIayYIvddhOXfmSsvgKwltFT5Q=";
       })
-      # removed urdf_world/types.h deprecation (#251)
-      # This fixes build failure in gz-dartsim-vendor
-      (self.fetchpatch2 {
-        url = "https://github.com/ros/urdfdom/commit/3cd0cc726f8cb42e890974b1d6f5602a87ac3ee4.patch";
-        hash = "sha256-sCRShtKm4XHkrC2CeLoZiINoqjpUdVyGus/dYkJU5tI=";
-      })
     ];
   });
 
@@ -643,12 +637,6 @@ in {
       (self.fetchpatch {
         url = "https://github.com/ros/urdfdom_headers/commit/90efa6072dc239f78d37288a49f24d8aee1aaad2.patch";
         hash = "sha256-3q3K+fiINvS9eUrkHS3cgnn8GuA0Nz+FvVBMpsRAcFM=";
-      })
-      # Cleanup declaration of ModelInterface's SharedPtrs (#99)
-      # This fixes build failure in ros-rolling-sdformat-urdf-2.1.0-r1
-      (self.fetchpatch2 {
-        url = "https://github.com/ros/urdfdom_headers/commit/f5b665d218addb536458ff69a6adf6a4e7b716eb.patch";
-        hash = "sha256-r73yJtAP1Su/MQbu+kJX8T5GV1WO5wzSRb/V9R8Blu0=";
       })
     ];
   });

--- a/distros/rolling/pendulum-control/default.nix
+++ b/distros/rolling/pendulum-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pendulum-msgs, rclcpp, rmw-implementation-cmake, ros2run, rttest, tlsf-cpp }:
 buildRosPackage {
   pname = "ros-rolling-pendulum-control";
-  version = "0.37.7-r1";
+  version = "0.37.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_control/0.37.7-1.tar.gz";
-    name = "0.37.7-1.tar.gz";
-    sha256 = "7e29a180b41555f926be50f5a00936b9989709809e573b6eae5f3d435734d00b";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_control/0.37.8-1.tar.gz";
+    name = "0.37.8-1.tar.gz";
+    sha256 = "a44458b326cd6ab0d519c66271369977f391531bbf7b4d58f4d50fc34bcdb83c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pendulum-msgs/default.nix
+++ b/distros/rolling/pendulum-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-pendulum-msgs";
-  version = "0.37.7-r1";
+  version = "0.37.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_msgs/0.37.7-1.tar.gz";
-    name = "0.37.7-1.tar.gz";
-    sha256 = "29db33eabd9aae6e89a66c9073c40f9bc676c67a260b4105cfe0ae46ba917aa6";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_msgs/0.37.8-1.tar.gz";
+    name = "0.37.8-1.tar.gz";
+    sha256 = "a3480d8082756c19d4adb8c3acee0613376cbfbc6b5a86b0755e8dac8559cfcd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/quality-of-service-demo-cpp/default.nix
+++ b/distros/rolling/quality-of-service-demo-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, rclcpp, rclcpp-components, rcutils, rmw, rmw-implementation-cmake, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-quality-of-service-demo-cpp";
-  version = "0.37.7-r1";
+  version = "0.37.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_cpp/0.37.7-1.tar.gz";
-    name = "0.37.7-1.tar.gz";
-    sha256 = "1da9d0fe238cf63e2985f8ff60ceddb7c30e73fb33f0af3ee5d8b024cd75bf0a";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_cpp/0.37.8-1.tar.gz";
+    name = "0.37.8-1.tar.gz";
+    sha256 = "083ab4e7b63cdc3913ba107be63ad680a6284ebb9aa17a93622873013746e63d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/quality-of-service-demo-py/default.nix
+++ b/distros/rolling/quality-of-service-demo-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, example-interfaces, python3Packages, rclpy, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-quality-of-service-demo-py";
-  version = "0.37.7-r1";
+  version = "0.37.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_py/0.37.7-1.tar.gz";
-    name = "0.37.7-1.tar.gz";
-    sha256 = "278dc3956b63f47570bd7560cef36a2c94b82ad2ab6675938cacfeb54a66dec7";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_py/0.37.8-1.tar.gz";
+    name = "0.37.8-1.tar.gz";
+    sha256 = "e320c5cbd3e4e6d8cdc1b98bc37a9ca069739485ca1f0a7a6f9c14374eac07a3";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rcl-action/default.nix
+++ b/distros/rolling/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rcl-action";
-  version = "10.4.2-r1";
+  version = "10.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/10.4.2-1.tar.gz";
-    name = "10.4.2-1.tar.gz";
-    sha256 = "d3396b3063afb603631a2e6a0e20357a0842e954e4b9fb47d879d4fd8b8b6486";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/10.4.3-1.tar.gz";
+    name = "10.4.3-1.tar.gz";
+    sha256 = "b6a03cbeaa99c7c46dbb78f83c91623f8521df99baa7f9a3b9083e729c1e5023";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-interfaces/default.nix
+++ b/distros/rolling/rcl-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rcl-interfaces";
-  version = "2.4.3-r1";
+  version = "2.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/rcl_interfaces/2.4.3-1.tar.gz";
-    name = "2.4.3-1.tar.gz";
-    sha256 = "9218c0af9ff357c122de705bc89052b4d50deac780b016d042fbb673c5f51986";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/rcl_interfaces/2.4.4-1.tar.gz";
+    name = "2.4.4-1.tar.gz";
+    sha256 = "3974db134ada30d4a70785f4994cc2002074b60cd4625bf920cce00d4785d740";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-lifecycle/default.nix
+++ b/distros/rolling/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rcl-lifecycle";
-  version = "10.4.2-r1";
+  version = "10.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/10.4.2-1.tar.gz";
-    name = "10.4.2-1.tar.gz";
-    sha256 = "fcd7f591330ee79f9dba1fe31db7656ad276303334268c15c1def4a0b72bff19";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/10.4.3-1.tar.gz";
+    name = "10.4.3-1.tar.gz";
+    sha256 = "7d0db83cd7066e32f5f59362d04e547ebbbb58953f25708a35184442e833b4e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-yaml-param-parser/default.nix
+++ b/distros/rolling/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-rolling-rcl-yaml-param-parser";
-  version = "10.4.2-r1";
+  version = "10.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/10.4.2-1.tar.gz";
-    name = "10.4.2-1.tar.gz";
-    sha256 = "8efba6730f436c298814bb80724a52ecd28cb99e16a8d9c029ba4acf0da51106";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/10.4.3-1.tar.gz";
+    name = "10.4.3-1.tar.gz";
+    sha256 = "6bb3facff829cb311f763d4fcfc20df470ce4b0c1f0a4fe8a43817244adde9d0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl/default.nix
+++ b/distros/rolling/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-implementation, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, rosidl-runtime-cpp, service-msgs, test-msgs, tracetools, type-description-interfaces }:
 buildRosPackage {
   pname = "ros-rolling-rcl";
-  version = "10.4.2-r1";
+  version = "10.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/10.4.2-1.tar.gz";
-    name = "10.4.2-1.tar.gz";
-    sha256 = "654a7681219f4f65ab89b49b5002e44066840b026eec7f65ff302ad2cd177691";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/10.4.3-1.tar.gz";
+    name = "10.4.3-1.tar.gz";
+    sha256 = "fadef552b7d238c629cd410b9ad2940be120542728c1190d4585f623725ce1c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-action/default.nix
+++ b/distros/rolling/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-action";
-  version = "31.0.2-r1";
+  version = "31.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/31.0.2-1.tar.gz";
-    name = "31.0.2-1.tar.gz";
-    sha256 = "bd0236fb160e61f978305a179e6120e96c552cb763d6767e9beef6aa97e99307";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/31.0.3-1.tar.gz";
+    name = "31.0.3-1.tar.gz";
+    sha256 = "451fdb5ce77144dbcdd1aaee832acb28114b46f3c4f8adb4abfa024065223423";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-components/default.nix
+++ b/distros/rolling/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, rcl-interfaces, rclcpp, rcpputils, rmw }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-components";
-  version = "31.0.2-r1";
+  version = "31.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/31.0.2-1.tar.gz";
-    name = "31.0.2-1.tar.gz";
-    sha256 = "9c86f44cb77a3f7ff694552f90f59f9c6927fd2a8a43b91b5efe0f6032be7c7c";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/31.0.3-1.tar.gz";
+    name = "31.0.3-1.tar.gz";
+    sha256 = "7691370c6695ae64d6d44df231920f6512d62e001026743cf70b0c4ccc34c5e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-lifecycle/default.nix
+++ b/distros/rolling/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-lifecycle";
-  version = "31.0.2-r1";
+  version = "31.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/31.0.2-1.tar.gz";
-    name = "31.0.2-1.tar.gz";
-    sha256 = "4ba00c6446f46aaa8efff4a9de94b10064dc154e6a08328a2aa1212b669a8611";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/31.0.3-1.tar.gz";
+    name = "31.0.3-1.tar.gz";
+    sha256 = "fcd63147c4ccdfe2761a7b3cb23b616497f1e7b7df2a0713a92a7b190ee4e2b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp/default.nix
+++ b/distros/rolling/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, python3Packages, rcl, rcl-interfaces, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp";
-  version = "31.0.2-r1";
+  version = "31.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/31.0.2-1.tar.gz";
-    name = "31.0.2-1.tar.gz";
-    sha256 = "cd7ee2ff2b7a9ad56df8a293b6d43560b45fd198b7b87efb8b8975b780eb5ab6";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/31.0.3-1.tar.gz";
+    name = "31.0.3-1.tar.gz";
+    sha256 = "e2c30dad8f503861feaf049b04a8ab414f3fa2ba3265631a49231c9c50fc89c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclpy/default.nix
+++ b/distros/rolling/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, lifecycle-msgs, python3, python3Packages, rcl, rcl-action, rcl-interfaces, rcl-lifecycle, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rosidl-pycommon, rosidl-runtime-c, rpyutils, service-msgs, test-msgs, type-description-interfaces, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclpy";
-  version = "10.0.8-r1";
+  version = "10.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/rolling/rclpy/10.0.8-1.tar.gz";
-    name = "10.0.8-1.tar.gz";
-    sha256 = "4cde4add4b3004178d245c10f3adb83edb4212eb6d5db0512438308e63ced084";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/rolling/rclpy/10.0.9-1.tar.gz";
+    name = "10.0.9-1.tar.gz";
+    sha256 = "97115793f1ecc8b0cf8824c7a2e64d2339e438a3b0a02c4572cb1b96deb17f90";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcutils/default.nix
+++ b/distros/rolling/rcutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros-core, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture }:
 buildRosPackage {
   pname = "ros-rolling-rcutils";
-  version = "7.0.8-r1";
+  version = "7.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/rolling/rcutils/7.0.8-1.tar.gz";
-    name = "7.0.8-1.tar.gz";
-    sha256 = "347ae62911c07a69064294e2736ea99d119823d3551ba72a95fdd23d5e22bac8";
+    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/rolling/rcutils/7.0.9-1.tar.gz";
+    name = "7.0.9-1.tar.gz";
+    sha256 = "7979e4d733a85c3c47d45292e2b545f7fb639f157c4ce088a5a4ea151d790627";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/resource-retriever-interfaces/default.nix
+++ b/distros/rolling/resource-retriever-interfaces/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-rolling-resource-retriever-interfaces";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/resource_retriever_service-release/archive/release/rolling/resource_retriever_interfaces/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "077542af35fc969a1e7c42878c02e724493806aa2b0375e1955da52feb56d1eb";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "ROS interfaces for working with resources like meshes.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/resource-retriever-service-plugin/default.nix
+++ b/distros/rolling/resource-retriever-service-plugin/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, resource-retriever, resource-retriever-interfaces }:
+buildRosPackage {
+  pname = "ros-rolling-resource-retriever-service-plugin";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/resource_retriever_service-release/archive/release/rolling/resource_retriever_service_plugin/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "8fbc43f04dd1c6e035deea2be3715b702a0fe561c9f2f8875076012aecb01ba0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp resource-retriever resource-retriever-interfaces ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = "A resource retriever plugin that relies on talking to a service (specified by resource_retriever_interfaces) for retrieving resources like meshes.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/resource-retriever-service/default.nix
+++ b/distros/rolling/resource-retriever-service/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, resource-retriever-interfaces }:
+buildRosPackage {
+  pname = "ros-rolling-resource-retriever-service";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/resource_retriever_service-release/archive/release/rolling/resource_retriever_service/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "824ecbb33cdc6ad27e501252ea96475e52f850df6af58325044d31557ffff2af";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp resource-retriever-interfaces ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = "An in memory implementation of the resource_retriever_interfaces service.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/rmw-cyclonedds-cpp/default.nix
+++ b/distros/rolling/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros-core, ament-lint-auto, ament-lint-common, cyclonedds, iceoryx-binding-c, rcpputils, rcutils, rmw, rmw-dds-common, rmw-security-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-cyclonedds-cpp";
-  version = "4.1.3-r1";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/rolling/rmw_cyclonedds_cpp/4.1.3-1.tar.gz";
-    name = "4.1.3-1.tar.gz";
-    sha256 = "8404452dbc0144aa8e5661b286df689f3bd1d8bfaa121e5bfff747d2521b0b8d";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/rolling/rmw_cyclonedds_cpp/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "e9042dfa7e445c8cfe039eff314ddf6950ed8dfa37150a6c3b6596e0dba60296";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros-core, ament-lint-auto, ament-lint-common, fastcdr, fastdds, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-buffer-backend-registry, rosidl-dynamic-typesupport, rosidl-dynamic-typesupport-fastrtps, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-cpp";
-  version = "9.4.6-r3";
+  version = "9.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_cpp/9.4.6-3.tar.gz";
-    name = "9.4.6-3.tar.gz";
-    sha256 = "4b4cc135716fea6dca02912c69b76c4509f28d8c544abe755be7812584d4b633";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_cpp/9.4.7-1.tar.gz";
+    name = "9.4.7-1.tar.gz";
+    sha256 = "01603e5cab0c29f27d062ae0288b76caa2c9abb520a3f2adce3b6aceb4c18d43";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros-core, ament-lint-auto, ament-lint-common, fastcdr, fastdds, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-buffer, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-dynamic-cpp";
-  version = "9.4.6-r3";
+  version = "9.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_dynamic_cpp/9.4.6-3.tar.gz";
-    name = "9.4.6-3.tar.gz";
-    sha256 = "ae11f23e5b11a63a415db79ba04a0c00034dad9ec6917a96d108bf77c4eada1d";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_dynamic_cpp/9.4.7-1.tar.gz";
+    name = "9.4.7-1.tar.gz";
+    sha256 = "bdd9fd36c5a2096b93b61847b90969a6a67f79e987f836f19bed2c30b96ac9db";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros-core, ament-lint-auto, ament-lint-common, fastcdr, fastdds, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-security-common, rosidl-buffer-backend-registry, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-shared-cpp";
-  version = "9.4.6-r3";
+  version = "9.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_shared_cpp/9.4.6-3.tar.gz";
-    name = "9.4.6-3.tar.gz";
-    sha256 = "76e8415650868a0c7571c2f3cb87919ac59834cb5bb95c4e747e23cc976ab3cf";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_shared_cpp/9.4.7-1.tar.gz";
+    name = "9.4.7-1.tar.gz";
+    sha256 = "e570495be9497a714c73dce0ce149946e33ccce4b5f877223eed42a4568008df";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-zenoh-cpp/default.nix
+++ b/distros/rolling/rmw-zenoh-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, fastcdr, nlohmann_json, rcpputils, rcutils, rmw, rmw-test-fixture, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, tracetools, zenoh-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rmw-zenoh-cpp";
-  version = "0.10.2-r1";
+  version = "0.10.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/rolling/rmw_zenoh_cpp/0.10.2-1.tar.gz";
-    name = "0.10.2-1.tar.gz";
-    sha256 = "2bd1957a4ab11c8b8af4b5b6e900c0f70ce6266c2336c8cb3725ec136086745c";
+    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/rolling/rmw_zenoh_cpp/0.10.3-1.tar.gz";
+    name = "0.10.3-1.tar.gz";
+    sha256 = "394859837b5a4bffed9501a912d7a4e66bcf46ed5a4045e9b30a38a2c9f58912";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2action/default.nix
+++ b/distros/rolling/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2action";
-  version = "0.40.5-r1";
+  version = "0.40.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2action/0.40.5-1.tar.gz";
-    name = "0.40.5-1.tar.gz";
-    sha256 = "69b57449072f5258557d28848e2627a1aef33d8405819b7635f6b5d48448a5b0";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2action/0.40.6-1.tar.gz";
+    name = "0.40.6-1.tar.gz";
+    sha256 = "00ecb2c05f415fc81f2cd5df852bff921c29c450514dff4ea953f2b706ca0306";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2bag/default.nix
+++ b/distros/rolling/ros2bag/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosbag2-py, rosbag2-storage-default-plugins, rosbag2-test-common }:
 buildRosPackage {
   pname = "ros-rolling-ros2bag";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/ros2bag/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "8c3bd01e2a53c5f61014b6e69a5d5c909ff573ba489ac40202e9135d014400f4";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/ros2bag/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "6c671c36265c57db8d760efe2a4f2229180310ca025494f5a96198c809ea0bfe";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint launch-testing launch-testing-ros python3Packages.pytest rosbag2-storage-default-plugins rosbag2-test-common ];
-  propagatedBuildInputs = [ ament-index-python python3Packages.pyyaml rclpy ros2cli rosbag2-py ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint launch-testing launch-testing-ros python3Packages.pytest python3Packages.pytest-timeout rosbag2-storage-default-plugins rosbag2-test-common ];
+  propagatedBuildInputs = [ ament-index-python python3Packages.pyyaml rclpy ros2cli rosbag2-py rosbag2-storage-default-plugins ];
 
   meta = {
     description = "Entry point for rosbag in ROS 2";

--- a/distros/rolling/ros2cli-test-interfaces/default.nix
+++ b/distros/rolling/ros2cli-test-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-ros2cli-test-interfaces";
-  version = "0.40.5-r1";
+  version = "0.40.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli_test_interfaces/0.40.5-1.tar.gz";
-    name = "0.40.5-1.tar.gz";
-    sha256 = "2f493b3e152162d6f19298133991a3766c96aa9eb9f5f7f42ee343c3c2b5f736";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli_test_interfaces/0.40.6-1.tar.gz";
+    name = "0.40.6-1.tar.gz";
+    sha256 = "2c97307d1ef8bd84c0652859aaf9b3e242683cd6f69ea079cde0dea2fea70004";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2cli/default.nix
+++ b/distros/rolling/ros2cli/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, fzf, python3Packages, rclpy, test-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, fzf, python3Packages, rclpy, rmw-test-fixture-implementation, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2cli";
-  version = "0.40.5-r1";
+  version = "0.40.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli/0.40.5-1.tar.gz";
-    name = "0.40.5-1.tar.gz";
-    sha256 = "b3e96c4d915b027757775dd0be29e7d6bb24ab445d5a234bea6f607a6ec6c9e2";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli/0.40.6-1.tar.gz";
+    name = "0.40.6-1.tar.gz";
+    sha256 = "f2ce2b8ae287de07d3da99507d871987a679e47bd62d40f1e3bdd365ae602829";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest python3Packages.pytest-timeout test-msgs ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest python3Packages.pytest-timeout rmw-test-fixture-implementation test-msgs ];
   propagatedBuildInputs = [ fzf python3Packages.argcomplete python3Packages.packaging python3Packages.psutil rclpy ];
 
   meta = {

--- a/distros/rolling/ros2component/default.nix
+++ b/distros/rolling/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, python3Packages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-rolling-ros2component";
-  version = "0.40.5-r1";
+  version = "0.40.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2component/0.40.5-1.tar.gz";
-    name = "0.40.5-1.tar.gz";
-    sha256 = "42ab79011368a5f101fdaba37b9205950f81aa154e4f1d81744d6d74b9f1a391";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2component/0.40.6-1.tar.gz";
+    name = "0.40.6-1.tar.gz";
+    sha256 = "1657df40bd7a8305a93bb3d2422661ecc9e01c8e25f2cfcbe431294a7fa4fad4";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2doctor/default.nix
+++ b/distros/rolling/ros2doctor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros-environment, ros2action, ros2cli, std-msgs, std-srvs, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2doctor";
-  version = "0.40.5-r1";
+  version = "0.40.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2doctor/0.40.5-1.tar.gz";
-    name = "0.40.5-1.tar.gz";
-    sha256 = "3583b076b03e7b619426ca27089f185bd898f15258101b5b62961c53943d2694";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2doctor/0.40.6-1.tar.gz";
+    name = "0.40.6-1.tar.gz";
+    sha256 = "65a7df675b114df935b81b9ee55e8b76be1ca232696c49675ca31fe33deefd5f";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2interface/default.nix
+++ b/distros/rolling/ros2interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, ros2cli, ros2cli-test-interfaces, rosidl-adapter, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2interface";
-  version = "0.40.5-r1";
+  version = "0.40.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2interface/0.40.5-1.tar.gz";
-    name = "0.40.5-1.tar.gz";
-    sha256 = "7d4620743db37100ad704a4bea224ff6e2e398d87e263f6f879506223a269645";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2interface/0.40.6-1.tar.gz";
+    name = "0.40.6-1.tar.gz";
+    sha256 = "aa1038d704955459618fd7a3797f525b2b249813a59832881cbd9e51010ff97d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2lifecycle-test-fixtures/default.nix
+++ b/distros/rolling/ros2lifecycle-test-fixtures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-rolling-ros2lifecycle-test-fixtures";
-  version = "0.40.5-r1";
+  version = "0.40.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle_test_fixtures/0.40.5-1.tar.gz";
-    name = "0.40.5-1.tar.gz";
-    sha256 = "581a721a21a9270c043b93fa2e2e32c226f2657e0857612c405faeeedc57260f";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle_test_fixtures/0.40.6-1.tar.gz";
+    name = "0.40.6-1.tar.gz";
+    sha256 = "8041e35bbd78667c3087454039e1127649166193163c00ab55e52791ac8bb497";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2lifecycle/default.nix
+++ b/distros/rolling/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, lifecycle-msgs, python3Packages, rclpy, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-rolling-ros2lifecycle";
-  version = "0.40.5-r1";
+  version = "0.40.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle/0.40.5-1.tar.gz";
-    name = "0.40.5-1.tar.gz";
-    sha256 = "0922304ecc4c8455d45c1090fb2bd1e1a11e6adabad6d86fc78bd6bd1237f909";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle/0.40.6-1.tar.gz";
+    name = "0.40.6-1.tar.gz";
+    sha256 = "f154489aa94ebf501756d7ce0876ecddd1220de792d51e88cf827f38746f3ba0";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2multicast/default.nix
+++ b/distros/rolling/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, ros2cli }:
 buildRosPackage {
   pname = "ros-rolling-ros2multicast";
-  version = "0.40.5-r1";
+  version = "0.40.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2multicast/0.40.5-1.tar.gz";
-    name = "0.40.5-1.tar.gz";
-    sha256 = "e96bce1a07c2a2efe43d0ea2eedb74a439bb2d050121034a4efa9038c3a12ad0";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2multicast/0.40.6-1.tar.gz";
+    name = "0.40.6-1.tar.gz";
+    sha256 = "6c016d1476384b77115275c8130080c2dd3bb4b59fc0c5677181cbdfa6cca3ce";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2node/default.nix
+++ b/distros/rolling/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2node";
-  version = "0.40.5-r1";
+  version = "0.40.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2node/0.40.5-1.tar.gz";
-    name = "0.40.5-1.tar.gz";
-    sha256 = "28381247986317543f13c4b0250db428d9f26e8de85922180a9baa8b408f7be7";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2node/0.40.6-1.tar.gz";
+    name = "0.40.6-1.tar.gz";
+    sha256 = "583316a19ace8216ace5a18d86a359d40964ed7dd6791368cee4f55c62c62bd7";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2param/default.nix
+++ b/distros/rolling/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-rolling-ros2param";
-  version = "0.40.5-r1";
+  version = "0.40.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2param/0.40.5-1.tar.gz";
-    name = "0.40.5-1.tar.gz";
-    sha256 = "d2061ad3ed49ed2429527fdc40214a013579967d445e797997b97ae5cd14b47c";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2param/0.40.6-1.tar.gz";
+    name = "0.40.6-1.tar.gz";
+    sha256 = "d13746c7ed97035a29320d10024cf587e3f5c9c677a6e2d81611c7f6300ac10b";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2pkg/default.nix
+++ b/distros/rolling/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, ros2cli }:
 buildRosPackage {
   pname = "ros-rolling-ros2pkg";
-  version = "0.40.5-r1";
+  version = "0.40.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2pkg/0.40.5-1.tar.gz";
-    name = "0.40.5-1.tar.gz";
-    sha256 = "396710c9f4d06efb4af56dec8a12ca71e4ff492387e59d8149d67adb8a6a7eff";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2pkg/0.40.6-1.tar.gz";
+    name = "0.40.6-1.tar.gz";
+    sha256 = "157e81515fc53079050ad0767eb4fb268b26537f62259092e1efbb05acd40ed3";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2run/default.nix
+++ b/distros/rolling/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-rolling-ros2run";
-  version = "0.40.5-r1";
+  version = "0.40.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2run/0.40.5-1.tar.gz";
-    name = "0.40.5-1.tar.gz";
-    sha256 = "5521f8353687c1bcea31fce580bd3abe6361cbc11ce1c5b721732d1bc27fc9d4";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2run/0.40.6-1.tar.gz";
+    name = "0.40.6-1.tar.gz";
+    sha256 = "f5908bc3fc5d020af6fc6dda71f616a2104ba6242acd8b74df0257b38ec5cc84";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2service/default.nix
+++ b/distros/rolling/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2service";
-  version = "0.40.5-r1";
+  version = "0.40.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2service/0.40.5-1.tar.gz";
-    name = "0.40.5-1.tar.gz";
-    sha256 = "55e2fdc4d3c111d00b13b433c4734afc4445298fd5b9e5bce233ad05b7843386";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2service/0.40.6-1.tar.gz";
+    name = "0.40.6-1.tar.gz";
+    sha256 = "6c0d5cd734a0a696613fc9ee7fd67e32ad69d1962edda9c93ad2ce1c1d5b19f0";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2topic/default.nix
+++ b/distros/rolling/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosgraph-msgs, rosidl-runtime-py, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2topic";
-  version = "0.40.5-r1";
+  version = "0.40.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2topic/0.40.5-1.tar.gz";
-    name = "0.40.5-1.tar.gz";
-    sha256 = "73a5c6ce6ef984b30370013954e90df7b503af0d1cb0cf74b814feee448cef58";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2topic/0.40.6-1.tar.gz";
+    name = "0.40.6-1.tar.gz";
+    sha256 = "7338fbe23338d6ba424f7e60895a9cac6c9ea30b83e351dbd98489eb2c94750d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosbag2-compression-zstd/default.nix
+++ b/distros/rolling/rosbag2-compression-zstd/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcutils, rosbag2-compression, rosbag2-test-common, zstd-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcutils, rosbag2-compression, rosbag2-test-common, zstd-cmake-module }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-compression-zstd";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression_zstd/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "6e30e98490d351382a064595eb4368246fa93bff51ba6e25b0c59fec8ff6ce6d";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression_zstd/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "e4e4f6b847d0d7dfa69c9f4bef099995ac0c8ec9d6fd9d52023e97809b087a3a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common rclcpp rosbag2-test-common ];
-  propagatedBuildInputs = [ pluginlib rcutils rosbag2-compression zstd-vendor ];
+  propagatedBuildInputs = [ pluginlib rcutils rosbag2-compression zstd-cmake-module ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/rosbag2-compression/default.nix
+++ b/distros/rolling/rosbag2-compression/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-compression";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "a6c50b29daa2e239d248420df7d486887851a136ffd8beb8490e6807881edeec";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "e765631f82bc22561f49ba5103b8c8d7c26610a0d567cdd19d5ecdfad63472eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-cpp/default.nix
+++ b/distros/rolling/rosbag2-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-test-msgdefs, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-cpp";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_cpp/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "5b393e69d9a76c5224908949aea9d68a5c38b706d715d35226db83c53d2b92c4";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_cpp/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "ec24c3b0bad4ee2bfa0b274762bf3f2e9e52971ce515e4318d9ba817a8e02f99";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-examples-cpp/default.nix
+++ b/distros/rolling/rosbag2-examples-cpp/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rosbag2-cpp, rosbag2-transport }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rosbag2-compression, rosbag2-cpp, rosbag2-transport }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-examples-cpp";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_cpp/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "902778d7b287eccc4ded4c04f472eb3df99c5561784d12c9060b2fa09aae40a1";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_cpp/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "e3710e7b159db645a591fd25c8a33ff03598c19be29b91f538baea7915876341";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ example-interfaces rclcpp rosbag2-cpp rosbag2-transport ];
+  propagatedBuildInputs = [ example-interfaces rclcpp rosbag2-compression rosbag2-cpp rosbag2-transport ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/rosbag2-examples-py/default.nix
+++ b/distros/rolling/rosbag2-examples-py/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, example-interfaces, python3Packages, rclpy, rosbag2-py, rosidl-runtime-py, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, example-interfaces, python3Packages, rclpy, rosbag2-compression, rosbag2-py, rosidl-runtime-py, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-examples-py";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_py/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "b764b80d80804c60b4bfdbc56991c0154295f7b2a37983a67edb8de99565c9ce";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_py/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "741ba685199b50671ddb4ef930e75b79c4b781396be581777c6096b60b19dd76";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest ];
-  propagatedBuildInputs = [ example-interfaces rclpy rosbag2-py rosidl-runtime-py std-msgs ];
+  propagatedBuildInputs = [ example-interfaces rclpy rosbag2-compression rosbag2-py rosidl-runtime-py std-msgs ];
 
   meta = {
     description = "Python bag writing tutorial";

--- a/distros/rolling/rosbag2-interfaces/default.nix
+++ b/distros/rolling/rosbag2-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-interfaces";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_interfaces/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "c82bd0d39f7d08c474f71570fd315350601f83d286a9bf29090589063f2c47ad";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_interfaces/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "5eec42d623e18661fe7b159e4a876fb0b7139affdb5787883e074bfe052459b9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-performance-benchmarking-msgs/default.nix
+++ b/distros/rolling/rosbag2-performance-benchmarking-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, rosidl-typesupport-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-performance-benchmarking-msgs";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking_msgs/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "8ce0ab6e70b10cdfff7538495f1ae2e2c2b24285cb6d938a4121ce6058808da5";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking_msgs/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "67c4c393e05a6f1abd4a2210ab08308f9e6ef85c321f80d9bad72dec2342c3ce";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-performance-benchmarking/default.nix
+++ b/distros/rolling/rosbag2-performance-benchmarking/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, launch, launch-ros, python3Packages, rclcpp, rmw, ros-testing, ros2bag, ros2launch, rosbag2-compression, rosbag2-cpp, rosbag2-performance-benchmarking-msgs, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, sensor-msgs, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, launch, launch-ros, python3Packages, rclcpp, rmw, ros-testing, ros2bag, ros2launch, rosbag2-compression, rosbag2-cpp, rosbag2-performance-benchmarking-msgs, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-performance-benchmarking";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "c5ab9492de90282b259c4b63fb3d83b20fd5d3d20a995eaf917044d5b9009e94";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "6a407c6ab01dec2804a45995c269fba3ec839d07c9fd956fb42e97c19c2dc569";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common launch-ros ros-testing ros2bag ros2launch rosbag2-storage-default-plugins rosbag2-test-common ];
-  propagatedBuildInputs = [ ament-index-python launch launch-ros python3Packages.psutil rclcpp rmw rosbag2-compression rosbag2-cpp rosbag2-performance-benchmarking-msgs rosbag2-py rosbag2-storage sensor-msgs yaml-cpp-vendor ];
+  propagatedBuildInputs = [ ament-index-python launch launch-ros python3Packages.psutil rclcpp rmw rosbag2-compression rosbag2-cpp rosbag2-performance-benchmarking-msgs rosbag2-py rosbag2-storage sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/rosbag2-py/default.nix
+++ b/distros/rolling/rosbag2-py/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, pybind11-vendor, python3, python3Packages, rcl-interfaces, rclpy, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-test-msgdefs, rosbag2-transport, rosidl-runtime-py, rpyutils, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, python3, python3Packages, rcl-interfaces, rclpy, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-test-msgdefs, rosbag2-transport, rosidl-runtime-py, rpyutils, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-py";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_py/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "63011cd0bf8ebfa549f6aec66809455770302a9aa40050f950b184cd8c0060d2";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_py/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "0d2ad4d4a57d411499af63277f21b4779784ecb75c41c089298305cbf2142a25";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-python ament-cmake-ros python3 ];
+  buildInputs = [ ament-cmake-python ament-cmake-ros python3 python3Packages.pybind11 ];
   checkInputs = [ ament-lint-auto ament-lint-common python3Packages.pytest rcl-interfaces rosbag2-compression-zstd rosbag2-storage-default-plugins rosbag2-test-common rosbag2-test-msgdefs rosidl-runtime-py std-msgs ];
-  propagatedBuildInputs = [ pybind11-vendor rclpy rosbag2-compression rosbag2-cpp rosbag2-storage rosbag2-transport rpyutils ];
+  propagatedBuildInputs = [ rclpy rosbag2-compression rosbag2-cpp rosbag2-storage rosbag2-transport rpyutils ];
   nativeBuildInputs = [ ament-cmake-python ament-cmake-ros ];
 
   meta = {

--- a/distros/rolling/rosbag2-storage-default-plugins/default.nix
+++ b/distros/rolling/rosbag2-storage-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosbag2-storage-mcap, rosbag2-storage-sqlite3 }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage-default-plugins";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_default_plugins/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "84f13f9621ddd687af24376ac91dfd89d5ef60b34f891fd363a66ba64f5f4d05";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_default_plugins/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "dda11dd70a964cacf007641f32e7ec435f0c28566da8092df005249f06ac063e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-storage-mcap/default.nix
+++ b/distros/rolling/rosbag2-storage-mcap/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcutils, rosbag2-storage, rosbag2-test-common, std-msgs, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcutils, rosbag2-storage, rosbag2-test-common, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage-mcap";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_mcap/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "ab03e016d7d70fd8034eb6a3f7945050d237fc02349591b8673efb7343dd6122";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_mcap/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "31d712acfeb9410d32ab816272d6680c33b639ae2cda75a2608352762abe95a4";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-cmake-clang-format ament-cmake-gmock ament-lint-auto ament-lint-common rosbag2-test-common std-msgs ];
-  propagatedBuildInputs = [ ament-index-cpp mcap-vendor pluginlib rcutils rosbag2-storage yaml-cpp-vendor ];
+  propagatedBuildInputs = [ ament-index-cpp mcap-vendor pluginlib rcutils rosbag2-storage ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/rolling/rosbag2-storage-sqlite3/default.nix
+++ b/distros/rolling/rosbag2-storage-sqlite3/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, sqlite3-vendor, std-msgs, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, sqlite, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage-sqlite3";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_sqlite3/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "f5af51c09f65100b3b16a960c4869d00a77815501b20b99e5b4d718b7523315c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_sqlite3/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "1a62fdf14d51ab0a48a09d6d118c96595a726ed47635e046e9035bd840e75a3c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common rosbag2-test-common std-msgs ];
-  propagatedBuildInputs = [ pluginlib rcpputils rcutils rosbag2-storage sqlite3-vendor yaml-cpp-vendor ];
+  propagatedBuildInputs = [ pluginlib rcpputils rcutils rosbag2-storage sqlite yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/rolling/rosbag2-storage/default.nix
+++ b/distros/rolling/rosbag2-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcutils, rmw, rosbag2-test-common, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "17b74092191f04e81eab8691998a4ee12a48bf5a4308f9e2f1b7982789ab30c8";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "98d1aa2a4f248a663c0f0582b675b3b9a688a603611064298382b072181a0652";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-test-common/default.nix
+++ b/distros/rolling/rosbag2-test-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-action, rcpputils, rcutils, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-test-common";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_common/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "4081efd073303c067e54fbd5ea7f233cc5db6ed421201318ebd6e4bbe04b972d";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_common/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "276e47e9e01d84d6c1ba8de960ecc6c6b0c920eebc673466317e3f92d82dada7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-test-msgdefs/default.nix
+++ b/distros/rolling/rosbag2-test-msgdefs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-test-msgdefs";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_msgdefs/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "45d531e501ec301f40567069f7d5218ae7ae98c4b97f1a6029410166d38d4599";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_msgdefs/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "41dfb6dabd02315a8ab3327097939112c6f2ad19c13be9ffa52eade451303277";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-tests/default.nix
+++ b/distros/rolling/rosbag2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-transport, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-tests";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_tests/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "72c3d80d3d460e2746bf84a44737f1e8c5bfc6df3fb6cc01465967d2dbc76ed1";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_tests/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "37cf0bba1fe7dd92077ca89e60803d13bfdf625dbd8016940bcb3004d56c2cf6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-transport/default.nix
+++ b/distros/rolling/rosbag2-transport/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, composition-interfaces, keyboard-handler, rclcpp, rclcpp-action, rclcpp-components, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, test-msgs, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, composition-interfaces, keyboard-handler, rclcpp, rclcpp-action, rclcpp-components, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-transport";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_transport/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "1b0ff6be6d86bede2b2e1a40eb66c80db27afa3627a455061d72aa4242011dbf";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_transport/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "13e83f7758b91158842347b4cc841a43a3dab28bbb297dc86b9c7b5620a56b70";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-cmake-gmock ament-index-cpp ament-lint-auto ament-lint-common composition-interfaces rmw-implementation-cmake rosbag2-compression-zstd rosbag2-storage-default-plugins rosbag2-test-common test-msgs ];
-  propagatedBuildInputs = [ keyboard-handler rclcpp rclcpp-action rclcpp-components rcpputils rcutils rmw rosbag2-compression rosbag2-cpp rosbag2-interfaces rosbag2-storage yaml-cpp-vendor ];
+  propagatedBuildInputs = [ keyboard-handler rclcpp rclcpp-action rclcpp-components rcpputils rcutils rmw rosbag2-compression rosbag2-cpp rosbag2-interfaces rosbag2-storage ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/rolling/rosbag2/default.nix
+++ b/distros/rolling/rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-tests, rosbag2-transport }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "3776f06d6e48a72a200dd31974345eab1efc594e963710f8b0d5380c58a9c77b";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "495b20648503637353fce0f0ad31f18de758927eae6d91c57d48983a67571290";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosgraph-msgs/default.nix
+++ b/distros/rolling/rosgraph-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rosgraph-msgs";
-  version = "2.4.3-r1";
+  version = "2.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/rosgraph_msgs/2.4.3-1.tar.gz";
-    name = "2.4.3-1.tar.gz";
-    sha256 = "5ba0f71e8b5c3ff093a5776930244e4c2ff2b9b5b6c58c073cd74fb985b38719";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/rosgraph_msgs/2.4.4-1.tar.gz";
+    name = "2.4.4-1.tar.gz";
+    sha256 = "c3ba25f9db19daba40aeff71b2ffc0a16d13d41e886ad72421090b906d9a87d8";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-lint-common ];
-  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  propagatedBuildInputs = [ builtin-interfaces rcl-interfaces rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/rolling/rosidl-dynamic-typesupport/default.nix
+++ b/distros/rolling/rosidl-dynamic-typesupport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros-core, rcutils, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-dynamic-typesupport";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_dynamic_typesupport-release/archive/release/rolling/rosidl_dynamic_typesupport/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "5b9cb6365f839325fa66d68035015a355259cc60ee7fb36ad44c233d1553ebea";
+    url = "https://github.com/ros2-gbp/rosidl_dynamic_typesupport-release/archive/release/rolling/rosidl_dynamic_typesupport/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "57cc0204c8cbaf16994cdbe4a468a5123606fda187368b0b10abae1122e1f5ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-py/default.nix
+++ b/distros/rolling/rosidl-generator-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-mypy, ament-cmake-pep257, ament-cmake-pytest, ament-cmake-uncrustify, ament-index-python, ament-lint-auto, ament-lint-common, python3Packages, rmw, rosidl-buffer-py, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-c, rpyutils, test-interface-files }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-py";
-  version = "0.27.1-r1";
+  version = "0.27.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_python-release/archive/release/rolling/rosidl_generator_py/0.27.1-1.tar.gz";
-    name = "0.27.1-1.tar.gz";
-    sha256 = "1a805ab637894fbb4f17df1054b51344c55dff9a15ec69dea5bf70dcf38fa2f2";
+    url = "https://github.com/ros2-gbp/rosidl_python-release/archive/release/rolling/rosidl_generator_py/0.27.2-1.tar.gz";
+    name = "0.27.2-1.tar.gz";
+    sha256 = "7bf6671653afd65eebfe00be1c556b09a586380c1006265a427ee033c247f7e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-fastrtps-c/default.nix
+++ b/distros/rolling/rosidl-typesupport-fastrtps-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros-core, ament-index-python, ament-lint-auto, ament-lint-common, fastcdr, osrf-testing-tools-cpp, performance-test-fixture, python3, rcutils, rmw, rosidl-cli, rosidl-generator-c, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-fastrtps-c";
-  version = "3.9.4-r1";
+  version = "3.9.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/rosidl_typesupport_fastrtps_c/3.9.4-1.tar.gz";
-    name = "3.9.4-1.tar.gz";
-    sha256 = "01f0655ad84b45591670928338434b3b0617bb5a06a31583724397d266c87b28";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/rosidl_typesupport_fastrtps_c/3.9.5-1.tar.gz";
+    name = "3.9.5-1.tar.gz";
+    sha256 = "c443564ab283ac182e692e6ec78e52bf85fcbb44f18232690da28affa861326d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-fastrtps-cpp/default.nix
+++ b/distros/rolling/rosidl-typesupport-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros-core, ament-index-python, ament-lint-auto, ament-lint-common, fastcdr, osrf-testing-tools-cpp, performance-test-fixture, python3, rcutils, rmw, rosidl-buffer-backend, rosidl-cli, rosidl-generator-c, rosidl-generator-cpp, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-fastrtps-cpp";
-  version = "3.9.4-r1";
+  version = "3.9.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/rosidl_typesupport_fastrtps_cpp/3.9.4-1.tar.gz";
-    name = "3.9.4-1.tar.gz";
-    sha256 = "8cab0567257343c57e26d2ae7f587a40402710da466d1abf958a23b6b3ce23fa";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/rosidl_typesupport_fastrtps_cpp/3.9.5-1.tar.gz";
+    name = "3.9.5-1.tar.gz";
+    sha256 = "9e8f51bb3a2b1770e05cbe526dbf0da123f332b58b5ad423634f5c51136a45f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-common/default.nix
+++ b/distros/rolling/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, message-filters, pluginlib, qt6, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml-2, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-common";
-  version = "15.1.19-r1";
+  version = "15.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/15.1.19-1.tar.gz";
-    name = "15.1.19-1.tar.gz";
-    sha256 = "0627ede7cb6d0e6003ff04f792dcf7ceffc320f1a854964b013c904a94e5e69e";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/15.2.0-1.tar.gz";
+    name = "15.2.0-1.tar.gz";
+    sha256 = "883908b6079ea1690941dfe409014f48352f83f499b577a34b842d0f38fcd1aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-default-plugins/default.nix
+++ b/distros/rolling/rviz-default-plugins/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, gz-math-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt6, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-resource-interfaces, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, gz-math-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt6, rclcpp, resource-retriever, resource-retriever-service-plugin, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz-default-plugins";
-  version = "15.1.19-r1";
+  version = "15.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/15.1.19-1.tar.gz";
-    name = "15.1.19-1.tar.gz";
-    sha256 = "ab8d9b232651f91bdc6569de598d863edac48f7dbbec516cab0315229bdc6dd6";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/15.2.0-1.tar.gz";
+    name = "15.2.0-1.tar.gz";
+    sha256 = "8f61fd63db067c78294269299fba378941f2eca46c58490fb08888dd9a743631";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-cmake-lint-cmake ament-index-cpp ament-lint-auto ament-lint-common rviz-rendering-tests rviz-visual-testing-framework ];
-  propagatedBuildInputs = [ geometry-msgs gz-math-vendor image-transport interactive-markers laser-geometry map-msgs nav-msgs pluginlib point-cloud-transport qt6.qtbase rclcpp resource-retriever rviz-common rviz-ogre-vendor rviz-rendering rviz-resource-interfaces tf2 tf2-geometry-msgs tf2-ros urdf visualization-msgs ];
+  propagatedBuildInputs = [ geometry-msgs gz-math-vendor image-transport interactive-markers laser-geometry map-msgs nav-msgs pluginlib point-cloud-transport qt6.qtbase rclcpp resource-retriever resource-retriever-service-plugin rviz-common rviz-ogre-vendor rviz-rendering tf2 tf2-geometry-msgs tf2-ros urdf visualization-msgs ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/rolling/rviz-ogre-vendor/default.nix
+++ b/distros/rolling/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, glew, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-rolling-rviz-ogre-vendor";
-  version = "15.1.19-r1";
+  version = "15.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/15.1.19-1.tar.gz";
-    name = "15.1.19-1.tar.gz";
-    sha256 = "faccf8c232f2d4c7f231758c7009f262f8d7ceb86942a419881836680658368a";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/15.2.0-1.tar.gz";
+    name = "15.2.0-1.tar.gz";
+    sha256 = "cb494e331e04fd59125612ad90fbc5819b4d82736d0984308273cf6ff4a0dcc0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering-tests/default.nix
+++ b/distros/rolling/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, qt6, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering-tests";
-  version = "15.1.19-r1";
+  version = "15.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/15.1.19-1.tar.gz";
-    name = "15.1.19-1.tar.gz";
-    sha256 = "7e793b1b81658dac2f571f63a417a26a3be62296def8dc9f9088c67b2f173171";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/15.2.0-1.tar.gz";
+    name = "15.2.0-1.tar.gz";
+    sha256 = "812c344391da20e12d7820dc13b06c6bfd12b3061121e86b1d86af6ea4e1472c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering/default.nix
+++ b/distros/rolling/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, assimp, eigen, eigen3-cmake-module, qt6, resource-retriever, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering";
-  version = "15.1.19-r1";
+  version = "15.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/15.1.19-1.tar.gz";
-    name = "15.1.19-1.tar.gz";
-    sha256 = "d7253654de801f1100d1dac0315ba9dfc1ab35cd97f3683317b60aa1b0442675";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/15.2.0-1.tar.gz";
+    name = "15.2.0-1.tar.gz";
+    sha256 = "bc4e43572e46dbade8812139a2bdb354935493b13aaa0dc731870858512b1e42";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-visual-testing-framework/default.nix
+++ b/distros/rolling/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, qt6, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rviz-visual-testing-framework";
-  version = "15.1.19-r1";
+  version = "15.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/15.1.19-1.tar.gz";
-    name = "15.1.19-1.tar.gz";
-    sha256 = "c313d8855138004a620fbae7dea49c3c3d9bdd0a9131acd9bc0d2054a41fe460";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/15.2.0-1.tar.gz";
+    name = "15.2.0-1.tar.gz";
+    sha256 = "5f67365b6d7a54b107fd5d417cbc93b42bc13a085f2e967154c0c81774603fbf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz2/default.nix
+++ b/distros/rolling/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, python3, python3Packages, qt6, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz2";
-  version = "15.1.19-r1";
+  version = "15.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/15.1.19-1.tar.gz";
-    name = "15.1.19-1.tar.gz";
-    sha256 = "f1681710e23acd09289866a792279cf9b5fcb3f694ebd672d348674ec9848414";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/15.2.0-1.tar.gz";
+    name = "15.2.0-1.tar.gz";
+    sha256 = "08d592b38416a5768f0037a430849976cfe25e04cee858bfb86e26b63689345d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sensor-msgs-py/default.nix
+++ b/distros/rolling/sensor-msgs-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-sensor-msgs-py";
-  version = "5.9.1-r1";
+  version = "5.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs_py/5.9.1-1.tar.gz";
-    name = "5.9.1-1.tar.gz";
-    sha256 = "356868506c21f785b677e96dc04bae76937c58b520a723d66e0f2f979f3f679f";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs_py/5.9.2-1.tar.gz";
+    name = "5.9.2-1.tar.gz";
+    sha256 = "37cc1acd3b24657387729abe71cb790d017152ba423dd0e048f608a2c3a61b7e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/sensor-msgs/default.nix
+++ b/distros/rolling/sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-sensor-msgs";
-  version = "5.9.1-r1";
+  version = "5.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs/5.9.1-1.tar.gz";
-    name = "5.9.1-1.tar.gz";
-    sha256 = "f9fd2a9ee86ef101906c73934fcadd99ac91870efd0168342337c4a5ae225ac4";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs/5.9.2-1.tar.gz";
+    name = "5.9.2-1.tar.gz";
+    sha256 = "73dc9629a6467e3b1881f01c285e4cd11b987fffc6349f1a494ed4b6db0c7231";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/service-msgs/default.nix
+++ b/distros/rolling/service-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-core-generators, rosidl-core-runtime }:
 buildRosPackage {
   pname = "ros-rolling-service-msgs";
-  version = "2.4.3-r1";
+  version = "2.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/service_msgs/2.4.3-1.tar.gz";
-    name = "2.4.3-1.tar.gz";
-    sha256 = "1a495b37b1141387886762adcbe3185b6a951dc86f1c2ba9c00c7cd3247a54ae";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/service_msgs/2.4.4-1.tar.gz";
+    name = "2.4.4-1.tar.gz";
+    sha256 = "9837d9a50a9f18fca829e6ce12223b13ad3477127c2e72d785f11a96ddc77b15";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/shape-msgs/default.nix
+++ b/distros/rolling/shape-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-shape-msgs";
-  version = "5.9.1-r1";
+  version = "5.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/shape_msgs/5.9.1-1.tar.gz";
-    name = "5.9.1-1.tar.gz";
-    sha256 = "04f0e384e94b9375e8ebbf0277d04a358319ccc5d3ec934b522b609a879930d2";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/shape_msgs/5.9.2-1.tar.gz";
+    name = "5.9.2-1.tar.gz";
+    sha256 = "8a18de1f9fcd818fe873bf400140d0882776220a30b93c587b54233b20be605f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/statistics-msgs/default.nix
+++ b/distros/rolling/statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-statistics-msgs";
-  version = "2.4.3-r1";
+  version = "2.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/statistics_msgs/2.4.3-1.tar.gz";
-    name = "2.4.3-1.tar.gz";
-    sha256 = "8b77d98a7be02cdde8062b2510389e776654471ff0c1632b11b876c1b244af28";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/statistics_msgs/2.4.4-1.tar.gz";
+    name = "2.4.4-1.tar.gz";
+    sha256 = "9215861a4799be6428d2f164ca58c184b30f4b6ad0c0a9b133e45986101831ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/std-msgs/default.nix
+++ b/distros/rolling/std-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-std-msgs";
-  version = "5.9.1-r1";
+  version = "5.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_msgs/5.9.1-1.tar.gz";
-    name = "5.9.1-1.tar.gz";
-    sha256 = "69cf99708628cf16549c24722621312b39a8ebcedc79b43519d2ff5a62335ecd";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_msgs/5.9.2-1.tar.gz";
+    name = "5.9.2-1.tar.gz";
+    sha256 = "99d8ae72181eefc9e7cc47cdf6a3d4e767edaa0e74d591c58f25a41541be85e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/std-srvs/default.nix
+++ b/distros/rolling/std-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-std-srvs";
-  version = "5.9.1-r1";
+  version = "5.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_srvs/5.9.1-1.tar.gz";
-    name = "5.9.1-1.tar.gz";
-    sha256 = "e9a96afc732bd014801dd30b5e1b9d44a92c4ef4555da12520ae2e3ce7f460d2";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_srvs/5.9.2-1.tar.gz";
+    name = "5.9.2-1.tar.gz";
+    sha256 = "2214333624d798cb0a7badf118b7314e20f7bbdd070600023d0ea25eacd0dfc8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/stereo-msgs/default.nix
+++ b/distros/rolling/stereo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-stereo-msgs";
-  version = "5.9.1-r1";
+  version = "5.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/stereo_msgs/5.9.1-1.tar.gz";
-    name = "5.9.1-1.tar.gz";
-    sha256 = "b6b11f2a39c24d0d1205b991a6af8ab703907175ec456fed1b5a67f9c9ababa7";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/stereo_msgs/5.9.2-1.tar.gz";
+    name = "5.9.2-1.tar.gz";
+    sha256 = "c239cfb65502b389808bd6df6694fdd138a46ef480e62f521b8c774ae26b10ce";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/test-msgs/default.nix
+++ b/distros/rolling/test-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, test-interface-files }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-mypy, ament-lint-auto, ament-lint-common, builtin-interfaces, python3Packages, rosidl-default-generators, rosidl-default-runtime, test-interface-files }:
 buildRosPackage {
   pname = "ros-rolling-test-msgs";
-  version = "2.4.3-r1";
+  version = "2.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/test_msgs/2.4.3-1.tar.gz";
-    name = "2.4.3-1.tar.gz";
-    sha256 = "b907549fe8b38bc9aa92595e28b479bc0fbecc021cec00061dbed2e6beb380e1";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/test_msgs/2.4.4-1.tar.gz";
+    name = "2.4.4-1.tar.gz";
+    sha256 = "6bfd8e2b408671183756f55d3805f84ae97cf67e08752a7a68e4df4abc0bffef";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators test-interface-files ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-mypy ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces python3Packages.typing-extensions rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/rolling/topic-monitor/default.nix
+++ b/distros/rolling/topic-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, example-interfaces, launch, launch-ros, python3Packages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-topic-monitor";
-  version = "0.37.7-r1";
+  version = "0.37.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_monitor/0.37.7-1.tar.gz";
-    name = "0.37.7-1.tar.gz";
-    sha256 = "777e8698b157ad64780e7ea1317ae83363c0b03d4676d82e1ab9e56b38e87b9b";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_monitor/0.37.8-1.tar.gz";
+    name = "0.37.8-1.tar.gz";
+    sha256 = "f6e5032d05c983a0141712447ef486fde673bd91ed060e4a65e45f8d8fa4fcc2";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/topic-statistics-demo/default.nix
+++ b/distros/rolling/topic-statistics-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rcutils, sensor-msgs, statistics-msgs }:
 buildRosPackage {
   pname = "ros-rolling-topic-statistics-demo";
-  version = "0.37.7-r1";
+  version = "0.37.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_statistics_demo/0.37.7-1.tar.gz";
-    name = "0.37.7-1.tar.gz";
-    sha256 = "b3a69c9f720ff6221a059539026551db7349163ed9ec87916a068d2286baddde";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_statistics_demo/0.37.8-1.tar.gz";
+    name = "0.37.8-1.tar.gz";
+    sha256 = "662bbc0ebdcd4b671505b104c2b8ee87c919f2c8c92ab5f075e7ae94da08bb64";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/toppra/default.nix
+++ b/distros/rolling/toppra/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, eigen, python3, python3Packages }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, eigen, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-toppra";
-  version = "0.6.6-r2";
+  version = "0.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/toppra-release/archive/release/rolling/toppra/0.6.6-2.tar.gz";
-    name = "0.6.6-2.tar.gz";
-    sha256 = "fc0a7d24f7056c7a4017ac3eca102dd3b9b917ab69a694bc3dee933f3e6bdb35";
+    url = "https://github.com/ros2-gbp/toppra-release/archive/release/rolling/toppra/0.6.7-1.tar.gz";
+    name = "0.6.7-1.tar.gz";
+    sha256 = "631f2175a1e080e9647f62aeb250ba9cdaf503c726b1421dd4693862da787333";
   };
 
   buildType = "catkin";
   buildInputs = [ ament-cmake ament-cmake-python python3 python3Packages.pybind11 ];
+  checkInputs = [ ament-cmake-gtest ];
   propagatedBuildInputs = [ eigen ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 

--- a/distros/rolling/trajectory-msgs/default.nix
+++ b/distros/rolling/trajectory-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-trajectory-msgs";
-  version = "5.9.1-r1";
+  version = "5.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/trajectory_msgs/5.9.1-1.tar.gz";
-    name = "5.9.1-1.tar.gz";
-    sha256 = "3d1dc9c412cb9aa1bd886efcd14151528515a695e8941c5cb7ea2c0bb2f32231";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/trajectory_msgs/5.9.2-1.tar.gz";
+    name = "5.9.2-1.tar.gz";
+    sha256 = "a0b85839db120483a10c788f59bd0aeeb3bc23aa76ee35843f0b13eb3f1c44ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/type-description-interfaces/default.nix
+++ b/distros/rolling/type-description-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-core-generators, rosidl-core-runtime, service-msgs }:
 buildRosPackage {
   pname = "ros-rolling-type-description-interfaces";
-  version = "2.4.3-r1";
+  version = "2.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/type_description_interfaces/2.4.3-1.tar.gz";
-    name = "2.4.3-1.tar.gz";
-    sha256 = "4d55b64b62f6db2c482dfe280a8bae49bb57a6a137ce27e6a3137e6b4882bb71";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/type_description_interfaces/2.4.4-1.tar.gz";
+    name = "2.4.4-1.tar.gz";
+    sha256 = "6403e1f2d84831bd8ca63eab30a80a9f4fd8d7a0567ce7d191fdb917da856a3a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-dgnss-node/default.nix
+++ b/distros/rolling/ublox-dgnss-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-index-cpp, ament-lint-auto, ament-lint-common, libusb1, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ublox-dgnss-node";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_dgnss_node/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "44ee723f6fc2019765018103ab4232cfc193a5aad5103bfc0d142679ec83c5a7";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_dgnss_node/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "3aba9a16e35995db2f05d9be8453d00620e598bc93b3c5c08943bb53baa89692";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-dgnss/default.nix
+++ b/distros/rolling/ublox-dgnss/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ntrip-client-node, ublox-dgnss-node, ublox-nav-sat-fix-hp-node, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ublox-dgnss";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_dgnss/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "5efaed9504a5a2646739b7f564bf6e3542855fe4e5b93e7200d6eba348414171";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_dgnss/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "04fadadcac5f6bb4116e4c9a09f56195d2bab7adf112c9775f87757903e37207";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-nav-sat-fix-hp-node/default.nix
+++ b/distros/rolling/ublox-nav-sat-fix-hp-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ublox-nav-sat-fix-hp-node";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_nav_sat_fix_hp_node/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "42b6fc2ce326ec564f3fb28bac8d535149f35e177b8784e846ae9e2adae60365";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_nav_sat_fix_hp_node/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "9d6a87c63a82c27c8bb2837184519599514c46f0c5def18e4db36734149bb032";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-ubx-interfaces/default.nix
+++ b/distros/rolling/ublox-ubx-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-rolling-ublox-ubx-interfaces";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_ubx_interfaces/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "734b70e1112fcf60e0aa76468cf84c4eb39c8b4da992dfc3ce9d9313021b7deb";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_ubx_interfaces/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "f30866f58642f98b3ce3d1397d7176d1f3505e943d970a6768bdfdf19d4f15ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-ubx-msgs/default.nix
+++ b/distros/rolling/ublox-ubx-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ublox-ubx-msgs";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_ubx_msgs/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "a82785df122899c95552891f5886c0b39b078fcd2dd7def629ec5f809cff77b6";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_ubx_msgs/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "ef010ff811a8b6ac7044946a98b86e4a75862f77c15be993732946cf0bf03391";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/urdfdom-headers/default.nix
+++ b/distros/rolling/urdfdom-headers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-rolling-urdfdom-headers";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/urdfdom_headers-release/archive/release/rolling/urdfdom_headers/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "f07c86e95e29dd88b2e20d44537c2378781c4f03324b0032834b9a4df8d894dd";
+    url = "https://github.com/ros2-gbp/urdfdom_headers-release/archive/release/rolling/urdfdom_headers/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "b68fa9ef07078ab63c37838a5c7fb2155e970a93172a9cfb41bc6861b893b34c";
   };
 
   buildType = "cmake";

--- a/distros/rolling/urdfdom/default.nix
+++ b/distros/rolling/urdfdom/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, console-bridge-vendor, python3, tinyxml-2, urdfdom-headers }:
 buildRosPackage {
   pname = "ros-rolling-urdfdom";
-  version = "5.1.0-r1";
+  version = "5.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/urdfdom-release/archive/release/rolling/urdfdom/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "820080238d4dc43f45a0fd812bfee81ba737ef22c0627062158cdd1461726b87";
+    url = "https://github.com/ros2-gbp/urdfdom-release/archive/release/rolling/urdfdom/5.1.1-1.tar.gz";
+    name = "5.1.1-1.tar.gz";
+    sha256 = "9285ba99589a52bc76c2aeb7621e5d586d7f368ba31b0f7e341dde8f8b063146";
   };
 
   buildType = "cmake";

--- a/distros/rolling/visualization-msgs/default.nix
+++ b/distros/rolling/visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-visualization-msgs";
-  version = "5.9.1-r1";
+  version = "5.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/visualization_msgs/5.9.1-1.tar.gz";
-    name = "5.9.1-1.tar.gz";
-    sha256 = "69ce1cddc9632b31b6b966e7363873e564e6eaddbcc35376fcd03a5cad5527b8";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/visualization_msgs/5.9.2-1.tar.gz";
+    name = "5.9.2-1.tar.gz";
+    sha256 = "b9e2035dce66b2d576f8332db5142e1d01f083307cfbd4a5e6b292823cae0c48";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/warehouse-ros-sqlite/default.nix
+++ b/distros/rolling/warehouse-ros-sqlite/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite3-vendor, warehouse-ros }:
+{ lib, buildRosPackage, fetchurl, _unresolved_sqlite3_vendor, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, warehouse-ros }:
 buildRosPackage {
   pname = "ros-rolling-warehouse-ros-sqlite";
   version = "1.0.6-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake boost ];
   checkInputs = [ ament-cmake-copyright ament-cmake-gtest ament-lint-auto ament-lint-common geometry-msgs ];
-  propagatedBuildInputs = [ class-loader rclcpp sqlite3-vendor warehouse-ros ];
+  propagatedBuildInputs = [ _unresolved_sqlite3_vendor class-loader rclcpp warehouse-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/zenoh-cpp-vendor/default.nix
+++ b/distros/rolling/zenoh-cpp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, cargo, clang, git }:
 buildRosPackage {
   pname = "ros-rolling-zenoh-cpp-vendor";
-  version = "0.10.2-r1";
+  version = "0.10.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/rolling/zenoh_cpp_vendor/0.10.2-1.tar.gz";
-    name = "0.10.2-1.tar.gz";
-    sha256 = "6cb75c5dc704272a2b43d58c02021d27725ea1eb965301946679198cb3f03b52";
+    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/rolling/zenoh_cpp_vendor/0.10.3-1.tar.gz";
+    name = "0.10.3-1.tar.gz";
+    sha256 = "23210c8393cd27c3e6915cfad9dc44d9f8ef7dbeff888740510973e2af19c809";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/zenoh-cpp-vendor/vendored-source.json
+++ b/distros/rolling/zenoh-cpp-vendor/vendored-source.json
@@ -1,12 +1,12 @@
 {
   "zenoh_c_vendor": {
     "url": "https://github.com/eclipse-zenoh/zenoh-c.git",
-    "rev": "f376456ccf75ed837a21a186bdf5191cba50eb3b",
-    "hash": "sha256-r5OgKy4AfWSKlI6xQrqmb+ZW4V6nynkoMuVSWgNM/F4="
+    "rev": "05bd370343b5161ca9269649b9a914c9c2dc4170",
+    "hash": "sha256-HfQJMKE8G6NF5uzuhbaDGkM+wbNof+vZKA2C/QNS40M="
   },
   "zenoh_cpp_vendor": {
     "url": "https://github.com/eclipse-zenoh/zenoh-cpp",
-    "rev": "0cd54f291039a65b96921a5951a66aeef088e67c",
-    "hash": "sha256-Tjc6hhMX2eH4PH8FDx+nTWUej2WXVYR/0+M6KZXm8ZM="
+    "rev": "af381b420cc8837ac7da42c9984594ef8f110e90",
+    "hash": "sha256-OWWmQhdgea4FBT0p5NHyPh+4yIztO5sXlidetFxBQcc="
   }
 }

--- a/distros/rolling/zenoh-cpp-vendor/zenoh-c.patch
+++ b/distros/rolling/zenoh-cpp-vendor/zenoh-c.patch
@@ -1,9 +1,9 @@
 diff --git a/buildrs/opaque_types_generator.rs b/buildrs/opaque_types_generator.rs
-index c1d0bdd3..2d190518 100644
+index af482179..c0020f3f 100644
 --- a/buildrs/opaque_types_generator.rs
 +++ b/buildrs/opaque_types_generator.rs
-@@ -14,7 +14,10 @@ pub fn generate_opaque_types() {
-     let data_in = std::fs::read_to_string(path_in).unwrap();
+@@ -18,7 +18,10 @@ pub fn generate_opaque_types() {
+         .replace('\r', "\n");
  
      // Check for cargo-level errors (dependency resolution, manifest parsing, etc.)
 -    if data_in.contains("error: failed to") || data_in.contains("Caused by:") {
@@ -14,12 +14,12 @@ index c1d0bdd3..2d190518 100644
          panic!(
              "Failed to generate opaque types due to cargo error:\n\nCommand executed:\n\n{command}\n\nCargo output:\n\n{data_in}"
          );
-@@ -127,6 +130,8 @@ fn produce_opaque_types_data() -> (String, PathBuf) {
-         .arg("build")
+@@ -135,6 +138,8 @@ fn produce_opaque_types_data() -> (String, PathBuf) {
+         .arg("--no-default-features")
          .args(feature_args)
          .args(linker_args)
 +        .arg("--config")
 +        .arg(std::env::var("NIX_ZENOH_OPAQUE_TYPES_CARGO_CONFIG").unwrap())
-         .arg("--target")
-         .arg(target)
-         .arg("--manifest-path")
+         .arg("--color")
+         .arg("never")
+         .arg("--offline") // The opaque types are supposed to use same crates as the main build

--- a/distros/rolling/zenoh-security-tools/default.nix
+++ b/distros/rolling/zenoh-security-tools/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, nlohmann_json, rcpputils, rcutils, rmw, rmw-security-common, tinyxml-2, zenoh-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, nlohmann_json, rcpputils, rcutils, rmw-security-common, tinyxml-2, zenoh-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-zenoh-security-tools";
-  version = "0.10.2-r1";
+  version = "0.10.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/rolling/zenoh_security_tools/0.10.2-1.tar.gz";
-    name = "0.10.2-1.tar.gz";
-    sha256 = "e552b6659330bbfdfeec2135f89576ad4f8393eeb5616604a3c5cf3cc0d513df";
+    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/rolling/zenoh_security_tools/0.10.3-1.tar.gz";
+    name = "0.10.3-1.tar.gz";
+    sha256 = "dad180f00df95cbc72a73463b7976083db095e1bec1d5c0d70605a0ee0468520";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ nlohmann_json ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ rcpputils rcutils rmw rmw-security-common tinyxml-2 zenoh-cpp-vendor ];
+  propagatedBuildInputs = [ rcpputils rcutils rmw-security-common tinyxml-2 zenoh-cpp-vendor ];
 
   meta = {
     description = "This package generates config files to enforce security with Zenoh";

--- a/distros/rolling/zstd-cmake-module/default.nix
+++ b/distros/rolling/zstd-cmake-module/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, zstd }:
+buildRosPackage {
+  pname = "ros-rolling-zstd-cmake-module";
+  version = "0.33.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/zstd_cmake_module/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "027c64e3a9ecee6f79d577774ad700deee34db4396432699c4e6da288559777b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ zstd ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ZSTD compression cmake module package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'kilted', 'rolling'] from nix-ros-overlay commit 9a72e7379c0e1cb676ef948d9349f2403c2697c0.
This pull request was generated by running the following command:

```
superflore-gen-nix --dry-run --output-repository-path . --all --tar-archive-dir /home/runner/.ros/tar --upstream-branch develop
```

Changes:
========
Humble Changes:
---------------
* *clearpath-common 1.3.9-r1 --> 1.3.10-r1*
* *clearpath-control 1.3.9-r1 --> 1.3.10-r1*
* *clearpath-customization 1.3.9-r1 --> 1.3.10-r1*
* *clearpath-description 1.3.9-r1 --> 1.3.10-r1*
* *clearpath-generator-common 1.3.9-r1 --> 1.3.10-r1*
* *clearpath-manipulators 1.3.9-r1 --> 1.3.10-r1*
* *clearpath-manipulators-description 1.3.9-r1 --> 1.3.10-r1*
* *clearpath-mounts-description 1.3.9-r1 --> 1.3.10-r1*
* *clearpath-platform-description 1.3.9-r1 --> 1.3.10-r1*
* *clearpath-sensors-description 1.3.9-r1 --> 1.3.10-r1*
* *gz-ros2-control 0.7.18-r1 --> 0.7.19-r1*
* *gz-ros2-control-demos 0.7.18-r1 --> 0.7.19-r1*
* *gz-ros2-control-tests 0.7.18-r1 --> 0.7.19-r1*
* *ign-ros2-control 0.7.18-r1 --> 0.7.19-r1*
* *ign-ros2-control-demos 0.7.18-r1 --> 0.7.19-r1*
* *message-filters 4.3.15-r1 --> 4.3.16-r1*
* *mola-sm-loop-closure 1.0.0-r1*
* *mrpt-apps 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libapps 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libbase 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libgui 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libhwdrivers 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libmaps 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libmath 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libnav 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libobs 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libopengl 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libposes 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libslam 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libtclap 2.15.12-r1 --> 2.15.13-r1*
* *ntrip-client-node 0.7.3-r1 --> 0.7.4-r1*
* *toppra 0.6.6-r1 --> 0.6.7-r1*
* *ublox-dgnss 0.7.3-r1 --> 0.7.4-r1*
* *ublox-dgnss-node 0.7.3-r1 --> 0.7.4-r1*
* *ublox-nav-sat-fix-hp-node 0.7.3-r1 --> 0.7.4-r1*
* *ublox-ubx-interfaces 0.7.3-r1 --> 0.7.4-r1*
* *ublox-ubx-msgs 0.7.3-r1 --> 0.7.4-r1*

Jazzy Changes:
--------------
* *clearpath-bms-broadcaster 2.9.6-r1*
* *clearpath-bt-joy 2.9.5-r1 --> 2.9.6-r1*
* *clearpath-common 2.9.5-r1 --> 2.9.6-r1*
* *clearpath-control 2.9.5-r1 --> 2.9.6-r1*
* *clearpath-customization 2.9.5-r1 --> 2.9.6-r1*
* *clearpath-description 2.9.5-r1 --> 2.9.6-r1*
* *clearpath-diagnostics 2.9.5-r1 --> 2.9.6-r1*
* *clearpath-generator-common 2.9.5-r1 --> 2.9.6-r1*
* *clearpath-manipulators 2.9.5-r1 --> 2.9.6-r1*
* *clearpath-manipulators-description 2.9.5-r1 --> 2.9.6-r1*
* *clearpath-mounts-description 2.9.5-r1 --> 2.9.6-r1*
* *clearpath-platform-description 2.9.5-r1 --> 2.9.6-r1*
* *clearpath-sensors-description 2.9.5-r1 --> 2.9.6-r1*
* *gz-ros2-control 1.2.17-r1 --> 1.2.18-r1*
* *gz-ros2-control-demos 1.2.17-r1 --> 1.2.18-r1*
* *message-filters 4.11.12-r1 --> 4.11.13-r1*
* *mola-sm-loop-closure 1.0.0-r1*
* *mrpt-apps 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libapps 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libbase 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libgui 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libhwdrivers 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libmaps 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libmath 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libnav 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libobs 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libopengl 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libposes 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libslam 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libtclap 2.15.12-r1 --> 2.15.13-r1*
* *ntrip-client-node 0.7.3-r1 --> 0.7.4-r1*
* *toppra 0.6.6-r1 --> 0.6.7-r1*
* *ublox-dgnss 0.7.3-r1 --> 0.7.4-r1*
* *ublox-dgnss-node 0.7.3-r1 --> 0.7.4-r1*
* *ublox-nav-sat-fix-hp-node 0.7.3-r1 --> 0.7.4-r1*
* *ublox-ubx-interfaces 0.7.3-r1 --> 0.7.4-r1*
* *ublox-ubx-msgs 0.7.3-r1 --> 0.7.4-r1*

Kilted Changes:
---------------
* *gz-ros2-control 2.0.14-r1 --> 2.0.15-r1*
* *gz-ros2-control-demos 2.0.14-r1 --> 2.0.15-r1*
* *mola-sm-loop-closure 1.0.0-r1*
* *mrpt-apps 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libapps 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libbase 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libgui 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libhwdrivers 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libmaps 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libmath 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libnav 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libobs 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libopengl 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libposes 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libslam 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libtclap 2.15.12-r1 --> 2.15.13-r1*
* *ntrip-client-node 0.7.3-r1 --> 0.7.4-r1*
* *rqt-bag 2.0.2-r2 --> 2.0.3-r2*
* *rqt-bag-plugins 2.0.2-r2 --> 2.0.3-r2*
* *rqt-msg 1.6.0-r2 --> 1.6.1-r1*
* *rqt-plot 1.6.3-r1 --> 1.6.4-r1*
* *rqt-publisher 1.9.0-r2 --> 1.9.1-r4*
* *rqt-service-caller 1.4.0-r2 --> 1.4.1-r2*
* *toppra 0.6.6-r1 --> 0.6.7-r1*
* *ublox-dgnss 0.7.3-r1 --> 0.7.4-r1*
* *ublox-dgnss-node 0.7.3-r1 --> 0.7.4-r1*
* *ublox-nav-sat-fix-hp-node 0.7.3-r1 --> 0.7.4-r1*
* *ublox-ubx-interfaces 0.7.3-r1 --> 0.7.4-r1*
* *ublox-ubx-msgs 0.7.3-r1 --> 0.7.4-r1*

Rolling Changes:
----------------
* *action-msgs 2.4.3-r1 --> 2.4.4-r1*
* *action-tutorials-cpp 0.37.7-r1 --> 0.37.8-r1*
* *action-tutorials-py 0.37.7-r1 --> 0.37.8-r1*
* *builtin-interfaces 2.4.3-r1 --> 2.4.4-r1*
* *class-loader 2.9.3-r1 --> 2.9.4-r1*
* *common-interfaces 5.9.1-r1 --> 5.9.2-r1*
* *composition 0.37.7-r1 --> 0.37.8-r1*
* *composition-interfaces 2.4.3-r1 --> 2.4.4-r1*
* *demo-nodes-cpp 0.37.7-r1 --> 0.37.8-r1*
* *demo-nodes-cpp-native 0.37.7-r1 --> 0.37.8-r1*
* *demo-nodes-py 0.37.7-r1 --> 0.37.8-r1*
* *diagnostic-msgs 5.9.1-r1 --> 5.9.2-r1*
* *dummy-map-server 0.37.7-r1 --> 0.37.8-r1*
* *dummy-robot-bringup 0.37.7-r1 --> 0.37.8-r1*
* *dummy-sensors 0.37.7-r1 --> 0.37.8-r1*
* *geometry-msgs 5.9.1-r1 --> 5.9.2-r1*
* *gz-ros2-control 3.0.6-r1 --> 3.0.7-r1*
* *gz-ros2-control-demos 3.0.6-r1 --> 3.0.7-r1*
* *image-tools 0.37.7-r1 --> 0.37.8-r1*
* *intra-process-demo 0.37.7-r1 --> 0.37.8-r1*
* *libyaml-vendor 1.8.0-r1 --> 1.8.1-r1*
* *lifecycle 0.37.7-r1 --> 0.37.8-r1*
* *lifecycle-msgs 2.4.3-r1 --> 2.4.4-r1*
* *lifecycle-py 0.37.7-r1 --> 0.37.8-r1*
* *logging-demo 0.37.7-r1 --> 0.37.8-r1*
* *lz4-cmake-module 0.33.1-r1*
* *mcap-vendor 0.33.0-r1 --> 0.33.1-r1*
* *mola-sm-loop-closure 1.0.0-r1*
* *mrpt-apps 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libapps 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libbase 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libgui 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libhwdrivers 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libmaps 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libmath 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libnav 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libobs 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libopengl 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libposes 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libslam 2.15.12-r1 --> 2.15.13-r1*
* *mrpt-libtclap 2.15.12-r1 --> 2.15.13-r1*
* *nav-msgs 5.9.1-r1 --> 5.9.2-r1*
* *ntrip-client-node 0.7.3-r1 --> 0.7.4-r1*
* *pendulum-control 0.37.7-r1 --> 0.37.8-r1*
* *pendulum-msgs 0.37.7-r1 --> 0.37.8-r1*
* *quality-of-service-demo-cpp 0.37.7-r1 --> 0.37.8-r1*
* *quality-of-service-demo-py 0.37.7-r1 --> 0.37.8-r1*
* *rcl 10.4.2-r1 --> 10.4.3-r1*
* *rcl-action 10.4.2-r1 --> 10.4.3-r1*
* *rcl-interfaces 2.4.3-r1 --> 2.4.4-r1*
* *rcl-lifecycle 10.4.2-r1 --> 10.4.3-r1*
* *rcl-yaml-param-parser 10.4.2-r1 --> 10.4.3-r1*
* *rclcpp 31.0.2-r1 --> 31.0.3-r1*
* *rclcpp-action 31.0.2-r1 --> 31.0.3-r1*
* *rclcpp-components 31.0.2-r1 --> 31.0.3-r1*
* *rclcpp-lifecycle 31.0.2-r1 --> 31.0.3-r1*
* *rclpy 10.0.8-r1 --> 10.0.9-r1*
* *rcutils 7.0.8-r1 --> 7.0.9-r1*
* *resource-retriever-interfaces 0.0.1-r1*
* *resource-retriever-service 0.0.1-r1*
* *resource-retriever-service-plugin 0.0.1-r1*
* *rmw-cyclonedds-cpp 4.1.3-r1 --> 4.1.4-r1*
* *rmw-fastrtps-cpp 9.4.6-r3 --> 9.4.7-r1*
* *rmw-fastrtps-dynamic-cpp 9.4.6-r3 --> 9.4.7-r1*
* *rmw-fastrtps-shared-cpp 9.4.6-r3 --> 9.4.7-r1*
* *rmw-zenoh-cpp 0.10.2-r1 --> 0.10.3-r1*
* *ros2action 0.40.5-r1 --> 0.40.6-r1*
* *ros2bag 0.33.0-r1 --> 0.33.1-r1*
* *ros2cli 0.40.5-r1 --> 0.40.6-r1*
* *ros2cli-test-interfaces 0.40.5-r1 --> 0.40.6-r1*
* *ros2component 0.40.5-r1 --> 0.40.6-r1*
* *ros2doctor 0.40.5-r1 --> 0.40.6-r1*
* *ros2interface 0.40.5-r1 --> 0.40.6-r1*
* *ros2lifecycle 0.40.5-r1 --> 0.40.6-r1*
* *ros2lifecycle-test-fixtures 0.40.5-r1 --> 0.40.6-r1*
* *ros2multicast 0.40.5-r1 --> 0.40.6-r1*
* *ros2node 0.40.5-r1 --> 0.40.6-r1*
* *ros2param 0.40.5-r1 --> 0.40.6-r1*
* *ros2pkg 0.40.5-r1 --> 0.40.6-r1*
* *ros2run 0.40.5-r1 --> 0.40.6-r1*
* *ros2service 0.40.5-r1 --> 0.40.6-r1*
* *ros2topic 0.40.5-r1 --> 0.40.6-r1*
* *rosbag2 0.33.0-r1 --> 0.33.1-r1*
* *rosbag2-compression 0.33.0-r1 --> 0.33.1-r1*
* *rosbag2-compression-zstd 0.33.0-r1 --> 0.33.1-r1*
* *rosbag2-cpp 0.33.0-r1 --> 0.33.1-r1*
* *rosbag2-examples-cpp 0.33.0-r1 --> 0.33.1-r1*
* *rosbag2-examples-py 0.33.0-r1 --> 0.33.1-r1*
* *rosbag2-interfaces 0.33.0-r1 --> 0.33.1-r1*
* *rosbag2-performance-benchmarking 0.33.0-r1 --> 0.33.1-r1*
* *rosbag2-performance-benchmarking-msgs 0.33.0-r1 --> 0.33.1-r1*
* *rosbag2-py 0.33.0-r1 --> 0.33.1-r1*
* *rosbag2-storage 0.33.0-r1 --> 0.33.1-r1*
* *rosbag2-storage-default-plugins 0.33.0-r1 --> 0.33.1-r1*
* *rosbag2-storage-mcap 0.33.0-r1 --> 0.33.1-r1*
* *rosbag2-storage-sqlite3 0.33.0-r1 --> 0.33.1-r1*
* *rosbag2-test-common 0.33.0-r1 --> 0.33.1-r1*
* *rosbag2-test-msgdefs 0.33.0-r1 --> 0.33.1-r1*
* *rosbag2-tests 0.33.0-r1 --> 0.33.1-r1*
* *rosbag2-transport 0.33.0-r1 --> 0.33.1-r1*
* *rosgraph-msgs 2.4.3-r1 --> 2.4.4-r1*
* *rosidl-dynamic-typesupport 0.4.0-r1 --> 0.4.1-r1*
* *rosidl-generator-py 0.27.1-r1 --> 0.27.2-r1*
* *rosidl-typesupport-fastrtps-c 3.9.4-r1 --> 3.9.5-r1*
* *rosidl-typesupport-fastrtps-cpp 3.9.4-r1 --> 3.9.5-r1*
* *rviz-common 15.1.19-r1 --> 15.2.0-r1*
* *rviz-default-plugins 15.1.19-r1 --> 15.2.0-r1*
* *rviz-ogre-vendor 15.1.19-r1 --> 15.2.0-r1*
* *rviz-rendering 15.1.19-r1 --> 15.2.0-r1*
* *rviz-rendering-tests 15.1.19-r1 --> 15.2.0-r1*
* *rviz-visual-testing-framework 15.1.19-r1 --> 15.2.0-r1*
* *rviz2 15.1.19-r1 --> 15.2.0-r1*
* *sensor-msgs 5.9.1-r1 --> 5.9.2-r1*
* *sensor-msgs-py 5.9.1-r1 --> 5.9.2-r1*
* *service-msgs 2.4.3-r1 --> 2.4.4-r1*
* *shape-msgs 5.9.1-r1 --> 5.9.2-r1*
* *statistics-msgs 2.4.3-r1 --> 2.4.4-r1*
* *std-msgs 5.9.1-r1 --> 5.9.2-r1*
* *std-srvs 5.9.1-r1 --> 5.9.2-r1*
* *stereo-msgs 5.9.1-r1 --> 5.9.2-r1*
* *test-msgs 2.4.3-r1 --> 2.4.4-r1*
* *topic-monitor 0.37.7-r1 --> 0.37.8-r1*
* *topic-statistics-demo 0.37.7-r1 --> 0.37.8-r1*
* *toppra 0.6.6-r2 --> 0.6.7-r1*
* *trajectory-msgs 5.9.1-r1 --> 5.9.2-r1*
* *type-description-interfaces 2.4.3-r1 --> 2.4.4-r1*
* *ublox-dgnss 0.7.3-r1 --> 0.7.4-r1*
* *ublox-dgnss-node 0.7.3-r1 --> 0.7.4-r1*
* *ublox-nav-sat-fix-hp-node 0.7.3-r1 --> 0.7.4-r1*
* *ublox-ubx-interfaces 0.7.3-r1 --> 0.7.4-r1*
* *ublox-ubx-msgs 0.7.3-r1 --> 0.7.4-r1*
* *urdfdom 5.1.0-r1 --> 5.1.1-r1*
* *urdfdom-headers 2.1.0-r1 --> 2.1.1-r1*
* *visualization-msgs 5.9.1-r1 --> 5.9.2-r1*
* *zenoh-cpp-vendor 0.10.2-r1 --> 0.10.3-r1*
* *zenoh-security-tools 0.10.2-r1 --> 0.10.3-r1*
* *zstd-cmake-module 0.33.1-r1*


No missing dependencies.