### PR TITLE
Use fetchpatch2 with full_index=1 URLs everywhere

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -211,29 +211,29 @@ let
       patchesFor.gz_ogre_next_vendor = [
         (self.fetchpatch2 {
           # Add simple implementation for STBIImageCodec::magicNumberToFileExt()
-          url = "https://github.com/OGRECave/ogre-next/commit/98c9095c6e288fceb59ccb3504d9127d88eb1b51.patch";
-          hash = "sha256-4fa+IbqtIL48nJ0frrrexCzQIauVNDtpoU+4216MTuA=";
+          url = "https://github.com/OGRECave/ogre-next/commit/98c9095c6e288fceb59ccb3504d9127d88eb1b51.patch?full_index=1";
+          hash = "sha256-Zw6pFjHbDezbO79SLD/yo9tblgph1PKH58PV7r1dcZM=";
         })
         (self.fetchpatch2 {
           # Fix loading of images in STBICodec
-          url = "https://github.com/OGRECave/ogre-next/commit/37d4876eb71c70b9eb3464e5b72c6e6d6be03232.patch";
-          hash = "sha256-U84MU2ORhEThJ/rqfSkOhyAEgDEHJiaVuWIyeKLpwZw=";
+          url = "https://github.com/OGRECave/ogre-next/commit/37d4876eb71c70b9eb3464e5b72c6e6d6be03232.patch?full_index=1";
+          hash = "sha256-MgqoU9cw0vJcgI7hLuqlVRFdmOTwmQ93FBTgzDl69hg=";
         })
         (self.fetchpatch2 {
           # Handle row padding correctly for 1, 2 and 4-channel images in STBICodec
-          url = "https://github.com/OGRECave/ogre-next/commit/96a3bb016b2c9b4f9cca9df1a65d619220e21d78.patch";
-          hash = "sha256-gJjlpkp3qhthF+6TbGLuToGPvOngqZrgE5sBucbvL4g=";
+          url = "https://github.com/OGRECave/ogre-next/commit/96a3bb016b2c9b4f9cca9df1a65d619220e21d78.patch?full_index=1";
+          hash = "sha256-Mczkta9SUSKs6HpQ9L/59dLxaqfBEGcIqSI9qPUUH34=";
         })
         (self.fetchpatch2 {
           # Fix STLAllocator compatibility with GCC 15 and modern C++ standards
-          url = "https://github.com/wentasah/ogre-next/commit/45f449741b3283b43bec6572db8ad6d7af9b2efa.patch";
-          hash = "sha256-Jqc7TF9belxpGdUbli+jEeAUJ9x8VsX9JhRll1NU7Y8=";
+          url = "https://github.com/wentasah/ogre-next/commit/45f449741b3283b43bec6572db8ad6d7af9b2efa.patch?full_index=1";
+          hash = "sha256-Hs+seuQrQZY9G6H4NqV4QVevtDyBzd+qMyvxIK+buBI=";
         })
         (self.fetchpatch2 {
           # Fix RGB channel swap in STBICodec RGB-to-RGBA conversion
           # https://github.com/OGRECave/ogre-next/pull/567
-          url = "https://github.com/OGRECave/ogre-next/commit/960aabcda2f0ba5d2281d742506aab3e3e91b396.patch";
-          hash = "sha256-Z6YAqoM8H/hhyyXzA2vwQdvbfcQuHR861ee1FidpRus=";
+          url = "https://github.com/OGRECave/ogre-next/commit/960aabcda2f0ba5d2281d742506aab3e3e91b396.patch?full_index=1";
+          hash = "sha256-WU/91+H7z8bUzFc0XH2zGc3Yv7Th0beVxdRFy9JWpDo=";
         })
       ];
     }).overrideAttrs(({

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -94,8 +94,8 @@ in with lib; {
     patches = patches ++ [
       (self.fetchpatch2 {
         # https://github.com/autowarefoundation/autoware_core/pull/1000
-        url = "https://github.com/nim65s/autoware_core/commit/6839e4e99db8b0110d5d45c118a0f681b1734de2.patch";
-        hash = "sha256-qwPpMn/Jz2QgGG8C9JUAYKp3NXy43b9ZQD6+q8n51ks=";
+        url = "https://github.com/nim65s/autoware_core/commit/6839e4e99db8b0110d5d45c118a0f681b1734de2.patch?full_index=1";
+        hash = "sha256-WncxH5T8EtSA8N2eTw+qMQkMu30beGGltnntv4twTWc=";
         stripLen = 2;
       })
     ];
@@ -178,8 +178,8 @@ in with lib; {
     patches = [
       # Fix compile errors with Boost >= 1.87
       (self.fetchpatch2 {
-        url = "https://github.com/fkie/async_web_server_cpp/pull/8/commits/0aa036c4c3908ef0d9ac85bf623a15906bccaefd.patch";
-        hash = "sha256-GXUYxWmNq2W7DCetmgHGD5/MFBWgDYFNIdUThwj8vt8=";
+        url = "https://github.com/fkie/async_web_server_cpp/pull/8/commits/0aa036c4c3908ef0d9ac85bf623a15906bccaefd.patch?full_index=1";
+        hash = "sha256-uZym/R8c4e/Ypo8xGQwGdasuFixjbddX9hzQeNqXIDc=";
       })
     ];
   });
@@ -202,9 +202,9 @@ in with lib; {
     patches = [
       # Fix paths in pkg-config file
       # https://github.com/eclipse-cyclonedds/cyclonedds/pull/1453
-      (self.fetchpatch {
-        url = "https://github.com/eclipse-cyclonedds/cyclonedds/commit/3ff967e32b8078d497a8b9c70735849c04eaebf6.patch";
-        hash = "sha256-F5zofoO0YbYfqLrb6s30un9k9+R8rQazLHw+uND1UxE=";
+      (self.fetchpatch2 {
+        url = "https://github.com/eclipse-cyclonedds/cyclonedds/commit/3ff967e32b8078d497a8b9c70735849c04eaebf6.patch?full_index=1";
+        hash = "sha256-j1NXVjtVfN+eIBK8S7Kx/70gJrkrirFi83ZFXBuHZfA=";
       })
     ];
   });
@@ -373,9 +373,9 @@ in with lib; {
     patches ? [], ...
   }: {
     patches = patches ++ [
-      (self.fetchpatch {
-        url = "https://github.com/eclipse-iceoryx/iceoryx/commit/acc1e979a2d5ca30737efb077b00b42f1c4a8429.patch";
-        hash = "sha256-npFHdb0a3JBA8T6vke54DA08C93aNc/7c6xrfMBo7zI=";
+      (self.fetchpatch2 {
+        url = "https://github.com/eclipse-iceoryx/iceoryx/commit/acc1e979a2d5ca30737efb077b00b42f1c4a8429.patch?full_index=1";
+        hash = "sha256-M2ItntTMGqH6YkUNMEF0opJobyqgbZq62vBkyWxxol0=";
         stripLen = 1;
       })
     ];
@@ -387,8 +387,8 @@ in with lib; {
     patches = patches ++ [
       # fix for asio 1.36: https://github.com/ros-drivers/transport_drivers/pull/113
       (self.fetchpatch2 {
-        url = "https://github.com/nim65s/transport_drivers/commit/7be52848f624c82ea720416360d7a754fff65c33.patch";
-        hash = "sha256-frE2449PirPJMnln/mGW87JHXCJfb2wo+SBDunTPanc=";
+        url = "https://github.com/nim65s/transport_drivers/commit/7be52848f624c82ea720416360d7a754fff65c33.patch?full_index=1";
+        hash = "sha256-IYQTlSnJjUvnOp0RbN+1P7C/RclAjouyzmBT9LJpyN4=";
         stripLen = 1;
       })
     ];
@@ -409,8 +409,8 @@ in with lib; {
   }: {
     # https://github.com/AutonicsLiDAR/lsc_ros2_driver/pull/3
     patches = patches ++ [(self.fetchpatch2 {
-      url = "https://github.com/nim65s/lsc_ros2_driver/commit/6c2c5cf64fea0099358e610a7fff40db7c0922be.patch";
-      hash = "sha256-Xwlhjg1wjIiH1H3Roh0iV6HYLmWyGye/6CdvuSVWdSc=";
+      url = "https://github.com/nim65s/lsc_ros2_driver/commit/6c2c5cf64fea0099358e610a7fff40db7c0922be.patch?full_index=1";
+      hash = "sha256-sCgXA4aZ6mTJmkTv41c8PjwsaiDC1/tlwyZJ6Cg5kEo=";
     })];
   });
 
@@ -439,9 +439,9 @@ in with lib; {
   }: {
     patches = patches ++ [
       # Fix build with Python 3.12
-      (self.fetchpatch {
-        url = "https://github.com/openembedded/meta-openembedded/raw/7d8115d5507bac6c018fbff8a7aa9bc513c2bc46/meta-multimedia/recipes-multimedia/libcamera/libcamera/0001-mojom-Drop-using-imp-module.patch";
-        hash = "sha256-Q5tPOfbwO28Lg+bP/IINykTZC2ZL1jeWf6TGP7ZUAE8=";
+      (self.fetchpatch2 {
+        url = "https://github.com/openembedded/meta-openembedded/raw/7d8115d5507bac6c018fbff8a7aa9bc513c2bc46/meta-multimedia/recipes-multimedia/libcamera/libcamera/0001-mojom-Drop-using-imp-module.patch?full_index=1";
+        hash = "sha256-EJqS8x17XI/s250G+H2Qz2sUEuSH9gKxYkFRoKV20iY=";
       })
     ];
     postPatch = postPatch + ''
@@ -584,8 +584,8 @@ in with lib; {
     # ref. https://github.com/moveit/moveit_task_constructor/pull/712
     patches = patches ++ [
       (self.fetchpatch2 {
-        url = "https://github.com/moveit/moveit_task_constructor/commit/ed99e6b8656867cbdfd52ca4e9e85c743e59edf1.patch";
-        hash = "sha256-WxTkG5bnpA+fDQ7EJufxxAQJ/UvN2uehPAPROezCCiQ=";
+        url = "https://github.com/moveit/moveit_task_constructor/commit/ed99e6b8656867cbdfd52ca4e9e85c743e59edf1.patch?full_index=1";
+        hash = "sha256-Iz2nkUzhrNxJCJfObgm90OZXnvR8R0xHmKhsAoiElQw=";
         stripLen = 1;
       })
     ];
@@ -597,8 +597,8 @@ in with lib; {
     patches = patches ++ [
       # ref. https://github.com/ika-rwth-aachen/mqtt_client/pull/93
       (self.fetchpatch2 {
-        url = "https://github.com/nim65s/mqtt_client/commit/fbbaf1ab684689019edc930c1528b33ec2319d8f.patch";
-        hash = "sha256-ESKIlHaESNxIZtAPpOcCpmClLiu8hydYEfBC8wwyoZI=";
+        url = "https://github.com/nim65s/mqtt_client/commit/fbbaf1ab684689019edc930c1528b33ec2319d8f.patch?full_index=1";
+        hash = "sha256-rNj5n1WkfRtkthzyjW4YI1+Z7U92Pu64lx1eNKgBrd0=";
         stripLen = 1;
       })
     ];
@@ -611,12 +611,12 @@ in with lib; {
     # ref. https://github.com/KIT-MRT/mrt_cmake_modules/pull/40
     patches = patches ++ [
       (self.fetchpatch2 {
-        url = "https://github.com/KIT-MRT/mrt_cmake_modules/commit/e0b17b017affcf715514c9895008dfff654c2873.patch";
-        hash = "sha256-2UmmwV0OYWTYdOAQdrAlk5zmVGQn0LOVYh+IGONxrW4=";
+        url = "https://github.com/KIT-MRT/mrt_cmake_modules/commit/e0b17b017affcf715514c9895008dfff654c2873.patch?full_index=1";
+        hash = "sha256-zy6TVF5P4r+g8kqbF53oqotom0Avpztp67whZ4DzF00=";
       })
       (self.fetchpatch2 {
-        url = "https://github.com/KIT-MRT/mrt_cmake_modules/commit/56bb3808fd7883c1afb216bb9b974fb4d6f16ed0.patch";
-        hash = "sha256-p/TMEttj8dIdKAXvvw4P4BTyQKMKwz++CuyGAYdVqJ8=";
+        url = "https://github.com/KIT-MRT/mrt_cmake_modules/commit/56bb3808fd7883c1afb216bb9b974fb4d6f16ed0.patch?full_index=1";
+        hash = "sha256-6BclHo/NEXPSnjjZ1TNF1cPdDCy3t4tjSP5oAgDQS50=";
       })
     ];
   });
@@ -701,9 +701,9 @@ in with lib; {
   }: {
     patches = patches ++ [
       # fix errors with recent compilers and C++17/20 standard
-      (self.fetchpatch {
-        url = "https://github.com/OctoMap/octomap/commit/8178b4f28c72a8c7b84ece25bda7a59df8d14eb8.patch";
-        hash = "sha256-vI3FEWJbAnDPNxG6s2pPX1UTorpokexOawY0AmDo8xY=";
+      (self.fetchpatch2 {
+        url = "https://github.com/OctoMap/octomap/commit/8178b4f28c72a8c7b84ece25bda7a59df8d14eb8.patch?full_index=1";
+        hash = "sha256-BT6WeDyKntIkx2+Z4WfW//+MhDWLs+47kubeDvQ8BFI=";
         # cmdinclude/octomap/OcTreeBase.h:46:21: error: template-id not allowed for constructor in C++20 [-Werror=template-id-cdtor]
         includes = [ "include/octomap/OcTreeBase.h*" ];
         stripLen = 1;
@@ -730,8 +730,8 @@ in with lib; {
     patches = patches ++ [
       # fix for asio 1.36, ref. https://github.com/bosch-engineering/off_highway_sensor_drivers/pull/33
       (self.fetchpatch2 {
-        url = "https://github.com/nim65s/off_highway_sensor_drivers/commit/61c88d4c1c844e2eb24eab30ea23cdd2dfd066b5.patch";
-        hash = "sha256-3Dx5Mg1HwSqi8wFQDmXxBHLovCzjdLacjKO7b1bCIKA=";
+        url = "https://github.com/nim65s/off_highway_sensor_drivers/commit/61c88d4c1c844e2eb24eab30ea23cdd2dfd066b5.patch?full_index=1";
+        hash = "sha256-vGdu9MfPQrxg71tPxyFD2MKt0c92agQMGn04amwWY7Y=";
         stripLen = 1;
       })
     ];
@@ -743,8 +743,8 @@ in with lib; {
     patches = patches ++ [
       # fix for asio 1.36, ref. https://github.com/bosch-engineering/off_highway_sensor_drivers/pull/33
       (self.fetchpatch2 {
-        url = "https://github.com/nim65s/off_highway_sensor_drivers/commit/c2e2fba65f812284790687a0c4f9c5982bd6fd14.patch";
-        hash = "sha256-83SK6kU8HmQgpCXJKbYKb2FTzL6AVbKbKeyRRO9+22w=";
+        url = "https://github.com/nim65s/off_highway_sensor_drivers/commit/c2e2fba65f812284790687a0c4f9c5982bd6fd14.patch?full_index=1";
+        hash = "sha256-sevjNaBo/nnRCB/Pfa33l0mvjs3W8bmVMaqhyyQrYJU=";
         stripLen = 1;
       })
     ];
@@ -804,13 +804,13 @@ in with lib; {
     patches = patches ++ [
       # cmake: Fix link problem, merged upstream
       (self.fetchpatch2 {
-        url = "https://github.com/fmrico/popf/commit/8eabc3b0c6e4f6e718f4ac3564230dccfcfee46b.patch";
-        hash = "sha256-4inVYUHGiDd677wicbRlMoBtZ5HJbJ61xSFQpBrtU7c=";
+        url = "https://github.com/fmrico/popf/commit/8eabc3b0c6e4f6e718f4ac3564230dccfcfee46b.patch?full_index=1";
+        hash = "sha256-xyjHkPnRRUdLAbgRYE2OmCB3+rzeM12Y+HxWz5SsxiA=";
       })
       # cmake: fix missing includes, ref. https://github.com/fmrico/popf/pull/12
       (self.fetchpatch2 {
-        url = "https://github.com/nim65s/popf/commit/e8ba226f67e0513689d0efc84e9b4e8b55394bd4.patch";
-        hash = "sha256-Sw/rY4MsmoWIpC9VQzimM18mlvdGwb8Q6EmwY2rg0pw=";
+        url = "https://github.com/nim65s/popf/commit/e8ba226f67e0513689d0efc84e9b4e8b55394bd4.patch?full_index=1";
+        hash = "sha256-fHorf5CyGDIbx3WLb4XOfGVSXhOXjtBq9iVNLywCDQQ=";
       })
     ];
   });
@@ -819,13 +819,13 @@ in with lib; {
     patches ? [], ...
   }: {
     patches = patches ++ [
-      (self.fetchpatch {
-        url = "https://github.com/ros-visualization/python_qt_binding/commit/e78372fd63eda527c9fad5fcdab8ca31eb3f36d2.patch";
-        hash = "sha256-8+58ggPUJmEQIS9C4RzT4PhK1pT9ms98nppn3ZA8AEo=";
+      (self.fetchpatch2 {
+        url = "https://github.com/ros-visualization/python_qt_binding/commit/e78372fd63eda527c9fad5fcdab8ca31eb3f36d2.patch?full_index=1";
+        hash = "sha256-8injdFw4qKue+8JvT1kCrZHfxFYudXYlcQccVpropXM=";
       })
-      (self.fetchpatch {
-        url = "https://github.com/ros-visualization/python_qt_binding/commit/ee4d43bcdb0c5c5d40f81dea3de6185298ab34a7.patch";
-        hash = "sha256-+n7wqQ9jDybwxVeUEjOQSQJh7nnU8JXv5DNCoK/5Sm4=";
+      (self.fetchpatch2 {
+        url = "https://github.com/ros-visualization/python_qt_binding/commit/ee4d43bcdb0c5c5d40f81dea3de6185298ab34a7.patch?full_index=1";
+        hash = "sha256-LgzWQ4Kvn25OAgaSIvCobLRzqCNzuDT/mZAXjyoXqTE=";
       })
     ];
   });
@@ -853,8 +853,8 @@ in with lib; {
     patches = patches ++ [
       # fix for GCC 15, ref. https://github.com/open-rmf/rmf_task/pull/133
       (self.fetchpatch2 {
-        url = "https://github.com/nim65s/rmf_task/commit/8aaacbe009022540cce1cd3ff3282413cf08a42c.patch";
-        hash = "sha256-9nXoYlfw6yuXP2TFelWl1/T6ho3G49n5vRoxC5qxQCA=";
+        url = "https://github.com/nim65s/rmf_task/commit/8aaacbe009022540cce1cd3ff3282413cf08a42c.patch?full_index=1";
+        hash = "sha256-xpn2yWMRyXUPTf0OdCjGGkKcNLHO6jAnWz4NeXInI2I=";
         stripLen = 1;
       })
     ];
@@ -866,8 +866,8 @@ in with lib; {
     patches = [
       # https://github.com/open-rmf/rmf_traffic/pull/131
       (self.fetchpatch2 {
-        url = "https://github.com/open-rmf/rmf_traffic/commit/c20b8d71507880387185666c78d105557e5003a9.patch";
-        hash = "sha256-4Elg7oF6OQHd2trn3e+r73hghW9Qf90PrGjID7RsdEI=";
+        url = "https://github.com/open-rmf/rmf_traffic/commit/c20b8d71507880387185666c78d105557e5003a9.patch?full_index=1";
+        hash = "sha256-2f2jT9Be5f/Bzh5sLxXwmdD+fwtvdoDuBrejlns1GWg=";
         stripLen = 1;
       })
     ];
@@ -880,8 +880,8 @@ in with lib; {
     patches = patches ++ [
       # fix for asio 1.36, ref. https://github.com/robotont/robotont_driver/pull/22
       (self.fetchpatch2 {
-        url = "https://github.com/nim65s/robotont_driver/commit/16910c7d40c5300829d0dc113189f8a0312e8638.patch";
-        hash = "sha256-M5ZcQexVU3N7zPZiybEFIP398BmWB5vpBm4kfJlq2jc=";
+        url = "https://github.com/nim65s/robotont_driver/commit/16910c7d40c5300829d0dc113189f8a0312e8638.patch?full_index=1";
+        hash = "sha256-J53fq0E3dJadXqPhQoGarquwSCISW0AQLLvxlrTigTI=";
       })
     ];
   });
@@ -899,8 +899,8 @@ in with lib; {
       # Add ROS Humble compatibility for parameter callbacks
       # https://github.com/fujitatomoya/ros2_persist_parameter_server/pull/91
       (self.fetchpatch2 {
-        url = "https://github.com/wentasah/ros2_persist_parameter_server/commit/9ff4569fc1b6f5f8fa1f99b5520161865ec243c9.patch";
-        hash = "sha256-lSdu8MLNisnKIwO6h18dW+aikmzK1xd35oa9D/ZtOpY=";
+        url = "https://github.com/wentasah/ros2_persist_parameter_server/commit/9ff4569fc1b6f5f8fa1f99b5520161865ec243c9.patch?full_index=1";
+        hash = "sha256-42dfVkYc0ELFbjtQAAd1Xehi2UbNGlUCxkyCz2KxpBQ=";
       })
     ];
   });
@@ -962,8 +962,8 @@ in with lib; {
     patches = patches ++ [
       # fix for gcc15, ref https://github.com/SICKAG/sick_scan_xd/pull/557
       (self.fetchpatch2 {
-        url = "https://github.com/SICKAG/sick_scan_xd/commit/f5ac360b4cfb319c981b022a9b817a5e86639d5c.patch";
-        hash = "sha256-zh3UDjy6k7LI3YOYr9F9jt8+4pkdgeOpUUqHcqme6Bs=";
+        url = "https://github.com/SICKAG/sick_scan_xd/commit/f5ac360b4cfb319c981b022a9b817a5e86639d5c.patch?full_index=1";
+        hash = "sha256-UJQZO0cStf7b3890BBrpHBxzgWnJXPOxmW6SKsuAsWw=";
       })
     ];
   });
@@ -992,8 +992,8 @@ in with lib; {
     patches = patches ++ [
       # Fix for asio 1.36, ref https://github.com/KumarRobotics/ublox/pull/273
       (self.fetchpatch2 {
-        url = "https://github.com/nim65s/ublox/commit/da37a9628db91aaafbcbe8b247c28c0d5863159f.patch";
-        hash = "sha256-m7lsEHF/uS47zYrNBd5RSL62CmvmNcKXQiLM24R6LZA=";
+        url = "https://github.com/nim65s/ublox/commit/da37a9628db91aaafbcbe8b247c28c0d5863159f.patch?full_index=1";
+        hash = "sha256-S1h+tw9juDe10I/oITnTYkGFtybI7sMEO7BftKhHo1I=";
         stripLen = 1;
       })
     ];
@@ -1005,8 +1005,8 @@ in with lib; {
     # fix for asio 1.36: https://github.com/ros-drivers/transport_drivers/pull/114
     patches = patches ++ [
       (self.fetchpatch2 {
-        url = "https://github.com/nim65s/transport_drivers/commit/6a5a003a07850afda9681843978f1c5f46d04000.patch";
-        hash = "sha256-0j3Ps2RbkWcv9K+I6KW0fn2/4Nhsw8TIOoZAhAVixMk=";
+        url = "https://github.com/nim65s/transport_drivers/commit/6a5a003a07850afda9681843978f1c5f46d04000.patch?full_index=1";
+        hash = "sha256-rOBbfYxqdrA0hQsl+dFKhyuEsLNXHIF1fj54sSf0FQY=";
         stripLen = 1;
       })
     ];
@@ -1018,14 +1018,14 @@ in with lib; {
     patches = patches ++ [
       # Fix CMake relative install dir assumptions
       # https://github.com/ros/urdfdom/pull/142
-      (self.fetchpatch {
-        url = "https://github.com/ros/urdfdom/commit/cbe6884d267779463bb444be851f6404e692cc0a.patch";
-        hash = "sha256-1gTRKIGqiSRion76bGecSfFJSBskYUJguUIa6ePIiX4=";
+      (self.fetchpatch2 {
+        url = "https://github.com/ros/urdfdom/commit/cbe6884d267779463bb444be851f6404e692cc0a.patch?full_index=1";
+        hash = "sha256-K1SaI7L2tajqxBthrhXjEknMJyNG7erspu5WGewXRGI=";
       })
       # fix: missing header
       (self.fetchpatch2 {
-        url = "https://github.com/ros/urdfdom/commit/4768260074a90510571810d7439113960a304d44.patch";
-        hash = "sha256-bl49jkxvHMtNWPSnc0T3MHonAGSFVJhjhJc8ApaOdSo=";
+        url = "https://github.com/ros/urdfdom/commit/4768260074a90510571810d7439113960a304d44.patch?full_index=1";
+        hash = "sha256-K13ALfH5OwvOX6qplRBe4IqfF4RrgukIYqb+UT7GCLU=";
       })
     ];
   });
@@ -1036,14 +1036,14 @@ in with lib; {
     patches = patches ++ [
       # Fix CMake relative install dir assumptions
       # https://github.com/ros/urdfdom_headers/pull/66
-      (self.fetchpatch {
-        url = "https://github.com/ros/urdfdom_headers/commit/c9c993147bbf18d5ec83bae684c5780281e529b4.patch";
-        hash = "sha256-BnYPdcetYSim2O1R38N0d1tY0Id++AgKNic8+dlM6Vg=";
+      (self.fetchpatch2 {
+        url = "https://github.com/ros/urdfdom_headers/commit/c9c993147bbf18d5ec83bae684c5780281e529b4.patch?full_index=1";
+        hash = "sha256-12jJEf+YKO25HbMdUmBbGi+CNkYxY0b7QXroWps24BA=";
       })
       # Update cmake_minimum_required
       (self.fetchpatch2 {
-        url = "https://github.com/ros/urdfdom_headers/commit/aedc2f08310e74d00c5eadefd07461fa52890fbb.patch";
-        hash = "sha256-ieeHfnxSmyuBnT5376s1cbO+Qin4Ay8fUiTUIGXwo9c=";
+        url = "https://github.com/ros/urdfdom_headers/commit/aedc2f08310e74d00c5eadefd07461fa52890fbb.patch?full_index=1";
+        hash = "sha256-6pShWs+FiZUwbNRC5Tys73mlW2FoPMd4D9pCN75unJc=";
       })
     ];
   });
@@ -1054,14 +1054,14 @@ in with lib; {
   }: {
     patches = patches ++ [
       # Remove undocumented pix_fmt (AV_PIX_FMT_XVMC) breaking the build
-      (self.fetchpatch {
-        url = "https://github.com/ros-drivers/usb_cam/commit/1d1970b1a88fb1be3b961073748879900d2b1a70.patch";
-        hash = "sha256-0iWl2DtqdjkyFy7lKa7aLxXjynm4ggNEQLxB45Mqf/Y=";
+      (self.fetchpatch2 {
+        url = "https://github.com/ros-drivers/usb_cam/commit/1d1970b1a88fb1be3b961073748879900d2b1a70.patch?full_index=1";
+        hash = "sha256-W1ihgS2dHQT1SN2GyVkUdiId82ys6A1a2hwuk26ZXXk=";
       })
       # fix for newer ffmpeg, ref https://github.com/ros-drivers/usb_cam/pull/342, merged upstream
       (self.fetchpatch2 {
-        url = "https://github.com/ros-drivers/usb_cam/commit/9c7e4dad36f7ddc20c207aa2e4d1512a5188a60a.patch";
-        hash = "sha256-sSM7J35wKA8Z4GzXe5YL5Rw1I1jks4efTaCFDNqdKFQ=";
+        url = "https://github.com/ros-drivers/usb_cam/commit/9c7e4dad36f7ddc20c207aa2e4d1512a5188a60a.patch?full_index=1";
+        hash = "sha256-JVoZgReNfYsh30qMFbIM25AALyq1KTdEGh63u1/B2e4=";
       })
     ];
 
@@ -1073,9 +1073,9 @@ in with lib; {
   }: {
     patches = patches ++ [
       # Fix compatibility with recent CMake versions
-      (self.fetchpatch {
-        url = "https://github.com/vrpn/vrpn/commit/04d86b71de06cb6cb8d2cb7276fef27275d083d2.patch";
-        hash = "sha256-AEiTLXPYcFdZrE4KzvCkXH4GiSFmhCl14wkq+0MRWLo=";
+      (self.fetchpatch2 {
+        url = "https://github.com/vrpn/vrpn/commit/04d86b71de06cb6cb8d2cb7276fef27275d083d2.patch?full_index=1";
+        hash = "sha256-DgXKd6w1+2t4GC918YbkBpecnFeGRmMyuAzegLXZee4=";
       })
     ];
     postPatch = postPatch + ''

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -20,8 +20,8 @@ in {
     patches = [
       # Fix compile errors with Boost >= 1.87
       (self.fetchpatch2 {
-        url = "https://github.com/fkie/async_web_server_cpp/pull/8/commits/0aa036c4c3908ef0d9ac85bf623a15906bccaefd.patch";
-        hash = "sha256-GXUYxWmNq2W7DCetmgHGD5/MFBWgDYFNIdUThwj8vt8=";
+        url = "https://github.com/fkie/async_web_server_cpp/pull/8/commits/0aa036c4c3908ef0d9ac85bf623a15906bccaefd.patch?full_index=1";
+        hash = "sha256-uZym/R8c4e/Ypo8xGQwGdasuFixjbddX9hzQeNqXIDc=";
       })
     ];
   });
@@ -50,8 +50,8 @@ in {
       # cmake: Find aravis library with pkg-config if available
       # https://github.com/FraunhoferIOSB/camera_aravis2/pull/63
       (self.fetchpatch2 {
-        url = "https://github.com/FraunhoferIOSB/camera_aravis2/commit/fb2460536f51841452ff31458da428fa5c8e5804.patch";
-        hash = "sha256-1jkrN+u+IKbZROUP0d2Toe51U1v1jgqQZPZmUEOk4CQ=";
+        url = "https://github.com/FraunhoferIOSB/camera_aravis2/commit/fb2460536f51841452ff31458da428fa5c8e5804.patch?full_index=1";
+        hash = "sha256-6Jd6ul8Kr1QyllLrrU2p6DIon5ri/JqPrr1A6ZlwUA0=";
         stripLen = 1;
       })
     ];
@@ -65,9 +65,9 @@ in {
     patches = [
       # Fix paths in pkg-config file
       # https://github.com/eclipse-cyclonedds/cyclonedds/pull/1453
-      (self.fetchpatch {
-        url = "https://github.com/eclipse-cyclonedds/cyclonedds/commit/3ff967e32b8078d497a8b9c70735849c04eaebf6.patch";
-        hash = "sha256-F5zofoO0YbYfqLrb6s30un9k9+R8rQazLHw+uND1UxE=";
+      (self.fetchpatch2 {
+        url = "https://github.com/eclipse-cyclonedds/cyclonedds/commit/3ff967e32b8078d497a8b9c70735849c04eaebf6.patch?full_index=1";
+        hash = "sha256-j1NXVjtVfN+eIBK8S7Kx/70gJrkrirFi83ZFXBuHZfA=";
       })
     ];
   });
@@ -79,8 +79,8 @@ in {
       # Don't use rosbag2_cpp/typesupport_helpers.hpp for Jazzy and later
       # https://github.com/ros2/domain_bridge/pull/89
       (self.fetchpatch2 {
-        url = "https://github.com/ros2/domain_bridge/commit/4abe8a63ba82c816ccb46ec67bc89b05ff842604.patch";
-        hash = "sha256-R+v5SC/yKMsIPuuXVDrrJ/G6DfKHjUr/58dVBFiz+U4=";
+        url = "https://github.com/ros2/domain_bridge/commit/4abe8a63ba82c816ccb46ec67bc89b05ff842604.patch?full_index=1";
+        hash = "sha256-GVMGWs8e/sT3awBtyQWAzEkPiLJ05ot1+PSVEhj4hZk=";
       })
     ];
   });
@@ -102,8 +102,8 @@ in {
       # Remove unused include of rosbag2_cpp/typesupport_helpers.hpp
       # https://github.com/ros-event-camera/event_image_reconstruction_fibar/pull/6
       (self.fetchpatch2 {
-        url = "https://github.com/ros-event-camera/event_image_reconstruction_fibar/commit/7f296ace2dcde06a6384425af3f4e8e7ad8eacd4.patch";
-        hash = "sha256-oXciDL2uVR7RU2Sshfn6led/fsl8iz8DTy89yiYVvNQ=";
+        url = "https://github.com/ros-event-camera/event_image_reconstruction_fibar/commit/7f296ace2dcde06a6384425af3f4e8e7ad8eacd4.patch?full_index=1";
+        hash = "sha256-GPd19YyZP8PkpcK89alg0oPWat/eRCYep+75IiQxHl0=";
       })
     ];
   });
@@ -128,8 +128,8 @@ in {
       # Don't fail with boost >= 1.86
       # https://github.com/locusrobotics/fuse/pull/423
       (self.fetchpatch2 {
-        url = "https://github.com/wentasah/fuse/commit/037b417d9db394b3d5154a800283c30d0ae30cee.patch";
-        hash = "sha256-j3ezP0QYP55mhj+F60Yv0Mv8M8Nu/AHmMoPn1lmI4Bg=";
+        url = "https://github.com/wentasah/fuse/commit/037b417d9db394b3d5154a800283c30d0ae30cee.patch?full_index=1";
+        hash = "sha256-ShWKk5H/6eaViWfAOL0T+ynCps2FgsPWtAZDoUjvR50=";
         stripLen = 1;
       })
     ];
@@ -207,13 +207,13 @@ in {
     patchesFor.gz_common_vendor = [
       (self.fetchpatch2 {
         # Replace FreeImage dependency with stb (gazebosim#725 updated for Jazzy)
-        url = "https://github.com/wentasah/gz-common/commit/9fbe891b3a8f30ff11e8367b1aecea5b0ef7521e.patch";
-        hash = "sha256-TqGMvFLR81P3AJm+GK/Ot1i+EDGGE/E0HqLtpcKDZt4=";
+        url = "https://github.com/wentasah/gz-common/commit/9fbe891b3a8f30ff11e8367b1aecea5b0ef7521e.patch?full_index=1";
+        hash = "sha256-akHFbLY9RsYITWrw0/hTxDwXM1r5f9GqDLRAYHnhIf0=";
       })
       (self.fetchpatch2 {
         # Added missing includes (#672)
-        url = "https://github.com/gazebosim/gz-common/commit/8f235cb2cb7ae9c2251c8ef155a2980ba4f0e764.patch";
-        hash = "sha256-0R0T/HTJzA6rx10psBz2+YycUnIDn2FaetinkprCQOE=";
+        url = "https://github.com/gazebosim/gz-common/commit/8f235cb2cb7ae9c2251c8ef155a2980ba4f0e764.patch?full_index=1";
+        hash = "sha256-B95SFeGraKR7/2SxmAlP4U4UDGe/ZpbhkftjoRJyi8M=";
       })
     ];
   }).overrideAttrs ({
@@ -231,8 +231,8 @@ in {
     patchesFor.gz_gui_vendor = [
       # Fix compatibility with protobuf v30 (cpp 6.30.0)
       (self.fetchpatch2 {
-        url = "https://github.com/gazebosim/gz-gui/commit/8db77b5d0bdc4e87dbc17383d4e15dd8e95a2ccc.patch";
-        hash = "sha256-5Pb3dPAcJJ8Esd5wmD0vhfJjfTQeZpBk9yMDbF1QLZc=";
+        url = "https://github.com/gazebosim/gz-gui/commit/8db77b5d0bdc4e87dbc17383d4e15dd8e95a2ccc.patch?full_index=1";
+        hash = "sha256-MId7fumD01PSsAUtRw1sydLNQJLxakiPDcSwale8K20=";
       })
     ];
   }).overrideAttrs ({
@@ -249,8 +249,8 @@ in {
     patchesFor.gz_launch_vendor = [
       # Fix compatibility with protobuf v30 (cpp 6.30.0)
       (self.fetchpatch2 {
-        url = "https://github.com/gazebosim/gz-launch/commit/246d180753c758445b7f1c11b3ae3b1840a65ae4.patch";
-        hash = "sha256-ySv5YF9LacOW2owxoW9CvLYQ9LklYlD4LM39OqpgApQ=";
+        url = "https://github.com/gazebosim/gz-launch/commit/246d180753c758445b7f1c11b3ae3b1840a65ae4.patch?full_index=1";
+        hash = "sha256-7qrOotQjRtHMo6rn5Qqcyr4keYq25Z9TXe3yFQcnIBA=";
       })
     ];
   };
@@ -261,8 +261,8 @@ in {
     patchesFor.gz_msgs_vendor = [
       # Fix compatibility with protobuf v30 (cpp 6.30.0)
       (self.fetchpatch2 {
-        url = "https://github.com/gazebosim/gz-msgs/commit/ebdd05f6d51c990876085bcc9db9f79df59d375a.patch";
-        hash = "sha256-EkonVJ7Q3XJvXnqkhYWxNrknnEOFpNvjwcnyc1bQHDE=";
+        url = "https://github.com/gazebosim/gz-msgs/commit/ebdd05f6d51c990876085bcc9db9f79df59d375a.patch?full_index=1";
+        hash = "sha256-0uscwyYZafHfzooxcrrhtcfcxknpDTEcZ6Ie0WWySVw=";
       })
     ];
   };
@@ -275,8 +275,8 @@ in {
     patchesFor.gz_rendering_vendor = [
       (self.fetchpatch2 {
         # Added missing includes (#1128)
-        url = "https://github.com/gazebosim/gz-rendering/commit/b7973e14778baba95c94798b15391183d9261c16.patch";
-        hash = "sha256-MWw/jw+MzA4E9q3n5Kyc6ipiGUmrZEyx/QhB/oMkeKI=";
+        url = "https://github.com/gazebosim/gz-rendering/commit/b7973e14778baba95c94798b15391183d9261c16.patch?full_index=1";
+        hash = "sha256-oO5awcuPZ4PqDyo08zxq3mKQxJ4Y4MnywRbs7ZNk0KM=";
       })
     ];
   };
@@ -319,9 +319,9 @@ in {
     patches ? [], ...
   }: {
     patches = patches ++ [
-      (self.fetchpatch {
-        url = "https://github.com/eclipse-iceoryx/iceoryx/commit/acc1e979a2d5ca30737efb077b00b42f1c4a8429.patch";
-        hash = "sha256-npFHdb0a3JBA8T6vke54DA08C93aNc/7c6xrfMBo7zI=";
+      (self.fetchpatch2 {
+        url = "https://github.com/eclipse-iceoryx/iceoryx/commit/acc1e979a2d5ca30737efb077b00b42f1c4a8429.patch?full_index=1";
+        hash = "sha256-M2ItntTMGqH6YkUNMEF0opJobyqgbZq62vBkyWxxol0=";
         stripLen = 1;
       })
     ];
@@ -333,8 +333,8 @@ in {
     patches = patches ++ [
       # fix for asio 1.36: https://github.com/ros-drivers/transport_drivers/pull/113
       (self.fetchpatch2 {
-        url = "https://github.com/nim65s/transport_drivers/commit/7be52848f624c82ea720416360d7a754fff65c33.patch";
-        hash = "sha256-frE2449PirPJMnln/mGW87JHXCJfb2wo+SBDunTPanc=";
+        url = "https://github.com/nim65s/transport_drivers/commit/7be52848f624c82ea720416360d7a754fff65c33.patch?full_index=1";
+        hash = "sha256-IYQTlSnJjUvnOp0RbN+1P7C/RclAjouyzmBT9LJpyN4=";
         stripLen = 1;
       })
     ];
@@ -382,9 +382,9 @@ in {
   }: {
     patches = patches ++ [
       # Fix failing build due to deprecated boost::filesystem functions
-      (self.fetchpatch {
-        url = "https://github.com/norlab-ulaval/libpointmatcher/commit/74435b8f434ffd36aab1c7f309facbe2911403df.patch";
-        hash = "sha256-/JaEmFbJrthEpyC4sAHfdn43eHbcSZD78nqgy++OSGM=";
+      (self.fetchpatch2 {
+        url = "https://github.com/norlab-ulaval/libpointmatcher/commit/74435b8f434ffd36aab1c7f309facbe2911403df.patch?full_index=1";
+        hash = "sha256-U0I5UuJoNtKzNSKriWaiGHr79Y9QWe3Pf1y77YJvaK8=";
       })
     ];
   });
@@ -450,8 +450,8 @@ in {
     patches = patches ++ [
       # Add missing #include <fmt/ranges.h>
       (self.fetchpatch2 {
-        url = "https://github.com/moveit/moveit2/commit/b3c23c989ff45c66ec692a71535330b42be09879.patch";
-        hash = "sha256-1rVN6kgBNHGG2EH1XCw49PPY1JzPud06l3LZAzp2XNU=";
+        url = "https://github.com/moveit/moveit2/commit/b3c23c989ff45c66ec692a71535330b42be09879.patch?full_index=1";
+        hash = "sha256-lETKOTjyioqajQ5d5KEPMUUmdJ60l5fQBCz1sWEuTr8=";
         includes = [ "src/urdf_config.cpp" ];
         stripLen = 2;
       })
@@ -529,9 +529,9 @@ in {
     patches ? [], ...
   }: {
     patches = patches ++ [
-      (self.fetchpatch {
-        url = "https://github.com/ros-navigation/navigation2/commit/e6f500e5b7528737f4a883598293b62c72c83946.patch";
-        hash = "sha256-XFQjW9eb/CVF+wDgNTG+wyXoz1Hwa3qEU/cIXRcBY6Y=";
+      (self.fetchpatch2 {
+        url = "https://github.com/ros-navigation/navigation2/commit/e6f500e5b7528737f4a883598293b62c72c83946.patch?full_index=1";
+        hash = "sha256-cAlbj3YaiRGv9KaDKyJcxgDu8DeWeXNqFOJMRBIvcJo=";
         stripLen = 1;
       })
     ];
@@ -551,8 +551,8 @@ in {
     patches = patches ++ [
       # fix for asio 1.36, ref. https://github.com/bosch-engineering/off_highway_sensor_drivers/pull/33
       (self.fetchpatch2 {
-        url = "https://github.com/nim65s/off_highway_sensor_drivers/commit/61c88d4c1c844e2eb24eab30ea23cdd2dfd066b5.patch";
-        hash = "sha256-3Dx5Mg1HwSqi8wFQDmXxBHLovCzjdLacjKO7b1bCIKA=";
+        url = "https://github.com/nim65s/off_highway_sensor_drivers/commit/61c88d4c1c844e2eb24eab30ea23cdd2dfd066b5.patch?full_index=1";
+        hash = "sha256-vGdu9MfPQrxg71tPxyFD2MKt0c92agQMGn04amwWY7Y=";
         stripLen = 1;
       })
     ];
@@ -564,8 +564,8 @@ in {
     patches = patches ++ [
       # fix for asio 1.36, ref. https://github.com/bosch-engineering/off_highway_sensor_drivers/pull/33
       (self.fetchpatch2 {
-        url = "https://github.com/nim65s/off_highway_sensor_drivers/commit/c2e2fba65f812284790687a0c4f9c5982bd6fd14.patch";
-        hash = "sha256-83SK6kU8HmQgpCXJKbYKb2FTzL6AVbKbKeyRRO9+22w=";
+        url = "https://github.com/nim65s/off_highway_sensor_drivers/commit/c2e2fba65f812284790687a0c4f9c5982bd6fd14.patch?full_index=1";
+        hash = "sha256-sevjNaBo/nnRCB/Pfa33l0mvjs3W8bmVMaqhyyQrYJU=";
         stripLen = 1;
       })
     ];
@@ -589,19 +589,19 @@ in {
     patches = patches ++ [
       # add formatting consistent with plotjuggler App
       (self.fetchpatch2 {
-        url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins/commit/3b9e06ce35b33792f738afc22397e8aecb9ad691.patch";
-        hash = "sha256-EEiDwji9Y8tAs0adKEgxsae6h9Qy23RzTAeRBHEQB7k=";
+        url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins/commit/3b9e06ce35b33792f738afc22397e8aecb9ad691.patch?full_index=1";
+        hash = "sha256-yBuHzNwI72BgH/TjVqFooL5neFFzNguh5IgeB4DYCYQ=";
       })
       # new formatting rules
       (self.fetchpatch2 {
-        url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins/commit/d3575cbd2ba583f0d3c73973979154bfbba87dad.patch";
-        hash = "sha256-i1k3KpA1bubXlTlQgDyyBVol7ErDic/LUYIxt1wo+0E=";
+        url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins/commit/d3575cbd2ba583f0d3c73973979154bfbba87dad.patch?full_index=1";
+        hash = "sha256-NXS+tYoHKjKG3jLEmsALfncuw52ERtZLkx0vA6UUCls=";
       })
       # Replace rosbag2_cpp typesupport helpers with rclcpp typesupport helpers
       # https://github.com/PlotJuggler/plotjuggler-ros-plugins/pull/105
       (self.fetchpatch2 {
-        url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins/commit/82b9d41908bc8258d16ba33736bd295b54d8654b.patch";
-        hash = "sha256-+haJAdjD3NYCKpkw+mW+kx0CskxknPoY0xx24vNaqV0=";
+        url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins/commit/82b9d41908bc8258d16ba33736bd295b54d8654b.patch?full_index=1";
+        hash = "sha256-oMHQTaGyFSRQi84jaCOyOi89cWdZ9lUJyaJ1umoLTRQ=";
       })
     ];
   });
@@ -616,8 +616,8 @@ in {
     patches = patches ++ [
       # cmake: fix missing includes, ref. https://github.com/fmrico/popf/pull/12
       (self.fetchpatch2 {
-        url = "https://github.com/nim65s/popf/commit/e8ba226f67e0513689d0efc84e9b4e8b55394bd4.patch";
-        hash = "sha256-Sw/rY4MsmoWIpC9VQzimM18mlvdGwb8Q6EmwY2rg0pw=";
+        url = "https://github.com/nim65s/popf/commit/e8ba226f67e0513689d0efc84e9b4e8b55394bd4.patch?full_index=1";
+        hash = "sha256-fHorf5CyGDIbx3WLb4XOfGVSXhOXjtBq9iVNLywCDQQ=";
       })
     ];
   });
@@ -666,8 +666,8 @@ in {
     patches = patches ++ [
       # fix for GCC 15, ref. https://github.com/open-rmf/rmf_task/pull/133
       (self.fetchpatch2 {
-        url = "https://github.com/nim65s/rmf_task/commit/8aaacbe009022540cce1cd3ff3282413cf08a42c.patch";
-        hash = "sha256-9nXoYlfw6yuXP2TFelWl1/T6ho3G49n5vRoxC5qxQCA=";
+        url = "https://github.com/nim65s/rmf_task/commit/8aaacbe009022540cce1cd3ff3282413cf08a42c.patch?full_index=1";
+        hash = "sha256-xpn2yWMRyXUPTf0OdCjGGkKcNLHO6jAnWz4NeXInI2I=";
         stripLen = 1;
       })
     ];
@@ -679,8 +679,8 @@ in {
     patches = [
       # https://github.com/open-rmf/rmf_traffic/pull/131
       (self.fetchpatch2 {
-        url = "https://github.com/open-rmf/rmf_traffic/commit/c20b8d71507880387185666c78d105557e5003a9.patch";
-        hash = "sha256-4Elg7oF6OQHd2trn3e+r73hghW9Qf90PrGjID7RsdEI=";
+        url = "https://github.com/open-rmf/rmf_traffic/commit/c20b8d71507880387185666c78d105557e5003a9.patch?full_index=1";
+        hash = "sha256-2f2jT9Be5f/Bzh5sLxXwmdD+fwtvdoDuBrejlns1GWg=";
         stripLen = 1;
       })
     ];
@@ -728,8 +728,8 @@ in {
     patches = patches ++ [
       # fix for gcc15, ref https://github.com/SICKAG/sick_scan_xd/pull/557
       (self.fetchpatch2 {
-        url = "https://github.com/SICKAG/sick_scan_xd/commit/f5ac360b4cfb319c981b022a9b817a5e86639d5c.patch";
-        hash = "sha256-zh3UDjy6k7LI3YOYr9F9jt8+4pkdgeOpUUqHcqme6Bs=";
+        url = "https://github.com/SICKAG/sick_scan_xd/commit/f5ac360b4cfb319c981b022a9b817a5e86639d5c.patch?full_index=1";
+        hash = "sha256-UJQZO0cStf7b3890BBrpHBxzgWnJXPOxmW6SKsuAsWw=";
       })
     ];
   });
@@ -760,8 +760,8 @@ in {
     patches = patches ++ [
       # Fix for asio 1.36, ref https://github.com/KumarRobotics/ublox/pull/273
       (self.fetchpatch2 {
-        url = "https://github.com/nim65s/ublox/commit/da37a9628db91aaafbcbe8b247c28c0d5863159f.patch";
-        hash = "sha256-m7lsEHF/uS47zYrNBd5RSL62CmvmNcKXQiLM24R6LZA=";
+        url = "https://github.com/nim65s/ublox/commit/da37a9628db91aaafbcbe8b247c28c0d5863159f.patch?full_index=1";
+        hash = "sha256-S1h+tw9juDe10I/oITnTYkGFtybI7sMEO7BftKhHo1I=";
         stripLen = 1;
       })
     ];
@@ -773,8 +773,8 @@ in {
     # fix for asio 1.36: https://github.com/ros-drivers/transport_drivers/pull/114
     patches = patches ++ [
       (self.fetchpatch2 {
-        url = "https://github.com/nim65s/transport_drivers/commit/6a5a003a07850afda9681843978f1c5f46d04000.patch";
-        hash = "sha256-0j3Ps2RbkWcv9K+I6KW0fn2/4Nhsw8TIOoZAhAVixMk=";
+        url = "https://github.com/nim65s/transport_drivers/commit/6a5a003a07850afda9681843978f1c5f46d04000.patch?full_index=1";
+        hash = "sha256-rOBbfYxqdrA0hQsl+dFKhyuEsLNXHIF1fj54sSf0FQY=";
         stripLen = 1;
       })
     ];
@@ -786,9 +786,9 @@ in {
     patches = patches ++ [
       # Fix CMake relative install dir assumptions
       # https://github.com/ros/urdfdom/pull/142
-      (self.fetchpatch {
-        url = "https://github.com/ros/urdfdom/commit/61a7e35cd5abece97259e76aed8504052b2f5b53.patch";
-        hash = "sha256-b3bEbbaSUDkwTEHJ8gVPEb+AR/zuWwLqiAW5g1T1dPU=";
+      (self.fetchpatch2 {
+        url = "https://github.com/ros/urdfdom/commit/61a7e35cd5abece97259e76aed8504052b2f5b53.patch?full_index=1";
+        hash = "sha256-VaAjqVAytynFy03qpHfTvqPPcI3jKmd2HGoAQp2CBYQ=";
       })
     ];
   });
@@ -799,9 +799,9 @@ in {
     patches = patches ++ [
       # Fix CMake relative install dir assumptions
       # https://github.com/ros/urdfdom_headers/pull/66
-      (self.fetchpatch {
-        url = "https://github.com/ros/urdfdom_headers/commit/fa89f2d4744839827f41579004537c966a097681.patch";
-        hash = "sha256-w6PPKCpbR4dGsudVEz+SO9ylXVayLPRAl3VvpMt4DHo=";
+      (self.fetchpatch2 {
+        url = "https://github.com/ros/urdfdom_headers/commit/fa89f2d4744839827f41579004537c966a097681.patch?full_index=1";
+        hash = "sha256-rwAlK2aeu4YYZ6B3K14l4FOt1A90vkblIv1k0zPtaSY=";
       })
     ];
   });
@@ -811,14 +811,14 @@ in {
   }: {
     patches = patches ++ [
       # Remove undocumented pix_fmt (AV_PIX_FMT_XVMC) breaking the build
-      (self.fetchpatch {
-        url = "https://github.com/ros-drivers/usb_cam/commit/1d1970b1a88fb1be3b961073748879900d2b1a70.patch";
-        hash = "sha256-0iWl2DtqdjkyFy7lKa7aLxXjynm4ggNEQLxB45Mqf/Y=";
+      (self.fetchpatch2 {
+        url = "https://github.com/ros-drivers/usb_cam/commit/1d1970b1a88fb1be3b961073748879900d2b1a70.patch?full_index=1";
+        hash = "sha256-W1ihgS2dHQT1SN2GyVkUdiId82ys6A1a2hwuk26ZXXk=";
       })
       # Remove avcodec_close() removed in FFmpeg 8.0 (avcodec_free_context suffices)
-      (self.fetchpatch {
-        url = "https://github.com/ros-drivers/usb_cam/commit/41805f7eb50f31e16839bb302df1bb5c6f30cb50.patch";
-        hash = "sha256-UXjqIHCkplBo5MWmH+ZlcRyy0IJgr8Qdld9QMq03SPI=";
+      (self.fetchpatch2 {
+        url = "https://github.com/ros-drivers/usb_cam/commit/41805f7eb50f31e16839bb302df1bb5c6f30cb50.patch?full_index=1";
+        hash = "sha256-JVoZgReNfYsh30qMFbIM25AALyq1KTdEGh63u1/B2e4=";
       })
     ];
   });

--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -10,8 +10,8 @@ in {
     patches = [
       # Fix compile errors with Boost >= 1.87
       (self.fetchpatch2 {
-        url = "https://github.com/fkie/async_web_server_cpp/pull/8/commits/0aa036c4c3908ef0d9ac85bf623a15906bccaefd.patch";
-        hash = "sha256-GXUYxWmNq2W7DCetmgHGD5/MFBWgDYFNIdUThwj8vt8=";
+        url = "https://github.com/fkie/async_web_server_cpp/pull/8/commits/0aa036c4c3908ef0d9ac85bf623a15906bccaefd.patch?full_index=1";
+        hash = "sha256-uZym/R8c4e/Ypo8xGQwGdasuFixjbddX9hzQeNqXIDc=";
       })
     ];
   });
@@ -40,8 +40,8 @@ in {
       # cmake: Find aravis library with pkg-config if available
       # https://github.com/FraunhoferIOSB/camera_aravis2/pull/63
       (self.fetchpatch2 {
-        url = "https://github.com/FraunhoferIOSB/camera_aravis2/commit/fb2460536f51841452ff31458da428fa5c8e5804.patch";
-        hash = "sha256-1jkrN+u+IKbZROUP0d2Toe51U1v1jgqQZPZmUEOk4CQ=";
+        url = "https://github.com/FraunhoferIOSB/camera_aravis2/commit/fb2460536f51841452ff31458da428fa5c8e5804.patch?full_index=1";
+        hash = "sha256-6Jd6ul8Kr1QyllLrrU2p6DIon5ri/JqPrr1A6ZlwUA0=";
         stripLen = 1;
       })
     ];
@@ -55,9 +55,9 @@ in {
     patches = [
       # Fix paths in pkg-config file
       # https://github.com/eclipse-cyclonedds/cyclonedds/pull/1453
-      (self.fetchpatch {
-        url = "https://github.com/eclipse-cyclonedds/cyclonedds/commit/3ff967e32b8078d497a8b9c70735849c04eaebf6.patch";
-        hash = "sha256-F5zofoO0YbYfqLrb6s30un9k9+R8rQazLHw+uND1UxE=";
+      (self.fetchpatch2 {
+        url = "https://github.com/eclipse-cyclonedds/cyclonedds/commit/3ff967e32b8078d497a8b9c70735849c04eaebf6.patch?full_index=1";
+        hash = "sha256-j1NXVjtVfN+eIBK8S7Kx/70gJrkrirFi83ZFXBuHZfA=";
       })
     ];
   });
@@ -116,8 +116,8 @@ in {
       # Don't fail with boost >= 1.86
       # https://github.com/locusrobotics/fuse/pull/423
       (self.fetchpatch2 {
-        url = "https://github.com/wentasah/fuse/commit/037b417d9db394b3d5154a800283c30d0ae30cee.patch";
-        hash = "sha256-j3ezP0QYP55mhj+F60Yv0Mv8M8Nu/AHmMoPn1lmI4Bg=";
+        url = "https://github.com/wentasah/fuse/commit/037b417d9db394b3d5154a800283c30d0ae30cee.patch?full_index=1";
+        hash = "sha256-ShWKk5H/6eaViWfAOL0T+ynCps2FgsPWtAZDoUjvR50=";
         stripLen = 1;
       })
     ];
@@ -159,8 +159,8 @@ in {
     patchesFor.gz_common_vendor = [
       (self.fetchpatch2 {
         # Replace FreeImage dependency with stb (#725 updated for Kilted)
-        url = "https://github.com/gazebosim/gz-common/commit/7a6bb5bf196c2e3f515fda5c3982190641be36c9.patch";
-        hash = "sha256-h1wbOim4vuM0jV3DaH0LnJoy/TuvEwENRXF5GIw9B1M=";
+        url = "https://github.com/gazebosim/gz-common/commit/7a6bb5bf196c2e3f515fda5c3982190641be36c9.patch?full_index=1";
+        hash = "sha256-NMsj9WuOx4JxkF1Noy52s4X41nwqiVXlhWBAE2X/liw=";
         excludes = ["tutorials/install.md"];
       })
     ];
@@ -230,9 +230,9 @@ in {
     patches ? [], ...
   }: {
     patches = patches ++ [
-      (self.fetchpatch {
-        url = "https://github.com/eclipse-iceoryx/iceoryx/commit/acc1e979a2d5ca30737efb077b00b42f1c4a8429.patch";
-        hash = "sha256-npFHdb0a3JBA8T6vke54DA08C93aNc/7c6xrfMBo7zI=";
+      (self.fetchpatch2 {
+        url = "https://github.com/eclipse-iceoryx/iceoryx/commit/acc1e979a2d5ca30737efb077b00b42f1c4a8429.patch?full_index=1";
+        hash = "sha256-M2ItntTMGqH6YkUNMEF0opJobyqgbZq62vBkyWxxol0=";
         stripLen = 1;
       })
     ];
@@ -244,8 +244,8 @@ in {
     patches = patches ++ [
       # fix for asio 1.36: https://github.com/ros-drivers/transport_drivers/pull/113
       (self.fetchpatch2 {
-        url = "https://github.com/nim65s/transport_drivers/commit/7be52848f624c82ea720416360d7a754fff65c33.patch";
-        hash = "sha256-frE2449PirPJMnln/mGW87JHXCJfb2wo+SBDunTPanc=";
+        url = "https://github.com/nim65s/transport_drivers/commit/7be52848f624c82ea720416360d7a754fff65c33.patch?full_index=1";
+        hash = "sha256-IYQTlSnJjUvnOp0RbN+1P7C/RclAjouyzmBT9LJpyN4=";
         stripLen = 1;
       })
     ];
@@ -257,8 +257,8 @@ in {
     patches = [
       # fix compile error
       (self.fetchpatch2 {
-        url = "https://github.com/ros2/ros2_tracing/commit/e175cde407a2da7fab2a75890cdb9d0e626cc73b.patch";
-        hash = "sha256-X4d82I0OP+noDC48ft2LDbzbzKwF2D2nbqv2YpBiwl8=";
+        url = "https://github.com/ros2/ros2_tracing/commit/e175cde407a2da7fab2a75890cdb9d0e626cc73b.patch?full_index=1";
+        hash = "sha256-U0G8/WNTmaDHu0NN8OxGBFJlnebgW2XZIVNeTpUqgmY=";
         stripLen = 1;
       })
     ];
@@ -372,8 +372,8 @@ in {
     patches = patches ++ [
       # Add missing #include <fmt/ranges.h>
       (self.fetchpatch2 {
-        url = "https://github.com/moveit/moveit2/commit/b3c23c989ff45c66ec692a71535330b42be09879.patch";
-        hash = "sha256-1rVN6kgBNHGG2EH1XCw49PPY1JzPud06l3LZAzp2XNU=";
+        url = "https://github.com/moveit/moveit2/commit/b3c23c989ff45c66ec692a71535330b42be09879.patch?full_index=1";
+        hash = "sha256-lETKOTjyioqajQ5d5KEPMUUmdJ60l5fQBCz1sWEuTr8=";
         includes = [ "src/urdf_config.cpp" ];
         stripLen = 2;
       })
@@ -456,8 +456,8 @@ in {
     patches = patches ++ [
       # cmake: fix missing includes, ref. https://github.com/fmrico/popf/pull/12
       (self.fetchpatch2 {
-        url = "https://github.com/nim65s/popf/commit/e8ba226f67e0513689d0efc84e9b4e8b55394bd4.patch";
-        hash = "sha256-Sw/rY4MsmoWIpC9VQzimM18mlvdGwb8Q6EmwY2rg0pw=";
+        url = "https://github.com/nim65s/popf/commit/e8ba226f67e0513689d0efc84e9b4e8b55394bd4.patch?full_index=1";
+        hash = "sha256-fHorf5CyGDIbx3WLb4XOfGVSXhOXjtBq9iVNLywCDQQ=";
       })
     ];
   });
@@ -489,8 +489,8 @@ in {
     patches = patches ++ [
       # fix for GCC 15, ref. https://github.com/open-rmf/rmf_task/pull/133
       (self.fetchpatch2 {
-        url = "https://github.com/nim65s/rmf_task/commit/8aaacbe009022540cce1cd3ff3282413cf08a42c.patch";
-        hash = "sha256-9nXoYlfw6yuXP2TFelWl1/T6ho3G49n5vRoxC5qxQCA=";
+        url = "https://github.com/nim65s/rmf_task/commit/8aaacbe009022540cce1cd3ff3282413cf08a42c.patch?full_index=1";
+        hash = "sha256-xpn2yWMRyXUPTf0OdCjGGkKcNLHO6jAnWz4NeXInI2I=";
         stripLen = 1;
       })
     ];
@@ -502,8 +502,8 @@ in {
     patches = [
       # https://github.com/open-rmf/rmf_traffic/pull/131
       (self.fetchpatch2 {
-        url = "https://github.com/open-rmf/rmf_traffic/commit/c20b8d71507880387185666c78d105557e5003a9.patch";
-        hash = "sha256-4Elg7oF6OQHd2trn3e+r73hghW9Qf90PrGjID7RsdEI=";
+        url = "https://github.com/open-rmf/rmf_traffic/commit/c20b8d71507880387185666c78d105557e5003a9.patch?full_index=1";
+        hash = "sha256-2f2jT9Be5f/Bzh5sLxXwmdD+fwtvdoDuBrejlns1GWg=";
         stripLen = 1;
       })
     ];
@@ -562,8 +562,8 @@ in {
     patches = patches ++ [
       # fix for gcc15, ref https://github.com/SICKAG/sick_scan_xd/pull/557
       (self.fetchpatch2 {
-        url = "https://github.com/SICKAG/sick_scan_xd/commit/f5ac360b4cfb319c981b022a9b817a5e86639d5c.patch";
-        hash = "sha256-zh3UDjy6k7LI3YOYr9F9jt8+4pkdgeOpUUqHcqme6Bs=";
+        url = "https://github.com/SICKAG/sick_scan_xd/commit/f5ac360b4cfb319c981b022a9b817a5e86639d5c.patch?full_index=1";
+        hash = "sha256-UJQZO0cStf7b3890BBrpHBxzgWnJXPOxmW6SKsuAsWw=";
       })
     ];
   });
@@ -599,8 +599,8 @@ in {
     patches = patches ++ [
       # Fix for asio 1.36, ref https://github.com/KumarRobotics/ublox/pull/273
       (self.fetchpatch2 {
-        url = "https://github.com/nim65s/ublox/commit/da37a9628db91aaafbcbe8b247c28c0d5863159f.patch";
-        hash = "sha256-m7lsEHF/uS47zYrNBd5RSL62CmvmNcKXQiLM24R6LZA=";
+        url = "https://github.com/nim65s/ublox/commit/da37a9628db91aaafbcbe8b247c28c0d5863159f.patch?full_index=1";
+        hash = "sha256-S1h+tw9juDe10I/oITnTYkGFtybI7sMEO7BftKhHo1I=";
         stripLen = 1;
       })
     ];
@@ -612,8 +612,8 @@ in {
     # fix for asio 1.36: https://github.com/ros-drivers/transport_drivers/pull/114
     patches = patches ++ [
       (self.fetchpatch2 {
-        url = "https://github.com/nim65s/transport_drivers/commit/6a5a003a07850afda9681843978f1c5f46d04000.patch";
-        hash = "sha256-0j3Ps2RbkWcv9K+I6KW0fn2/4Nhsw8TIOoZAhAVixMk=";
+        url = "https://github.com/nim65s/transport_drivers/commit/6a5a003a07850afda9681843978f1c5f46d04000.patch?full_index=1";
+        hash = "sha256-rOBbfYxqdrA0hQsl+dFKhyuEsLNXHIF1fj54sSf0FQY=";
         stripLen = 1;
       })
     ];
@@ -625,9 +625,9 @@ in {
     patches = patches ++ [
       # Fix CMake relative install dir assumptions
       # https://github.com/ros/urdfdom/pull/142
-      (self.fetchpatch {
-        url = "https://github.com/ros/urdfdom/commit/61a7e35cd5abece97259e76aed8504052b2f5b53.patch";
-        hash = "sha256-b3bEbbaSUDkwTEHJ8gVPEb+AR/zuWwLqiAW5g1T1dPU=";
+      (self.fetchpatch2 {
+        url = "https://github.com/ros/urdfdom/commit/61a7e35cd5abece97259e76aed8504052b2f5b53.patch?full_index=1";
+        hash = "sha256-VaAjqVAytynFy03qpHfTvqPPcI3jKmd2HGoAQp2CBYQ=";
       })
     ];
   });
@@ -638,9 +638,9 @@ in {
     patches = patches ++ [
       # Fix CMake relative install dir assumptions
       # https://github.com/ros/urdfdom_headers/pull/90
-      (self.fetchpatch {
-        url = "https://github.com/ros/urdfdom_headers/commit/90efa6072dc239f78d37288a49f24d8aee1aaad2.patch";
-        hash = "sha256-3q3K+fiINvS9eUrkHS3cgnn8GuA0Nz+FvVBMpsRAcFM=";
+      (self.fetchpatch2 {
+        url = "https://github.com/ros/urdfdom_headers/commit/90efa6072dc239f78d37288a49f24d8aee1aaad2.patch?full_index=1";
+        hash = "sha256-XFudlWVAcj2m7PwW/1KakDsG7ArVSijCio+xfVrbfb8=";
       })
     ];
   });
@@ -650,14 +650,14 @@ in {
   }: {
     patches = patches ++ [
       # Remove undocumented pix_fmt (AV_PIX_FMT_XVMC) breaking the build
-      (self.fetchpatch {
-        url = "https://github.com/ros-drivers/usb_cam/commit/1d1970b1a88fb1be3b961073748879900d2b1a70.patch";
-        hash = "sha256-0iWl2DtqdjkyFy7lKa7aLxXjynm4ggNEQLxB45Mqf/Y=";
+      (self.fetchpatch2 {
+        url = "https://github.com/ros-drivers/usb_cam/commit/1d1970b1a88fb1be3b961073748879900d2b1a70.patch?full_index=1";
+        hash = "sha256-W1ihgS2dHQT1SN2GyVkUdiId82ys6A1a2hwuk26ZXXk=";
       })
       # Remove avcodec_close() removed in FFmpeg 8.0 (avcodec_free_context suffices)
-      (self.fetchpatch {
-        url = "https://github.com/ros-drivers/usb_cam/commit/41805f7eb50f31e16839bb302df1bb5c6f30cb50.patch";
-        hash = "sha256-UXjqIHCkplBo5MWmH+ZlcRyy0IJgr8Qdld9QMq03SPI=";
+      (self.fetchpatch2 {
+        url = "https://github.com/ros-drivers/usb_cam/commit/41805f7eb50f31e16839bb302df1bb5c6f30cb50.patch?full_index=1";
+        hash = "sha256-JVoZgReNfYsh30qMFbIM25AALyq1KTdEGh63u1/B2e4=";
       })
     ];
   });

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -10,8 +10,8 @@ in {
     patches = [
       # Fix compile errors with Boost >= 1.87
       (self.fetchpatch2 {
-        url = "https://github.com/fkie/async_web_server_cpp/pull/8/commits/0aa036c4c3908ef0d9ac85bf623a15906bccaefd.patch";
-        hash = "sha256-GXUYxWmNq2W7DCetmgHGD5/MFBWgDYFNIdUThwj8vt8=";
+        url = "https://github.com/fkie/async_web_server_cpp/pull/8/commits/0aa036c4c3908ef0d9ac85bf623a15906bccaefd.patch?full_index=1";
+        hash = "sha256-uZym/R8c4e/Ypo8xGQwGdasuFixjbddX9hzQeNqXIDc=";
       })
     ];
   });
@@ -39,8 +39,8 @@ in {
       # Fix compile error caused by rosidl_buffer introduction
       # https://github.com/wep21/bag2_to_image/pull/8
       (self.fetchpatch2 {
-        url = "https://github.com/wep21/bag2_to_image/commit/1c6ff87fa27244db7f15597c9cd6ecad34479208.patch";
-        hash = "sha256-dCAy/FZvAAsmqZGxPZd0DKrLrMdbwGH7VLqoYKb/Cb0=";
+        url = "https://github.com/wep21/bag2_to_image/commit/1c6ff87fa27244db7f15597c9cd6ecad34479208.patch?full_index=1";
+        hash = "sha256-GFPd1MdWgjxnDBqwiO/GKIYLHkY3eGG297HKOAoZacw=";
       })
     ];
   });
@@ -52,8 +52,8 @@ in {
       # Fix compile error with latest realtime_tools
       # https://github.com/ipa320/ros_battery_monitoring/pull/12
       (self.fetchpatch2 {
-        url = "https://github.com/ipa320/ros_battery_monitoring/commit/b9ee8af78e8154b95fc4b8202c53320466c4c69b.patch";
-        hash = "sha256-QXcJRw+ByI1p4D5GhWC7tELUu7RW2Yecn8ZqbhXTsVg=";
+        url = "https://github.com/ipa320/ros_battery_monitoring/commit/b9ee8af78e8154b95fc4b8202c53320466c4c69b.patch?full_index=1";
+        hash = "sha256-6rYpWL4w2s/BoADZHFNQHFrYQO0pewsvs5ri1M3dTIc=";
         stripLen = 1;
       })
     ];
@@ -128,8 +128,8 @@ in {
       # Don't fail with boost >= 1.86
       # https://github.com/locusrobotics/fuse/pull/423
       (self.fetchpatch2 {
-        url = "https://github.com/wentasah/fuse/commit/037b417d9db394b3d5154a800283c30d0ae30cee.patch";
-        hash = "sha256-j3ezP0QYP55mhj+F60Yv0Mv8M8Nu/AHmMoPn1lmI4Bg=";
+        url = "https://github.com/wentasah/fuse/commit/037b417d9db394b3d5154a800283c30d0ae30cee.patch?full_index=1";
+        hash = "sha256-ShWKk5H/6eaViWfAOL0T+ynCps2FgsPWtAZDoUjvR50=";
         stripLen = 1;
       })
     ];
@@ -168,8 +168,8 @@ in {
     patchesFor.gz_common_vendor = [
       (self.fetchpatch2 {
         # Replace FreeImage dependency with stb (#725 updated for gz-common7)
-        url = "https://github.com/gazebosim/gz-common/commit/73af365810c97f19d3db4068678e3a07690a2fd7.patch";
-        hash = "sha256-tLGyEPkaQQboLCSMesF2Nmb0OXc6QBf52NGcs8KAqs8=";
+        url = "https://github.com/gazebosim/gz-common/commit/73af365810c97f19d3db4068678e3a07690a2fd7.patch?full_index=1";
+        hash = "sha256-0JoNlI5LcueF6WdQGhLt9wEGtEvT5rkrywzlWniJfz4=";
         excludes = ["tutorials/install.md"];
       })
     ];
@@ -238,8 +238,8 @@ in {
       # Fix build error with GCC 15 in joint_trajectory_controller
       # https://github.com/ros-controls/ros2_control/pull/3174
       (self.fetchpatch2 {
-        url = "https://github.com/wentasah/ros2_control/commit/4f8c27fc8b7e8ff855258318fe3e301f3ac52f99.patch";
-        hash = "sha256-TfhVA5aSkKOusCylfxne8/MEQcIqCZQU3LeiQ5SdN/A=";
+        url = "https://github.com/wentasah/ros2_control/commit/4f8c27fc8b7e8ff855258318fe3e301f3ac52f99.patch?full_index=1";
+        hash = "sha256-l+ouh9M2ZlPjLT5Q3xrLtPpTGAAcfS2AR0VCsOs2V4o=";
         stripLen = 1;
       })
     ];
@@ -251,8 +251,8 @@ in {
     patches = patches ++ [
       # fix for asio 1.36: https://github.com/ros-drivers/transport_drivers/pull/113
       (self.fetchpatch2 {
-        url = "https://github.com/nim65s/transport_drivers/commit/7be52848f624c82ea720416360d7a754fff65c33.patch";
-        hash = "sha256-frE2449PirPJMnln/mGW87JHXCJfb2wo+SBDunTPanc=";
+        url = "https://github.com/nim65s/transport_drivers/commit/7be52848f624c82ea720416360d7a754fff65c33.patch?full_index=1";
+        hash = "sha256-IYQTlSnJjUvnOp0RbN+1P7C/RclAjouyzmBT9LJpyN4=";
         stripLen = 1;
       })
     ];
@@ -262,9 +262,9 @@ in {
     patches ? [], ...
   }: {
     patches = patches ++ [
-      (self.fetchpatch {
-        url = "https://github.com/eclipse-iceoryx/iceoryx/commit/acc1e979a2d5ca30737efb077b00b42f1c4a8429.patch";
-        hash = "sha256-npFHdb0a3JBA8T6vke54DA08C93aNc/7c6xrfMBo7zI=";
+      (self.fetchpatch2 {
+        url = "https://github.com/eclipse-iceoryx/iceoryx/commit/acc1e979a2d5ca30737efb077b00b42f1c4a8429.patch?full_index=1";
+        hash = "sha256-M2ItntTMGqH6YkUNMEF0opJobyqgbZq62vBkyWxxol0=";
         stripLen = 1;
       })
     ];
@@ -387,8 +387,8 @@ in {
       # Fix compile errors in pcl-ros caused by rosidl_buffer introduction
       # https://github.com/ros-perception/perception_pcl/pull/529
       (self.fetchpatch2 {
-        url = "https://github.com/ros-perception/perception_pcl/commit/bb5cc41a2491138005bb0f733b0f0e26b8055c50.patch";
-        hash = "sha256-eNkf9YGSlLfcZjCRRCMUM6riNmRKRNzNZkCKbBOqLFs=";
+        url = "https://github.com/ros-perception/perception_pcl/commit/bb5cc41a2491138005bb0f733b0f0e26b8055c50.patch?full_index=1";
+        hash = "sha256-fCooAtkdesigd0jggYA7TYmc7LsK0rTL9eLAKAVVDOY=";
         stripLen = 1;
       })
     ];
@@ -400,20 +400,20 @@ in {
   }: {
     patches = patches ++ [
       # ref. https://github.com/ros-visualization/python_qt_binding/pull/143
-      (self.fetchpatch {
+      (self.fetchpatch2 {
         name = "support-qt6.patch";
-        url = "https://github.com/ros-visualization/python_qt_binding/commit/fa854d325ad4fa5f6e788d70b3ba9ccf9ee5c80f.patch";
-        hash = "sha256-P/xScO83zRL7qtqRzLiHkQtCpYdcxOaXwWj/83GhFpk=";
+        url = "https://github.com/ros-visualization/python_qt_binding/commit/fa854d325ad4fa5f6e788d70b3ba9ccf9ee5c80f.patch?full_index=1";
+        hash = "sha256-bszIhxh1ThuUdDDiKoHi7eQA/KGb41XmPjMaGpuf658=";
       })
-      (self.fetchpatch {
+      (self.fetchpatch2 {
         name = "make-linters-happy.patch";
-        url = "https://github.com/ros-visualization/python_qt_binding/commit/bd88c0d5d51add58e329c40bba20a7b04c3df063.patch";
-        hash = "sha256-1YuTIUGDmgFZtz/1LoRIkayH9M84H5rs8QqhW9SnNAQ=";
+        url = "https://github.com/ros-visualization/python_qt_binding/commit/bd88c0d5d51add58e329c40bba20a7b04c3df063.patch?full_index=1";
+        hash = "sha256-b3aoTkzxn+ngxJXt7mIaqA3oFkiDelxy/b+QuKaQXIo=";
       })
-      (self.fetchpatch {
+      (self.fetchpatch2 {
         name = "fixes.patch";
-        url = "https://github.com/ros-visualization/python_qt_binding/commit/d710e1afb2ac0effed1e8d6ab90eee53354366bb.patch";
-        hash = "sha256-+ou08BZCIhRMDi9GMyAOLmdoGJNZaqLpA7nMszZOFgg=";
+        url = "https://github.com/ros-visualization/python_qt_binding/commit/d710e1afb2ac0effed1e8d6ab90eee53354366bb.patch?full_index=1";
+        hash = "sha256-+QQzU6FXa+69QG8JaB/miBC1QxsvS9v0mPMJznPHl+c=";
       })
     ];
     propagatedBuildInputs = propagatedBuildInputs ++ (with rosSelf.pythonPackages; [
@@ -466,8 +466,8 @@ in {
     patches = patches ++ [
       # fix for GCC 15, ref. https://github.com/open-rmf/rmf_task/pull/133
       (self.fetchpatch2 {
-        url = "https://github.com/nim65s/rmf_task/commit/8aaacbe009022540cce1cd3ff3282413cf08a42c.patch";
-        hash = "sha256-9nXoYlfw6yuXP2TFelWl1/T6ho3G49n5vRoxC5qxQCA=";
+        url = "https://github.com/nim65s/rmf_task/commit/8aaacbe009022540cce1cd3ff3282413cf08a42c.patch?full_index=1";
+        hash = "sha256-xpn2yWMRyXUPTf0OdCjGGkKcNLHO6jAnWz4NeXInI2I=";
         stripLen = 1;
       })
     ];
@@ -479,8 +479,8 @@ in {
     patches = [
       # https://github.com/open-rmf/rmf_traffic/pull/131
       (self.fetchpatch2 {
-        url = "https://github.com/open-rmf/rmf_traffic/commit/c20b8d71507880387185666c78d105557e5003a9.patch";
-        hash = "sha256-4Elg7oF6OQHd2trn3e+r73hghW9Qf90PrGjID7RsdEI=";
+        url = "https://github.com/open-rmf/rmf_traffic/commit/c20b8d71507880387185666c78d105557e5003a9.patch?full_index=1";
+        hash = "sha256-2f2jT9Be5f/Bzh5sLxXwmdD+fwtvdoDuBrejlns1GWg=";
         stripLen = 1;
       })
     ];
@@ -608,8 +608,8 @@ in {
     patches = patches ++ [
       # Fix for asio 1.36, ref https://github.com/KumarRobotics/ublox/pull/273
       (self.fetchpatch2 {
-        url = "https://github.com/nim65s/ublox/commit/da37a9628db91aaafbcbe8b247c28c0d5863159f.patch";
-        hash = "sha256-m7lsEHF/uS47zYrNBd5RSL62CmvmNcKXQiLM24R6LZA=";
+        url = "https://github.com/nim65s/ublox/commit/da37a9628db91aaafbcbe8b247c28c0d5863159f.patch?full_index=1";
+        hash = "sha256-S1h+tw9juDe10I/oITnTYkGFtybI7sMEO7BftKhHo1I=";
         stripLen = 1;
       })
     ];
@@ -621,9 +621,9 @@ in {
     patches = patches ++ [
       # Fix CMake relative install dir assumptions
       # https://github.com/ros/urdfdom/pull/224
-      (self.fetchpatch {
-        url = "https://github.com/ros/urdfdom/commit/229c3ae867ba770dcade50b3ee520d81ff3b0413.patch";
-        hash = "sha256-cfPnSux7qmTDngzwPYIayYIvddhOXfmSsvgKwltFT5Q=";
+      (self.fetchpatch2 {
+        url = "https://github.com/ros/urdfdom/commit/229c3ae867ba770dcade50b3ee520d81ff3b0413.patch?full_index=1";
+        hash = "sha256-yOkgsmFRVwkmV6XMKaiPkBUIqxhZ6kfGK5H+dieuMls=";
       })
     ];
   });
@@ -634,9 +634,9 @@ in {
     patches = patches ++ [
       # Fix CMake relative install dir assumptions
       # https://github.com/ros/urdfdom_headers/pull/90
-      (self.fetchpatch {
-        url = "https://github.com/ros/urdfdom_headers/commit/90efa6072dc239f78d37288a49f24d8aee1aaad2.patch";
-        hash = "sha256-3q3K+fiINvS9eUrkHS3cgnn8GuA0Nz+FvVBMpsRAcFM=";
+      (self.fetchpatch2 {
+        url = "https://github.com/ros/urdfdom_headers/commit/90efa6072dc239f78d37288a49f24d8aee1aaad2.patch?full_index=1";
+        hash = "sha256-XFudlWVAcj2m7PwW/1KakDsG7ArVSijCio+xfVrbfb8=";
       })
     ];
   });
@@ -646,14 +646,14 @@ in {
   }: {
     patches = patches ++ [
       # Remove undocumented pix_fmt (AV_PIX_FMT_XVMC) breaking the build
-      (self.fetchpatch {
-        url = "https://github.com/ros-drivers/usb_cam/commit/1d1970b1a88fb1be3b961073748879900d2b1a70.patch";
-        hash = "sha256-0iWl2DtqdjkyFy7lKa7aLxXjynm4ggNEQLxB45Mqf/Y=";
+      (self.fetchpatch2 {
+        url = "https://github.com/ros-drivers/usb_cam/commit/1d1970b1a88fb1be3b961073748879900d2b1a70.patch?full_index=1";
+        hash = "sha256-W1ihgS2dHQT1SN2GyVkUdiId82ys6A1a2hwuk26ZXXk=";
       })
       # Remove avcodec_close() removed in FFmpeg 8.0 (avcodec_free_context suffices)
-      (self.fetchpatch {
-        url = "https://github.com/ros-drivers/usb_cam/commit/41805f7eb50f31e16839bb302df1bb5c6f30cb50.patch";
-        hash = "sha256-UXjqIHCkplBo5MWmH+ZlcRyy0IJgr8Qdld9QMq03SPI=";
+      (self.fetchpatch2 {
+        url = "https://github.com/ros-drivers/usb_cam/commit/41805f7eb50f31e16839bb302df1bb5c6f30cb50.patch?full_index=1";
+        hash = "sha256-JVoZgReNfYsh30qMFbIM25AALyq1KTdEGh63u1/B2e4=";
       })
     ];
   });
@@ -690,8 +690,8 @@ in {
       # Add missing include
       # https://github.com/uleroboticsgroup/yasmin/pull/92
       (self.fetchpatch2 {
-        url = "https://github.com/wentasah/yasmin/commit/2445d87187c421b8eb3fc651e12cc28efaaf9867.patch";
-        hash = "sha256-ufHY20rQQ4IGGOzCPYRN9OVW78qUwKMrS2paM7k0CpM=";
+        url = "https://github.com/wentasah/yasmin/commit/2445d87187c421b8eb3fc651e12cc28efaaf9867.patch?full_index=1";
+        hash = "sha256-lJLzm2E/j2mXn4/3FAti6w7Abfk5pMUwtmc7qAkNf0Y=";
         stripLen = 1;
       })
     ];

--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -118,9 +118,9 @@ with rosSelf.lib; {
   }: {
     patches = patches ++ [
       # Fix compilation with glog >= 0.7.0 (https://github.com/ros2/cartographer_ros/pull/76)
-      (self.fetchpatch {
-        url = "https://github.com/ros2/cartographer_ros/commit/58cd253615606efbf0bf69d16a932d35aadef1f7.patch";
-        hash = "sha256-rmolyUYIWPT37kYITDW4cRO0XJNdIYs6AoUWgWVb8PU=";
+      (self.fetchpatch2 {
+        url = "https://github.com/ros2/cartographer_ros/commit/58cd253615606efbf0bf69d16a932d35aadef1f7.patch?full_index=1";
+        hash = "sha256-Qlo6V44AhbDYCSIxfDFr/puTNP3n2qICiM3HSZbr9zA=";
         stripLen = 1;
       })
     ];
@@ -203,9 +203,9 @@ with rosSelf.lib; {
     cmakeFlags ? [], ...
   }: {
     patches = patches ++ [
-      (self.fetchpatch {
-        url = "https://github.com/eclipse-iceoryx/iceoryx/commit/d4519632964794553791ef3f951ed47ca52ebbb6.patch";
-        hash = "sha256-f4kITUql8uFSptFmu7LZGChlfDG63b0gmsRyHp1NsWw=";
+      (self.fetchpatch2 {
+        url = "https://github.com/eclipse-iceoryx/iceoryx/commit/d4519632964794553791ef3f951ed47ca52ebbb6.patch?full_index=1";
+        hash = "sha256-4RPcmeZqdwc2uFW+j3DA5IqE2Jop6U/u4M7sdIeE+jg=";
         stripLen = 1;
       })
     ];
@@ -219,9 +219,9 @@ with rosSelf.lib; {
   }: {
     patches = patches ++ [
       # Fix compilation with Boost 1.87
-      (self.fetchpatch {
-        url = "https://github.com/fzi-forschungszentrum-informatik/Lanelet2/pull/399/commits/ab7d2f4dee299563c6313336c070ed99635aba3f.patch";
-        hash = "sha256-RKTjYPlnFY4JPGMa4YfyHUEY9X/Y1UpkNzB7AHmk4p0=";
+      (self.fetchpatch2 {
+        url = "https://github.com/fzi-forschungszentrum-informatik/Lanelet2/pull/399/commits/ab7d2f4dee299563c6313336c070ed99635aba3f.patch?full_index=1";
+        hash = "sha256-aFpKnQwd0FmyaDK2mHi5bWri8nKTWbgAt/PF7EpuYmE=";
         stripLen = 1;
       })
     ];

--- a/pkgs/bloom/default.nix
+++ b/pkgs/bloom/default.nix
@@ -3,7 +3,7 @@
   catkin-pkg,
   empy_3,
   fetchFromGitHub,
-  fetchpatch,
+  fetchpatch2,
   lib,
   rosdep,
   rosdistro,
@@ -24,11 +24,11 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (fetchpatch {
+    (fetchpatch2 {
       # ref. https://github.com/ros-infrastructure/bloom/pull/705
       name = "debian-architecture-independant.patch";
-      url = "https://github.com/ros-infrastructure/bloom/commit/9e2de64bf1aa286087c70ddad658b0d57339d1fd.patch";
-      hash = "sha256-zX6g0TdaJ6kEnRXiA/lBd7mO8mAefKEyYbd77KPXMjk=";
+      url = "https://github.com/ros-infrastructure/bloom/commit/9e2de64bf1aa286087c70ddad658b0d57339d1fd.patch?full_index=1";
+      hash = "sha256-j9aAX60ydkXPGJasmiRd/h7h9AsEZ/pdqdDfJFSvKcI=";
     })
   ];
 

--- a/pkgs/vcstools/default.nix
+++ b/pkgs/vcstools/default.nix
@@ -1,7 +1,7 @@
 {
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
+  fetchpatch2,
   lib,
   looseversion,
   python-dateutil,
@@ -23,19 +23,19 @@ buildPythonPackage rec {
 
   patches = [
     # fix python 3.12 compatibility: don't import imp
-    (fetchpatch {
-      url = "https://github.com/meyerj/vcstools/commit/1d32c81af6768345b413de364c9bc526d6309f5d.patch";
-      hash = "sha256-KeuKyNUDo/GYxP5NMXzibGtUwAxbRCZ8nqNkxLh3LeI=";
+    (fetchpatch2 {
+      url = "https://github.com/meyerj/vcstools/commit/1d32c81af6768345b413de364c9bc526d6309f5d.patch?full_index=1";
+      hash = "sha256-564/L4sHGImt/iclawnX1hqAwees1vpBX/PBRtvs7Ng=";
     })
     # fix syntax warning
-    (fetchpatch {
-      url = "https://github.com/meyerj/vcstools/commit/29236587452e02b618ef4b7467b0e45768a422e6.patch";
-      hash = "sha256-GY9Or0BZYD2GS9z4IsQxhHtQsm5ZuoSlEQ+GMDatbqM=";
+    (fetchpatch2 {
+      url = "https://github.com/meyerj/vcstools/commit/29236587452e02b618ef4b7467b0e45768a422e6.patch?full_index=1";
+      hash = "sha256-Tz38gsUOCKOvEDVrHY0rAMyo4T6/AcrdpV8BSD8rtM8=";
     })
     # fix python 3.12 compatibility: don't import distutils
-    (fetchpatch {
-      url = "https://github.com/nim65s/vcstools/commit/b940aacc4bcf96892b5d75ae6e58dc9bba5fff60.patch";
-      hash = "sha256-yKDrd9t0vuuDqyDUlmOIlL4l1Uc6svtXVxuavnV0uOM=";
+    (fetchpatch2 {
+      url = "https://github.com/nim65s/vcstools/commit/b940aacc4bcf96892b5d75ae6e58dc9bba5fff60.patch?full_index=1";
+      hash = "sha256-6FJPUaKZrYlETL2gB5HsIM4lzvwmwrZqicFRhK1FEgI=";
     })
   ];
 


### PR DESCRIPTION
I noticed that building usb-cam results in hash mismatch in the needed patch. The error message looked like this:

    building '/nix/store/772lzkrsqmyprd1zr8av2l3hhafn0g42-41805f7eb50f31e16839bb302df1bb5c6f30cb50.patch.drv'...
    structuredAttrs is enabled

    trying https://github.com/ros-drivers/usb_cam/commit/41805f7eb50f31e16839bb302df1bb5c6f30cb50.patch
      % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                     Dload  Upload   Total   Spent    Left  Speed
    100  1192 100  1192   0     0  4212     0  --:--:-- --:--:-- --:--:--  4226
    error: hash mismatch in fixed-output derivation '/nix/store/772lzkrsqmyprd1zr8av2l3hhafn0g42-41805f7eb50f31e16839bb302df1bb5c6f30cb50.patch.drv':
             specified: sha256-UXjqIHCkplBo5MWmH+ZlcRyy0IJgr8Qdld9QMq03SPI=
                got:    sha256-IKSzezNmy7qQzeo/eQJIiUMZ0KEbIr5CbUOOQkTpleo=
    error: Cannot build '/nix/store/di3pvvsrja65fs7xsg3dkl6lpdvvh6s1-ros-jazzy-usb-cam-0.8.1-r1.drv'.
           Reason: 1 dependency failed.
           Output paths:
             /nix/store/ajlplgm81knv3h8jkgd87rx1clxxf0yz-ros-jazzy-usb-cam-0.8.1-r1-debug
             /nix/store/nraxvmnymyaz3lgkjyjycx8qphnjfygp-ros-jazzy-usb-cam-0.8.1-r1

The reason is that github changes the length of commit hashes inside the patches dynamically (see e.g.
https://github.com/NixOS/nixpkgs/issues/257446). The recommended way to fetch patches seems to be using fetchpatch2 and appending "?full_index=1" to the URL. See
https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#fetching-patches This should guarantee the hash of the patch won't change.

For this reason, we convert all fetched patches to the recommended form and update their hashes.

To check that this commit makes only the above mentioned changes, you can use the following commands (when this commit is HEAD):

    sed -i -e 's/\?full_index=1//' $(git show --name-only --format="")
    git diff -U0 --color HEAD^|grep -vE '(hash =|fetchpatch)'

This will show in color (red and green) the other changes than the above. As can be seen, it shows only the URLs that already had "?full_index=1" in the past.