### PR TITLE
rosdistro sync, Fri Apr 24 16:36:13 2026

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -48,7 +48,7 @@ let
           originalRev = "\${MRPT_VERSION_TO_DOWNLOAD}";
           inherit rev;
           fetchgitArgs.hash = {
-            "2.15.13" = "sha256-pSEE4hHVzwXkxlwX+0tDCRbKQVaaU9Wrw8sjp09KJJw=";
+            "2.15.14" = "sha256-WudCeaOJWNIK2NaD6JNal68kU+eOhnrd6XF3CLb3pg8=";
           }.${rev};
         }).overrideAttrs ({ postPatch ? "", buildInputs ? [], ... }: {
           postPatch = postPatch + ''

--- a/distros/humble/ackermann-steering-controller/default.nix
+++ b/distros/humble/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-ackermann-steering-controller";
-  version = "2.53.0-r1";
+  version = "2.53.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.53.0-1.tar.gz";
-    name = "2.53.0-1.tar.gz";
-    sha256 = "5cef27674074e7cac1782b697ad866964085f7f1016221cd2c14833e07865567";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.53.1-1.tar.gz";
+    name = "2.53.1-1.tar.gz";
+    sha256 = "3b899387b8a8d44da78e9a8c45306c11fe980afb92ec8ec955edf77038e38435";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/admittance-controller/default.nix
+++ b/distros/humble/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, tinyxml-2, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-admittance-controller";
-  version = "2.53.0-r1";
+  version = "2.53.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.53.0-1.tar.gz";
-    name = "2.53.0-1.tar.gz";
-    sha256 = "82f6790fc5a76d01f305e6ea2c56238f6652b0afa11bb4320b6f730a5cd82ef7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.53.1-1.tar.gz";
+    name = "2.53.1-1.tar.gz";
+    sha256 = "18cd97cab44c0773104264f66a7f9b125aeb613f2887dd73a1044a86b1148028";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/beluga-amcl/default.nix
+++ b/distros/humble/beluga-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, beluga, beluga-ros, bondcpp, message-filters, rclcpp, rclcpp-components, rclcpp-lifecycle, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-beluga-amcl";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/beluga-release/archive/release/humble/beluga_amcl/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "ed7d9b835051d30da91f30b0487e15242676e169c7bc9e9418ed58cb2103005e";
+    url = "https://github.com/ros2-gbp/beluga-release/archive/release/humble/beluga_amcl/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "ecfd25150afec336c5e8da95acc07de00ffbd315410fa03b8cf29a370e423632";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/beluga-ros/default.nix
+++ b/distros/humble/beluga-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-cmake-ros, beluga, geometry-msgs, nav-msgs, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-beluga-ros";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/beluga-release/archive/release/humble/beluga_ros/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "b656dbb9b7587766a976202759d7b0757f8eb0eb368f1fb08b669012e5cbf587";
+    url = "https://github.com/ros2-gbp/beluga-release/archive/release/humble/beluga_ros/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "8618b867bfc6a52d6274eaa6ea18f545632e9561d84a0eede924a4a0f73b92ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/beluga/default.nix
+++ b/distros/humble/beluga/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, clang, cmake, eigen, gbenchmark, gtest, hdf5, onetbb, range-v3, sophus }:
 buildRosPackage {
   pname = "ros-humble-beluga";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/beluga-release/archive/release/humble/beluga/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "ffe47e3c5a6910e7cb9a8439bec10f2c7a479d6ff9f3c7edef95c1a3b291078d";
+    url = "https://github.com/ros2-gbp/beluga-release/archive/release/humble/beluga/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "a885f4067b0c0e3b60f8a920646aa536e79501e321326501f2846564f09b57af";
   };
 
   buildType = "cmake";

--- a/distros/humble/bicycle-steering-controller/default.nix
+++ b/distros/humble/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-bicycle-steering-controller";
-  version = "2.53.0-r1";
+  version = "2.53.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.53.0-1.tar.gz";
-    name = "2.53.0-1.tar.gz";
-    sha256 = "f9fdaac4c0afb27aa8f124c63c72f3895f05820eee335b4de223958c69f44cc7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.53.1-1.tar.gz";
+    name = "2.53.1-1.tar.gz";
+    sha256 = "cede05a3a6f87ec82f744ede11aa7f645bc900c9cd634fa2b536d0e73004707b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/cloudini-lib/default.nix
+++ b/distros/humble/cloudini-lib/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, lz4, pcl, zstd }:
 buildRosPackage {
   pname = "ros-humble-cloudini-lib";
-  version = "1.0.4-r1";
+  version = "1.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/cloudini-release/archive/release/humble/cloudini_lib/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "8e0066f6ece1cb53111440e8a0d89f302e8ef07b65d43edc43ebce61d606c05b";
+    url = "https://github.com/facontidavide/cloudini-release/archive/release/humble/cloudini_lib/1.1.0-2.tar.gz";
+    name = "1.1.0-2.tar.gz";
+    sha256 = "3e7b536f3609c19b48c22747286509a792ff477ee56bbbc4c66aecde836ffd24";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/cloudini-ros/default.nix
+++ b/distros/humble/cloudini-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cloudini-lib, pcl-conversions, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, rclcpp-components, rosbag2-cpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-cloudini-ros";
-  version = "1.0.4-r1";
+  version = "1.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/cloudini-release/archive/release/humble/cloudini_ros/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "66b0575bb0072463bb3d7eaabd4ff8e3851f79333456e39d09a6448383cf0d2a";
+    url = "https://github.com/facontidavide/cloudini-release/archive/release/humble/cloudini_ros/1.1.0-2.tar.gz";
+    name = "1.1.0-2.tar.gz";
+    sha256 = "236ab726e023223f770bc25563fcb8459619077df6ae10f3d16259ee8329bc76";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/compressed-depth-image-transport/default.nix
+++ b/distros/humble/compressed-depth-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-humble-compressed-depth-image-transport";
-  version = "2.5.4-r1";
+  version = "2.5.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/humble/compressed_depth_image_transport/2.5.4-1.tar.gz";
-    name = "2.5.4-1.tar.gz";
-    sha256 = "80ef886f2692cae7d8d617453acfd906e118de09c41c54a46a49b467f4e07ec6";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/humble/compressed_depth_image_transport/2.5.5-1.tar.gz";
+    name = "2.5.5-1.tar.gz";
+    sha256 = "175af467b7b2bba2126710668e41357c7125e0c89d2abfa128d0c03113b5473d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/compressed-image-transport/default.nix
+++ b/distros/humble/compressed-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-humble-compressed-image-transport";
-  version = "2.5.4-r1";
+  version = "2.5.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/humble/compressed_image_transport/2.5.4-1.tar.gz";
-    name = "2.5.4-1.tar.gz";
-    sha256 = "e25838caaf802588c7e9ef9c69bbda85bc8745390fd22952cd96f35d2b8850f2";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/humble/compressed_image_transport/2.5.5-1.tar.gz";
+    name = "2.5.5-1.tar.gz";
+    sha256 = "1cddf6c65b57e70b0e1ec4b5a148b4cb3019bb225836082893ceb07ca037f6b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diff-drive-controller/default.nix
+++ b/distros/humble/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-diff-drive-controller";
-  version = "2.53.0-r1";
+  version = "2.53.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.53.0-1.tar.gz";
-    name = "2.53.0-1.tar.gz";
-    sha256 = "03608cafc158e1d9dc1ddc95fbc413b65f38bdb7cfdbab6551315a1766741834";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.53.1-1.tar.gz";
+    name = "2.53.1-1.tar.gz";
+    sha256 = "fae3e6ad1b534a561da9338f2906eb194f7b0b7aca959725cc2c944b72908eef";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/effort-controllers/default.nix
+++ b/distros/humble/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-effort-controllers";
-  version = "2.53.0-r1";
+  version = "2.53.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.53.0-1.tar.gz";
-    name = "2.53.0-1.tar.gz";
-    sha256 = "9a0e8dccbaea240903ce64a35346da2ad4cba963aea8f7c11701b58a2f0dbc0a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.53.1-1.tar.gz";
+    name = "2.53.1-1.tar.gz";
+    sha256 = "e365d6a4111586746b131e7d4c91dc3f95d06b25dcf1cf6600eeeb246246ef72";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/force-torque-sensor-broadcaster/default.nix
+++ b/distros/humble/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-force-torque-sensor-broadcaster";
-  version = "2.53.0-r1";
+  version = "2.53.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.53.0-1.tar.gz";
-    name = "2.53.0-1.tar.gz";
-    sha256 = "cdbaddd81fe555522e87898658c2567a873f23203e57c5a9cf09cbaef50ccd85";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.53.1-1.tar.gz";
+    name = "2.53.1-1.tar.gz";
+    sha256 = "1a4d4df0b77b8f1f4fc7de3016d3aa6b82d25752e204e93be5592d4f7927e1ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/forward-command-controller/default.nix
+++ b/distros/humble/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-forward-command-controller";
-  version = "2.53.0-r1";
+  version = "2.53.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.53.0-1.tar.gz";
-    name = "2.53.0-1.tar.gz";
-    sha256 = "9bf3b9958814818602f0c47b3a2d3013dd15237b51317d59e9d5ffef24bde37b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.53.1-1.tar.gz";
+    name = "2.53.1-1.tar.gz";
+    sha256 = "78a5a8ff3dc99a6342c0ef6ebbcb90c9fed3579d806382083f16118918853219";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gpio-controllers/default.nix
+++ b/distros/humble/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gpio-controllers";
-  version = "2.53.0-r1";
+  version = "2.53.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gpio_controllers/2.53.0-1.tar.gz";
-    name = "2.53.0-1.tar.gz";
-    sha256 = "63d189dccdc95d2a24655ba3faa3dddf181b81a3d51858ea111d2102dfbd4202";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gpio_controllers/2.53.1-1.tar.gz";
+    name = "2.53.1-1.tar.gz";
+    sha256 = "f052948d7ed4dc048bc9ce7162ed3c7165306d73729108bad19861d1e769accc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gripper-controllers/default.nix
+++ b/distros/humble/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gripper-controllers";
-  version = "2.53.0-r1";
+  version = "2.53.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.53.0-1.tar.gz";
-    name = "2.53.0-1.tar.gz";
-    sha256 = "7b521c65abc80115ee9a28da9f84e12a6ae10ccdec1f7f149c7e8d80262e3f98";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.53.1-1.tar.gz";
+    name = "2.53.1-1.tar.gz";
+    sha256 = "2490ccb1ff6a62cf2c80100954346f538ae29e5e2169801b55b07f5accab60d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/image-transport-plugins/default.nix
+++ b/distros/humble/image-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, compressed-depth-image-transport, compressed-image-transport, theora-image-transport }:
 buildRosPackage {
   pname = "ros-humble-image-transport-plugins";
-  version = "2.5.4-r1";
+  version = "2.5.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/humble/image_transport_plugins/2.5.4-1.tar.gz";
-    name = "2.5.4-1.tar.gz";
-    sha256 = "aa521fc469bd306b3d4b871b88eb188e1d0256ed88acfd972f6571f374a9256a";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/humble/image_transport_plugins/2.5.5-1.tar.gz";
+    name = "2.5.5-1.tar.gz";
+    sha256 = "79dea10a27d243f4f96a106838a49699d9f70e1c3f28bd75df4157e229de8a0c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/imu-sensor-broadcaster/default.nix
+++ b/distros/humble/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-imu-sensor-broadcaster";
-  version = "2.53.0-r1";
+  version = "2.53.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.53.0-1.tar.gz";
-    name = "2.53.0-1.tar.gz";
-    sha256 = "695f52a1328284701b78565da031ac75a6d535cfa9b2e5f1e5ac1d290be6cb2d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.53.1-1.tar.gz";
+    name = "2.53.1-1.tar.gz";
+    sha256 = "3976c69f5ac3acb9f4d9aa0fc06c5a58a100e50fee73742d2577e507dddf0137";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-state-broadcaster/default.nix
+++ b/distros/humble/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-state-broadcaster";
-  version = "2.53.0-r1";
+  version = "2.53.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.53.0-1.tar.gz";
-    name = "2.53.0-1.tar.gz";
-    sha256 = "1900c7e80879734ea636238d48abd5ac17cb39fbbec157223a77b62df51f3a24";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.53.1-1.tar.gz";
+    name = "2.53.1-1.tar.gz";
+    sha256 = "7fb765f473a01f897f27f2f7b470d14d7bc933c71c0fa2561580327ce7a3e8ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-trajectory-controller/default.nix
+++ b/distros/humble/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected-nixpkgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-trajectory-controller";
-  version = "2.53.0-r1";
+  version = "2.53.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.53.0-1.tar.gz";
-    name = "2.53.0-1.tar.gz";
-    sha256 = "b2a3418ad4ae612fe401fc74b30291d0038593508352f63a819881327331f232";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.53.1-1.tar.gz";
+    name = "2.53.1-1.tar.gz";
+    sha256 = "ca765947fe154b667827bb8cc9a84a23a3ebdd03eab46fe9862b223d7d764caf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kitti-metrics-eval/default.nix
+++ b/distros/humble/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmath, mrpt-libposes, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-humble-kitti-metrics-eval";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/kitti_metrics_eval/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "00024ca7bd206046018d9d1f47ee5fa38bc5e88c3b3e35fc02727f3327cacd7c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/kitti_metrics_eval/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "ebc5bccadd57834cb82d34bd3646916c6e83652b6da545cc77ff8006d6a78822";
   };
 
   buildType = "cmake";

--- a/distros/humble/mecanum-drive-controller/default.nix
+++ b/distros/humble/mecanum-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-mecanum-drive-controller";
-  version = "2.53.0-r1";
+  version = "2.53.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/mecanum_drive_controller/2.53.0-1.tar.gz";
-    name = "2.53.0-1.tar.gz";
-    sha256 = "ad9b3afd56897c947040719d2ee5194d59080e0e8d911c03bbd753cd4f7d8322";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/mecanum_drive_controller/2.53.1-1.tar.gz";
+    name = "2.53.1-1.tar.gz";
+    sha256 = "033dd6045b0b0e19dd5ae0ac01125081baf34c3e2fcbd602788bd626f00363f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-bridge-ros2/default.nix
+++ b/distros/humble/mola-bridge-ros2/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, geographic-msgs, geometry-msgs, gps-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, diagnostic-msgs, geographic-msgs, geometry-msgs, gps-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-mola-bridge-ros2";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_bridge_ros2/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "3e5822b21857f74e645ae51b827c4eb7bde06c5fbd1c815dac7d8827e4b53d3b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_bridge_ros2/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "b2b823c3516ae0bac225527ebd44f4650d0595497c8e29fde845337950b391d9";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ros-environment ];
   checkInputs = [ ament-cmake-xmllint ament-lint-auto ament-lint-cmake ];
-  propagatedBuildInputs = [ geographic-msgs geometry-msgs gps-msgs mola-common mola-kernel mola-msgs mrpt-libmaps mrpt-libros-bridge mrpt-nav-interfaces nav-msgs rclcpp sensor-msgs tf2 tf2-geometry-msgs ];
+  propagatedBuildInputs = [ diagnostic-msgs geographic-msgs geometry-msgs gps-msgs mola-common mola-kernel mola-msgs mrpt-libmaps mrpt-libros-bridge mrpt-nav-interfaces nav-msgs rclcpp sensor-msgs tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/humble/mola-demos/default.nix
+++ b/distros/humble/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-demos";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_demos/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "b59b7878dabb04d9ce439df47dcc649e75897bb37e9106697e3bec45d9599549";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_demos/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "bdb8047bd29a09afdada6a6ec11b9fb5e97f7866cc732e899a40545285dc473b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-imu-preintegration/default.nix
+++ b/distros/humble/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-imu-preintegration";
-  version = "1.15.0-r1";
+  version = "1.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_imu_preintegration-release/archive/release/humble/mola_imu_preintegration/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "86137bc9d86e1d0e92312363248d4e008f627caa331ec07195feb75636d7bff4";
+    url = "https://github.com/ros2-gbp/mola_imu_preintegration-release/archive/release/humble/mola_imu_preintegration/1.16.0-1.tar.gz";
+    name = "1.16.0-1.tar.gz";
+    sha256 = "bb42a0b034fd54df6306f5a0649cfbb37aeb6bf8b214719b0ac4c347c35059bd";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-euroc-dataset/default.nix
+++ b/distros/humble/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmath, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-input-euroc-dataset";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_euroc_dataset/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "c041073662bccafc532ca8895c74a1ff990bac772958853f88b9308c38e43737";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_euroc_dataset/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "90cb0de13b05d2476a64255dafd81207a1d8f9cba9a38acea635b73b7c6dd1ea";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-kitti-dataset/default.nix
+++ b/distros/humble/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-humble-mola-input-kitti-dataset";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti_dataset/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "3bb83873a1f976825a5466bdaa8685f58c1de8d9bd350b4857069b9a0fb47bb1";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti_dataset/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "c8eb6baa17471886d16e77725352fed33f305d23a25d9cd7dd0351f465d3ce11";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-kitti360-dataset/default.nix
+++ b/distros/humble/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-humble-mola-input-kitti360-dataset";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti360_dataset/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "81c9214276f79013577dd5d1913365ac98fbba8e97c53f8d04a9c679eda13a35";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti360_dataset/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "6884f9be73e46a2166366655bae70208e08a4329ec1c05a9def94040d43bd306";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-lidar-bin-dataset/default.nix
+++ b/distros/humble/mola-input-lidar-bin-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-humble-mola-input-lidar-bin-dataset";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_lidar_bin_dataset/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "aa394a029cd30e1ac59cf0ddcbef1a2b3ecb716c3568fa97b1d5064c2498be13";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_lidar_bin_dataset/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "bc0aaf8e4b553cb02c5ab4c0badb5395e78a4521f23efb1adad170415a00ac18";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-mulran-dataset/default.nix
+++ b/distros/humble/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-humble-mola-input-mulran-dataset";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_mulran_dataset/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "da19681d19b1064c7afb47ea7afc9fb0ef6c3a286fba837a860fa27596d8888f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_mulran_dataset/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "0cbde61042be0725e1e66b589ce7fcf27557cc4b19e45c7d822fd4c70021bdc0";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-paris-luco-dataset/default.nix
+++ b/distros/humble/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-humble-mola-input-paris-luco-dataset";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_paris_luco_dataset/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "6434edc1bb6aa701134282aa4ef7a98915e04b9ab7595a57df9c8abe1b9908bb";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_paris_luco_dataset/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "ed29c54f4c62f0c3ef0bbd3de77a63c56b64b441ca1cb03d63c4695ee03d9594";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-rawlog/default.nix
+++ b/distros/humble/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-input-rawlog";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rawlog/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "113d84026b46619f52e0a88c5722909977522ec4fab912f8326890c9da0a04e6";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rawlog/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "0d93080b533d74f9caa4f25b37f90e4274ffad9b9c93770e8a80cc9e7f6ec739";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-rosbag2/default.nix
+++ b/distros/humble/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, gps-msgs, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-mola-input-rosbag2";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rosbag2/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "5d418c3302a6f90eda60df54c10866e747eb604a997c6661ea4717c8305affb0";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rosbag2/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "20f68ed658ee535be84c9b13b7d209494e6c14e99ae25e5d914face6754200fb";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-video/default.nix
+++ b/distros/humble/mola-input-video/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libhwdrivers, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-input-video";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_video/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "93f3f77d896a70f727c121109ad6d54a8ae2c124b496c3dc85e2c8070c568177";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_video/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "54d5afd68e28ae8c7eefa75d313b2cc5b922a5c75ca1fde0054eb98d93238994";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-kernel/default.nix
+++ b/distros/humble/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libgui, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-kernel";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_kernel/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "00865ff634da30e9f152bb15567d6ac822754f7c4eab9195e3895e6ab73b4eae";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_kernel/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "dfbc6c7c85d3fe7fcf90d1a51dcf0fe617993c1089af7ab7f6758d13e14b0d55";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-launcher/default.nix
+++ b/distros/humble/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-xmllint, ament-lint-auto, cmake, mola-kernel, mrpt-libbase, mrpt-libtclap, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-launcher";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_launcher/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "7dcb4e4047e1afa7565d10cce6ac370a2ca0399c2412d43beb65010a0dfa90cd";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_launcher/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "81c0e3b38e524e217cf4422a96935e85b91edc49abb4b96bbab53120bfec112a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-metric-maps/default.nix
+++ b/distros/humble/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mp2p-icp, mrpt-libmaps, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-metric-maps";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_metric_maps/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "9b789a3c472016f106d89e0592c8009c2e4510070e79f7fbe9af342cadaed26a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_metric_maps/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "8d1895a7745b4c9802287b42b8a716ec3c1685831d602ebd3afb84614d88cdea";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-msgs/default.nix
+++ b/distros/humble/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-mola-msgs";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_msgs/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "cc495fde9f7d8206e8cffe197cfcd3dbf527a0c402a76f93913ef63142de6c65";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_msgs/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "477be2bee50be9dccf3d813fab5e7a6f80f4487eb79577ab45337c2c1efde919";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-pose-list/default.nix
+++ b/distros/humble/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-humble-mola-pose-list";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_pose_list/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "0adba1e89a00ca4d192677435464108126d38c80d443afb39aa16ae93ccae555";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_pose_list/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "30fccc5aacacefe85fab04123a2bbfc3d9048b5c33cce6d5be51a9b39402a973";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-relocalization/default.nix
+++ b/distros/humble/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-humble-mola-relocalization";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_relocalization/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "e222755cfe3bb14489c1608d08d2c991f45cde588d8bf53fc8c40109d03b466b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_relocalization/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "5959be367f0d3c19345ac6910150904bb4416325a51d1f4698ce903ab759f1f5";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-traj-tools/default.nix
+++ b/distros/humble/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-humble-mola-traj-tools";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_traj_tools/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "ff9fba9826d54f05a3be2b9b9de980818ebecc646ebdc78434e7c0183ec67165";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_traj_tools/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "8d93b757ba65569d0906ea0f7325b8d7a3b0b23b498027d5e014c9ec75d3888f";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-viz/default.nix
+++ b/distros/humble/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-humble-mola-viz";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_viz/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "15c14b9aad22127938c378e148b76ddcf1d9c27f5ac44ba206ba03507aa59aa9";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_viz/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "e1e80b4075a45e0ac7d37adef7e87e5bd6ce8b9bf893cbd13cce46dac766dad9";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-yaml/default.nix
+++ b/distros/humble/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-humble-mola-yaml";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_yaml/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "83d3bcdba13cc31a5ac4f59c19becbfbc78e4d47bae1d0c532a90607df68abe9";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_yaml/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "98dac5247bf9f62c500d6b37fdf6014aa58ab86440ce0029c8e0dea614d3802a";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola/default.nix
+++ b/distros/humble/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-input-video, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-humble-mola";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "217fbe4bc683f0131675b3072eed849d098039d20c95f299fb5557de8b554e59";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "da0c29a70c00707a14c65a27a6179beaef68e63ac90d2bf9828952563bdd6e5d";
   };
 
   buildType = "cmake";

--- a/distros/humble/mp2p-icp/default.nix
+++ b/distros/humble/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mp2p-icp";
-  version = "2.8.1-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "54c66b12e9550b876066feb0c6c7210097db67aa9c4b41f908724e9a182f28a6";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "271b550726e8eb8f7fa98ad52c4d60ddc9ac01d349aa44028071a53be1dfd5a8";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-apps/default.nix
+++ b/distros/humble/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-apps";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_apps/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "336472662ccd6fde8df43f37fa5785b638d23cc9df7bee2e0784460d49f3f978";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_apps/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "2a65f396a2187384bca098bfb7c310e042a695c94704f02a2018db92a3d588a0";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libapps/default.nix
+++ b/distros/humble/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libapps";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libapps/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "cc232bca831404b8a59b52602bcb53a404bab8c16f9a435076431c448171190f";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libapps/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "c91a583768cbba0bd7ddbd32f6e26381bf6052163298b2a867bf5a094bdd3556";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libbase/default.nix
+++ b/distros/humble/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, onetbb, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib, zstd }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libbase";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libbase/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "a7640b784de3cdadfef0252b8868c8b251b0fb82b93f471f404cbc060caa877e";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libbase/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "92dd07b5fb82448d774e0f99bc4817a2c3183b8cb6d43368fc579c5432cb4f8d";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libgui/default.nix
+++ b/distros/humble/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libgui";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libgui/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "de142c6baacfe79253b507cd98710257fe94fa3fa1e95c05db170d308750c1bb";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libgui/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "b62b0c23962b0baed00f3e7d31daad4ecab371a21891ccf904a7a3c5332fb82b";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libhwdrivers/default.nix
+++ b/distros/humble/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libhwdrivers";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libhwdrivers/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "7bbda58614b8d574f89b99942c2f3ac64f51f5a082d28b841b5bb163f7cd4038";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libhwdrivers/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "2b6966866240f1fbfe07df9a5d9ef2ed2be983cc711b4a177906ac00a5ef6602";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libmaps/default.nix
+++ b/distros/humble/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libmaps";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmaps/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "9b1226005c44956cbd6cb70a6b6cb7f494bd580ce33b544bf92fc1dd7fbe1d5e";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmaps/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "acc36d84715651c5ee828ded39f004a0558feae09dd0e4c46ee7a30f7d5b3512";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libmath/default.nix
+++ b/distros/humble/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libmath";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmath/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "6dbdbad72a0e32194ea76baea4c3b2106da123655c24a15ece8d1929c191366d";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmath/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "e4d9cc73cb4416f793cd0c8c82f47608fea9eb51ba61c9eacd809d81e76c7d76";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libnav/default.nix
+++ b/distros/humble/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libnav";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libnav/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "56ba4c9e38328d09fc71d0b0c4b89e3cf385ba144c59576b8ea869deaf23edde";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libnav/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "5f7d81fd527a2fd09949454d1d83035d4a39b98a14002b4ca563ff69936f888e";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libobs/default.nix
+++ b/distros/humble/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libobs";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libobs/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "b3049e2537c9ad2233473e7b362ac602a5a9698ff7f9a6c42e342a5993634da3";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libobs/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "30e50a9f3d07cfea28aa230d66742d99a0a19868d8539d640d69bd990ddf8bd7";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libopengl/default.nix
+++ b/distros/humble/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libopengl";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libopengl/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "f54f1511c44fb8f1dd72ef26dab78a169b2878f72fd97348cf3d2f0f7119fa1c";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libopengl/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "69969b9a5832f6e798c69a2660136f9aa5d090f8e05d58fc30992c41568971da";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libposes/default.nix
+++ b/distros/humble/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libposes";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libposes/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "9461b0294cf22d3f8915c0a42ad37559c892237395dcb5702c6a5db5742fe758";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libposes/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "a51c3b7a3c23d651a7d1d1e90bcf90a13bd5cadb5726e304a7380460ec3fff31";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libros-bridge/default.nix
+++ b/distros/humble/mrpt-libros-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cmake, cv-bridge, geometry-msgs, gps-msgs, mrpt-libmaps, mrpt-libobs, nav-msgs, ros-environment, rosbag2-cpp, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libros-bridge";
-  version = "3.5.1-r1";
+  version = "3.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/humble/mrpt_libros_bridge/3.5.1-1.tar.gz";
-    name = "3.5.1-1.tar.gz";
-    sha256 = "26fc54ba91485e2d050b2af6237e4c31ada05fff12087230a38114ae1a470105";
+    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/humble/mrpt_libros_bridge/3.5.2-1.tar.gz";
+    name = "3.5.2-1.tar.gz";
+    sha256 = "391c81a6f93407f3f78cb8b261e252962af7012f87c2af4bcf055c79210c5f3f";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libslam/default.nix
+++ b/distros/humble/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, onetbb, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libslam";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libslam/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "dcd1f348dacc52e65d71d674856aa76a578e8e7c41e73ac1ad8cf021c2e0441d";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libslam/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "1e670f9781570432b7d8ba7f411d340a0950ac80516fffd9b2bb5b6cf098f259";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libtclap/default.nix
+++ b/distros/humble/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libtclap";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libtclap/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "b2a400c13d1610bb6c1710501bb0d21f44e97cfa8a66974c6c99edb5e54f240d";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libtclap/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "6b7a831c659ca17e11726dc7d11664d3de306f66546290090b67541edd8ce215";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-map-server/default.nix
+++ b/distros/humble/mrpt-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libros-bridge, mrpt-msgs, mrpt-nav-interfaces, rclcpp-components, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-mrpt-map-server";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_map_server/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "bf303d794e8927b30dd4a09fc8208823eb69c7269fbd655ec4bdc04df80dacdb";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_map_server/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "49d7f0b87db6205d57bd12034da0a9e347592c10ef6a0e73199429d6a998b086";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mrpt-msgs-bridge/default.nix
+++ b/distros/humble/mrpt-msgs-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, mrpt-libobs, mrpt-libros-bridge, mrpt-msgs, rclcpp, ros-environment, tf2 }:
 buildRosPackage {
   pname = "ros-humble-mrpt-msgs-bridge";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_msgs_bridge/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "36d7b0014ec56cadef663562a7d45124058919452b9604f74e4fe9022893b231";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_msgs_bridge/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "210b3cf58c870f80f22f793dd1fce770429a65676995f195053c2d4fb2c7bf5b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mrpt-nav-interfaces/default.nix
+++ b/distros/humble/mrpt-nav-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, geometry-msgs, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-mrpt-nav-interfaces";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_nav_interfaces/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "9649fb194285edffcbe6b8e0c2182aa292451aed2237ea58c09010c17a263914";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_nav_interfaces/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "887c1743fe706dfac635e267b23d40a36c2342c804059c5e3fc2a03bccb95dbc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mrpt-navigation/default.nix
+++ b/distros/humble/mrpt-navigation/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-map-server, mrpt-nav-interfaces, mrpt-pf-localization, mrpt-pointcloud-pipeline, mrpt-reactivenav2d, mrpt-tutorials }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-map-server, mrpt-msgs-bridge, mrpt-nav-interfaces, mrpt-pf-localization, mrpt-pointcloud-pipeline, mrpt-reactivenav2d, mrpt-tps-astar-planner, mrpt-tutorials }:
 buildRosPackage {
   pname = "ros-humble-mrpt-navigation";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_navigation/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "fac0a177e7ef3c105eb50da4ba2f1509dd19ee243419f19f67dbff627456de18";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_navigation/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "655933322170c820fad7ba22d7b300fe9fe6607317250d8d18374bfc5e7ba6a3";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto mrpt-map-server mrpt-nav-interfaces mrpt-pf-localization mrpt-pointcloud-pipeline mrpt-reactivenav2d mrpt-tutorials ];
+  propagatedBuildInputs = [ ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto mrpt-map-server mrpt-msgs-bridge mrpt-nav-interfaces mrpt-pf-localization mrpt-pointcloud-pipeline mrpt-reactivenav2d mrpt-tps-astar-planner mrpt-tutorials ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/mrpt-pf-localization/default.nix
+++ b/distros/humble/mrpt-pf-localization/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, cmake, mola-relocalization, mp2p-icp, mrpt-libgui, mrpt-libros-bridge, mrpt-libslam, mrpt-msgs, mrpt-msgs-bridge, mrpt-tutorials, nav-msgs, pose-cov-ops, rclcpp, rclcpp-components, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, cmake, mola-relocalization, mp2p-icp, mrpt-libgui, mrpt-libros-bridge, mrpt-libslam, mrpt-msgs, mrpt-msgs-bridge, mrpt-tutorials, nav-msgs, pose-cov-ops, rclcpp, rclcpp-components, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-mrpt-pf-localization";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_pf_localization/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "e214da0cc8d737746aa62d52c91363c34dbeda2896b7e27aec836dba8804b9b2";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_pf_localization/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "7f7be32255a5b0f32eeb1d52432a26b0136626f03f2deea68accddc5de48a1c6";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake cmake ];
-  checkInputs = [ mrpt-tutorials ];
+  checkInputs = [ ament-cmake-gtest mrpt-tutorials ];
   propagatedBuildInputs = [ ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto mola-relocalization mp2p-icp mrpt-libgui mrpt-libros-bridge mrpt-libslam mrpt-msgs mrpt-msgs-bridge nav-msgs pose-cov-ops rclcpp rclcpp-components sensor-msgs std-msgs tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ ament-cmake cmake ];
 

--- a/distros/humble/mrpt-pointcloud-pipeline/default.nix
+++ b/distros/humble/mrpt-pointcloud-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, mp2p-icp, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libros-bridge, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-mrpt-pointcloud-pipeline";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_pointcloud_pipeline/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "5dd0aec031186044e033e15814bbbbef68a1268201dced7d8fa7af08948d679f";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_pointcloud_pipeline/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "a673a058fa9c277e36cce6d8cc96919175bd6b5cd2393fd6382d9bd741953099";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mrpt-reactivenav2d/default.nix
+++ b/distros/humble/mrpt-reactivenav2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, mrpt-libnav, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-mrpt-reactivenav2d";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_reactivenav2d/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "0af8f99a04bb162ee4d9037bdf989972c37fb973e444ef9edc8a2fc84c5564fa";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_reactivenav2d/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "a5957d7c3361fd72a7a0f1c7c96071e2ea5eff0a8d3c7e06031bb99ed4b8426e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mrpt-tps-astar-planner/default.nix
+++ b/distros/humble/mrpt-tps-astar-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-libgui, mrpt-libmaps, mrpt-libnav, mrpt-libros-bridge, mrpt-msgs, mrpt-nav-interfaces, mrpt-path-planning, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-mrpt-tps-astar-planner";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_tps_astar_planner/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "29e6e4c806fb675411b2efbe198a92a6faf54bdb2d0c2352bce8f50c11ddade2";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_tps_astar_planner/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "10284a0b4c2b6cbe5fa36a7c4b2c4bd6d9d419d4df887f80248af12949622349";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mrpt-tutorials/default.nix
+++ b/distros/humble/mrpt-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, cmake, mvsim, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-humble-mrpt-tutorials";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_tutorials/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "da21977359642e71681c38d65a155cdc809b4d89d9b6bfe06c14ff2362f3530c";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_tutorials/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "d6922f363be11db9020bebb869242dc885ccd03e8bc4b25e8f98b4e3547c26b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -150,7 +150,7 @@ in with lib; {
   });
 
   autoware-trajectory = rosSuper.autoware-trajectory.overrideAttrs ({
-    buildInputs ? [], postPatch ? "", ...
+    buildInputs ? [], propagatedBuildInputs ? [], postPatch ? "", patches ? [], ...
   }: {
     # https://github.com/autowarefoundation/autoware_core/issues/855
     buildInputs = buildInputs ++ [
@@ -159,10 +159,29 @@ in with lib; {
       rosSelf.autoware-test-utils
       rosSelf.pybind11-vendor
     ];
+    propagatedBuildInputs = propagatedBuildInputs ++ [
+      self.tl-expected
+    ];
+    patches = patches ++ [
+      # Switch to libexpected-dev
+      # https://github.com/autowarefoundation/autoware_core/pull/1058
+      (self.fetchpatch2 {
+        url = "https://github.com/wentasah/autoware_core/commit/fd1243468c37f3c96031ede5717b0c0cc1a3ff11.patch?full_index=1";
+        hash = "sha256-o4GhZPWXGuUyzsBm8ddTWClQAMfQ6RVg9dWgBjiASp0=";
+        stripLen = 2;
+        excludes = [
+          "include/autoware/trajectory/temporal_trajectory.hpp"
+          "package.xml"
+        ];
+      })
+    ];
     # https://github.com/autowarefoundation/autoware_core/pull/853
     postPatch = postPatch + ''
       substituteInPlace include/autoware/trajectory/interpolator/detail/interpolator_common_interface.hpp \
         --replace-fail '#include <vector>' "#include <vector>"$'\n'"#include <algorithm>"
+      # This change is not needed in main branch, so it is not included in the patch above.
+      substituteInPlace include/autoware/trajectory/utils/pretty_build.hpp \
+        --replace-fail 'tl_expected/expected.hpp' 'tl/expected.hpp'
     '';
   });
 

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -800,6 +800,36 @@ in with lib; {
     '';
   });
 
+  generate-parameter-library = rosSuper.generate-parameter-library.overrideAttrs ({
+    patches ? [], ...
+  }: {
+    # Needed to build autoware-path-generator-1.7.0-r2
+    patches = patches ++ [
+      # Use libexpected-dev instead of tl_expected (#322) (#333)
+      (self.fetchpatch2 {
+        url = "https://github.com/PickNikRobotics/generate_parameter_library/commit/1fdc466f84499c0cec05beccaa211ffcb2bb100b.patch?full_index=1";
+        hash = "sha256-RsvJmV9dymcZ3mFjjn/u1dgkqmT76E0UouSv4BB1hKE=";
+        relative = "generate_parameter_library";
+      })
+      # Silence deprecation warning for tl_expected (backport #350)
+      (self.fetchpatch2 {
+        url = "https://github.com/PickNikRobotics/generate_parameter_library/commit/0c6457dc682c69274f28994366fbc587d48259c5.patch?full_index=1";
+        hash = "sha256-l/dG9nly945ogdBRZpQ0F0nuzDcE1hjn0SKqmMn9HI4=";
+        relative = "generate_parameter_library";
+      })
+    ];
+  });
+
+  parameter-traits = rosSuper.parameter-traits.overrideAttrs ({
+    postPatch ? "", ...
+  }: {
+    # Needed to build autoware-path-generator-1.7.0-r2
+    postPatch = postPatch + ''
+      substituteInPlace include/parameter_traits/parameter_traits.hpp \
+        --replace-fail 'tl_expected/expected.hpp' 'tl/expected.hpp'
+    '';
+  });
+
   plotjuggler = rosSuper.plotjuggler.overrideAttrs ({
     nativeBuildInputs ? [], ...
   }: {

--- a/distros/humble/pid-controller/default.nix
+++ b/distros/humble/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-pid-controller";
-  version = "2.53.0-r1";
+  version = "2.53.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pid_controller/2.53.0-1.tar.gz";
-    name = "2.53.0-1.tar.gz";
-    sha256 = "d72c9c1cd51f3298e27a670c35533d35bf52a312b446c6a663d7297e3a55552d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pid_controller/2.53.1-1.tar.gz";
+    name = "2.53.1-1.tar.gz";
+    sha256 = "83518c15a101cdb32bcb1edf1a73fd53585f7e956fbbc26c9597154a97afcde8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pose-broadcaster/default.nix
+++ b/distros/humble/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-pose-broadcaster";
-  version = "2.53.0-r1";
+  version = "2.53.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pose_broadcaster/2.53.0-1.tar.gz";
-    name = "2.53.0-1.tar.gz";
-    sha256 = "e261b49358c6ab1acf4ffac647dd140fdcb5f8f2af3a9c1f799243964439059a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pose_broadcaster/2.53.1-1.tar.gz";
+    name = "2.53.1-1.tar.gz";
+    sha256 = "58afefdae3fef4ba5c63ff7de1456375c964f5e4f308cf7f92d0c18208cd218c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/position-controllers/default.nix
+++ b/distros/humble/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-position-controllers";
-  version = "2.53.0-r1";
+  version = "2.53.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.53.0-1.tar.gz";
-    name = "2.53.0-1.tar.gz";
-    sha256 = "5bcc96d55bfb40feec52ab21b932c4c68c2fb5e30238a2326f33abf0023aefab";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.53.1-1.tar.gz";
+    name = "2.53.1-1.tar.gz";
+    sha256 = "ccba3d477919ec00aa38805336eb5b0cec7990e49ef7c962c3f057d57947cca3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/range-sensor-broadcaster/default.nix
+++ b/distros/humble/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-range-sensor-broadcaster";
-  version = "2.53.0-r1";
+  version = "2.53.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/range_sensor_broadcaster/2.53.0-1.tar.gz";
-    name = "2.53.0-1.tar.gz";
-    sha256 = "1d7e448ec5656cca587b92ff3a2d139aaf3310ccbbfc7d921f1128840075fc19";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/range_sensor_broadcaster/2.53.1-1.tar.gz";
+    name = "2.53.1-1.tar.gz";
+    sha256 = "72f6bb629861c1732acfb032d5009603ff4a0cc124d047682368d49ac24bdf39";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rcl-action/default.nix
+++ b/distros/humble/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rcl-action";
-  version = "5.3.12-r1";
+  version = "5.3.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_action/5.3.12-1.tar.gz";
-    name = "5.3.12-1.tar.gz";
-    sha256 = "c0aa05d44b3c004ab868aaf4fc19a04c452009a22d240df1e8906269fc0586ba";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_action/5.3.13-1.tar.gz";
+    name = "5.3.13-1.tar.gz";
+    sha256 = "ff97a6fa9176b0a81965bc140401aa8d2e79c66c3db115125121cd01e9eb2c3f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rcl-lifecycle/default.nix
+++ b/distros/humble/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-humble-rcl-lifecycle";
-  version = "5.3.12-r1";
+  version = "5.3.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_lifecycle/5.3.12-1.tar.gz";
-    name = "5.3.12-1.tar.gz";
-    sha256 = "aa6b0e9a4c09324e20efbef3fd34119cc4a5d69b54c5fd32c83769dbd0656d43";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_lifecycle/5.3.13-1.tar.gz";
+    name = "5.3.13-1.tar.gz";
+    sha256 = "1e23eeacc3d834d50ba245325fba54b264b7e9bfae0b72ce43076e0049aa3192";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rcl-yaml-param-parser/default.nix
+++ b/distros/humble/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-humble-rcl-yaml-param-parser";
-  version = "5.3.12-r1";
+  version = "5.3.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_yaml_param_parser/5.3.12-1.tar.gz";
-    name = "5.3.12-1.tar.gz";
-    sha256 = "76a4ef46f32f0ac1d4887296ebd20468954347fe084e0aea3627463174085d0c";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_yaml_param_parser/5.3.13-1.tar.gz";
+    name = "5.3.13-1.tar.gz";
+    sha256 = "bfa8a2f393a1387b9346a8fcca0e34d341db60abb78f7c184b5dfc1e1d70d9eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rcl/default.nix
+++ b/distros/humble/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-humble-rcl";
-  version = "5.3.12-r1";
+  version = "5.3.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl/5.3.12-1.tar.gz";
-    name = "5.3.12-1.tar.gz";
-    sha256 = "700e13446171c92095183390e4d6656d5da8788a63ed1e5443fb26fa9c4a0540";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl/5.3.13-1.tar.gz";
+    name = "5.3.13-1.tar.gz";
+    sha256 = "0dca75f250198aca100b5ea9ff299b694a6d409701142e60859c3a20a69e24a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-controllers-test-nodes/default.nix
+++ b/distros/humble/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers-test-nodes";
-  version = "2.53.0-r1";
+  version = "2.53.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.53.0-1.tar.gz";
-    name = "2.53.0-1.tar.gz";
-    sha256 = "758e94a6e645e9cb1d7bba239b72ee99b21cb3250497c4545abf253f862ba4b4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.53.1-1.tar.gz";
+    name = "2.53.1-1.tar.gz";
+    sha256 = "413550d327ea308e04d4ae5197d3646ed867dbdc02aebded28b2bf83c2ba298c";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2-controllers/default.nix
+++ b/distros/humble/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gripper-controllers, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers";
-  version = "2.53.0-r1";
+  version = "2.53.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.53.0-1.tar.gz";
-    name = "2.53.0-1.tar.gz";
-    sha256 = "a6ee5ceece259db97e0ca32f05007af81de26a37db3409c2d66a9436440fe96e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.53.1-1.tar.gz";
+    name = "2.53.1-1.tar.gz";
+    sha256 = "a7d20599ed7a60eda2b267335de56fe81cbdafaf4e7444bcabb2cabdbe45cf57";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2rawlog/default.nix
+++ b/distros/humble/rosbag2rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, cli11, cmake, cv-bridge, mrpt-libmaps, mrpt-libros-bridge, mrpt-msgs, nav-msgs, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-rosbag2rawlog";
-  version = "3.5.1-r1";
+  version = "3.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/humble/rosbag2rawlog/3.5.1-1.tar.gz";
-    name = "3.5.1-1.tar.gz";
-    sha256 = "c7b0bc9f6b8c719027dced4bb3843a355dcd1d9d9869bbd9b4b3c10db7d89d2f";
+    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/humble/rosbag2rawlog/3.5.2-1.tar.gz";
+    name = "3.5.2-1.tar.gz";
+    sha256 = "59c90f7cc1d2b21f4f034374df106b88858cd0f88e79271ed4ac1a2e0b6155a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rqt-joint-trajectory-controller/default.nix
+++ b/distros/humble/rqt-joint-trajectory-controller/default.nix
@@ -5,15 +5,16 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-rqt-joint-trajectory-controller";
-  version = "2.53.0-r1";
+  version = "2.53.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.53.0-1.tar.gz";
-    name = "2.53.0-1.tar.gz";
-    sha256 = "4867643b2f650729aaec4623bff2d6ab6c95d83938afc8fe3d39485699c1b9ca";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.53.1-1.tar.gz";
+    name = "2.53.1-1.tar.gz";
+    sha256 = "a39bb039d1bd5f3813e09b0e70471561dad052a2fc718e46bd58f44a8a4342aa";
   };
 
   buildType = "ament_python";
+  checkInputs = [ python3Packages.pytest ];
   propagatedBuildInputs = [ control-msgs controller-manager-msgs python-qt-binding python3Packages.rospkg qt-gui rclpy rqt-gui rqt-gui-py trajectory-msgs ];
 
   meta = {

--- a/distros/humble/steering-controllers-library/default.nix
+++ b/distros/humble/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-steering-controllers-library";
-  version = "2.53.0-r1";
+  version = "2.53.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.53.0-1.tar.gz";
-    name = "2.53.0-1.tar.gz";
-    sha256 = "e3102d5d236ea4b874fbbfe0f6fff908eaf6ef7b7b86e26d0bc9945c8cdc5ace";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.53.1-1.tar.gz";
+    name = "2.53.1-1.tar.gz";
+    sha256 = "0494a9e202cc42dff465f0ad457abebba5f3cc38f2f57425e406d578a0d95a27";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tcb-span/default.nix
+++ b/distros/humble/tcb-span/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-humble-tcb-span";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/humble/tcb_span/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "e2508258caeb0d816042e354d6cd12fd1e71384fd871601d12a2791e11ca3b4c";
+    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/humble/tcb_span/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "1ac2caec5d141bdb3022c900dd89ec77c8c9c82ed96786d5e7f5ee3eaff1cd2c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/theora-image-transport/default.nix
+++ b/distros/humble/theora-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, cv-bridge, image-transport, libogg, libtheora, opencv, pkg-config, pluginlib, rclcpp, rcutils, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-theora-image-transport";
-  version = "2.5.4-r1";
+  version = "2.5.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/humble/theora_image_transport/2.5.4-1.tar.gz";
-    name = "2.5.4-1.tar.gz";
-    sha256 = "d362b8d8732aac82cc134fa7faf1cb821d3de888036f2f4e511cec483b3ab9ee";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/humble/theora_image_transport/2.5.5-1.tar.gz";
+    name = "2.5.5-1.tar.gz";
+    sha256 = "06554c70bb540c1574f47323fccd6e2ef3765da668e1d82ad6697c17f138775f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tl-expected/default.nix
+++ b/distros/humble/tl-expected/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-tl-expected";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/humble/tl_expected/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "9bf4e6922dc936811063abc591035ed376a65779465f3dfd7e254982e12893e2";
+    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/humble/tl_expected/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "b2b3bcfed611ed2e305979ad96fa23e4ba702fcd288968415fa4d8417230443e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-controller/default.nix
+++ b/distros/humble/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-tricycle-controller";
-  version = "2.53.0-r1";
+  version = "2.53.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.53.0-1.tar.gz";
-    name = "2.53.0-1.tar.gz";
-    sha256 = "1b181e2fba09b90b05f2c7efc7281b89ed4aca45c3b9804db1a018b78c9e6c51";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.53.1-1.tar.gz";
+    name = "2.53.1-1.tar.gz";
+    sha256 = "b372e0a57c835d963e33fafb3a226909d6ce730b5e80f09063a847bc6eaa0682";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-steering-controller/default.nix
+++ b/distros/humble/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-tricycle-steering-controller";
-  version = "2.53.0-r1";
+  version = "2.53.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.53.0-1.tar.gz";
-    name = "2.53.0-1.tar.gz";
-    sha256 = "6554725880d6c6a06c040abf8decb6c7340130c885d16d95be427d4da0ef774e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.53.1-1.tar.gz";
+    name = "2.53.1-1.tar.gz";
+    sha256 = "1a308ad8d0ec54ae751e20bf27982d465639dc0e191b41bf80f038308447ef7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-client-library/default.nix
+++ b/distros/humble/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-humble-ur-client-library";
-  version = "2.9.0-r1";
+  version = "2.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/humble/ur_client_library/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "794be84cd89e91d9e2c6b70bd13b11a2280efea36db6be822e535c7881f60ae1";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/humble/ur_client_library/2.10.0-1.tar.gz";
+    name = "2.10.0-1.tar.gz";
+    sha256 = "51f2008238db90258e7c2c356ecad42e6288022bef5d46c8ce3adc09d399c6a2";
   };
 
   buildType = "cmake";

--- a/distros/humble/velocity-controllers/default.nix
+++ b/distros/humble/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-velocity-controllers";
-  version = "2.53.0-r1";
+  version = "2.53.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.53.0-1.tar.gz";
-    name = "2.53.0-1.tar.gz";
-    sha256 = "ef7157da0b0568493f62b4406fa85363622bafb07583da17fe87546bda57845c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.53.1-1.tar.gz";
+    name = "2.53.1-1.tar.gz";
+    sha256 = "e5361b235d7605c4d5075131089ef69209545e019f633a253c6c57db077ef6c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ackermann-steering-controller/default.nix
+++ b/distros/jazzy/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-ackermann-steering-controller";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ackermann_steering_controller/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "a750ddba34d94975dbdeb7432942717859ecbe94121f7bc9fe926baede42c963";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ackermann_steering_controller/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "bf8e01b28e7aede1767de9089c26ef4ffab8b12803cc75ea5cdec467e3315acd";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/admittance-controller/default.nix
+++ b/distros/jazzy/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, tinyxml-2, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-admittance-controller";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/admittance_controller/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "3a02b79b6113aa567043e6f1507110c723f2b7d48593597eeb5c9cb709e279ab";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/admittance_controller/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "5f49cc34163a3e8614aaa3c2b5deb9416db3c7e2c4b482796dac7d1ebbcc91cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/beluga-amcl/default.nix
+++ b/distros/jazzy/beluga-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, beluga, beluga-ros, bondcpp, message-filters, rclcpp, rclcpp-components, rclcpp-lifecycle, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-beluga-amcl";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/beluga-release/archive/release/jazzy/beluga_amcl/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "bf0a75128826c067b891c82ede8b3b48f6d95e416771a531030b16a39af2af2e";
+    url = "https://github.com/ros2-gbp/beluga-release/archive/release/jazzy/beluga_amcl/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "47c6a1f995c6d666f4fa2e6e98bdf3e304de9866bf88af9fe227c9cea28f4ff5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/beluga-ros/default.nix
+++ b/distros/jazzy/beluga-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-cmake-ros, beluga, geometry-msgs, nav-msgs, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-beluga-ros";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/beluga-release/archive/release/jazzy/beluga_ros/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "26cf593c120692a3018944f9f2ee33d8cb1c8a90a937c4c5997e65f178874787";
+    url = "https://github.com/ros2-gbp/beluga-release/archive/release/jazzy/beluga_ros/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "1baf137f3c0b5521fc7323339838bf32db49b242f7d295d7d2af14d7fdbd53df";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/beluga/default.nix
+++ b/distros/jazzy/beluga/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, clang, cmake, eigen, gbenchmark, gtest, hdf5, onetbb, range-v3, sophus }:
 buildRosPackage {
   pname = "ros-jazzy-beluga";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/beluga-release/archive/release/jazzy/beluga/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "98edbe4fc0d184e41fc24d811fb1de4c97ed0116b8a54d055a1569a741b03972";
+    url = "https://github.com/ros2-gbp/beluga-release/archive/release/jazzy/beluga/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "40475ac312fdcd36d84c517c98a52da1b75353856184b78c8f5eda22470d3fd2";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/bicycle-steering-controller/default.nix
+++ b/distros/jazzy/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-bicycle-steering-controller";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/bicycle_steering_controller/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "abdbd9d4ada6a33993edc62b845dcee9975632e865e70a1bf1b01995ac0940e8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/bicycle_steering_controller/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "a232261e63c302e977239193a198878940a224fe95c9c7a4b790363b73581726";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/chained-filter-controller/default.nix
+++ b/distros/jazzy/chained-filter-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, filters, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-chained-filter-controller";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/chained_filter_controller/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "d9682ef048d5302861924ea82123a1f6c850aaafa762814ed6e2effa0e4464e0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/chained_filter_controller/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "0e306c0816cabc66465fd8181adf9f0d4525b07d71ec82f73f4b42d5ca8c8ddc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-generator-gz/default.nix
+++ b/distros/jazzy/clearpath-generator-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-generator-common, cv-bridge, ptz-action-server-msgs, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-generator-gz";
-  version = "2.9.0-r1";
+  version = "2.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/jazzy/clearpath_generator_gz/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "af624ce23c5f6561048a9d51b40821fae65d317eaff1e8936577bd2197de3fdb";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/jazzy/clearpath_generator_gz/2.9.1-1.tar.gz";
+    name = "2.9.1-1.tar.gz";
+    sha256 = "6ef5fa06775338b388e5358f726fbffefd2b55b0b445eb9840b46212d2425869";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-gz/default.nix
+++ b/distros/jazzy/clearpath-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-common, clearpath-generator-gz, clearpath-viz, gz-ros2-control, ros-gz }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-gz";
-  version = "2.9.0-r1";
+  version = "2.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/jazzy/clearpath_gz/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "dd106972fd5bb34f62df0c73fa98404884dc860e9daef32b86377339085988f5";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/jazzy/clearpath_gz/2.9.1-1.tar.gz";
+    name = "2.9.1-1.tar.gz";
+    sha256 = "89ee73a2736a901da47b5c51281714ac2c5e7d5cc444c8157253d8fa9cda0d20";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-simulator/default.nix
+++ b/distros/jazzy/clearpath-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-generator-gz, clearpath-gz }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-simulator";
-  version = "2.9.0-r1";
+  version = "2.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/jazzy/clearpath_simulator/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "be1cd3c84b0ecc55a6b95336b414a937f68b881b2237f99aab5c91081d87156a";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/jazzy/clearpath_simulator/2.9.1-1.tar.gz";
+    name = "2.9.1-1.tar.gz";
+    sha256 = "bfeda5ccb52238c9f2c0ffe78bdfd12160d77eb4f6f759e021caf63afa55a998";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/cloudini-lib/default.nix
+++ b/distros/jazzy/cloudini-lib/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, lz4, pcl, zstd }:
 buildRosPackage {
   pname = "ros-jazzy-cloudini-lib";
-  version = "1.0.4-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/cloudini-release/archive/release/jazzy/cloudini_lib/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "fa7445c5417640e0b533a9b30ff99b10ae10b52439fcac346844ea4a46f9a7b0";
+    url = "https://github.com/facontidavide/cloudini-release/archive/release/jazzy/cloudini_lib/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "575d6cce4ae6df0486f170264814608a52008dbdb32b56c6a18766dc7a7f1067";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/cloudini-ros/default.nix
+++ b/distros/jazzy/cloudini-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cloudini-lib, pcl-conversions, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, rclcpp-components, rosbag2-cpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-cloudini-ros";
-  version = "1.0.4-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/cloudini-release/archive/release/jazzy/cloudini_ros/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "5a05c47171903e55e0f383e0335c086be2a35bd94a9974e1098f93bedd8a58fd";
+    url = "https://github.com/facontidavide/cloudini-release/archive/release/jazzy/cloudini_ros/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "4d077bcf15baed9fe68c17d4ffddfd6212a0928ba18323ec0e0667b349f0fd29";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/compass-msgs/default.nix
+++ b/distros/jazzy/compass-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-compass-msgs";
-  version = "0.1.1-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/compass_msgs/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "562ced58f02d7bf9a3eeb817221042dce4d99e8b48092824ddfca77a17fbe01a";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/compass_msgs/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "d82a882d12564b2b2d29f06f1841697090cd997347a84975ad9556bd53e62a37";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {
-    description = "ROS 2 port of compass_msgs — messages related to compass and azimuth.
+    description = "ROS 2 port of compass_msgs: messages related to compass and azimuth.
     Message definition identical to ctu-vras/compass for compatibility.";
     license = with lib.licenses; [ bsdOriginal ];
   };

--- a/distros/jazzy/compressed-depth-image-transport/default.nix
+++ b/distros/jazzy/compressed-depth-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-jazzy-compressed-depth-image-transport";
-  version = "4.0.6-r1";
+  version = "4.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/compressed_depth_image_transport/4.0.6-1.tar.gz";
-    name = "4.0.6-1.tar.gz";
-    sha256 = "516d96ecaa8245c124aeb484fa66419f436840bd38e1352e1bbe527689238355";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/compressed_depth_image_transport/4.0.7-1.tar.gz";
+    name = "4.0.7-1.tar.gz";
+    sha256 = "996f2084769522a204460ca01454822e3a710e4e8169a7cb06f79056ad04e067";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/compressed-image-transport/default.nix
+++ b/distros/jazzy/compressed-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-jazzy-compressed-image-transport";
-  version = "4.0.6-r1";
+  version = "4.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/compressed_image_transport/4.0.6-1.tar.gz";
-    name = "4.0.6-1.tar.gz";
-    sha256 = "b68a6da8db6dd6a53b5a1f46490fe298e8420c7c859f526964904d1d935b5055";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/compressed_image_transport/4.0.7-1.tar.gz";
+    name = "4.0.7-1.tar.gz";
+    sha256 = "9854af5fc761a19ac175a7860d9e53ed9443a4b05629f183f282fafdf422550b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/control-toolbox/default.nix
+++ b/distros/jazzy/control-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, eigen, filters, fmt, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-cmake, rsl, tf2, tf2-geometry-msgs, tf2-ros, tl-expected-nixpkgs }:
 buildRosPackage {
   pname = "ros-jazzy-control-toolbox";
-  version = "4.10.0-r1";
+  version = "4.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/jazzy/control_toolbox/4.10.0-1.tar.gz";
-    name = "4.10.0-1.tar.gz";
-    sha256 = "d9b5b0e16ed4247b119cd265a5682fc247972e43439cd7925e796375969d552d";
+    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/jazzy/control_toolbox/4.11.0-1.tar.gz";
+    name = "4.11.0-1.tar.gz";
+    sha256 = "b9356ab794d2bae077e42722542785bacc1397c9c22197d29f386e42e9952226";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/controller-interface/default.nix
+++ b/distros/jazzy/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, fmt, geometry-msgs, hardware-interface, pal-statistics, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-controller-interface";
-  version = "4.44.0-r1";
+  version = "4.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_interface/4.44.0-1.tar.gz";
-    name = "4.44.0-1.tar.gz";
-    sha256 = "5d81870c6105cf473ff9f9cb2e7a6921466161242c170c6becd76ff1fde2b41b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_interface/4.45.0-1.tar.gz";
+    name = "4.45.0-1.tar.gz";
+    sha256 = "2eac523be077c5186a88dc9de365800f49e0eb935749d23f3191810108324797";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/controller-manager-msgs/default.nix
+++ b/distros/jazzy/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-controller-manager-msgs";
-  version = "4.44.0-r1";
+  version = "4.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager_msgs/4.44.0-1.tar.gz";
-    name = "4.44.0-1.tar.gz";
-    sha256 = "8f6038f05c26f68a34a8912e3e3da99b2ecb44464496018fcd814cec5e7d6a85";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager_msgs/4.45.0-1.tar.gz";
+    name = "4.45.0-1.tar.gz";
+    sha256 = "a59c17695151496236eeb3f53c764a66c9cb1fa703c7a94d9c6dfd6ee3d55d41";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/controller-manager/default.nix
+++ b/distros/jazzy/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, example-interfaces, fmt, generate-parameter-library, hardware-interface, hardware-interface-testing, launch, launch-ros, launch-testing, launch-testing-ros, libstatistics-collector, lifecycle-msgs, pluginlib, python3Packages, rcl-interfaces, rclcpp, rclpy, realtime-tools, robot-state-publisher, ros2-control-cmake, ros2-control-test-assets, ros2param, ros2pkg, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-controller-manager";
-  version = "4.44.0-r1";
+  version = "4.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager/4.44.0-1.tar.gz";
-    name = "4.44.0-1.tar.gz";
-    sha256 = "151d6996c0b4e88f942debdb4ab808e8e90c69cc732aaae5b679a8f184ed50ec";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager/4.45.0-1.tar.gz";
+    name = "4.45.0-1.tar.gz";
+    sha256 = "0e6acbe9ddd5d67ad024bdf86cbbe111b1e6776afaf37847bc69553b23e3d099";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/diff-drive-controller/default.nix
+++ b/distros/jazzy/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-diff-drive-controller";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/diff_drive_controller/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "6069c25b2514506bde7b7223ee0e083840f9d7b8db0042d6bca334c2e7c85b0c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/diff_drive_controller/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "cbed18aa324ce5c01cc552fc1c1cf04a38428291bdc17f1b8295af3a4902d44c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/effort-controllers/default.nix
+++ b/distros/jazzy/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-effort-controllers";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/effort_controllers/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "4930d4953c043b752b569bf41a3320b4fa229cb23b976dfa23ef51babe0be9be";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/effort_controllers/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "2989f2ac4c445cc0f137ebc856277f75e5cf4195047d6e60dc5ff794c4fe0ae1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/flir-ptu-description/default.nix
+++ b/distros/jazzy/flir-ptu-description/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-jazzy-flir-ptu-description";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/flir_ptu-release/archive/release/jazzy/flir_ptu_description/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "4840c0627b562e261beb346d4bc983d9183f9a95b2ba5387ede27164b816e9fd";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "URDF description of the FLIR PTUs.";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/jazzy/flir-ptu-driver/default.nix
+++ b/distros/jazzy/flir-ptu-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, diagnostic-updater, rclcpp, robot-state-publisher, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-flir-ptu-driver";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/flir_ptu-release/archive/release/jazzy/flir_ptu_driver/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "d27a5eb141b53361eac43a02ae56c9ac54ded649fb21f17c793f8fa4dd864d51";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ diagnostic-updater rclcpp robot-state-publisher sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS 2 driver for FLIR pan-tilt units with serial and TCP/Ethernet support.";
+    license = with lib.licenses; [ "GPL-2.0-or-later" ];
+  };
+}

--- a/distros/jazzy/flir-ptu-viz/default.nix
+++ b/distros/jazzy/flir-ptu-viz/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, flir-ptu-description, flir-ptu-driver, interactive-markers, joint-state-publisher, joint-state-publisher-gui, rclpy, robot-state-publisher, rviz2, sensor-msgs, visualization-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-jazzy-flir-ptu-viz";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/flir_ptu-release/archive/release/jazzy/flir_ptu_viz/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "97d65309fcd6f30ab8706c072f3ff263c471fb88374ee73225fa6c2d1c8ed78e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ flir-ptu-description flir-ptu-driver interactive-markers joint-state-publisher joint-state-publisher-gui rclpy robot-state-publisher rviz2 sensor-msgs visualization-msgs xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Launch files and RViz configs to assist with visualizing the FLIR PTUs.";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/jazzy/force-torque-sensor-broadcaster/default.nix
+++ b/distros/jazzy/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-force-torque-sensor-broadcaster";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/force_torque_sensor_broadcaster/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "0e1e71f273dcd698af7383989b52ed6ae66691b097f0e75bd8ef045a2a99948a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/force_torque_sensor_broadcaster/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "94e9e5134f47c01318bd781aa5e16809eb864b9820d1e6634cd10bd4e80a3f49";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/forward-command-controller/default.nix
+++ b/distros/jazzy/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-forward-command-controller";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/forward_command_controller/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "2e3462e22c5192a4cf259511a6505ee19b02cbb623cd903e9070eaef47322a27";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/forward_command_controller/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "d5ede13563593d8fa854251acd90454a162a97ad6192366051eb85f79d83cd44";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fusioncore-core/default.nix
+++ b/distros/jazzy/fusioncore-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module }:
 buildRosPackage {
   pname = "ros-jazzy-fusioncore-core";
-  version = "0.1.1-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/fusioncore_core/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "a13edee9380b81ecb751235280e7dcc70ccc665534fb658848f234fad371aaf5";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/fusioncore_core/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "e720c351fb8aaa83e8e70d18cdb4248676f50bd4fbff4c34cf3573938902a6cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fusioncore-datasets/default.nix
+++ b/distros/jazzy/fusioncore-datasets/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, fusioncore-ros, geometry-msgs, nav-msgs, rclpy, robot-localization, rosgraph-msgs, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-fusioncore-datasets";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/fusioncore_datasets/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "1f0b22463a56eb57d264e89c9383f929cb3859a4025e2a856c8ed9bd28564675";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ fusioncore-ros geometry-msgs nav-msgs rclpy robot-localization rosgraph-msgs sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "NCLT dataset adapter and benchmark pipeline for FusionCore vs robot_localization";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/fusioncore-gazebo/default.nix
+++ b/distros/jazzy/fusioncore-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fusioncore-ros, nav-msgs, rclpy, robot-state-publisher, ros-gz-bridge, ros-gz-sim, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-fusioncore-gazebo";
-  version = "0.1.1-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/fusioncore_gazebo/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "f9910192033f1b01ef7800b43c77329b666f52f6407e06a43bb4f44dad04f205";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/fusioncore_gazebo/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "5c55515f99b37158127974d3160afa922e3b5b5d95dd63ba0ec8dbfedcb540f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fusioncore-ros/default.nix
+++ b/distros/jazzy/fusioncore-ros/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, compass-msgs, eigen3-cmake-module, fusioncore-core, geometry-msgs, nav-msgs, rclcpp, rclcpp-lifecycle, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, compass-msgs, diagnostic-msgs, eigen3-cmake-module, fusioncore-core, geometry-msgs, nav-msgs, proj, rclcpp, rclcpp-lifecycle, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-fusioncore-ros";
-  version = "0.1.1-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/fusioncore_ros/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "208f0b393d0d1672738ae878ddbc0c4b82dd7950218e541c2a976a24d7ab5cf1";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/fusioncore_ros/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "4b49030b6f833a562b9caa94a92b9fc1e0083dd32b008f9bfc47c45cc4a83030";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ compass-msgs eigen3-cmake-module fusioncore-core geometry-msgs nav-msgs rclcpp rclcpp-lifecycle sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ compass-msgs diagnostic-msgs eigen3-cmake-module fusioncore-core geometry-msgs nav-msgs proj rclcpp rclcpp-lifecycle sensor-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "FusionCore ROS 2 Jazzy wrapper — sensor fusion node";
+    description = "FusionCore ROS 2 Jazzy wrapper: sensor fusion node";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -1174,6 +1174,12 @@ self: super: {
 
  flir-camera-msgs = self.callPackage ./flir-camera-msgs {};
 
+ flir-ptu-description = self.callPackage ./flir-ptu-description {};
+
+ flir-ptu-driver = self.callPackage ./flir-ptu-driver {};
+
+ flir-ptu-viz = self.callPackage ./flir-ptu-viz {};
+
  fluent-rviz = self.callPackage ./fluent-rviz {};
 
  fmi-adapter = self.callPackage ./fmi-adapter {};
@@ -1231,6 +1237,8 @@ self: super: {
  fuse-viz = self.callPackage ./fuse-viz {};
 
  fusioncore-core = self.callPackage ./fusioncore-core {};
+
+ fusioncore-datasets = self.callPackage ./fusioncore-datasets {};
 
  fusioncore-gazebo = self.callPackage ./fusioncore-gazebo {};
 
@@ -1327,6 +1335,8 @@ self: super: {
  gripper-controllers = self.callPackage ./gripper-controllers {};
 
  gscam = self.callPackage ./gscam {};
+
+ gstreamer-ros-babel-fish = self.callPackage ./gstreamer-ros-babel-fish {};
 
  gtest-vendor = self.callPackage ./gtest-vendor {};
 
@@ -3010,6 +3020,8 @@ self: super: {
 
  ros-babel-fish-test-msgs = self.callPackage ./ros-babel-fish-test-msgs {};
 
+ ros-babel-fish-tools = self.callPackage ./ros-babel-fish-tools {};
+
  ros-base = self.callPackage ./ros-base {};
 
  ros-core = self.callPackage ./ros-core {};
@@ -3205,6 +3217,14 @@ self: super: {
  rplidar-ros = self.callPackage ./rplidar-ros {};
 
  rpyutils = self.callPackage ./rpyutils {};
+
+ rqml = self.callPackage ./rqml {};
+
+ rqml-core = self.callPackage ./rqml-core {};
+
+ rqml-default-plugins = self.callPackage ./rqml-default-plugins {};
+
+ rqml-plugin-example = self.callPackage ./rqml-plugin-example {};
 
  rqt = self.callPackage ./rqt {};
 

--- a/distros/jazzy/gpio-controllers/default.nix
+++ b/distros/jazzy/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-gpio-controllers";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gpio_controllers/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "19917962f151fe5b7457d3ff52ea7a243d55b8bd06e975422ea5837fc89ee131";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gpio_controllers/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "612536ae1b43812a0d3f21e1e7bee0d2ec1264f36500f6664680428ab2e0527b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gps-sensor-broadcaster/default.nix
+++ b/distros/jazzy/gps-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-gps-sensor-broadcaster";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gps_sensor_broadcaster/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "3d90535b8a0823ee72af02e52881db19ea70d2a5d71ded2269ff197f453d3e44";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gps_sensor_broadcaster/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "e23f296feb8de6fca29a1f1a7b2126b513319268a666436817ff953238a82dee";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gripper-controllers/default.nix
+++ b/distros/jazzy/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-gripper-controllers";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gripper_controllers/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "090214b8946a7727e864289ec175f5e2690155544c828d8d09bc453c1efedff9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gripper_controllers/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "cb3ba5a53623ee5354e53b32940085ea7a3003687d4d9de455381e6b8c1b4439";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gstreamer-ros-babel-fish/default.nix
+++ b/distros/jazzy/gstreamer-ros-babel-fish/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, gst_all_1, rclcpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-gstreamer-ros-babel-fish";
+  version = "1.26.40-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gstreamer_ros_babel_fish-release/archive/release/jazzy/gstreamer_ros_babel_fish/1.26.40-1.tar.gz";
+    name = "1.26.40-1.tar.gz";
+    sha256 = "5de07f0c5e9de089bc4324c9704baaf61a263c3f01e0d9ecadd883cdeabfe464";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good gst_all_1.gstreamer rclcpp sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "GStreamer elements for bidirectional ROS 2 image streaming";
+    license = with lib.licenses; [ "AGPL-3.0-only" ];
+  };
+}

--- a/distros/jazzy/gz-math-vendor/default.nix
+++ b/distros/jazzy/gz-math-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, eigen, gz-cmake-vendor, gz-utils-vendor, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-gz-math-vendor";
-  version = "0.0.8-r1";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_math_vendor-release/archive/release/jazzy/gz_math_vendor/0.0.8-1.tar.gz";
-    name = "0.0.8-1.tar.gz";
-    sha256 = "508430a2a1e9471c74c9d1e994d971ed592b5bf9b19606c133995a5f56f1cbc9";
+    url = "https://github.com/ros2-gbp/gz_math_vendor-release/archive/release/jazzy/gz_math_vendor/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "c01ba644ab5398e4f1c537a804dacede28357fdafbf152e1ef111cd7e19db451";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-math7 7.5.2
+    description = "Vendor package for: gz-math7 7.6.0
 
     Gazebo Math : Math classes and functions for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/jazzy/gz-math-vendor/vendored-source.json
+++ b/distros/jazzy/gz-math-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_math_vendor": {
     "url": "https://github.com/gazebosim/gz-math.git",
-    "rev": "gz-math7_7.5.2",
-    "hash": "sha256-LwYeyv8nwX06n5ju+ra2uqNMedMSLRumem8qDHXtNns="
+    "rev": "gz-math7_7.6.0",
+    "hash": "sha256-dsIldb2yDDQsCzhi2B4CKCN8XQsQgPfTJG16MEgiOiM="
   }
 }

--- a/distros/jazzy/hardware-interface-testing/default.nix
+++ b/distros/jazzy/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, fmt, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-hardware-interface-testing";
-  version = "4.44.0-r1";
+  version = "4.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface_testing/4.44.0-1.tar.gz";
-    name = "4.44.0-1.tar.gz";
-    sha256 = "147aaf126e757bc3e80d73553c1b24f50a8f97a0aad344193b2ef813e42bcdf7";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface_testing/4.45.0-1.tar.gz";
+    name = "4.45.0-1.tar.gz";
+    sha256 = "35efa680e39e4874c7081a50ee144179c464aecb9468f215afcc50ed45d9e0ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/hardware-interface/default.nix
+++ b/distros/jazzy/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, control-msgs, fmt, joint-limits, lifecycle-msgs, pal-statistics, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sdformat-urdf, tinyxml2-vendor, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-hardware-interface";
-  version = "4.44.0-r1";
+  version = "4.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface/4.44.0-1.tar.gz";
-    name = "4.44.0-1.tar.gz";
-    sha256 = "5008de7090799b222e8accdcc73a71c998755993b279c18f631854d1bd15a4b0";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface/4.45.0-1.tar.gz";
+    name = "4.45.0-1.tar.gz";
+    sha256 = "8a553a366918fc71d14f1b19a89b2b74a3497ad223aaee8384a9900322351392";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/image-transport-plugins/default.nix
+++ b/distros/jazzy/image-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, compressed-depth-image-transport, compressed-image-transport, theora-image-transport, zstd-image-transport }:
 buildRosPackage {
   pname = "ros-jazzy-image-transport-plugins";
-  version = "4.0.6-r1";
+  version = "4.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/image_transport_plugins/4.0.6-1.tar.gz";
-    name = "4.0.6-1.tar.gz";
-    sha256 = "f72ec18902d5867f362cba7487d74fde868b78a0615068b769ad4b2ee94313e0";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/image_transport_plugins/4.0.7-1.tar.gz";
+    name = "4.0.7-1.tar.gz";
+    sha256 = "77225001ba016923504a97f349ccd3025cb441ee07f773a3d78116e837ec42ed";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/imu-sensor-broadcaster/default.nix
+++ b/distros/jazzy/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-imu-sensor-broadcaster";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/imu_sensor_broadcaster/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "47c634daa8b70aaf29c5923e56edfc78b90239fb4965fdfe15fd9837f5e3a408";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/imu_sensor_broadcaster/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "4909bb3603dc2779fbfd2969849c45d1890b0aaf521be2a335752255609dbba0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-limits/default.nix
+++ b/distros/jazzy/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, fmt, generate-parameter-library, launch-ros, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-limits";
-  version = "4.44.0-r1";
+  version = "4.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/joint_limits/4.44.0-1.tar.gz";
-    name = "4.44.0-1.tar.gz";
-    sha256 = "b8ade561c8f354da26e5f4a7e0b9e5766e659916914b20f428f3d2eeb4c5e2d1";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/joint_limits/4.45.0-1.tar.gz";
+    name = "4.45.0-1.tar.gz";
+    sha256 = "fa0d6c7f0ec74299bfc42e1aa64168249a712296c6c4a80ae105dbce363fa49c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-state-broadcaster/default.nix
+++ b/distros/jazzy/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-state-broadcaster";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_state_broadcaster/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "0810d3a3af4dba50b784d13b2a7eae1344b7eb2460ef9742dd50feb6cc1bef11";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_state_broadcaster/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "035ddf6a553d1977847fcf23e987d965d623d43ab69882935a5b3abeb753db24";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-trajectory-controller/default.nix
+++ b/distros/jazzy/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, rsl, tl-expected-nixpkgs, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-trajectory-controller";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_trajectory_controller/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "1bd40b1fb48a7c6ad9fcb057876dd0cf90d4d21b00e541ec76f32788af4e4774";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_trajectory_controller/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "124c796928c02152f081224e5086a4d84bcdf9433da6eb6b8037b5b766ecda3e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/kitti-metrics-eval/default.nix
+++ b/distros/jazzy/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmath, mrpt-libposes, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-jazzy-kitti-metrics-eval";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/kitti_metrics_eval/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "c067e3e5d078491a43c4e79b27ab8f03dc3ba93761dc8f9befda2d7c60d4725a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/kitti_metrics_eval/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "d15b3f8197e9432b229f39c1a636d4f3ea71c4f92b80285625060055df652023";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mecanum-drive-controller/default.nix
+++ b/distros/jazzy/mecanum-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mecanum-drive-controller";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/mecanum_drive_controller/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "a9861b579534fa05e2992372566fcf4d89b0e91dd1da3aaaf57497e6e330e1ff";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/mecanum_drive_controller/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "ca4599d492f8d1270a1d298a02ff8c2ec1fbc09f9879d9f10c63b141affe9628";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-bridge-ros2/default.nix
+++ b/distros/jazzy/mola-bridge-ros2/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, geographic-msgs, geometry-msgs, gps-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, diagnostic-msgs, geographic-msgs, geometry-msgs, gps-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-bridge-ros2";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_bridge_ros2/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "b94ecaaf14322d9c1ecf762404b7f24d185e69326b9cca9ec5c3444e5f99d9e1";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_bridge_ros2/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "13e9875f3be14c30004a6c44bc37b6465757bdfde88442f4eab0c0bec2b6ab79";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ros-environment ];
   checkInputs = [ ament-cmake-xmllint ament-lint-auto ament-lint-cmake ];
-  propagatedBuildInputs = [ geographic-msgs geometry-msgs gps-msgs mola-common mola-kernel mola-msgs mrpt-libmaps mrpt-libros-bridge mrpt-nav-interfaces nav-msgs rclcpp sensor-msgs tf2 tf2-geometry-msgs ];
+  propagatedBuildInputs = [ diagnostic-msgs geographic-msgs geometry-msgs gps-msgs mola-common mola-kernel mola-msgs mrpt-libmaps mrpt-libros-bridge mrpt-nav-interfaces nav-msgs rclcpp sensor-msgs tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/jazzy/mola-demos/default.nix
+++ b/distros/jazzy/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-demos";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_demos/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "e1bb812cbb32242d0b056b0edc481a93b271c8e2ee23ffd5086638d5c561f0e2";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_demos/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "29e25c04ebc1712ff714e3321380461a75e1f4d2e3fe468af8714b7852fc0ab6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-imu-preintegration/default.nix
+++ b/distros/jazzy/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-imu-preintegration";
-  version = "1.15.0-r1";
+  version = "1.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_imu_preintegration-release/archive/release/jazzy/mola_imu_preintegration/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "fd05b9ed053aeab3bd784f39e0b0dc7cd58a6cc14a170f0452decbe2dc01c945";
+    url = "https://github.com/ros2-gbp/mola_imu_preintegration-release/archive/release/jazzy/mola_imu_preintegration/1.16.0-1.tar.gz";
+    name = "1.16.0-1.tar.gz";
+    sha256 = "a9b49adb22691b69c6cfbda525337f21d940bf19de137fd28b1217e6896a2e0d";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-euroc-dataset/default.nix
+++ b/distros/jazzy/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmath, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-euroc-dataset";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_euroc_dataset/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "0ac13648eba963a9b864fa0487a3a0fb4d2140b874bf5c85b8b6c58fe0c3cc78";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_euroc_dataset/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "665c5b4265d8c2ad8ec77089d87a35387317041c0a550bdccc6443b4e34be87e";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-kitti-dataset/default.nix
+++ b/distros/jazzy/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-kitti-dataset";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti_dataset/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "ccf12a97b9b5342805b3fac5ea2cdcdedf655272edc8d73b27d551cf31e6ee10";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti_dataset/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "adc650634a76afa41692a7eb65a63b43431b23313db616c4dfadae4472f78638";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-kitti360-dataset/default.nix
+++ b/distros/jazzy/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-kitti360-dataset";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti360_dataset/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "56bf443f8471250c0e9b868b8713781b1ed8584bf550a760503cfbef64cd76b8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti360_dataset/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "ab1f155f77a6cde2cfd09dbfb719fb88465bb3043241513818c6b2879453bdb7";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-lidar-bin-dataset/default.nix
+++ b/distros/jazzy/mola-input-lidar-bin-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-lidar-bin-dataset";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_lidar_bin_dataset/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "4c654196c500aadb096a536fe2f562c9b894a4642da5666cd75dd2e251f7d37a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_lidar_bin_dataset/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "1ab9dcf184db39655eb464064760d60484b65ba02c3ba7b36884e768a643ccd9";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-mulran-dataset/default.nix
+++ b/distros/jazzy/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-mulran-dataset";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_mulran_dataset/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "9602a3193d5328cd32267c15e3aa4251630086177fd122bd36ae060d543d68e9";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_mulran_dataset/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "f330d2c4bd516c91975b37644e59f22c36055a52f629cba40b5ff27411e6948a";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-paris-luco-dataset/default.nix
+++ b/distros/jazzy/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-paris-luco-dataset";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_paris_luco_dataset/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "a9352a69be1316ac68b20c35b07439a037b06c47ea76a549caf475d44e7323c7";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_paris_luco_dataset/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "81533b9aea3b259b1a0e6f30c7f6b6ef15f78c01dfb963bfc5fd2333808a000f";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-rawlog/default.nix
+++ b/distros/jazzy/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-rawlog";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rawlog/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "240bc12542fd6f27d8789f4606e682ad987c3a3433c3b15f0bb30131bfd3ec90";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rawlog/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "216dbecdca2d9e5fa4794aa9cdf0e7806518884484575338d6b1db93ee2417e1";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-rosbag2/default.nix
+++ b/distros/jazzy/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, gps-msgs, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-rosbag2";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rosbag2/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "c6922531d17250ae1ae60d311c4d4f2b4c8d0ccfab1a67275309128bfc25d9d6";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rosbag2/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "51871638626de5578b61727be16f61a1175a6df1dfcb92c1cbf8369b3062cedf";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-video/default.nix
+++ b/distros/jazzy/mola-input-video/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libhwdrivers, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-video";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_video/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "98a6cf38b5cb84a59fcf87652ac33e8a6cb42a5e282deea170ec905027abd566";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_video/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "8d8a39ed0a74075a54d64deed45ed10edd466f4196fe8859b813b20ae8d4f212";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-kernel/default.nix
+++ b/distros/jazzy/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libgui, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-kernel";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_kernel/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "bd6a726b1831ef95992d3e7b372028c8ad5a64507c1304e8064cac7cfbeda13e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_kernel/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "9d463738cd4eaf5cf557353ae088a916d49b8758e974af095c1f08bfcd76ec99";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-launcher/default.nix
+++ b/distros/jazzy/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-xmllint, ament-lint-auto, cmake, mola-kernel, mrpt-libbase, mrpt-libtclap, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-launcher";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_launcher/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "69428ef1ebb6391aa3e7fdf439fffc77ded53dbd177339820af2b75f5b3f4d25";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_launcher/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "debb608d89fee7be9f4a67c22ea68aeb7a64170cb040db440022c062bf5ac707";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-metric-maps/default.nix
+++ b/distros/jazzy/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mp2p-icp, mrpt-libmaps, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-metric-maps";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_metric_maps/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "3b36ed9af2d5d115ae19eb79e117cf17cb896ef4ca964cfe80a6b795c80013b1";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_metric_maps/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "eaf3f9b8aeebc1aeea2e6b694b633b1f305c6090f72dddbbe6a01bfbcf2dbe1d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-msgs/default.nix
+++ b/distros/jazzy/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-mola-msgs";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_msgs/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "294783c730600b9c5743dac10a50cc7c937f503569431ff4e564f1123afadd30";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_msgs/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "5d3e34471b0315dacd580cc5873bf0ac5f170319408a734f5eaff7e55326791f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-pose-list/default.nix
+++ b/distros/jazzy/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-jazzy-mola-pose-list";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_pose_list/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "1acdacf06d3802321b30a54e1633bf797ce215dcb32b369c3c31ab2c58c59d09";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_pose_list/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "c3f9062972df34ea6e558d41659ce7c6aa8e79025440647cba4b3b6f463b8eb3";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-relocalization/default.nix
+++ b/distros/jazzy/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-jazzy-mola-relocalization";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_relocalization/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "eed5cbeaa861d1044c43b11a58241fe96db57437a4f5ac2cf0d49d88769c1d92";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_relocalization/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "d765d09feb1bee5f052882bcbe5611359c4a796a22333c2f9639ba9071f5a0bf";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-traj-tools/default.nix
+++ b/distros/jazzy/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-jazzy-mola-traj-tools";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_traj_tools/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "e0b98e1d5bbcbab580b8f9e0580e2b22277d597a0a15a66ab97fdcbd4a5a8b91";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_traj_tools/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "44ae43213dd446fcadc14b14403a6bb55b3569f237f9952d38c50306137c1bb9";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-viz/default.nix
+++ b/distros/jazzy/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-jazzy-mola-viz";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_viz/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "ace1c0e216252fcf80f334c075fed7052112e6b90a72499022ea24078ae0b99d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_viz/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "0988eae8e07de5978d01b75d7500a548b88d8f02e2c5dd878c40c390612a0dd9";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-yaml/default.nix
+++ b/distros/jazzy/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-jazzy-mola-yaml";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_yaml/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "fd9c9e523756f8b3b021734748c5c21074a21e37dcef9568f3f48bb0b2ae9ed1";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_yaml/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "65c8bfaeb0e2c7e765ab00cc6f0ff0006f0a6f1234bbf855bcb9fd81359b96f9";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola/default.nix
+++ b/distros/jazzy/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-input-video, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-jazzy-mola";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "d3568d6201aff5f8fd839c131fdcc7d78985af0d36cf8d49a4869e93c080d998";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "565572c463b942f36dcf284bf4dd0f6881d1ad2d917d2573f0d166049b1d1952";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/motion-primitives-controllers/default.nix
+++ b/distros/jazzy/motion-primitives-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-motion-primitives-controllers";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/motion_primitives_controllers/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "f80f48662b5d4ea6d69c7a8641c58195c66ac556b4309512564be807e8d65ffc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/motion_primitives_controllers/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "6d4d22f5dcfa0bb3a60edb2087c9abcecf5ea431a4acf104c3d71293f05235b2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mp2p-icp/default.nix
+++ b/distros/jazzy/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mp2p-icp";
-  version = "2.8.1-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/jazzy/mp2p_icp/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "1fdfaa3344d261f31682c083d17a926af7e7178414ce61b7d1b4c3dea2216089";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/jazzy/mp2p_icp/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "0335e9df4caea3556512bae85720174b42f1b6332486d39e7e5858530d0c3285";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-apps/default.nix
+++ b/distros/jazzy/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-apps";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_apps/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "f3285406a701130ea38e5f9cf9952ae902834099ce900321fa62056344b7c3f4";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_apps/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "b7297a2d759627beef6878ab01fa22a0bd180003752ae7928d8666eb93c1f6e7";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libapps/default.nix
+++ b/distros/jazzy/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libapps";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libapps/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "a44578dd2fd45c4cd3c64e79adce5a52ab88c941b9ef462f1bc62ba818d40b34";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libapps/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "0882b39b10755a6a666b3d90b28ffa59093b268ec0a96c1dfa0b4e45a0be96f4";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libbase/default.nix
+++ b/distros/jazzy/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, onetbb, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib, zstd }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libbase";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libbase/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "d6688e6dbb8833769ba0cb1ebf83af7419ac729cc8cce1550c437cb2e8043ea5";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libbase/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "e42b74fd16dc5a10771f0c356eb621e74ad52f556b43c8d9b2d8a2d57ba6e886";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libgui/default.nix
+++ b/distros/jazzy/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libgui";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libgui/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "2cf6d38260cef07d30b7b528e9af50717ceafb963c4258f9307ad0d91de31ede";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libgui/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "a967ad40fd54a319861326ca3ec44d1ef423828af8cf4c0e156f60e39d9d39d3";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libhwdrivers/default.nix
+++ b/distros/jazzy/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libhwdrivers";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libhwdrivers/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "4ade780071bdb6d514ff94157cdf6024110d8469c854364fd7bb4bda92eb3464";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libhwdrivers/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "e78719c46e94340b33f77e3f42a6be3baac90b60b84414399eb2fd9a7092b31d";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libmaps/default.nix
+++ b/distros/jazzy/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libmaps";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libmaps/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "b8111b1cf91fe50fa6dc79a1e5e63026c3d65fcd71747e6992903aadb7fe8686";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libmaps/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "3f9d71872f20cc5acb4a3d8efb82ab7461f9459e3a47ceeb3cee3ea8d9aa6817";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libmath/default.nix
+++ b/distros/jazzy/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libmath";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libmath/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "d500cd2ac05cb9a4d4f39367462190ad0638ae0b93b86187abecf020446b2abe";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libmath/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "18a6cbc9a4b5b4f8aebaf50f8b7851684d66300896021c21e4b46228eaf69071";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libnav/default.nix
+++ b/distros/jazzy/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libnav";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libnav/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "dcf8140158f73e712a1af74c37daecb9f4a7aeaa3cf0566b2c2ff5f9e2d0b0fb";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libnav/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "2f801f763c5419f65c1c2f2e7f53dea84475691225a8eba0f99e4b838de87419";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libobs/default.nix
+++ b/distros/jazzy/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libobs";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libobs/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "7ddece6812bcf8be4ec11e9676827382d2acc4d17aa4ddd50f9d2278f94b48a9";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libobs/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "4bc1ed22ae5402f2b7bf7e82ec26c14f0aa2c7227f38966c69f41a79832fd295";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libopengl/default.nix
+++ b/distros/jazzy/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libopengl";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libopengl/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "fd10d52acc8d4ab2cf6bf8ec250c7009686bda068ff1d3d463b722eb26b2b656";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libopengl/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "99f6ca7687f3aea1baa1040e16c9fdf2d2b5dee790589136841c22b33e51c00e";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libposes/default.nix
+++ b/distros/jazzy/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libposes";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libposes/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "48a5dd191316af04f44e04377463b031d1d73a20ae1ac2c02e3f5c0242e1743c";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libposes/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "17df187b8d86fd627ca6f052661a0d8b500906e9705f0c1a110b238b759193c4";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libros-bridge/default.nix
+++ b/distros/jazzy/mrpt-libros-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cmake, cv-bridge, geometry-msgs, gps-msgs, mrpt-libmaps, mrpt-libobs, nav-msgs, ros-environment, rosbag2-cpp, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libros-bridge";
-  version = "3.5.1-r1";
+  version = "3.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/jazzy/mrpt_libros_bridge/3.5.1-1.tar.gz";
-    name = "3.5.1-1.tar.gz";
-    sha256 = "13857e01ba1e75026f09343c5180b5d9442c0f507b673ddf0642511865abd149";
+    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/jazzy/mrpt_libros_bridge/3.5.2-1.tar.gz";
+    name = "3.5.2-1.tar.gz";
+    sha256 = "d3574388a3627c9f663e80ad7659ffcd04e28db1cfbddd1f60dfd88f0faafc00";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libslam/default.nix
+++ b/distros/jazzy/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, onetbb, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libslam";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libslam/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "3c1cd50837d9aa4bab1e4c27f47e9696edac095e6cc199a372529f51eb4fabb5";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libslam/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "0852ea64899dac36cc504bcec7f9c713b3cb4c39a084b8134e276f1bed0b514a";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libtclap/default.nix
+++ b/distros/jazzy/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libtclap";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libtclap/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "7b829ac3318f16f47dcea6ac127d2ba945f3c7bffcb33402efc762693b6bdd27";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libtclap/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "756784f7e08834d2e762a94c1c0e3139bab295c83ce08f8e03a92f23f7f240d3";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-map-server/default.nix
+++ b/distros/jazzy/mrpt-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libros-bridge, mrpt-msgs, mrpt-nav-interfaces, rclcpp-components, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-map-server";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_map_server/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "0c93304eb5de81e23ca8eee5b4afff838a34de1b2298e5328cdf6e9c4cd2474b";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_map_server/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "910aa729b587b519d77fbba84b6c259b3fa73359ca952d901066e682a98ca01c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mrpt-msgs-bridge/default.nix
+++ b/distros/jazzy/mrpt-msgs-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, mrpt-libobs, mrpt-libros-bridge, mrpt-msgs, rclcpp, ros-environment, tf2 }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-msgs-bridge";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_msgs_bridge/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "31f34b786d24abbff981545ff65a89a829bee74a103eab44165f6552c5797b35";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_msgs_bridge/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "5d9f36aa0402e956d64c04f8278649819c4c6e09fc51166e13f6dbb7ad004380";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mrpt-nav-interfaces/default.nix
+++ b/distros/jazzy/mrpt-nav-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, geometry-msgs, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-nav-interfaces";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_nav_interfaces/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "54924d0a709aba599131a215899d97dbd39d4ce4ad828b5fc880835ca3353cbe";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_nav_interfaces/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "5a4dbafe2c0e78f3b0d2d51ae53804573395b12710b867697526f06863479f2e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mrpt-navigation/default.nix
+++ b/distros/jazzy/mrpt-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-map-server, mrpt-msgs-bridge, mrpt-nav-interfaces, mrpt-pf-localization, mrpt-pointcloud-pipeline, mrpt-reactivenav2d, mrpt-tps-astar-planner, mrpt-tutorials }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-navigation";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_navigation/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "00d24e6fdc740e0c4cfa93155467436700d5fb15ec3a7992e63c3396cdd510d7";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_navigation/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "88b2db01c4c025676c0db5ecf1e3e9d45b9958e9cf9ae3f3cc8979ecdf13a5f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mrpt-pf-localization/default.nix
+++ b/distros/jazzy/mrpt-pf-localization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, cmake, mola-relocalization, mp2p-icp, mrpt-libgui, mrpt-libros-bridge, mrpt-libslam, mrpt-msgs, mrpt-msgs-bridge, mrpt-tutorials, nav-msgs, pose-cov-ops, rclcpp, rclcpp-components, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-pf-localization";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_pf_localization/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "4dae8a30745850afe075aba526943853fc68f73ff5b2f97d2bffd6964c21d678";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_pf_localization/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "584db043b150e03991f940f5229a33e1cb50c55543c0fb1dbb1e51c3f8e16fc4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mrpt-pointcloud-pipeline/default.nix
+++ b/distros/jazzy/mrpt-pointcloud-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, mp2p-icp, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libros-bridge, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-pointcloud-pipeline";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_pointcloud_pipeline/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "8693b26e4c8d2df65d974b26754d75ff1770d9283421751efbb9fe7a8dd4e4b4";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_pointcloud_pipeline/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "c11a5b779cd69748f15ff57b77de2d85d9351770e56cd1ab875f9aac944201f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mrpt-reactivenav2d/default.nix
+++ b/distros/jazzy/mrpt-reactivenav2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, mrpt-libnav, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-reactivenav2d";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_reactivenav2d/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "716b0333bfe7769c14a943a50c34a6e98e174dc5dcbd277391ce1cf932d93732";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_reactivenav2d/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "901ea27a2260962224575a75fc044c5258dd344794fc835c1342985b87db1911";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mrpt-tps-astar-planner/default.nix
+++ b/distros/jazzy/mrpt-tps-astar-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-libgui, mrpt-libmaps, mrpt-libnav, mrpt-libros-bridge, mrpt-msgs, mrpt-nav-interfaces, mrpt-path-planning, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-tps-astar-planner";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_tps_astar_planner/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "222c06284194dd050b290ccb0bb52d60e629469ea8c1d967b86880a532c408e7";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_tps_astar_planner/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "9c06b16644c056f111726d33cc1a840de303174f2e42df870c7839d683b02403";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mrpt-tutorials/default.nix
+++ b/distros/jazzy/mrpt-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, cmake, mvsim, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-tutorials";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_tutorials/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "37de26a8458b51f0395d418c28fa2e0f4e5b240ace96f398048aae68a6e3ce1b";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_tutorials/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "e0eac5ebd5066c58b431bfdffafb184c31c2e36d1e512032655441838b9561b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/omni-wheel-drive-controller/default.nix
+++ b/distros/jazzy/omni-wheel-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, eigen, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-omni-wheel-drive-controller";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/omni_wheel_drive_controller/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "a98e817a1e56312ad48952d43a4430c252aca9e534714e02900af404d9dc4f8c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/omni_wheel_drive_controller/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "f6ee410bdc0ac911a2437c909d57c550898dc573b7d490e644c48acb2fdf57d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -135,6 +135,13 @@ in {
     ];
   });
 
+  fusioncore-ros = rosSuper.fusioncore-ros.overrideAttrs ({
+    buildInputs ? [], ...
+  }: {
+    # Nixpkgs contains newer proj than Ubuntu and it requires sqlite
+    buildInputs = buildInputs ++ [ self.sqlite ];
+  });
+
   foonathan-memory-vendor = lib.patchExternalProjectGit rosSuper.foonathan-memory-vendor {
     url = "https://github.com/foonathan/memory.git";
     rev = "v0.7-3";

--- a/distros/jazzy/parallel-gripper-controller/default.nix
+++ b/distros/jazzy/parallel-gripper-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-parallel-gripper-controller";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/parallel_gripper_controller/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "13c1fbec5554cb9b956c3c7158afbaed388bf93e49e8d151e1d86cc37b023cdd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/parallel_gripper_controller/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "e9a383bfbbed9e382aebb4e5ba25468c9f3d8b3b2f804ddb0189cc64cf153f64";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pid-controller/default.nix
+++ b/distros/jazzy/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-pid-controller";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pid_controller/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "1f3eaac10cd371202d8b3b3ba732a0fd06b8b85eed061b88aaa4e8d211565293";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pid_controller/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "e67d589f0d0d5760b60b7a41512dfcd6e55a1f7a9fa671f9d609283374c25a64";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pose-broadcaster/default.nix
+++ b/distros/jazzy/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-pose-broadcaster";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pose_broadcaster/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "a252153a8560739035d84664e353348d1343e2ad65d8247353bc9ef6463295d1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pose_broadcaster/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "7ceca38c6d067650d5e1485aac8950be1677968f0d3fe94f123aadb283c2b8fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/position-controllers/default.nix
+++ b/distros/jazzy/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-position-controllers";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/position_controllers/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "275b7dd9aa2e5771da31a12eb92d97c33105b74307c7468ab0c7dcc31cdf3f47";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/position_controllers/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "fcc131dabd39e8bf621f6ba003c68a38c029536fb57bb89fb0537a703a3b7618";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/qml6-ros2-plugin/default.nix
+++ b/distros/jazzy/qml6-ros2-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, example-interfaces, image-transport, qt6, rclcpp, ros-babel-fish, ros-babel-fish-test-msgs, std-srvs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-qml6-ros2-plugin";
-  version = "1.26.31-r1";
+  version = "1.26.41-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qml6_ros2_plugin-release/archive/release/jazzy/qml6_ros2_plugin/1.26.31-1.tar.gz";
-    name = "1.26.31-1.tar.gz";
-    sha256 = "ecb64ed871a0dc195246bbb31a002529ad592a725f161915f2fbeb24641e3003";
+    url = "https://github.com/ros2-gbp/qml6_ros2_plugin-release/archive/release/jazzy/qml6_ros2_plugin/1.26.41-1.tar.gz";
+    name = "1.26.41-1.tar.gz";
+    sha256 = "b7906230e52098730c200987967cc35807906b5cefcb9151b038261fd2d327fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/range-sensor-broadcaster/default.nix
+++ b/distros/jazzy/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-range-sensor-broadcaster";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/range_sensor_broadcaster/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "20874c1f2f722870150fdfb5169d4123cbdf7e7ecbeb9ad0b0689835a3683591";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/range_sensor_broadcaster/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "d1e1652165fddaa7085dcc980382ea9689ff6ecba66f50c2a06cf9873d1028f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros-babel-fish-test-msgs/default.nix
+++ b/distros/jazzy/ros-babel-fish-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros-babel-fish-test-msgs";
-  version = "2.25.111-r1";
+  version = "2.26.40-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_babel_fish-release/archive/release/jazzy/ros_babel_fish_test_msgs/2.25.111-1.tar.gz";
-    name = "2.25.111-1.tar.gz";
-    sha256 = "bbd7969b511a813f21c2a43de51d41d2ecd1d7684f04ef1a3473d39c1eef1879";
+    url = "https://github.com/ros2-gbp/ros_babel_fish-release/archive/release/jazzy/ros_babel_fish_test_msgs/2.26.40-1.tar.gz";
+    name = "2.26.40-1.tar.gz";
+    sha256 = "a34505cc407cfadabb99609c1005ebaed011d3f26ddaab150dd24b4390163ca2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros-babel-fish-tools/default.nix
+++ b/distros/jazzy/ros-babel-fish-tools/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, geometry-msgs, rclcpp, ros-babel-fish, ros-babel-fish-test-msgs, std-msgs, yaml-cpp-vendor }:
+buildRosPackage {
+  pname = "ros-jazzy-ros-babel-fish-tools";
+  version = "2.26.40-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros_babel_fish-release/archive/release/jazzy/ros_babel_fish_tools/2.26.40-1.tar.gz";
+    name = "2.26.40-1.tar.gz";
+    sha256 = "79fc6127092d4fa829a44938480c9dd490617e58074ea43188f4ba33f53aae10";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest geometry-msgs ros-babel-fish-test-msgs std-msgs ];
+  propagatedBuildInputs = [ rclcpp ros-babel-fish yaml-cpp-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Tooling for ROS 2 built on ros_babel_fish.
+    Provides header-only JSON and YAML serialization for dynamic messages and a CLI tool to echo topics.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/ros-babel-fish/default.nix
+++ b/distros/jazzy/ros-babel-fish/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, example-interfaces, geometry-msgs, rclcpp, rclcpp-action, rcpputils, ros-babel-fish-test-msgs, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, example-interfaces, geometry-msgs, rclcpp, rclcpp-action, rcpputils, ros-babel-fish-test-msgs, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros-babel-fish";
-  version = "2.25.111-r1";
+  version = "2.26.40-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_babel_fish-release/archive/release/jazzy/ros_babel_fish/2.25.111-1.tar.gz";
-    name = "2.25.111-1.tar.gz";
-    sha256 = "f4b42550d149c6c138254716e3e1240d34721ac151090238f62bc61d2709bd5d";
+    url = "https://github.com/ros2-gbp/ros_babel_fish-release/archive/release/jazzy/ros_babel_fish/2.26.40-1.tar.gz";
+    name = "2.26.40-1.tar.gz";
+    sha256 = "23b34652144e68c445b34c9b35379be57a49674aecf7f0167aa1ada8f0d90810";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake example-interfaces ];
-  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-gtest ament-lint-auto geometry-msgs ros-babel-fish-test-msgs std-msgs ];
+  checkInputs = [ ament-cmake-gtest geometry-msgs ros-babel-fish-test-msgs std-msgs ];
   propagatedBuildInputs = [ ament-index-cpp geometry-msgs rclcpp rclcpp-action rcpputils rosidl-runtime-cpp rosidl-typesupport-cpp rosidl-typesupport-introspection-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/jazzy/ros2-control-test-assets/default.nix
+++ b/distros/jazzy/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-control-test-assets";
-  version = "4.44.0-r1";
+  version = "4.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control_test_assets/4.44.0-1.tar.gz";
-    name = "4.44.0-1.tar.gz";
-    sha256 = "d39369f8eeaec0c31ee2df96f2a364a24e90730c1f43f1dfe1ccf9df2243661f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control_test_assets/4.45.0-1.tar.gz";
+    name = "4.45.0-1.tar.gz";
+    sha256 = "abf05c6433eaf4a40a2b417dadb195a5a820604b9d983fef51f6812f5dc4c675";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-control/default.nix
+++ b/distros/jazzy/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-control";
-  version = "4.44.0-r1";
+  version = "4.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control/4.44.0-1.tar.gz";
-    name = "4.44.0-1.tar.gz";
-    sha256 = "a09268d103b0cefeb27150221fbb93634ecf6f0e1fb4cbe3e6355cb1d9eff4f4";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control/4.45.0-1.tar.gz";
+    name = "4.45.0-1.tar.gz";
+    sha256 = "f8707aea40af177f955cf29f76a41a50de802a30d650dd1b34b6b4ff2cd67c51";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-controllers-test-nodes/default.nix
+++ b/distros/jazzy/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-controllers-test-nodes";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers_test_nodes/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "54eee658efcedef0b819c8f04385194cb5fb8bc1f218a946012a82cc2d559a50";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers_test_nodes/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "1f6dadefc080ed92b4105ad4e312a30302cbe4d39ae510afea5ff26b1749d116";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2-controllers/default.nix
+++ b/distros/jazzy/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, chained-filter-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gps-sensor-broadcaster, gripper-controllers, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, omni-wheel-drive-controller, parallel-gripper-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, state-interfaces-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-controllers";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "21ae83ea505cd751f5c29f8851347160424a136d99933feec0029c0b7ee9d9f5";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "6534375af363f66aae35d8d4a5cd9b1ce2fe46d9f78a64a41577efc52a9a5c48";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2controlcli/default.nix
+++ b/distros/jazzy/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-jazzy-ros2controlcli";
-  version = "4.44.0-r1";
+  version = "4.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2controlcli/4.44.0-1.tar.gz";
-    name = "4.44.0-1.tar.gz";
-    sha256 = "8e7e526b18fd147fb8ebccad3b4ea5095551dcf6382087744b0b8fcf386b9ee9";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2controlcli/4.45.0-1.tar.gz";
+    name = "4.45.0-1.tar.gz";
+    sha256 = "10af702b9dc49d38add751fa19c821e9b50571d9642afb40c537360b9e09d37f";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rosbag2rawlog/default.nix
+++ b/distros/jazzy/rosbag2rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, cli11, cmake, cv-bridge, mrpt-libmaps, mrpt-libros-bridge, mrpt-msgs, nav-msgs, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-rosbag2rawlog";
-  version = "3.5.1-r1";
+  version = "3.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/jazzy/rosbag2rawlog/3.5.1-1.tar.gz";
-    name = "3.5.1-1.tar.gz";
-    sha256 = "b208ec26c955ed8fe7748529c0e1bcd0e08b5bce2d4d45b06f537cdde859e382";
+    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/jazzy/rosbag2rawlog/3.5.2-1.tar.gz";
+    name = "3.5.2-1.tar.gz";
+    sha256 = "35e2638ee714f252a1c544eae0679e69cfb0816fd69ce51e44ddea25c21c0650";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbot-bringup/default.nix
+++ b/distros/jazzy/rosbot-bringup/default.nix
@@ -2,19 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake }:
+{ lib, buildRosPackage, fetchurl, _unresolved_micro_ros_agent, _unresolved_tf_namespace_bridge, ament-cmake, ament-cmake-pytest, launch, launch-pytest, launch-ros, nav-msgs, python3Packages, rclpy, rosbot-controller, rosbot-joy, rosbot-localization, rosbot-utils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rosbot-bringup";
-  version = "0.18.6-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbot_ros-release/archive/release/jazzy/rosbot_bringup/0.18.6-1.tar.gz";
-    name = "0.18.6-1.tar.gz";
-    sha256 = "5ddcc5c0d2beac80910e862d262b534cabaf92daec6f814520a1b86f68478f94";
+    url = "https://github.com/ros2-gbp/rosbot_ros-release/archive/release/jazzy/rosbot_bringup/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "89446d60453bc15ec7fd4be04e0e314d5f2360ec45245ccdaa80eb2098ce7a67";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-pytest launch launch-pytest launch-ros nav-msgs python3Packages.pytest rclpy sensor-msgs ];
+  propagatedBuildInputs = [ _unresolved_micro_ros_agent _unresolved_tf_namespace_bridge launch launch-ros rosbot-controller rosbot-joy rosbot-localization rosbot-utils ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/rosbot-controller/default.nix
+++ b/distros/jazzy/rosbot-controller/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, controller-manager, diff-drive-controller, imu-sensor-broadcaster, joint-state-broadcaster, launch, launch-ros, mecanum-drive-controller, nav2-common, position-controllers, python3Packages, ros2controlcli, rosbot-description, rosbot-moveit, rosbot-utils, udev, xacro }:
+{ lib, buildRosPackage, fetchurl, _unresolved_husarion_mecanum_drive_controller, ament-cmake, ament-cmake-pytest, controller-manager, diff-drive-controller, imu-sensor-broadcaster, joint-state-broadcaster, launch, launch-ros, nav2-common, position-controllers, python3Packages, ros2controlcli, rosbot-description, rosbot-hardware-interfaces, rosbot-moveit, rosbot-utils, udev, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-rosbot-controller";
-  version = "0.18.6-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbot_ros-release/archive/release/jazzy/rosbot_controller/0.18.6-1.tar.gz";
-    name = "0.18.6-1.tar.gz";
-    sha256 = "69fc6faf010d2b93ca7f014fa55facd68f5bcc0fca7416adac549ea29c4bd6ea";
+    url = "https://github.com/ros2-gbp/rosbot_ros-release/archive/release/jazzy/rosbot_controller/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "49273d9038b5d74b52355255cd8f1f089af2459467db230eec7462ff2fef8b46";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-pytest python3Packages.pytest rosbot-description xacro ];
-  propagatedBuildInputs = [ controller-manager diff-drive-controller imu-sensor-broadcaster joint-state-broadcaster launch launch-ros mecanum-drive-controller nav2-common position-controllers ros2controlcli rosbot-description rosbot-moveit rosbot-utils udev xacro ];
+  propagatedBuildInputs = [ _unresolved_husarion_mecanum_drive_controller controller-manager diff-drive-controller imu-sensor-broadcaster joint-state-broadcaster launch launch-ros nav2-common position-controllers ros2controlcli rosbot-description rosbot-hardware-interfaces rosbot-moveit rosbot-utils udev xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/rosbot-description/default.nix
+++ b/distros/jazzy/rosbot-description/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, husarion-components-description, joint-state-publisher, launch, launch-ros, open-manipulator-description, python3Packages, robot-state-publisher, rviz2, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, dynamixel-hardware-interface, husarion-components-description, joint-state-publisher, launch, launch-ros, open-manipulator-description, python3Packages, robot-state-publisher, rviz2, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-rosbot-description";
-  version = "0.18.6-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbot_ros-release/archive/release/jazzy/rosbot_description/0.18.6-1.tar.gz";
-    name = "0.18.6-1.tar.gz";
-    sha256 = "5af4b0e519305cb807ebf6a2799954ce6a5b1e448a5b312a988ae5796f9120c1";
+    url = "https://github.com/ros2-gbp/rosbot_ros-release/archive/release/jazzy/rosbot_description/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "e88bb2fd000b2029ada92c0d354d20f94b1417f089b1b3a8e43614baaf8f6d69";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-pytest python3Packages.pytest xacro ];
-  propagatedBuildInputs = [ husarion-components-description joint-state-publisher launch launch-ros open-manipulator-description robot-state-publisher rviz2 xacro ];
+  propagatedBuildInputs = [ dynamixel-hardware-interface husarion-components-description joint-state-publisher launch launch-ros open-manipulator-description robot-state-publisher rviz2 xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/rosbot-gazebo/default.nix
+++ b/distros/jazzy/rosbot-gazebo/default.nix
@@ -2,18 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl,  }:
+{ lib, buildRosPackage, fetchurl, _unresolved_husarion_gz_worlds, _unresolved_tf_namespace_bridge, ament-cmake, ament-cmake-pytest, geometry-msgs, gz-ros2-control, laser-filters, launch, launch-pytest, launch-ros, nav-msgs, python3Packages, rclpy, ros-gz-bridge, ros-gz-sim, rosbot-controller, rosbot-joy, rosbot-localization, rosbot-utils, rviz2, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rosbot-gazebo";
-  version = "0.18.6-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbot_ros-release/archive/release/jazzy/rosbot_gazebo/0.18.6-1.tar.gz";
-    name = "0.18.6-1.tar.gz";
-    sha256 = "6e8dd6bfaf24154cadc36f8c9d876234e49e038d3b1e7b222d6eaabc697433ce";
+    url = "https://github.com/ros2-gbp/rosbot_ros-release/archive/release/jazzy/rosbot_gazebo/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "e7a1a4cb8db24115abee2a2a41a26dc28c345aee28e8aefd0cf85bb88842b8e4";
   };
 
-  buildType = "ament_python";
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-pytest geometry-msgs launch launch-pytest launch-ros nav-msgs python3Packages.pytest rclpy sensor-msgs ];
+  propagatedBuildInputs = [ _unresolved_husarion_gz_worlds _unresolved_tf_namespace_bridge gz-ros2-control laser-filters launch launch-ros ros-gz-bridge ros-gz-sim rosbot-controller rosbot-joy rosbot-localization rosbot-utils rviz2 ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = "Gazebo simulation for ROSbot Series";

--- a/distros/jazzy/rosbot-hardware-interfaces/default.nix
+++ b/distros/jazzy/rosbot-hardware-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, diff-drive-controller, hardware-interface, imu-sensor-broadcaster, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rosbot-hardware-interfaces";
-  version = "0.18.6-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbot_ros-release/archive/release/jazzy/rosbot_hardware_interfaces/0.18.6-1.tar.gz";
-    name = "0.18.6-1.tar.gz";
-    sha256 = "66f268195193d9dd1a34d3eb8b5fa39cc99632c4c34a5d2ea1a13c48606612e0";
+    url = "https://github.com/ros2-gbp/rosbot_ros-release/archive/release/jazzy/rosbot_hardware_interfaces/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "f688b77d9e7f3f1335ea5e75f6da9492421c59eb8d731bc3952a64289e13c62c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbot-joy/default.nix
+++ b/distros/jazzy/rosbot-joy/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, control-msgs, geometry-msgs, joy, launch, launch-ros, moveit-msgs, moveit-ros-planning, moveit-ros-planning-interface, moveit-servo, rclcpp, sensor-msgs, teleop-twist-joy }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, control-msgs, geometry-msgs, joy, launch, launch-ros, moveit-msgs, moveit-ros-planning, moveit-ros-planning-interface, moveit-servo, rclcpp, rclcpp-action, sensor-msgs, std-srvs, teleop-twist-joy }:
 buildRosPackage {
   pname = "ros-jazzy-rosbot-joy";
-  version = "0.18.6-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbot_ros-release/archive/release/jazzy/rosbot_joy/0.18.6-1.tar.gz";
-    name = "0.18.6-1.tar.gz";
-    sha256 = "cf4d26ce6db306f6518863d4bad5f4b8c29f037fadffca028dc75539289e9178";
+    url = "https://github.com/ros2-gbp/rosbot_ros-release/archive/release/jazzy/rosbot_joy/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "c2c01f2c5ba86654c33129504e18cd3316480fb192cbf73527d83d54ce70f4a7";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ builtin-interfaces control-msgs geometry-msgs joy launch launch-ros moveit-msgs moveit-ros-planning moveit-ros-planning-interface moveit-servo rclcpp sensor-msgs teleop-twist-joy ];
+  propagatedBuildInputs = [ builtin-interfaces control-msgs geometry-msgs joy launch launch-ros moveit-msgs moveit-ros-planning moveit-ros-planning-interface moveit-servo rclcpp rclcpp-action sensor-msgs std-srvs teleop-twist-joy ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/rosbot-localization/default.nix
+++ b/distros/jazzy/rosbot-localization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch, launch-ros, robot-localization }:
 buildRosPackage {
   pname = "ros-jazzy-rosbot-localization";
-  version = "0.18.6-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbot_ros-release/archive/release/jazzy/rosbot_localization/0.18.6-1.tar.gz";
-    name = "0.18.6-1.tar.gz";
-    sha256 = "623121880e271161f5dd89f107748e758bfe295aea4579f33bf316888e4a1150";
+    url = "https://github.com/ros2-gbp/rosbot_ros-release/archive/release/jazzy/rosbot_localization/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "afe5df339e83cc6d858375e92eade6999f0c4c01f08a6c3b07f2ad3080820599";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbot-moveit/default.nix
+++ b/distros/jazzy/rosbot-moveit/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, joint-state-publisher, joint-state-publisher-gui, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-setup-assistant, moveit-simple-controller-manager, rosbot-description, rosbot-joy, rviz-common, rviz-default-plugins, rviz2, tf2-ros, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, moveit-configs-utils, moveit-kinematics, moveit-msgs, moveit-planners, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-visualization, moveit-servo, moveit-setup-assistant, moveit-simple-controller-manager, rclcpp, rosbot-description, rosbot-joy, rviz-common, rviz-default-plugins, rviz2 }:
 buildRosPackage {
   pname = "ros-jazzy-rosbot-moveit";
-  version = "0.18.6-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbot_ros-release/archive/release/jazzy/rosbot_moveit/0.18.6-1.tar.gz";
-    name = "0.18.6-1.tar.gz";
-    sha256 = "ae53a9a9e5138b0839475da9c7c184a7582cf6ba4d58b5c855e0fee203e49974";
+    url = "https://github.com/ros2-gbp/rosbot_ros-release/archive/release/jazzy/rosbot_moveit/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "21cee9563166bb63b2edeba0ed19c6aad10b544f307aa3c917310f9ea48aeb72";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ controller-manager joint-state-publisher joint-state-publisher-gui moveit-configs-utils moveit-kinematics moveit-planners moveit-ros-move-group moveit-ros-visualization moveit-servo moveit-setup-assistant moveit-simple-controller-manager rosbot-description rosbot-joy rviz-common rviz-default-plugins rviz2 tf2-ros xacro ];
+  propagatedBuildInputs = [ moveit-configs-utils moveit-kinematics moveit-msgs moveit-planners moveit-ros-move-group moveit-ros-planning moveit-ros-planning-interface moveit-ros-visualization moveit-servo moveit-setup-assistant moveit-simple-controller-manager rclcpp rosbot-description rosbot-joy rviz-common rviz-default-plugins rviz2 ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/rosbot-utils/default.nix
+++ b/distros/jazzy/rosbot-utils/default.nix
@@ -2,20 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-pep257, laser-filters, launch-ros, python3Packages, pythonPackages, stm32flash, usbutils }:
+{ lib, buildRosPackage, fetchurl, alsaUtils, ament-cmake, ament-cmake-python, ament-pep257, generate-parameter-library, laser-filters, launch-ros, python3Packages, pythonPackages, stm32flash, usbutils }:
 buildRosPackage {
   pname = "ros-jazzy-rosbot-utils";
-  version = "0.18.6-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbot_ros-release/archive/release/jazzy/rosbot_utils/0.18.6-1.tar.gz";
-    name = "0.18.6-1.tar.gz";
-    sha256 = "e4c9b9bb7b7d2fb60dd1a333b903e3cc3dcc976c095bab41c20824e8dc95e659";
+    url = "https://github.com/ros2-gbp/rosbot_ros-release/archive/release/jazzy/rosbot_utils/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "9b2fae57e38747ab3a6a73b842c418009ebcde047b90287347046cd3ff9416ae";
   };
 
-  buildType = "ament_python";
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-pep257 python3Packages.pytest ];
-  propagatedBuildInputs = [ laser-filters launch-ros python3Packages.argcomplete python3Packages.libgpiod python3Packages.pyftdi python3Packages.pyserial python3Packages.requests python3Packages.sh pythonPackages.pyudev stm32flash usbutils ];
+  propagatedBuildInputs = [ alsaUtils generate-parameter-library laser-filters launch-ros python3Packages.argcomplete python3Packages.libgpiod python3Packages.pyftdi python3Packages.pyserial python3Packages.sh pythonPackages.pyudev stm32flash usbutils ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = "Utilities for ROSbot Series";

--- a/distros/jazzy/rosbot/default.nix
+++ b/distros/jazzy/rosbot/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosbot-controller, rosbot-description, rosbot-hardware-interfaces, rosbot-joy, rosbot-localization, rosbot-moveit, rosbot-utils }:
 buildRosPackage {
   pname = "ros-jazzy-rosbot";
-  version = "0.18.6-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbot_ros-release/archive/release/jazzy/rosbot/0.18.6-1.tar.gz";
-    name = "0.18.6-1.tar.gz";
-    sha256 = "735bb8a6185e62980345fafc15a55f02980de732813f6d3b37a9f9be87a8df0b";
+    url = "https://github.com/ros2-gbp/rosbot_ros-release/archive/release/jazzy/rosbot/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "1b39fefd69a8d017dc8dc267df1fcb55f2b9a4dc9375a7bba9761b89bd6b9603";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ rosbot-controller rosbot-description rosbot-hardware-interfaces rosbot-joy rosbot-localization rosbot-moveit rosbot-utils ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/rqml-core/default.nix
+++ b/distros/jazzy/rqml-core/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, libGL, libGLU, nlohmann_json, qml6-ros2-plugin, qt6, ros-babel-fish-test-msgs, yaml-cpp-vendor }:
+buildRosPackage {
+  pname = "ros-jazzy-rqml-core";
+  version = "3.26.41-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqml-release/archive/release/jazzy/rqml_core/3.26.41-1.tar.gz";
+    name = "3.26.41-1.tar.gz";
+    sha256 = "61d79c6c64738d8a25e09b16362544a9037aa2c9eb344e7f7c7599549220e662";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake libGL libGLU nlohmann_json ];
+  checkInputs = [ ament-lint-auto ros-babel-fish-test-msgs ];
+  propagatedBuildInputs = [ ament-index-cpp qml6-ros2-plugin qt6.qtbase qt6.qtdeclarative yaml-cpp-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "QML-based robotics visualization and control tool for ROS 2.";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/jazzy/rqml-default-plugins/default.nix
+++ b/distros/jazzy/rqml-default-plugins/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, control-msgs, controller-manager-msgs, geometry-msgs, moveit-msgs, pal-statistics-msgs, qml6-ros2-plugin, qt6, rcl-interfaces, ros-babel-fish-test-msgs, rqml-core, sensor-msgs, tf2-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-rqml-default-plugins";
+  version = "3.26.41-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqml-release/archive/release/jazzy/rqml_default_plugins/3.26.41-1.tar.gz";
+    name = "3.26.41-1.tar.gz";
+    sha256 = "a1b1d97d287227f9238bf3492677eba2e1e96a50eea7997fa99ebceafa77ea74";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto qml6-ros2-plugin rcl-interfaces ros-babel-fish-test-msgs ];
+  propagatedBuildInputs = [ control-msgs controller-manager-msgs geometry-msgs moveit-msgs pal-statistics-msgs qml6-ros2-plugin qt6.qtdeclarative qt6.qtmultimedia rqml-core sensor-msgs tf2-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Default plugins for the QML-based robotics visualization and control tool RQml for ROS 2.";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/jazzy/rqml-plugin-example/default.nix
+++ b/distros/jazzy/rqml-plugin-example/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, qml6-ros2-plugin, qt6, rqml-core }:
+buildRosPackage {
+  pname = "ros-jazzy-rqml-plugin-example";
+  version = "3.26.41-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqml-release/archive/release/jazzy/rqml_plugin_example/3.26.41-1.tar.gz";
+    name = "3.26.41-1.tar.gz";
+    sha256 = "c762964d9357753c2c63efa0406da83c84715d73f0589014acfaf3f26a71d529";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ qml6-ros2-plugin qt6.qtdeclarative rqml-core ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "An example plugin for RQml";
+    license = with lib.licenses; [ "MIT-0" ];
+  };
+}

--- a/distros/jazzy/rqml/default.nix
+++ b/distros/jazzy/rqml/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rqml-core, rqml-default-plugins }:
+buildRosPackage {
+  pname = "ros-jazzy-rqml";
+  version = "3.26.41-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqml-release/archive/release/jazzy/rqml/3.26.41-1.tar.gz";
+    name = "3.26.41-1.tar.gz";
+    sha256 = "3ebf9e0b17ac9966032ed639d524c9608c41bc580400af386c8dd30d032d7964";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ rqml-core rqml-default-plugins ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "QML-based robotics visualization and control tool for ROS 2.";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/jazzy/rqt-controller-manager/default.nix
+++ b/distros/jazzy/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-jazzy-rqt-controller-manager";
-  version = "4.44.0-r1";
+  version = "4.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/rqt_controller_manager/4.44.0-1.tar.gz";
-    name = "4.44.0-1.tar.gz";
-    sha256 = "c6740f000f91a66538a5ed044d12f1785b052e405355d375d8cf8f46c793e28e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/rqt_controller_manager/4.45.0-1.tar.gz";
+    name = "4.45.0-1.tar.gz";
+    sha256 = "396ead513fc9bb58099344ba58fbe5a612ae97b77df3c1741e4db425bebe2905";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rqt-joint-trajectory-controller/default.nix
+++ b/distros/jazzy/rqt-joint-trajectory-controller/default.nix
@@ -5,15 +5,16 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rqt-joint-trajectory-controller";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/rqt_joint_trajectory_controller/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "467aa1ebc4300656c93e77d49f211bf1e41a5975fa16f1025e7591b368cdf4c9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/rqt_joint_trajectory_controller/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "e1b2c9d57ef36c090af217c33aad71b6adc74fcb614f7a83ad568f6124b8e0ac";
   };
 
   buildType = "ament_python";
+  checkInputs = [ python3Packages.pytest ];
   propagatedBuildInputs = [ control-msgs controller-manager-msgs python-qt-binding python3Packages.rospkg qt-gui rclpy rqt-gui rqt-gui-py trajectory-msgs ];
 
   meta = {

--- a/distros/jazzy/rtest/default.nix
+++ b/distros/jazzy/rtest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-clang-tidy, ament-cmake, ament-cmake-copyright, ament-cmake-ros, ament-lint-auto, ament-lint-common, boost, gmock-vendor, gtest, rcl, rcl-action, rclcpp, rclcpp-action, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-rtest";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rtest-release/archive/release/jazzy/rtest/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "d7a3d837d8ac48204c209cb3e56e9b4ef0163d9bbe2e1292f003d49a73e71417";
+    url = "https://github.com/ros2-gbp/rtest-release/archive/release/jazzy/rtest/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "4eab62d478eec2faf60fed7e91f6df98d8db6283e984d49e6a1529c14f0215ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/state-interfaces-broadcaster/default.nix
+++ b/distros/jazzy/state-interfaces-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-state-interfaces-broadcaster";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/state_interfaces_broadcaster/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "0046f1ee4fb8af805a35bb7deec7a14a613e0015337eb48e40e1681883fed8e1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/state_interfaces_broadcaster/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "72d74fa3fd3c8673a31702f9547a9bd800a91c99a3faf8a0c788569140d922b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/steering-controllers-library/default.nix
+++ b/distros/jazzy/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-steering-controllers-library";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/steering_controllers_library/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "e88f056b7444129f8e9d4c3b41d9415a280b716e25f7ac94e0e63307163bfa76";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/steering_controllers_library/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "028be217bbe4315f45837bfad4905a95a91381863c1057f51b099324d6abf138";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tcb-span/default.nix
+++ b/distros/jazzy/tcb-span/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-jazzy-tcb-span";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/jazzy/tcb_span/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "4d080d32255175c8ea63baa51b46eabf15cb6eb146cf57b61d1f01d552eba5d3";
+    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/jazzy/tcb_span/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "da07722cd74b94d529bcae1756cdf89d22a022d7442e8959ec1f438164efb4bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/theora-image-transport/default.nix
+++ b/distros/jazzy/theora-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, libogg, libtheora, opencv, pkg-config, pluginlib, rclcpp, rcutils, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-theora-image-transport";
-  version = "4.0.6-r1";
+  version = "4.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/theora_image_transport/4.0.6-1.tar.gz";
-    name = "4.0.6-1.tar.gz";
-    sha256 = "0e1737a2e020628d1122ebc48a6ee37b9b1eb0cd1735e30b37d75217760a1f47";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/theora_image_transport/4.0.7-1.tar.gz";
+    name = "4.0.7-1.tar.gz";
+    sha256 = "6eab3a97c0a71940b9e20b764afda38e6b5841a41af57d77859deeb32e53f6f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tl-expected/default.nix
+++ b/distros/jazzy/tl-expected/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-tl-expected";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/jazzy/tl_expected/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "58d90458a2230ebfc8d19a95fd5f829da9967ecbfb3bd3c9258bb76f96efccaf";
+    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/jazzy/tl_expected/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "c2da2844af35ad1ea6020a3cb1437da48e8a0dbdbd78345242c4fb93a63a0172";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/transmission-interface/default.nix
+++ b/distros/jazzy/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, fmt, hardware-interface, pluginlib, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-transmission-interface";
-  version = "4.44.0-r1";
+  version = "4.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/transmission_interface/4.44.0-1.tar.gz";
-    name = "4.44.0-1.tar.gz";
-    sha256 = "eb8510b266b0a6cfe3040040fff665ebf7a1a12f6e69d21f623f90f48d1bedc4";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/transmission_interface/4.45.0-1.tar.gz";
+    name = "4.45.0-1.tar.gz";
+    sha256 = "0dea1aabec424be78dbaf00179b147a2d499fe1bea0baa960716fa5820185f0f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tricycle-controller/default.nix
+++ b/distros/jazzy/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-tricycle-controller";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_controller/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "4b468b4de31cf09a38b361d589a6cebf085e1d90b04214f986e371c459ea9a37";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_controller/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "b536c6840896c905ae06ddf73f985164184fe76a84d71bd1be905410b27a11c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tricycle-steering-controller/default.nix
+++ b/distros/jazzy/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-tricycle-steering-controller";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_steering_controller/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "aa5c0b0b1c55934c31b39fc3bb20a49472cdb34c2f23031b1b5b5bacb5d73fe5";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_steering_controller/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "833521df821688bb16877d8a6b5e74e2ccad5b5eda8c99d2b5cead2ec0c8b9a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-client-library/default.nix
+++ b/distros/jazzy/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-jazzy-ur-client-library";
-  version = "2.9.0-r1";
+  version = "2.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/jazzy/ur_client_library/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "95143785951433b03298ebbdf2ba83217aa478564fe37d0440ccf6c2413c4ee5";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/jazzy/ur_client_library/2.10.0-1.tar.gz";
+    name = "2.10.0-1.tar.gz";
+    sha256 = "6d3af89cfa96ab4af46916262cb4dd219c1e956977cc1546bdb3c5cab2557319";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/velocity-controllers/default.nix
+++ b/distros/jazzy/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-velocity-controllers";
-  version = "4.39.0-r1";
+  version = "4.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/velocity_controllers/4.39.0-1.tar.gz";
-    name = "4.39.0-1.tar.gz";
-    sha256 = "1aa6764985b9482ba024ada3200944c77e4638c7c7046d66770a6102a20a6ff7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/velocity_controllers/4.40.0-1.tar.gz";
+    name = "4.40.0-1.tar.gz";
+    sha256 = "699d5302f4a202f543254245694294e99886056d34b8683f77ba34cebfe20683";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/zstd-image-transport/default.nix
+++ b/distros/jazzy/zstd-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, image-transport, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-zstd-image-transport";
-  version = "4.0.6-r1";
+  version = "4.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/zstd_image_transport/4.0.6-1.tar.gz";
-    name = "4.0.6-1.tar.gz";
-    sha256 = "5b7206630b5304f89e116d00d2d133888c5e08121df5b65a6a71a12ac67c36b9";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/zstd_image_transport/4.0.7-1.tar.gz";
+    name = "4.0.7-1.tar.gz";
+    sha256 = "4e79bbae5e361aaaf638258a077554e7579e798b60f7c04c3c24d5c84a7dce69";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ackermann-steering-controller/default.nix
+++ b/distros/kilted/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-kilted-ackermann-steering-controller";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/ackermann_steering_controller/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "27fead9283869ff38bab663ad1c64218230a7b05f3a8a60232c59ee85158e50f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/ackermann_steering_controller/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "8a54e47c1f0ec18f8d5167f41bbba78113547ecae332c6a75b5f465028ad9fb6";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/admittance-controller/default.nix
+++ b/distros/kilted/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, tinyxml-2, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kilted-admittance-controller";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/admittance_controller/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "529e5f5e1f0eb1f3d5358e2c94158f64cd2ef71ae73ba30384f50c304db5e695";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/admittance_controller/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "221bad730d0f253de654f10fb58dcabbe29fed23e7e641c3f2a12cec970995b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/beluga-amcl/default.nix
+++ b/distros/kilted/beluga-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, beluga, beluga-ros, bondcpp, message-filters, rclcpp, rclcpp-components, rclcpp-lifecycle, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-beluga-amcl";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/beluga-release/archive/release/kilted/beluga_amcl/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "0624a9134228870f1120468ffa00357a20e3859cd1b7e16edbd5d835eff61ac6";
+    url = "https://github.com/ros2-gbp/beluga-release/archive/release/kilted/beluga_amcl/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "a5348fe6876d72e5686e7ff92ca070109b31c841bdae3dfb7f723ea23eaa1320";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/beluga-ros/default.nix
+++ b/distros/kilted/beluga-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-cmake-ros, beluga, geometry-msgs, nav-msgs, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-beluga-ros";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/beluga-release/archive/release/kilted/beluga_ros/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "54cf9ea17e89c6c73ab28d5bf1d2ba7398d2aca1128e5dd3b65b2f420b4a954a";
+    url = "https://github.com/ros2-gbp/beluga-release/archive/release/kilted/beluga_ros/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "24ac17af308948c3829b642839854bc2253f81e01ad84b000222d0721eadc21f";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/beluga/default.nix
+++ b/distros/kilted/beluga/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, clang, cmake, eigen, gbenchmark, gtest, hdf5, onetbb, range-v3, sophus }:
 buildRosPackage {
   pname = "ros-kilted-beluga";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/beluga-release/archive/release/kilted/beluga/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "c2643cca2abdd694e7f88a82c2b00749afd37ef2efb29912802acb5652aef6ee";
+    url = "https://github.com/ros2-gbp/beluga-release/archive/release/kilted/beluga/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "5b666558715dc0f02e59ea5b6afdd6a7ff68e7559df40c4771c326be93dffbb2";
   };
 
   buildType = "cmake";

--- a/distros/kilted/bicycle-steering-controller/default.nix
+++ b/distros/kilted/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-kilted-bicycle-steering-controller";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/bicycle_steering_controller/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "d306eb0b569708b50610251e79679ee968750bc74dfce52713efd0d5ad1bc615";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/bicycle_steering_controller/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "e80af3a2e74094e23abfc31d7222f44c72a99f62c990103a74a1deb71bf70506";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/chained-filter-controller/default.nix
+++ b/distros/kilted/chained-filter-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, filters, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-chained-filter-controller";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/chained_filter_controller/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "e8bafa11cd4131a7dc52cc142ec217a93d0e35f833fc25d4682267f280dffd6d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/chained_filter_controller/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "481be5f08ff3fd413b87280052b4256e02fc29e4d5e37caa1975eece5f19471f";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/cloudini-lib/default.nix
+++ b/distros/kilted/cloudini-lib/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, lz4, pcl, zstd }:
 buildRosPackage {
   pname = "ros-kilted-cloudini-lib";
-  version = "1.0.4-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/cloudini-release/archive/release/kilted/cloudini_lib/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "73f6d63bad2b84210ec03587b81d0730a43a7de336a17c7f8c0a188e8b386557";
+    url = "https://github.com/facontidavide/cloudini-release/archive/release/kilted/cloudini_lib/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "dbdccdec0b75c595e1e1fdb9e19ba47fbc3000bfca589783e214a8dce256c70e";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/cloudini-ros/default.nix
+++ b/distros/kilted/cloudini-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cloudini-lib, pcl-conversions, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, rclcpp-components, rosbag2-cpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-cloudini-ros";
-  version = "1.0.4-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/cloudini-release/archive/release/kilted/cloudini_ros/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "dae74964033ad18cc979b8f2078a4a1f7b20d07cbc64e5428f4d6213234e10a1";
+    url = "https://github.com/facontidavide/cloudini-release/archive/release/kilted/cloudini_ros/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "d89b4c09faf6615ea542a55c6414a5177274f7a3a70f0aeb97f768212e1b40d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/compressed-depth-image-transport/default.nix
+++ b/distros/kilted/compressed-depth-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-kilted-compressed-depth-image-transport";
-  version = "5.1.1-r1";
+  version = "5.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/kilted/compressed_depth_image_transport/5.1.1-1.tar.gz";
-    name = "5.1.1-1.tar.gz";
-    sha256 = "e2770fca37cc62d3f61339574c2233284cf6e689214194535aba37167a87da40";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/kilted/compressed_depth_image_transport/5.1.2-1.tar.gz";
+    name = "5.1.2-1.tar.gz";
+    sha256 = "d82dc5c4305ce56c255b432c8b059e1d022e2d9da4af94994edbe3707a683398";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/compressed-image-transport/default.nix
+++ b/distros/kilted/compressed-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-kilted-compressed-image-transport";
-  version = "5.1.1-r1";
+  version = "5.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/kilted/compressed_image_transport/5.1.1-1.tar.gz";
-    name = "5.1.1-1.tar.gz";
-    sha256 = "04e529b89cc8aa782bf4b67eff3a62236fad69b2600e5f802add855a865bf967";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/kilted/compressed_image_transport/5.1.2-1.tar.gz";
+    name = "5.1.2-1.tar.gz";
+    sha256 = "87cc490ea871e64ef05d553ae7f0706e1d17cb4ec9e81033800ba2c269b34a11";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/control-toolbox/default.nix
+++ b/distros/kilted/control-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, eigen, filters, fmt, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-cmake, rsl, tf2, tf2-geometry-msgs, tf2-ros, tl-expected-nixpkgs }:
 buildRosPackage {
   pname = "ros-kilted-control-toolbox";
-  version = "5.9.1-r1";
+  version = "5.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/kilted/control_toolbox/5.9.1-1.tar.gz";
-    name = "5.9.1-1.tar.gz";
-    sha256 = "e973e103b1926309ac4dc1aa3f7dfbacace52e97949017bba402e57eaaec3c07";
+    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/kilted/control_toolbox/5.10.0-1.tar.gz";
+    name = "5.10.0-1.tar.gz";
+    sha256 = "82572d93ef7259f58c2844141949e5c062bd3f67bd82a9b0beaac2f0643d8837";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/controller-interface/default.nix
+++ b/distros/kilted/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, fmt, geometry-msgs, hardware-interface, pal-statistics, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-controller-interface";
-  version = "5.13.0-r1";
+  version = "5.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/controller_interface/5.13.0-1.tar.gz";
-    name = "5.13.0-1.tar.gz";
-    sha256 = "ee400bc71d67bb4fe6f53e8ea88a09e007bdddacc71e81b8636593332e687ea6";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/controller_interface/5.14.0-1.tar.gz";
+    name = "5.14.0-1.tar.gz";
+    sha256 = "b9e1310f655f0acdbf25f57d91f48d658c64f174c9f00ee0dc8beaaaeae71a53";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/controller-manager-msgs/default.nix
+++ b/distros/kilted/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-controller-manager-msgs";
-  version = "5.13.0-r1";
+  version = "5.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/controller_manager_msgs/5.13.0-1.tar.gz";
-    name = "5.13.0-1.tar.gz";
-    sha256 = "512e6082c32f7f1cb32fd1deeba4a66f15d8ee762b48ab1bd6db2f6e7fa2667f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/controller_manager_msgs/5.14.0-1.tar.gz";
+    name = "5.14.0-1.tar.gz";
+    sha256 = "0729d9ba17760ca23deef616aeea1fb477bf77aa05f8b4577e2930c1af9cd14b";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/controller-manager/default.nix
+++ b/distros/kilted/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, example-interfaces, fmt, generate-parameter-library, hardware-interface, hardware-interface-testing, launch, launch-ros, launch-testing, launch-testing-ros, libstatistics-collector, lifecycle-msgs, pluginlib, python3Packages, rcl-interfaces, rclcpp, rclpy, realtime-tools, robot-state-publisher, ros2-control-cmake, ros2-control-test-assets, ros2param, ros2pkg, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-controller-manager";
-  version = "5.13.0-r1";
+  version = "5.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/controller_manager/5.13.0-1.tar.gz";
-    name = "5.13.0-1.tar.gz";
-    sha256 = "8b14014e80d29eac4f2ac9da7c61487ec26eeb74b0fa4174b75dd67007026abb";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/controller_manager/5.14.0-1.tar.gz";
+    name = "5.14.0-1.tar.gz";
+    sha256 = "b9fe8785b6d940b29dcac361fa2a1cd08354a964ecde17e20d027b1a8bf51cb3";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/diff-drive-controller/default.nix
+++ b/distros/kilted/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-kilted-diff-drive-controller";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/diff_drive_controller/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "ce238f6a2c32d70a1746d0922ae0016eac8ffde126f26c87dc185b7680a9957a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/diff_drive_controller/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "75a451f7549e7e125bad100d00d96dd4be6a1ca0bea3344f4e01baaa612fa790";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/effort-controllers/default.nix
+++ b/distros/kilted/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-effort-controllers";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/effort_controllers/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "8d3c07c859ada113a9193383d4274b6d654f5a6b1bf2ed89ed58f435f431488e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/effort_controllers/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "9bc654d085f8f6a50a8024fd1a47025cd2a24e57479400654cf02389a3b27007";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/force-torque-sensor-broadcaster/default.nix
+++ b/distros/kilted/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-force-torque-sensor-broadcaster";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/force_torque_sensor_broadcaster/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "9cceaee87a60d3c8456057fa897e9a42bc42a8b82f24871ff24d2b56e38ef942";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/force_torque_sensor_broadcaster/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "b29bccb406862e617259afdfa7b41be6e1fcad681282af98a9a470cc7653822e";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/forward-command-controller/default.nix
+++ b/distros/kilted/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-forward-command-controller";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/forward_command_controller/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "42224bf43ece6ba03a50c3f447b1f7d6e719515f9eee292d990429070010b829";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/forward_command_controller/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "b4ac318d5c2e512abee2c3b57a4cd4a2a4c5ef94b362c56f796567e1a5c15e94";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/generated.nix
+++ b/distros/kilted/generated.nix
@@ -1032,6 +1032,8 @@ self: super: {
 
  gscam = self.callPackage ./gscam {};
 
+ gstreamer-ros-babel-fish = self.callPackage ./gstreamer-ros-babel-fish {};
+
  gtest-vendor = self.callPackage ./gtest-vendor {};
 
  gtsam = self.callPackage ./gtsam {};
@@ -2442,6 +2444,8 @@ self: super: {
 
  ros-babel-fish-test-msgs = self.callPackage ./ros-babel-fish-test-msgs {};
 
+ ros-babel-fish-tools = self.callPackage ./ros-babel-fish-tools {};
+
  ros-base = self.callPackage ./ros-base {};
 
  ros-core = self.callPackage ./ros-core {};
@@ -2617,6 +2621,14 @@ self: super: {
  rplidar-ros = self.callPackage ./rplidar-ros {};
 
  rpyutils = self.callPackage ./rpyutils {};
+
+ rqml = self.callPackage ./rqml {};
+
+ rqml-core = self.callPackage ./rqml-core {};
+
+ rqml-default-plugins = self.callPackage ./rqml-default-plugins {};
+
+ rqml-plugin-example = self.callPackage ./rqml-plugin-example {};
 
  rqt = self.callPackage ./rqt {};
 

--- a/distros/kilted/gpio-controllers/default.nix
+++ b/distros/kilted/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-gpio-controllers";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/gpio_controllers/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "afd1ec5e23b65048e47afac5cec253c655bc97b6d9ccd4410c1349222aa38563";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/gpio_controllers/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "839c234fe31d6a7085c3fd1137a48522dcf95721c96b0cea838a5a300c566014";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/gps-sensor-broadcaster/default.nix
+++ b/distros/kilted/gps-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-gps-sensor-broadcaster";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/gps_sensor_broadcaster/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "0ec3a1531930148ca80c7a67dd04c46520ce9098a199c88fb6c789b97757341a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/gps_sensor_broadcaster/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "28fd734d6e9906f16bafccd37b668fd6bf2f9e96d9c1d0cc3ef27ba461b7ea47";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/gstreamer-ros-babel-fish/default.nix
+++ b/distros/kilted/gstreamer-ros-babel-fish/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, gst_all_1, rclcpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-gstreamer-ros-babel-fish";
+  version = "1.26.40-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gstreamer_ros_babel_fish-release/archive/release/kilted/gstreamer_ros_babel_fish/1.26.40-1.tar.gz";
+    name = "1.26.40-1.tar.gz";
+    sha256 = "ea570a3afc5b8d663cd66b34dee413d92e866cdd6877da9e374a069d26a8afd2";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good gst_all_1.gstreamer rclcpp sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "GStreamer elements for bidirectional ROS 2 image streaming";
+    license = with lib.licenses; [ "AGPL-3.0-only" ];
+  };
+}

--- a/distros/kilted/gz-math-vendor/default.nix
+++ b/distros/kilted/gz-math-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, eigen, gz-cmake-vendor, gz-utils-vendor, python3Packages }:
 buildRosPackage {
   pname = "ros-kilted-gz-math-vendor";
-  version = "0.2.6-r1";
+  version = "0.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_math_vendor-release/archive/release/kilted/gz_math_vendor/0.2.6-1.tar.gz";
-    name = "0.2.6-1.tar.gz";
-    sha256 = "4be7624e28d3456e0b4073ccc5b43542d17a114dd2bed50838ffbd52e6ee9594";
+    url = "https://github.com/ros2-gbp/gz_math_vendor-release/archive/release/kilted/gz_math_vendor/0.2.7-1.tar.gz";
+    name = "0.2.7-1.tar.gz";
+    sha256 = "6d6084a61cb5fc2fbb88deea289413673d945201c29a2ff1883e29bb2f68d7ad";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-math8 8.2.1
+    description = "Vendor package for: gz-math8 8.3.0
 
     Gazebo Math : Math classes and functions for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/kilted/gz-math-vendor/vendored-source.json
+++ b/distros/kilted/gz-math-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_math_vendor": {
     "url": "https://github.com/gazebosim/gz-math.git",
-    "rev": "gz-math8_8.2.1",
-    "hash": "sha256-kdkSZSO7guPJbc0CjS7e42b0DkTJ7GoFpSa7fwVauU4="
+    "rev": "gz-math8_8.3.0",
+    "hash": "sha256-qXce3btwZn/iZoLFCWMWJGv/AK0RgIYx6zbKoXdHjzY="
   }
 }

--- a/distros/kilted/hardware-interface-testing/default.nix
+++ b/distros/kilted/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, fmt, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-hardware-interface-testing";
-  version = "5.13.0-r1";
+  version = "5.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/hardware_interface_testing/5.13.0-1.tar.gz";
-    name = "5.13.0-1.tar.gz";
-    sha256 = "ae0ffaf0d9c4516b59f49dbbe319ef2272610ae1ac681d9b9330af08fd2fd118";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/hardware_interface_testing/5.14.0-1.tar.gz";
+    name = "5.14.0-1.tar.gz";
+    sha256 = "475218714188bd19033ded9bff9686c8e2be30e6bdf2c48e8bda10f53dabf948";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/hardware-interface/default.nix
+++ b/distros/kilted/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, control-msgs, fmt, joint-limits, lifecycle-msgs, pal-statistics, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sdformat-urdf, tinyxml2-vendor, urdf }:
 buildRosPackage {
   pname = "ros-kilted-hardware-interface";
-  version = "5.13.0-r1";
+  version = "5.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/hardware_interface/5.13.0-1.tar.gz";
-    name = "5.13.0-1.tar.gz";
-    sha256 = "d054c0f68d5eb5363d2a8f8ee5f35afe7cf963302841471b6425e4dcc8c1f553";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/hardware_interface/5.14.0-1.tar.gz";
+    name = "5.14.0-1.tar.gz";
+    sha256 = "138cc59c19d359aa4fabbcce9e7313402b3c06a001e23e53e58cc7314ba9b0d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/image-transport-plugins/default.nix
+++ b/distros/kilted/image-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, compressed-depth-image-transport, compressed-image-transport, theora-image-transport, zstd-image-transport }:
 buildRosPackage {
   pname = "ros-kilted-image-transport-plugins";
-  version = "5.1.1-r1";
+  version = "5.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/kilted/image_transport_plugins/5.1.1-1.tar.gz";
-    name = "5.1.1-1.tar.gz";
-    sha256 = "9c2c9e91da41edc34f51ef800c0e2cfd6f303f1bcdc7249ed08c5c62cf0e531e";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/kilted/image_transport_plugins/5.1.2-1.tar.gz";
+    name = "5.1.2-1.tar.gz";
+    sha256 = "f81ec12e95b2ca037f4a80b0295f5625c4f1646af57a62908033f3f24beabe5c";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/imu-sensor-broadcaster/default.nix
+++ b/distros/kilted/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, eigen, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-kilted-imu-sensor-broadcaster";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/imu_sensor_broadcaster/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "433b5b1fbac0d17fd6cd4b58197af10c7c1a014efde02d588761d92ee3daebac";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/imu_sensor_broadcaster/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "ee90770e31b57d4a58c751fd3f3dfb6a0738e0422952574438dcacff06a65d97";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/joint-limits/default.nix
+++ b/distros/kilted/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, fmt, generate-parameter-library, launch-ros, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-kilted-joint-limits";
-  version = "5.13.0-r1";
+  version = "5.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/joint_limits/5.13.0-1.tar.gz";
-    name = "5.13.0-1.tar.gz";
-    sha256 = "626c62cd1d8cfe3706c26c4f8309e3de54eadfcebebd4b97f3b384c19ee9ba60";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/joint_limits/5.14.0-1.tar.gz";
+    name = "5.14.0-1.tar.gz";
+    sha256 = "382c59248f0a34be537c93ae1d3c46dd41462daee427a94b12dd089638d3ac4c";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/joint-state-broadcaster/default.nix
+++ b/distros/kilted/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, urdf }:
 buildRosPackage {
   pname = "ros-kilted-joint-state-broadcaster";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/joint_state_broadcaster/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "36784bba0e96d3d55f63b399329f0a1d2fb6257ba954406cfb18409407a356fd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/joint_state_broadcaster/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "d91e0c0c153d286d74fcebb88763031656a57e33aa51fa3c3293d1bffeb368c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/joint-trajectory-controller/default.nix
+++ b/distros/kilted/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, rsl, tl-expected-nixpkgs, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-kilted-joint-trajectory-controller";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/joint_trajectory_controller/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "5c5a6a2878e257b22fac9d24df33b1a691f3b31da824e01d5f8f1cb2b56508d8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/joint_trajectory_controller/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "7da3f61fbb83c34a621ae086e1d128f629b20dbbf29f004d7321968f6e434566";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/kitti-metrics-eval/default.nix
+++ b/distros/kilted/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmath, mrpt-libposes, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-kilted-kitti-metrics-eval";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/kitti_metrics_eval/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "44f2d5634083a87ae4cbb2b84aec26446c1a4d43200775624587670323c1926c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/kitti_metrics_eval/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "aa63884bc5c79c434465203b4dc6dcc1467c907b0ac7ef222ad452d49bf123ae";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mecanum-drive-controller/default.nix
+++ b/distros/kilted/mecanum-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mecanum-drive-controller";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/mecanum_drive_controller/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "55171af300e55f80b0bf70fb8ee76a44a943b3df529cceb6c9e808be18c58b5a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/mecanum_drive_controller/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "444988f1947f5310583c37111469188cd69e3b87f44e9b36f0c622c3a8c324e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mola-bridge-ros2/default.nix
+++ b/distros/kilted/mola-bridge-ros2/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, geographic-msgs, geometry-msgs, gps-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, diagnostic-msgs, geographic-msgs, geometry-msgs, gps-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mola-bridge-ros2";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_bridge_ros2/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "9f607238c6df9a8b4da3a44f5a2d2540d70709ed754f236b5436984df1a753f0";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_bridge_ros2/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "eb5b4fd102d7b47673b769308712577dc35ee503253510ae47f493b68457c358";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ros-environment ];
   checkInputs = [ ament-cmake-xmllint ament-lint-auto ament-lint-cmake ];
-  propagatedBuildInputs = [ geographic-msgs geometry-msgs gps-msgs mola-common mola-kernel mola-msgs mrpt-libmaps mrpt-libros-bridge mrpt-nav-interfaces nav-msgs rclcpp sensor-msgs tf2 tf2-geometry-msgs ];
+  propagatedBuildInputs = [ diagnostic-msgs geographic-msgs geometry-msgs gps-msgs mola-common mola-kernel mola-msgs mrpt-libmaps mrpt-libros-bridge mrpt-nav-interfaces nav-msgs rclcpp sensor-msgs tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/kilted/mola-demos/default.nix
+++ b/distros/kilted/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-kilted-mola-demos";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_demos/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "044a91aa8eefb45e4363fc1b650ce10632bf978081b9df81402566efc1b2cd38";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_demos/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "5a9ca82ca7edeaaaaa36146700431a6c221b6a02776004c6d3a68afd48b04d22";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mola-imu-preintegration/default.nix
+++ b/distros/kilted/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-kilted-mola-imu-preintegration";
-  version = "1.15.0-r1";
+  version = "1.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_imu_preintegration-release/archive/release/kilted/mola_imu_preintegration/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "6433955043a4979693a6790ba3119326bef645b96ff4daa86218bb16625d0907";
+    url = "https://github.com/ros2-gbp/mola_imu_preintegration-release/archive/release/kilted/mola_imu_preintegration/1.16.0-1.tar.gz";
+    name = "1.16.0-1.tar.gz";
+    sha256 = "c7eaa7dcd94fb739598f69e4caa45f91be9c2933cfa5a709136fb923f3194a62";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-input-euroc-dataset/default.nix
+++ b/distros/kilted/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmath, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-kilted-mola-input-euroc-dataset";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_euroc_dataset/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "b438d3e4f8ba2837c8fdde314f9d702d7fe244a96a22e301be3245327452e004";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_euroc_dataset/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "3b0a73395d2ffe94484c0e115ea1ae5371646206a5fa3b234ee6a54d530703aa";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-input-kitti-dataset/default.nix
+++ b/distros/kilted/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-kilted-mola-input-kitti-dataset";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_kitti_dataset/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "c35b84af165914e2c66711c1ff9f8eec7eedb2e2d13bbd07306e2bc86b61ec28";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_kitti_dataset/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "100a0dce2a37bdb290f351c4b001f08b0b0cb3cbac7b5a2204f72c8c7fbda372";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-input-kitti360-dataset/default.nix
+++ b/distros/kilted/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-kilted-mola-input-kitti360-dataset";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_kitti360_dataset/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "0d2850ecef4cd9f0911f6f04e8f88a41a9788350add8e61a2964b13b9f116a11";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_kitti360_dataset/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "899875b7697fee88973030cbbd170411a3141593e6c4fbc73be4bdab1fb90559";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-input-lidar-bin-dataset/default.nix
+++ b/distros/kilted/mola-input-lidar-bin-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-kilted-mola-input-lidar-bin-dataset";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_lidar_bin_dataset/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "05a1aa07926d04c8293222e720f0486447385be62f1c022fefbba5066ca2f79b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_lidar_bin_dataset/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "89db1af641ae5db6b7d321569b5dcf0dfad3ecb48b6a262f578a2617cca466bf";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-input-mulran-dataset/default.nix
+++ b/distros/kilted/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-kilted-mola-input-mulran-dataset";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_mulran_dataset/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "7c686df5d328de52b4a4c5a3cddd3964b30999bbbb599212121eaf3952c5f9c8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_mulran_dataset/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "2c036c2209abd1de614667254257c7f001cf6fe7cce6491099bfad18bbcc0bb8";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-input-paris-luco-dataset/default.nix
+++ b/distros/kilted/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-kilted-mola-input-paris-luco-dataset";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_paris_luco_dataset/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "6169d912489dfcaf503c23a518c527f3abe53a81f1116d5786f6bc245c13b673";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_paris_luco_dataset/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "6af1b5c006b72455fb203d00f1e3df8bcc360913c7ce20cecf6971f9581f2a52";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-input-rawlog/default.nix
+++ b/distros/kilted/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-kilted-mola-input-rawlog";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_rawlog/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "ccd5599abde2d8f5489b5c357654194268a51a7c12b04a7298a428b11d1ffd77";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_rawlog/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "3c0ede436b03bc009236e622dfbe5809caeb0ec8b3da2a3398de738038bc00ac";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-input-rosbag2/default.nix
+++ b/distros/kilted/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, gps-msgs, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-mola-input-rosbag2";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_rosbag2/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "b5822206833d2747bd39ec0f51917effb0733aba82da5f1fcb146c8e31ed075a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_rosbag2/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "bfa7ec1645f257036099f6be221805252e69f7f7edfea41104e214bc1aa443a8";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-input-video/default.nix
+++ b/distros/kilted/mola-input-video/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libhwdrivers, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-kilted-mola-input-video";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_video/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "c0ae9b4faf5e644042071d870658dd638f67265ebd28487be148750d873394ad";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_video/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "eeb414c2043649ea089a9bcb9c873eec514d3cfd3bdeb78fe262239aa73f7d1b";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-kernel/default.nix
+++ b/distros/kilted/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libgui, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-kilted-mola-kernel";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_kernel/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "76eb9d9b6281db2402002c64f9ba87e1deca12207d549e749eec57513ba25947";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_kernel/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "0aa73a15acb6f716c591898e6f90e8361e3517dc7bf9dfcba79333ffb3b7eca3";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-launcher/default.nix
+++ b/distros/kilted/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-xmllint, ament-lint-auto, cmake, mola-kernel, mrpt-libbase, mrpt-libtclap, ros-environment }:
 buildRosPackage {
   pname = "ros-kilted-mola-launcher";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_launcher/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "2e55d91efd6ab44f39fb60fdd729e45f48363fbf378dc409784e92b2388765e7";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_launcher/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "3a23af84413e904cb7c0bc99b0afa039cba8dd94056e71366afaef25f224c240";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mola-metric-maps/default.nix
+++ b/distros/kilted/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mp2p-icp, mrpt-libmaps, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-kilted-mola-metric-maps";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_metric_maps/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "e2acb4bcb25699d16083afa8416240637d09542527d60007ad1e5702cb756445";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_metric_maps/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "13805c3a415ad48bdbfe74b83dbc275a3d5d1049b0997f87408fe0914c40ee98";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mola-msgs/default.nix
+++ b/distros/kilted/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-kilted-mola-msgs";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_msgs/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "6d3cb4afaa36a012dea9b0f75aa61a68efe3b7a72be59b3c317d8ff568b8f026";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_msgs/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "3c86dcf069e4f3b749a2d08cc71bf2fa400da5ab7fcabe72aa8a36d824d6c45d";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mola-pose-list/default.nix
+++ b/distros/kilted/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-kilted-mola-pose-list";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_pose_list/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "770129e6da7c46a70f72d193e689cea78454226e9910a65ce54306cc7ca89189";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_pose_list/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "edd38cfde6a884d86231914824a3e467f874bf5b67cea344d0da11d5a1a82b6c";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-relocalization/default.nix
+++ b/distros/kilted/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-kilted-mola-relocalization";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_relocalization/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "cd94c9a2f6ead345e2b13a99ac6abefbe61a36a3b80e5e4beda5e617e56c713e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_relocalization/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "cded4535c4e83255855f5500692555be9ed450a6916ec9e146240b1da9e02a99";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-traj-tools/default.nix
+++ b/distros/kilted/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-kilted-mola-traj-tools";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_traj_tools/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "7ed434060bda8c4284889888b993f8845e355a29456d8bcd9522abc185b5d3b2";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_traj_tools/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "d4e43f185161b4eaddafe3d1b60af25646b35074a0ceaea46f16a6d6d963bebb";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-viz/default.nix
+++ b/distros/kilted/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-kilted-mola-viz";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_viz/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "c87b8019f1b995155374c038c29baf55c0448def8024bee249384798c5c74271";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_viz/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "6c963bcb0e2baee57a3b4e0410ad40f0e35e50e2a8cb2271f48c6402e21f320f";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-yaml/default.nix
+++ b/distros/kilted/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-kilted-mola-yaml";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_yaml/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "d373d0b99e858025369560494baf5c60235c5af58c3117ab9a559990fd9353d0";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_yaml/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "936cf536b947c81f622f5e3d9c8198e9b55bd06de6670affeddd8755e661fdd6";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola/default.nix
+++ b/distros/kilted/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-input-video, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-kilted-mola";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "d7978c9c3fb8daab3a766a72c9f89083443c4f1208991ece2c2c3dcab9185bdf";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "30fe42201fcda727cfbf9cb3bb42735c10e7bbb6cce1febe6a00631af79bd1a8";
   };
 
   buildType = "cmake";

--- a/distros/kilted/motion-primitives-controllers/default.nix
+++ b/distros/kilted/motion-primitives-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-kilted-motion-primitives-controllers";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/motion_primitives_controllers/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "74e6a94591075f62a2b985ada7ecfc703f35570936e40debce7a16de6136f3b1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/motion_primitives_controllers/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "22a73964ef8c34385391e0f1658112d7310f8cfeb4471f491c819613443da337";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-task-constructor-capabilities/default.nix
+++ b/distros/kilted/moveit-task-constructor-capabilities/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, fmt, launch-testing, launch-testing-ament-cmake, moveit-configs-utils, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-task-constructor-core, moveit-task-constructor-msgs, pluginlib, rclcpp-action, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, controller-manager, fmt, launch-testing, launch-testing-ament-cmake, moveit-configs-utils, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-task-constructor-core, moveit-task-constructor-msgs, pluginlib, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-moveit-task-constructor-capabilities";
-  version = "0.1.4-r2";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/kilted/moveit_task_constructor_capabilities/0.1.4-2.tar.gz";
-    name = "0.1.4-2.tar.gz";
-    sha256 = "367f1e7844cd4b891f92a77ee41494e027d2be227fc2fd85b7cddcd7c270f400";
+    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/kilted/moveit_task_constructor_capabilities/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "09ea8e766b608bc79b07a7e0265eb48a396a04edb4c8ee13a385d24768f9f3de";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gtest launch-testing launch-testing-ament-cmake moveit-configs-utils moveit-resources-panda-moveit-config ];
+  checkInputs = [ ament-cmake-gtest controller-manager launch-testing launch-testing-ament-cmake moveit-configs-utils moveit-resources-panda-moveit-config ];
   propagatedBuildInputs = [ fmt moveit-core moveit-ros-move-group moveit-ros-planning moveit-task-constructor-core moveit-task-constructor-msgs pluginlib rclcpp-action std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/kilted/moveit-task-constructor-core/default.nix
+++ b/distros/kilted/moveit-task-constructor-core/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, fmt, geometry-msgs, launch-testing-ament-cmake, moveit-configs-utils, moveit-core, moveit-planners, moveit-resources-fanuc-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, moveit-task-constructor-msgs, py-binding-tools, rclcpp, rviz-marker-tools, tf2-eigen, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, fmt, geometry-msgs, launch-testing-ament-cmake, moveit-configs-utils, moveit-core, moveit-planners, moveit-py, moveit-resources-fanuc-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, moveit-task-constructor-msgs, py-binding-tools, rclcpp, rviz-marker-tools, tf2-eigen, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-moveit-task-constructor-core";
-  version = "0.1.4-r2";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/kilted/moveit_task_constructor_core/0.1.4-2.tar.gz";
-    name = "0.1.4-2.tar.gz";
-    sha256 = "971f76ab97b98a8443b3f82939dfac183c72f96c7ca2a294fcd2fb19befc8bae";
+    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/kilted/moveit_task_constructor_core/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "8fb5a91ee7d6cbb89c0d47f0d989e8b60106847faeccb8b2322c1a1e4478af91";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-cmake-pytest launch-testing-ament-cmake moveit-configs-utils moveit-planners moveit-resources-fanuc-moveit-config ];
-  propagatedBuildInputs = [ fmt geometry-msgs moveit-core moveit-ros-planning moveit-ros-planning-interface moveit-task-constructor-msgs py-binding-tools rclcpp rviz-marker-tools tf2-eigen visualization-msgs ];
+  propagatedBuildInputs = [ fmt geometry-msgs moveit-core moveit-py moveit-ros-planning moveit-ros-planning-interface moveit-task-constructor-msgs py-binding-tools rclcpp rviz-marker-tools tf2-eigen visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/kilted/moveit-task-constructor-demo/default.nix
+++ b/distros/kilted/moveit-task-constructor-demo/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, generate-parameter-library, moveit-configs-utils, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, moveit-task-constructor-capabilities, moveit-task-constructor-core, moveit-task-constructor-visualization, py-binding-tools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, generate-parameter-library, moveit-configs-utils, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, moveit-task-constructor-capabilities, moveit-task-constructor-core, moveit-task-constructor-visualization, py-binding-tools }:
 buildRosPackage {
   pname = "ros-kilted-moveit-task-constructor-demo";
-  version = "0.1.4-r2";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/kilted/moveit_task_constructor_demo/0.1.4-2.tar.gz";
-    name = "0.1.4-2.tar.gz";
-    sha256 = "bfca18cee324361b5ee0f2350870ea3039a3692042596f46d4625ce99455f2e3";
+    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/kilted/moveit_task_constructor_demo/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "62ba824ab13cb778305052b6c0fd0bb92750722cf0c89ece2612997db0a649d3";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ generate-parameter-library moveit-configs-utils moveit-core moveit-resources-panda-moveit-config moveit-ros-planning-interface moveit-task-constructor-capabilities moveit-task-constructor-core moveit-task-constructor-visualization py-binding-tools ];
+  propagatedBuildInputs = [ controller-manager generate-parameter-library moveit-configs-utils moveit-core moveit-resources-panda-moveit-config moveit-ros-planning-interface moveit-task-constructor-capabilities moveit-task-constructor-core moveit-task-constructor-visualization py-binding-tools ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/moveit-task-constructor-msgs/default.nix
+++ b/distros/kilted/moveit-task-constructor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-msgs, rosidl-default-generators, rosidl-default-runtime, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-moveit-task-constructor-msgs";
-  version = "0.1.4-r2";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/kilted/moveit_task_constructor_msgs/0.1.4-2.tar.gz";
-    name = "0.1.4-2.tar.gz";
-    sha256 = "def1eed67bea817b1a7d27aa0531f1446ae02e4b70b98be62e165efe5d031013";
+    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/kilted/moveit_task_constructor_msgs/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "d822dad1d1e4b904a37e1c2c15adef3c8016e9a2ac88d69879bc92e42f33fd07";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/moveit-task-constructor-visualization/default.nix
+++ b/distros/kilted/moveit-task-constructor-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, fmt, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, libyaml-vendor, moveit-core, moveit-ros-visualization, moveit-task-constructor-core, moveit-task-constructor-msgs, qt5, rclcpp, rviz2 }:
 buildRosPackage {
   pname = "ros-kilted-moveit-task-constructor-visualization";
-  version = "0.1.4-r2";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/kilted/moveit_task_constructor_visualization/0.1.4-2.tar.gz";
-    name = "0.1.4-2.tar.gz";
-    sha256 = "08fa1ba813399ad320cc429065fe5391139df5c600bfb86ce959d8daafa3ef2f";
+    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/kilted/moveit_task_constructor_visualization/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "179fb089ce20e2062c596a9fd708b7c974df3a4a920ad874ec85fc94f9b94d64";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mp2p-icp/default.nix
+++ b/distros/kilted/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-kilted-mp2p-icp";
-  version = "2.8.1-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/kilted/mp2p_icp/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "88b81700c33c755135e1e1c161d898c37648bceb3444578d4a9e23e759160fd4";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/kilted/mp2p_icp/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "610592e07986aee841bd3d9fc903435b314902f19ce3590b1c42bb9a951a56c7";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-apps/default.nix
+++ b/distros/kilted/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-apps";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_apps/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "52aa97138c2eece451047a5eed8b47990ca903bb339140f64312b6f04b5d72d8";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_apps/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "449cbbc702c6e43eba321a0ad037387923e18ba9a9732cee0f74ff54506c18ec";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libapps/default.nix
+++ b/distros/kilted/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libapps";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libapps/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "3071cf28145974ee0f4ea748ae518f64bbc0320300a4921a3c3b1aa6e1fe6d54";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libapps/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "cda0a5be915b45566f464e5f12403b8f84c49c3d7a9bcf8209eff874b2904834";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libbase/default.nix
+++ b/distros/kilted/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, onetbb, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib, zstd }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libbase";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libbase/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "9deff76d2a504d6ccf58dbc35c08e08132acfe814c50642993478658f8b1a34c";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libbase/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "2bf37b44612a7eeb147f7e75fa76064cb3ddff4bef22771a0876b22f67f20fd3";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libgui/default.nix
+++ b/distros/kilted/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libgui";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libgui/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "21bce185f623aa3823ed42b54c27bd4f07410def70e70f7012c53b09b22c5d09";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libgui/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "3643419ae9e89c6c739b49202fdd460de5ac1e0132a0731af966696ca26f7c1a";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libhwdrivers/default.nix
+++ b/distros/kilted/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libhwdrivers";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libhwdrivers/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "af1516cb3f214e7e021c94d4738e37242682f0f4602aa2689f376c433a3356c5";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libhwdrivers/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "fa8fa6c541318030eca139100b18613860c2248f4bf35dbf605c085be0b37f21";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libmaps/default.nix
+++ b/distros/kilted/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libmaps";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libmaps/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "94f1637f11417385bf7089dc79c49e0f89bdb31fa31148c48dec22f3750e189d";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libmaps/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "c1dbf2f13666006f3db38d1410c07c93132eb64a9ec883a30e0134a306441cb1";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libmath/default.nix
+++ b/distros/kilted/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libmath";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libmath/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "dcfaa6f5921394a44ba4b8dcbf9aafa193dc68b96ffffdacff29d7d309a1b7f8";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libmath/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "4a38e9c5dafaec5c82f3b4e94fa52bcef7a82eeb3e37da21a0c8537ba1a2b230";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libnav/default.nix
+++ b/distros/kilted/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libnav";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libnav/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "a7d63eb80f3c0d698977aa44122be4df67f3422caf7417db5c03c4a286b1393a";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libnav/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "d8dfbca8f0db42bdc674d24446c1a8d1b851080ec00b8d7744482826bc45c691";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libobs/default.nix
+++ b/distros/kilted/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libobs";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libobs/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "f64250a23bb6a8395e1cb97f1e9f0a7f154e2aa1e06f196aa45e97a4ad5d88f6";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libobs/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "950669242c60f38cb1e37b8ede583aaf9a7ea37d49772d10882df03f4a78f1d9";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libopengl/default.nix
+++ b/distros/kilted/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libopengl";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libopengl/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "88d83c3d9674057a73106159dcca29feaeaacbe2faccda377d8a0c76959e3ec9";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libopengl/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "ba40bf4f269e12843b3fb407c9d23e6d40c20b684ba0ed360456648bf0e0b6f9";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libposes/default.nix
+++ b/distros/kilted/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libposes";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libposes/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "e6810660ec8bef62d81255bdd7290d478304c6aa8d0f52fc23583c02d9df2bdb";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libposes/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "400be3778c713b40d2d1c467edb64d3672047de84513fcfc65dfebda777c1794";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libros-bridge/default.nix
+++ b/distros/kilted/mrpt-libros-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cmake, cv-bridge, geometry-msgs, gps-msgs, mrpt-libmaps, mrpt-libobs, nav-msgs, ros-environment, rosbag2-cpp, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libros-bridge";
-  version = "3.5.1-r1";
+  version = "3.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/kilted/mrpt_libros_bridge/3.5.1-1.tar.gz";
-    name = "3.5.1-1.tar.gz";
-    sha256 = "c8b396270d758874eac7881f3206f21af6798eb41523dc25e7b26b430332d188";
+    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/kilted/mrpt_libros_bridge/3.5.2-1.tar.gz";
+    name = "3.5.2-1.tar.gz";
+    sha256 = "607f518278a571efb67c286a47dc962e5311d68bec27a56142a7461c70b35a4f";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libslam/default.nix
+++ b/distros/kilted/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, onetbb, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libslam";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libslam/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "491adc15845fe26d23d853d8e5494dc99744aa7f76dd445aeb4abced365cec4e";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libslam/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "e4ff17ed0b120b730b4f55aa6e3154fd80a82d0deed406bee18b02c6ca5a859f";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-libtclap/default.nix
+++ b/distros/kilted/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-libtclap";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libtclap/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "7f61d19cae7247bf1e60bfac263bd9665b3bf519cc41417a9432eb1657205622";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/kilted/mrpt_libtclap/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "d30773d7542fec977e91f44ffcf68d93f069ce1e3c4d5492bce0c376a4eb9e38";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mrpt-map-server/default.nix
+++ b/distros/kilted/mrpt-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libros-bridge, mrpt-msgs, mrpt-nav-interfaces, rclcpp-components, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-map-server";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/kilted/mrpt_map_server/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "9de3a3e2045e6ae70e9a0ca57d3a1249e269d547c6606b4d326086a3126dc503";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/kilted/mrpt_map_server/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "86187042ab2b3f1ee1cfeaa77b65fb0d12b121a61e02c9388dd5294ab311a467";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mrpt-msgs-bridge/default.nix
+++ b/distros/kilted/mrpt-msgs-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, mrpt-libobs, mrpt-libros-bridge, mrpt-msgs, rclcpp, ros-environment, tf2 }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-msgs-bridge";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/kilted/mrpt_msgs_bridge/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "1c96063f18c7a1f69b43d0b17013988f9dfa24f829326ade28e00b02bcc68afe";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/kilted/mrpt_msgs_bridge/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "83e2a1bcd053d056383b2b9b2573deb7090b305c807b33fb7148c8b362fd2193";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mrpt-nav-interfaces/default.nix
+++ b/distros/kilted/mrpt-nav-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, geometry-msgs, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-nav-interfaces";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/kilted/mrpt_nav_interfaces/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "ba9bfed3839d5f3bc5b9d3d7f7a592644590a149f7034383b4b04628dfe0360b";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/kilted/mrpt_nav_interfaces/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "216841756eaef2f344a749107ac88e044faeebf341c934d4aac832cf67fd2914";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mrpt-navigation/default.nix
+++ b/distros/kilted/mrpt-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-map-server, mrpt-msgs-bridge, mrpt-nav-interfaces, mrpt-pf-localization, mrpt-pointcloud-pipeline, mrpt-reactivenav2d, mrpt-tps-astar-planner, mrpt-tutorials }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-navigation";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/kilted/mrpt_navigation/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "452b8345d53c9a8a2afd6d35bbccc49adb07882f241d0b02065ab9dde70e9d17";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/kilted/mrpt_navigation/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "ceb206c3dfdbc59d3031a23dd51bd6a61e14838f6486df9d082b3ed6bafa6fe5";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mrpt-pf-localization/default.nix
+++ b/distros/kilted/mrpt-pf-localization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, cmake, mola-relocalization, mp2p-icp, mrpt-libgui, mrpt-libros-bridge, mrpt-libslam, mrpt-msgs, mrpt-msgs-bridge, mrpt-tutorials, nav-msgs, pose-cov-ops, rclcpp, rclcpp-components, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-pf-localization";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/kilted/mrpt_pf_localization/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "48b1493f645536ca6ca7d379a8f72bcbf482cfe2da755c9badcf7a6bdc29fda8";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/kilted/mrpt_pf_localization/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "c900f2a2c61ced3559a5ead12a0f1c5d64ca6ddf276f51ed82dd81fa64cbbdb3";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mrpt-pointcloud-pipeline/default.nix
+++ b/distros/kilted/mrpt-pointcloud-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, mp2p-icp, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libros-bridge, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-pointcloud-pipeline";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/kilted/mrpt_pointcloud_pipeline/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "1fba39bddf743117373ec8510f9676f8ce323979dd58b25a5bfe646d2443ed9a";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/kilted/mrpt_pointcloud_pipeline/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "c42f6aa4e98575f14448d06b9d498c5d30d2e503511fd9aaf9684d4f5dc4e717";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mrpt-reactivenav2d/default.nix
+++ b/distros/kilted/mrpt-reactivenav2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, mrpt-libnav, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-reactivenav2d";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/kilted/mrpt_reactivenav2d/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "74d7dd1dc7ecc7d0c14d674339609ffb0e2077e030b985cf3e0f2236495d55b7";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/kilted/mrpt_reactivenav2d/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "5860d0d7d5ec5c86ec0a704b531438a565b536f630c37f801548f3e68a0413df";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mrpt-tps-astar-planner/default.nix
+++ b/distros/kilted/mrpt-tps-astar-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-libgui, mrpt-libmaps, mrpt-libnav, mrpt-libros-bridge, mrpt-msgs, mrpt-nav-interfaces, mrpt-path-planning, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-tps-astar-planner";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/kilted/mrpt_tps_astar_planner/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "5b75f5a8ea2c4c994a066062fc5602cc14b0a7badfa9e4d3475343cf699e66e3";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/kilted/mrpt_tps_astar_planner/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "a3b0d061f28faa8b09a49c3998708ad46a73c6d969fe09fdb5599748e5685474";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mrpt-tutorials/default.nix
+++ b/distros/kilted/mrpt-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, cmake, mvsim, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-tutorials";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/kilted/mrpt_tutorials/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "3382d2d1c9695b42b7cfe6dc799d289d7b63a575be16242c9aa9687ac7f32b42";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/kilted/mrpt_tutorials/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "affd06fb80c373da204661939968b35fed6c21e4168e52b3eece935310cbd485";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/omni-wheel-drive-controller/default.nix
+++ b/distros/kilted/omni-wheel-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, eigen, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-kilted-omni-wheel-drive-controller";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/omni_wheel_drive_controller/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "69ecbaeddd14d550d3478674f0561ede39f4d8845cea6919cbdb2ffe44388843";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/omni_wheel_drive_controller/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "ff0c579cf8f9fef38bab11c280e5bed8f7b8842dc6d70d2fcc51a2492c8e37d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/parallel-gripper-controller/default.nix
+++ b/distros/kilted/parallel-gripper-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-parallel-gripper-controller";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/parallel_gripper_controller/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "f47a7d88d317586078d731f5cbfe9d99850e94f8b9959f567b49a445941b5ebb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/parallel_gripper_controller/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "00a804f89fc411f70353dbd42244ae4c889ebc7aab141842097984ae6e25d032";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/pid-controller/default.nix
+++ b/distros/kilted/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-kilted-pid-controller";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/pid_controller/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "5dbb75deebc453a9cfdcba380aa2561ccf16d53f76ee1620d4f0b6c97a3e858e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/pid_controller/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "b6ced483ffff0f5716dca1f36cc466d0c8678e59439ab530a92adbc83963be7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/pose-broadcaster/default.nix
+++ b/distros/kilted/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-kilted-pose-broadcaster";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/pose_broadcaster/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "01293cb39e7d898fb9d0c3c7eb804673e349c909d7a798df34cf049d6c1b8169";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/pose_broadcaster/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "a87d55b19ae3804149aca540afb20af5d333477440c4e59d7c726b16917caace";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/position-controllers/default.nix
+++ b/distros/kilted/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-position-controllers";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/position_controllers/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "5611339047e96c77ac134cddd11d34e9338a4b190cf5e48fd85472a9213dbba8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/position_controllers/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "1428100c8a07e2a578dd7fbe81a237938788d78eeb3f5f3d37501b49b328b284";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/qml6-ros2-plugin/default.nix
+++ b/distros/kilted/qml6-ros2-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, example-interfaces, image-transport, qt6, rclcpp, ros-babel-fish, ros-babel-fish-test-msgs, std-srvs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-kilted-qml6-ros2-plugin";
-  version = "2.26.31-r1";
+  version = "2.26.41-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qml6_ros2_plugin-release/archive/release/kilted/qml6_ros2_plugin/2.26.31-1.tar.gz";
-    name = "2.26.31-1.tar.gz";
-    sha256 = "30f5580e530059ea5ad0a7217810001fb42af61820cf5ad1c8b26350d764b20a";
+    url = "https://github.com/ros2-gbp/qml6_ros2_plugin-release/archive/release/kilted/qml6_ros2_plugin/2.26.41-1.tar.gz";
+    name = "2.26.41-1.tar.gz";
+    sha256 = "58fa166b4598c9d62b4c07bfe7a1570ef23806eb16dfd48ad07e110c743d1023";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/range-sensor-broadcaster/default.nix
+++ b/distros/kilted/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-range-sensor-broadcaster";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/range_sensor_broadcaster/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "910f77fdb03bf3f39e8c338f2c4f737e4c6a3986dd9c15f9c70cfd9480619dd4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/range_sensor_broadcaster/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "f95737218025c34b67b9f4076253d5392f600e1becdc8c696bdb43ca424d3e04";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros-babel-fish-test-msgs/default.nix
+++ b/distros/kilted/ros-babel-fish-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ros-babel-fish-test-msgs";
-  version = "3.26.31-r1";
+  version = "3.26.40-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_babel_fish-release/archive/release/kilted/ros_babel_fish_test_msgs/3.26.31-1.tar.gz";
-    name = "3.26.31-1.tar.gz";
-    sha256 = "96e13ea28447ab5eec8ecbd7e0a25e988f8c5e3c77a64d90008aace02a814740";
+    url = "https://github.com/ros2-gbp/ros_babel_fish-release/archive/release/kilted/ros_babel_fish_test_msgs/3.26.40-1.tar.gz";
+    name = "3.26.40-1.tar.gz";
+    sha256 = "25b45c02e30870a47adde9054f7d5cb491e5c969e42003dc209c89b3329e4c0d";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros-babel-fish-tools/default.nix
+++ b/distros/kilted/ros-babel-fish-tools/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, geometry-msgs, rclcpp, ros-babel-fish, ros-babel-fish-test-msgs, std-msgs, yaml-cpp-vendor }:
+buildRosPackage {
+  pname = "ros-kilted-ros-babel-fish-tools";
+  version = "3.26.40-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros_babel_fish-release/archive/release/kilted/ros_babel_fish_tools/3.26.40-1.tar.gz";
+    name = "3.26.40-1.tar.gz";
+    sha256 = "3ba75d2b79f0962ddba2887f6b440ed73c4b5a10516d9cffca0cc24fb132bf5e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest geometry-msgs ros-babel-fish-test-msgs std-msgs ];
+  propagatedBuildInputs = [ rclcpp ros-babel-fish yaml-cpp-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Tooling for ROS 2 built on ros_babel_fish.
+    Provides header-only JSON and YAML serialization for dynamic messages and a CLI tool to echo topics.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kilted/ros-babel-fish/default.nix
+++ b/distros/kilted/ros-babel-fish/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, example-interfaces, geometry-msgs, rclcpp, rclcpp-action, rcpputils, ros-babel-fish-test-msgs, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ros-babel-fish";
-  version = "3.26.31-r1";
+  version = "3.26.40-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_babel_fish-release/archive/release/kilted/ros_babel_fish/3.26.31-1.tar.gz";
-    name = "3.26.31-1.tar.gz";
-    sha256 = "fad5149832deece669081781dd9fb0dc41a5ff9fdd2415847a88a0ffd6329e83";
+    url = "https://github.com/ros2-gbp/ros_babel_fish-release/archive/release/kilted/ros_babel_fish/3.26.40-1.tar.gz";
+    name = "3.26.40-1.tar.gz";
+    sha256 = "241e43b5e1c183f5ef6380ef0dddcfd8e781a5a61053aa22bbe936a5ae770f1a";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros2-control-test-assets/default.nix
+++ b/distros/kilted/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-kilted-ros2-control-test-assets";
-  version = "5.13.0-r1";
+  version = "5.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/ros2_control_test_assets/5.13.0-1.tar.gz";
-    name = "5.13.0-1.tar.gz";
-    sha256 = "655a947ea86048155f5ca91f2e391bed323fce17bb3f4534e563a9f7dd86fa8f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/ros2_control_test_assets/5.14.0-1.tar.gz";
+    name = "5.14.0-1.tar.gz";
+    sha256 = "b575eddb9d8203a22819bb01c3f5f2873c90c071423696151b3fc7b0d4e617b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros2-control/default.nix
+++ b/distros/kilted/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-kilted-ros2-control";
-  version = "5.13.0-r1";
+  version = "5.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/ros2_control/5.13.0-1.tar.gz";
-    name = "5.13.0-1.tar.gz";
-    sha256 = "fe22aa4397134f9a7c0e6bf07625ad39c89fbde3d48554b826953aea18dd6fa8";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/ros2_control/5.14.0-1.tar.gz";
+    name = "5.14.0-1.tar.gz";
+    sha256 = "1fad05b795ef4928e85bf3c589c41eb90dcd9260cc086c26ea1c46e0b35e5cb9";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros2-controllers-test-nodes/default.nix
+++ b/distros/kilted/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ros2-controllers-test-nodes";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/ros2_controllers_test_nodes/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "30367a2090e165cba74e494d4d619aaf6282419ac46b26ac34588cace782de8a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/ros2_controllers_test_nodes/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "284ae9ca832a26fa2a1f0c4e272f3ed601ed06fa7bc948f8997bd5d6d96355e0";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/ros2-controllers/default.nix
+++ b/distros/kilted/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, chained-filter-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gps-sensor-broadcaster, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, motion-primitives-controllers, omni-wheel-drive-controller, parallel-gripper-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, state-interfaces-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-kilted-ros2-controllers";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/ros2_controllers/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "f5afecd9d610e5fdfcc3444ad7f63500792529e38a13ab68c4f86e539f95050a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/ros2_controllers/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "b70b43ba896b727810f4d0efb6b0963b24d1a7341178d27986b9050937f0183f";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros2controlcli/default.nix
+++ b/distros/kilted/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-kilted-ros2controlcli";
-  version = "5.13.0-r1";
+  version = "5.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/ros2controlcli/5.13.0-1.tar.gz";
-    name = "5.13.0-1.tar.gz";
-    sha256 = "a58a75fdfabb09615cca00a617efd849d60576db45b47d5711957cced9977851";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/ros2controlcli/5.14.0-1.tar.gz";
+    name = "5.14.0-1.tar.gz";
+    sha256 = "f23dbeefb4ca82ee78c9e38a9b038e0fe76743752254c99d30f8e2b8fea0d417";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/rosbag2rawlog/default.nix
+++ b/distros/kilted/rosbag2rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, cli11, cmake, cv-bridge, mrpt-libmaps, mrpt-libros-bridge, mrpt-msgs, nav-msgs, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-rosbag2rawlog";
-  version = "3.5.1-r1";
+  version = "3.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/kilted/rosbag2rawlog/3.5.1-1.tar.gz";
-    name = "3.5.1-1.tar.gz";
-    sha256 = "a978be6a199910f503be32c64d5b376faa27afa8552a0468fd428b16ecfa20ff";
+    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/kilted/rosbag2rawlog/3.5.2-1.tar.gz";
+    name = "3.5.2-1.tar.gz";
+    sha256 = "9192ce30cbc9a222872e771c063acb254a308d8c9256fb71a44643b068098a42";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rqml-core/default.nix
+++ b/distros/kilted/rqml-core/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, libGL, libGLU, nlohmann_json, qml6-ros2-plugin, qt6, ros-babel-fish-test-msgs, yaml-cpp-vendor }:
+buildRosPackage {
+  pname = "ros-kilted-rqml-core";
+  version = "3.26.41-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqml-release/archive/release/kilted/rqml_core/3.26.41-1.tar.gz";
+    name = "3.26.41-1.tar.gz";
+    sha256 = "351549340b97a2d105f0ea121408cfdbc59b20be10e552217921bb5fbfea716d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake libGL libGLU nlohmann_json ];
+  checkInputs = [ ament-lint-auto ros-babel-fish-test-msgs ];
+  propagatedBuildInputs = [ ament-index-cpp qml6-ros2-plugin qt6.qtbase qt6.qtdeclarative yaml-cpp-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "QML-based robotics visualization and control tool for ROS 2.";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/kilted/rqml-default-plugins/default.nix
+++ b/distros/kilted/rqml-default-plugins/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, control-msgs, controller-manager-msgs, geometry-msgs, moveit-msgs, pal-statistics-msgs, qml6-ros2-plugin, qt6, rcl-interfaces, ros-babel-fish-test-msgs, rqml-core, sensor-msgs, tf2-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-rqml-default-plugins";
+  version = "3.26.41-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqml-release/archive/release/kilted/rqml_default_plugins/3.26.41-1.tar.gz";
+    name = "3.26.41-1.tar.gz";
+    sha256 = "b81dbf087cca65d922aab0543c574df8796024c2676ffbabbb2bdbeaa557f51b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto qml6-ros2-plugin rcl-interfaces ros-babel-fish-test-msgs ];
+  propagatedBuildInputs = [ control-msgs controller-manager-msgs geometry-msgs moveit-msgs pal-statistics-msgs qml6-ros2-plugin qt6.qtdeclarative qt6.qtmultimedia rqml-core sensor-msgs tf2-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Default plugins for the QML-based robotics visualization and control tool RQml for ROS 2.";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/kilted/rqml-plugin-example/default.nix
+++ b/distros/kilted/rqml-plugin-example/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, qml6-ros2-plugin, qt6, rqml-core }:
+buildRosPackage {
+  pname = "ros-kilted-rqml-plugin-example";
+  version = "3.26.41-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqml-release/archive/release/kilted/rqml_plugin_example/3.26.41-1.tar.gz";
+    name = "3.26.41-1.tar.gz";
+    sha256 = "7ec9c4f1558042c2fc0fa9acaab36c3691e6564eb855399b3219ba3b0c8f1ded";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ qml6-ros2-plugin qt6.qtdeclarative rqml-core ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "An example plugin for RQml";
+    license = with lib.licenses; [ "MIT-0" ];
+  };
+}

--- a/distros/kilted/rqml/default.nix
+++ b/distros/kilted/rqml/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rqml-core, rqml-default-plugins }:
+buildRosPackage {
+  pname = "ros-kilted-rqml";
+  version = "3.26.41-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqml-release/archive/release/kilted/rqml/3.26.41-1.tar.gz";
+    name = "3.26.41-1.tar.gz";
+    sha256 = "ffac9f6290ccaff94c41727e9c38b77cc73b123be6288d2b4105dffc7dbba7c7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ rqml-core rqml-default-plugins ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "QML-based robotics visualization and control tool for ROS 2.";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/kilted/rqt-controller-manager/default.nix
+++ b/distros/kilted/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-kilted-rqt-controller-manager";
-  version = "5.13.0-r1";
+  version = "5.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/rqt_controller_manager/5.13.0-1.tar.gz";
-    name = "5.13.0-1.tar.gz";
-    sha256 = "d2fa07a162f5c51880aef19099a8db71388e2b87c0ef278b192bd3721f63c054";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/rqt_controller_manager/5.14.0-1.tar.gz";
+    name = "5.14.0-1.tar.gz";
+    sha256 = "5d4754f7d2075f63314a7e007bbdcf1e73dbd1219c77d251e1dbd8f6db5dfae9";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/rqt-joint-trajectory-controller/default.nix
+++ b/distros/kilted/rqt-joint-trajectory-controller/default.nix
@@ -5,15 +5,16 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kilted-rqt-joint-trajectory-controller";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/rqt_joint_trajectory_controller/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "3cafb570cab92d20e5ee1db6effac1aeece33bb8b5828c2d39b881db60dcb8cf";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/rqt_joint_trajectory_controller/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "51cba9134ab66c73465528a2ed768360ef3647f29027bc871c5af6d7b6dbad8a";
   };
 
   buildType = "ament_python";
+  checkInputs = [ python3Packages.pytest ];
   propagatedBuildInputs = [ control-msgs controller-manager-msgs python-qt-binding python3Packages.rospkg qt-gui rclpy rqt-gui rqt-gui-py trajectory-msgs ];
 
   meta = {

--- a/distros/kilted/rtest/default.nix
+++ b/distros/kilted/rtest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-clang-tidy, ament-cmake, ament-cmake-copyright, ament-cmake-ros, ament-lint-auto, ament-lint-common, boost, gmock-vendor, gtest, rcl, rcl-action, rclcpp, rclcpp-action, ros-environment }:
 buildRosPackage {
   pname = "ros-kilted-rtest";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rtest-release/archive/release/kilted/rtest/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "3deeb9b4ff2245001a2e3f3bcc722f2d8fea78d5f06cdabcf941822038c4f9f4";
+    url = "https://github.com/ros2-gbp/rtest-release/archive/release/kilted/rtest/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "be91173be79cf9185eee661a4b28685a1468b22ecb0dde7fcbfd876e4eecef64";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rviz-marker-tools/default.nix
+++ b/distros/kilted/rviz-marker-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, rclcpp, std-msgs, tf2-eigen, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-rviz-marker-tools";
-  version = "0.1.4-r2";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/kilted/rviz_marker_tools/0.1.4-2.tar.gz";
-    name = "0.1.4-2.tar.gz";
-    sha256 = "2a42620b29364c677d428d816430b9059b62fac225f5faed77babdadab32e17b";
+    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/kilted/rviz_marker_tools/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "5132644fef812603d99647661d8877844ac4ad46168cc363f764affaca8396b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/state-interfaces-broadcaster/default.nix
+++ b/distros/kilted/state-interfaces-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-state-interfaces-broadcaster";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/state_interfaces_broadcaster/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "e4ece6995bb45d9e40cb99ec1314720171c3d122aadbd097e126085ae60f29d0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/state_interfaces_broadcaster/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "dd11efd337041fd7bee22425807c0406bb149b797effc3205dcbaf63f110c47b";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/steering-controllers-library/default.nix
+++ b/distros/kilted/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-kilted-steering-controllers-library";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/steering_controllers_library/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "99061b8661c129cee3eacb4d57f5594a9ad0359ba349db5cc90bded7298b3709";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/steering_controllers_library/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "940854b528fcff8fce16f2313fe7697cacc39a2631e27257e17fea60957504e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/tcb-span/default.nix
+++ b/distros/kilted/tcb-span/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-kilted-tcb-span";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/kilted/tcb_span/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "2e37ce3750b5380807d9b4ae43bb0debf6fbe2442417061ac3d3c14f2ae64c13";
+    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/kilted/tcb_span/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "bc63ee119e7eae26ec33497b70c93d957c055af853bac3c5db404ffb949009be";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/theora-image-transport/default.nix
+++ b/distros/kilted/theora-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, libogg, libtheora, opencv, pkg-config, pluginlib, rclcpp, rcutils, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-theora-image-transport";
-  version = "5.1.1-r1";
+  version = "5.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/kilted/theora_image_transport/5.1.1-1.tar.gz";
-    name = "5.1.1-1.tar.gz";
-    sha256 = "7e221ca09417c056034b9e396cf74c5739f24353747e4dc6c8de8ea9e722d571";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/kilted/theora_image_transport/5.1.2-1.tar.gz";
+    name = "5.1.2-1.tar.gz";
+    sha256 = "8a9faea1853f3fd2d650cae1c7395ce19d3becfdb9e55508be3a107c1b082d62";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/tl-expected/default.nix
+++ b/distros/kilted/tl-expected/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-kilted-tl-expected";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/kilted/tl_expected/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "7f9bdde98825fe3e9431343895c1277c979f5265e0454903f8ee427a637744b7";
+    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/kilted/tl_expected/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "337bedfe3d4b5630f4ad4c0faa093b17763f00149281d1c00d0e1641c9ec462c";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/transmission-interface/default.nix
+++ b/distros/kilted/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, fmt, hardware-interface, pluginlib, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-transmission-interface";
-  version = "5.13.0-r1";
+  version = "5.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/transmission_interface/5.13.0-1.tar.gz";
-    name = "5.13.0-1.tar.gz";
-    sha256 = "2bb4339c5b9a70d7b54d587b9cabb95e4bc7a2bef9ab25ced8c9fd6f28f2684f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/kilted/transmission_interface/5.14.0-1.tar.gz";
+    name = "5.14.0-1.tar.gz";
+    sha256 = "88630b0c571792722a0fc5952fc694ee1219243c249b4090da5d1e26808be1c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/tricycle-controller/default.nix
+++ b/distros/kilted/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-kilted-tricycle-controller";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/tricycle_controller/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "de101c44564419dd00115f8ec986f69cd8dc9931fe5ae5d217bb931deccf3547";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/tricycle_controller/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "1a39818abd9d8927e5ae8dae5f1597831d7a3acfbadf709532fea68ce96c022c";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/tricycle-steering-controller/default.nix
+++ b/distros/kilted/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-kilted-tricycle-steering-controller";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/tricycle_steering_controller/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "b73658eeb8e1b0457e1d7dea719badaa058b02c8807a725b43e9860de48d8c63";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/tricycle_steering_controller/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "8810ff2093fcdc9c0fd6ec3393b576f30912172525737ab1316bd82aee9a3785";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ur-client-library/default.nix
+++ b/distros/kilted/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-kilted-ur-client-library";
-  version = "2.9.0-r1";
+  version = "2.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/kilted/ur_client_library/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "034f7266c39230d9d0a2b2f1456074d67e2294fbdaaaa4d5ac518859c982b00e";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/kilted/ur_client_library/2.10.0-1.tar.gz";
+    name = "2.10.0-1.tar.gz";
+    sha256 = "cdfca1500853df6fe48ae74d3cee2710f9a14b502cc0fa91246b08bda6d89391";
   };
 
   buildType = "cmake";

--- a/distros/kilted/velocity-controllers/default.nix
+++ b/distros/kilted/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-velocity-controllers";
-  version = "5.14.0-r1";
+  version = "5.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/velocity_controllers/5.14.0-1.tar.gz";
-    name = "5.14.0-1.tar.gz";
-    sha256 = "5262b7a842b55fe4e35a9567e435ecb4a09561c6fe7057d3c2e52b4fa77f7872";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/kilted/velocity_controllers/5.15.0-1.tar.gz";
+    name = "5.15.0-1.tar.gz";
+    sha256 = "6edaed922a7282d3c13d25afd98b04ec3e5390abdd26a792694eb368ec209052";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/zstd-image-transport/default.nix
+++ b/distros/kilted/zstd-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, image-transport, zlib }:
 buildRosPackage {
   pname = "ros-kilted-zstd-image-transport";
-  version = "5.1.1-r1";
+  version = "5.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/kilted/zstd_image_transport/5.1.1-1.tar.gz";
-    name = "5.1.1-1.tar.gz";
-    sha256 = "d6071e6e93d6999afd6b9e9dc94a748f989e3e5676d74fc16d0ca74c323e7958";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/kilted/zstd_image_transport/5.1.2-1.tar.gz";
+    name = "5.1.2-1.tar.gz";
+    sha256 = "f9d1a149808e9aecd3c20deaac6d63d2e07bbb353712293df957631f59100bc6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ackermann-steering-controller/default.nix
+++ b/distros/rolling/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-ackermann-steering-controller";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "16fa27f2c8e673b59185fe0d4a98e1177545ad927aefc5bbca21ee1aa5130397";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "5ae90df9ad5699ea86591956e2bbe9d38531cd2846b81c375ae6d87b4f5163c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/admittance-controller/default.nix
+++ b/distros/rolling/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, tinyxml-2, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-admittance-controller";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "427a6edf21af948c0084028725f0e761ef3db447e880052349d7f3ad7e414bca";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "06964be71193f7d6c6dfd765cd7091b3ad6bd09fecc17faf043c7284707cf690";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-ros-core/default.nix
+++ b/distros/rolling/ament-cmake-ros-core/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-libraries, ament-lint-auto, ament-lint-common }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-export-targets, ament-cmake-libraries, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-ros-core";
-  version = "0.15.6-r1";
+  version = "0.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/rolling/ament_cmake_ros_core/0.15.6-1.tar.gz";
-    name = "0.15.6-1.tar.gz";
-    sha256 = "742e085acb136376d89718cefba0890c0eb6229e25bf9de7d9f59ba66be77e09";
+    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/rolling/ament_cmake_ros_core/0.15.7-1.tar.gz";
+    name = "0.15.7-1.tar.gz";
+    sha256 = "be8dd459d006872394536ae3b259026f7543e64b2d8dc64f376cb0a66cebff86";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-export-dependencies ];
+  buildInputs = [ ament-cmake-export-dependencies ament-cmake-export-targets ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ ament-cmake-core ament-cmake-libraries ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-export-dependencies ament-cmake-libraries ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-export-dependencies ament-cmake-export-targets ament-cmake-libraries ];
 
   meta = {
     description = "Core ROS specific CMake bits in the ament buildsystem.";

--- a/distros/rolling/ament-cmake-ros/default.nix
+++ b/distros/rolling/ament-cmake-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros-core, ament-lint-auto, ament-lint-common, rmw-test-fixture-implementation }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-ros";
-  version = "0.15.6-r1";
+  version = "0.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/rolling/ament_cmake_ros/0.15.6-1.tar.gz";
-    name = "0.15.6-1.tar.gz";
-    sha256 = "5a1fe07b259c19e439f58d6f205060c59a8a6030d491b7691b021deeb57d923b";
+    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/rolling/ament_cmake_ros/0.15.7-1.tar.gz";
+    name = "0.15.7-1.tar.gz";
+    sha256 = "e7a41e06bdc8fa026340a35612cdb4c53c74c44a5b6194d8139d4e81f9c46598";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/bag2-to-image/default.nix
+++ b/distros/rolling/bag2-to-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, opencv, rclcpp, rclcpp-components, rosbag2-cpp, rosbag2-storage, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-bag2-to-image";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/bag2_to_image-release/archive/release/rolling/bag2_to_image/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "95b904d60b8b7ab5236928900f02e1f5f6285ce7136d837f18013e58d114860a";
+    url = "https://github.com/ros2-gbp/bag2_to_image-release/archive/release/rolling/bag2_to_image/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "80e6cc2b5684c68e695394c37464e7c978a26eb5b3a54c719420cce0f4a37165";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/bicycle-steering-controller/default.nix
+++ b/distros/rolling/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-bicycle-steering-controller";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "6dc9da2f27e200b90b2c2d563b0e3bf693a3f3d9c69f598794720831695c70fe";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "319ec01200f274c50ddab71fd5b00e04cf7747b5dac82e0cf795150510dbefc1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/chained-filter-controller/default.nix
+++ b/distros/rolling/chained-filter-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, filters, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-chained-filter-controller";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/chained_filter_controller/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "3da046f1e3843afdfbb0bea1ebb8cdabb372d149fa09e6a918a05d84820dd5cf";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/chained_filter_controller/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "73bbdf465e7018b85a37d5e394977198a675c86f555647d52bc0db07745b6c48";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/cloudini-lib/default.nix
+++ b/distros/rolling/cloudini-lib/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, lz4, pcl, zstd }:
 buildRosPackage {
   pname = "ros-rolling-cloudini-lib";
-  version = "1.0.4-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/cloudini-release/archive/release/rolling/cloudini_lib/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "9af3d38293dda7122c355b49ec2e4a41a5cb8f63e5e70ebb3f4fe456818089bb";
+    url = "https://github.com/facontidavide/cloudini-release/archive/release/rolling/cloudini_lib/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "204f644e845267736e9f4db85a1aa3ce0ca96764c53289b3c1ee760d77a95138";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/cloudini-ros/default.nix
+++ b/distros/rolling/cloudini-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cloudini-lib, pcl-conversions, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, rclcpp-components, rosbag2-cpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-cloudini-ros";
-  version = "1.0.4-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/cloudini-release/archive/release/rolling/cloudini_ros/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "127cf3d124387e2ee62712e528b434261d9ee3383a3e17b431e16cbce9aa25f7";
+    url = "https://github.com/facontidavide/cloudini-release/archive/release/rolling/cloudini_ros/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "cee35a64856de7722ed24cef8e72f17c49ba6052750287353f0dd732f70e2628";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/control-toolbox/default.nix
+++ b/distros/rolling/control-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, eigen, filters, fmt, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-cmake, rsl, tf2, tf2-geometry-msgs, tf2-ros, tl-expected-nixpkgs }:
 buildRosPackage {
   pname = "ros-rolling-control-toolbox";
-  version = "6.2.0-r1";
+  version = "6.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/rolling/control_toolbox/6.2.0-1.tar.gz";
-    name = "6.2.0-1.tar.gz";
-    sha256 = "ea77e6e2fa3240fd715e52e5c672e461e636780133b24c91fbbbeae3e4d163d0";
+    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/rolling/control_toolbox/6.3.0-1.tar.gz";
+    name = "6.3.0-1.tar.gz";
+    sha256 = "bd2b82294ffc1b53df1dc03a5a7201ba05742f4fbe0694ef01d7b2f0f92f935c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-interface/default.nix
+++ b/distros/rolling/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, fmt, geometry-msgs, hardware-interface, pal-statistics, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-interface";
-  version = "6.5.1-r1";
+  version = "6.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/6.5.1-1.tar.gz";
-    name = "6.5.1-1.tar.gz";
-    sha256 = "d54fe863241691ce6f1411ea92c2d4b83602dd82f4ee22ca1ddfa72fd714a591";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/6.7.0-1.tar.gz";
+    name = "6.7.0-1.tar.gz";
+    sha256 = "cf27d0dab19279d49d947f6ef94ae72a4ef535ccbbdc505f34a20bbd9c44ea4b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager-msgs/default.nix
+++ b/distros/rolling/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager-msgs";
-  version = "6.5.1-r1";
+  version = "6.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/6.5.1-1.tar.gz";
-    name = "6.5.1-1.tar.gz";
-    sha256 = "7bfb4e002756d16908a0c291b622252292e0e8aba28d52baa9db34dca8d52df7";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/6.7.0-1.tar.gz";
+    name = "6.7.0-1.tar.gz";
+    sha256 = "50bfeae5e53909f6807dc9d1ad2d85364a14f7e0e4dca9f07fe52f1ef35d4350";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager/default.nix
+++ b/distros/rolling/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, example-interfaces, fmt, generate-parameter-library, hardware-interface, hardware-interface-testing, launch, launch-ros, launch-testing, launch-testing-ros, libstatistics-collector, lifecycle-msgs, pluginlib, python3Packages, rcl-interfaces, rclcpp, rclpy, realtime-tools, robot-state-publisher, ros2-control-cmake, ros2-control-test-assets, ros2param, ros2pkg, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager";
-  version = "6.5.1-r1";
+  version = "6.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/6.5.1-1.tar.gz";
-    name = "6.5.1-1.tar.gz";
-    sha256 = "cf14470035b702e3a7f90641e38cd598fb47f66d0162da0a8c5a8d51b0034030";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/6.7.0-1.tar.gz";
+    name = "6.7.0-1.tar.gz";
+    sha256 = "4fb8b34bbcc64fe9a6d0831a77b965f67d5031ff085c0faabfff253d89b6508b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/diff-drive-controller/default.nix
+++ b/distros/rolling/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diff-drive-controller";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "f7c497c7fa83b3800f7465fec2068dc9cec763cdda3cbfd1a1ee007319fc6ba0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "37d2767ec4bfdcf759a29f534b6682d716bbd0ab8231cc70aa0c21d41decbebe";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/domain-coordinator/default.nix
+++ b/distros/rolling/domain-coordinator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-domain-coordinator";
-  version = "0.15.6-r1";
+  version = "0.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/rolling/domain_coordinator/0.15.6-1.tar.gz";
-    name = "0.15.6-1.tar.gz";
-    sha256 = "ec301c654687b6b21644ce21f6ffcdc45e5e50c795b0b67032b23dfbd84ce7f5";
+    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/rolling/domain_coordinator/0.15.7-1.tar.gz";
+    name = "0.15.7-1.tar.gz";
+    sha256 = "91fa23be2aeac2a4ff1912f961817ea69a525fffe770ba752bb13a59e28da9f8";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/effort-controllers/default.nix
+++ b/distros/rolling/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-effort-controllers";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "a0b323758110a362cbc671414600c8f4cd6f00860f48e36e85f703d0c31c5db0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "bf5f29cdd8e7dd57dd3ce804009ee765e4cbb553a377ac36dbc0497482233d12";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fastdds/default.nix
+++ b/distros/rolling/fastdds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, python3, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-rolling-fastdds";
-  version = "3.6.0-r1";
+  version = "3.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastdds-release/archive/release/rolling/fastdds/3.6.0-1.tar.gz";
-    name = "3.6.0-1.tar.gz";
-    sha256 = "3c58608585b274d49825947788ad5ce75acb814742fd45dd013d073bd4480b09";
+    url = "https://github.com/ros2-gbp/fastdds-release/archive/release/rolling/fastdds/3.6.1-1.tar.gz";
+    name = "3.6.1-1.tar.gz";
+    sha256 = "8cc2de1126a88b6affca50983a8941fef9b4cbeb10b2f33cab89960f1513c3cc";
   };
 
   buildType = "cmake";

--- a/distros/rolling/force-torque-sensor-broadcaster/default.nix
+++ b/distros/rolling/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-force-torque-sensor-broadcaster";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "0920da5ade3a752d8cf0ea80b6411c56889830cafa45122812d9a4962fd4e59e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "d9c2a1e034249cde97f2e94af679afeb3c870164831c6073515408bfc15b7a79";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/forward-command-controller/default.nix
+++ b/distros/rolling/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-forward-command-controller";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "72b7fa8ec7b23fc2deec3aea53d6f9cb78eb59f09f96dad4a68cec6348978199";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "4d54570a8aa6b20cc286dd3aadb8ca131c9a40d35f612828a3f598d3de6bbebd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -2248,6 +2248,8 @@ self: super: {
 
  ros-babel-fish-test-msgs = self.callPackage ./ros-babel-fish-test-msgs {};
 
+ ros-babel-fish-tools = self.callPackage ./ros-babel-fish-tools {};
+
  ros-base = self.callPackage ./ros-base {};
 
  ros-core = self.callPackage ./ros-core {};
@@ -2432,6 +2434,14 @@ self: super: {
 
  rpyutils = self.callPackage ./rpyutils {};
 
+ rqml = self.callPackage ./rqml {};
+
+ rqml-core = self.callPackage ./rqml-core {};
+
+ rqml-default-plugins = self.callPackage ./rqml-default-plugins {};
+
+ rqml-plugin-example = self.callPackage ./rqml-plugin-example {};
+
  rqt = self.callPackage ./rqt {};
 
  rqt-action = self.callPackage ./rqt-action {};
@@ -2539,6 +2549,8 @@ self: super: {
  rtabmap-viz = self.callPackage ./rtabmap-viz {};
 
  rtcm-msgs = self.callPackage ./rtcm-msgs {};
+
+ rtest = self.callPackage ./rtest {};
 
  rti-connext-dds-cmake-module = self.callPackage ./rti-connext-dds-cmake-module {};
 

--- a/distros/rolling/gpio-controllers/default.nix
+++ b/distros/rolling/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-gpio-controllers";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gpio_controllers/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "376b2c4adf30a8c171d09a3317f7fee857bc8a0cbaed580ef1d61252abb51f09";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gpio_controllers/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "fef70b98e72204f7285d8bca127828a914d01ec99f5e1cfb9290d1dd49d222e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gps-sensor-broadcaster/default.nix
+++ b/distros/rolling/gps-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-gps-sensor-broadcaster";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gps_sensor_broadcaster/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "e31d13f549cb3e8d08443e768ce32e6fa112a47832d5aec310b3573d008f7d73";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gps_sensor_broadcaster/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "b6656c58220ae242efe0f8e336d85c49a5d374833372f62447e3a18d906da77c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-cmake-vendor/default.nix
+++ b/distros/rolling/gz-cmake-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, pkg-config }:
 buildRosPackage {
   pname = "ros-rolling-gz-cmake-vendor";
-  version = "0.4.3-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_cmake_vendor-release/archive/release/rolling/gz_cmake_vendor/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "b75e3d13eb822220159554f548c194c2dfa500c5d2a3b2c0066b0e98ae92129b";
+    url = "https://github.com/ros2-gbp/gz_cmake_vendor-release/archive/release/rolling/gz_cmake_vendor/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "a9d45ce329c2c2554a68693daa97d2f2d614ef586b079e55935f48fbd5f55936";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake pkg-config ];
 
   meta = {
-    description = "Vendor package for: gz-cmake 5.0.2
+    description = "Vendor package for: gz-cmake 5.1.0
 
     Gazebo CMake : CMake Modules for Gazebo Projects";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-cmake-vendor/vendored-source.json
+++ b/distros/rolling/gz-cmake-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_cmake_vendor": {
     "url": "https://github.com/gazebosim/gz-cmake.git",
-    "rev": "gz-cmake5_5.0.2",
-    "hash": "sha256-OEEG4hQK8YxEl2SXqi02pNsLVD3biyKEW7kRQlFrRqs="
+    "rev": "gz-cmake5_5.1.0",
+    "hash": "sha256-o7JI3K1VuM1MKG0Wq0QUtyRI8cfBnHsW2mFuoapEQW8="
   }
 }

--- a/distros/rolling/gz-dartsim-vendor/default.nix
+++ b/distros/rolling/gz-dartsim-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp, boost, bullet, eigen, fcl, fmt, libccd, lz4, octomap, ode, tinyxml-2, urdfdom }:
 buildRosPackage {
   pname = "ros-rolling-gz-dartsim-vendor";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_dartsim_vendor-release/archive/release/rolling/gz_dartsim_vendor/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "50e76ad9f990ca6c81e2b8c015fc8e00c79af5c4fefc549ab6f0d10abbb24ba0";
+    url = "https://github.com/ros2-gbp/gz_dartsim_vendor-release/archive/release/rolling/gz_dartsim_vendor/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "c8b93c59676cda0f26c091485249484c633d413d760440bef592cd4ec23ec581";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package ];
 
   meta = {
-    description = "Vendor package for the DART physics engine v6.13.2";
+    description = "Vendor package for the DART physics engine v6.16.6";
     license = with lib.licenses; [ asl20 bsd2 ];
   };
 }

--- a/distros/rolling/gz-dartsim-vendor/vendored-source.json
+++ b/distros/rolling/gz-dartsim-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_dartsim_vendor": {
     "url": "https://github.com/dartsim/dart.git",
-    "rev": "v6.13.2",
-    "hash": "sha256-AfKPqUiW6BsM98TIzTY2ZcFP1WvURs8/dGOzanIiB9g="
+    "rev": "v6.16.6",
+    "hash": "sha256-4O5FaOG0J2DaHQ/Idt6DBhQkNqocL70ZC1MQEfoElCM="
   }
 }

--- a/distros/rolling/gz-math-vendor/default.nix
+++ b/distros/rolling/gz-math-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, eigen, gz-cmake-vendor, gz-utils-vendor, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-gz-math-vendor";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_math_vendor-release/archive/release/rolling/gz_math_vendor/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "7e531185225ffc28be4680458c79561e53f5ebedb3dc6e13b327bf34ec249410";
+    url = "https://github.com/ros2-gbp/gz_math_vendor-release/archive/release/rolling/gz_math_vendor/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "474342c489e05f39f53d9d2ca119c3ec7826e6391f354200d549c4b7621ac855";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-math 9.0.0
+    description = "Vendor package for: gz-math 9.1.0
 
     Gazebo Math : Math classes and functions for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-math-vendor/vendored-source.json
+++ b/distros/rolling/gz-math-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_math_vendor": {
     "url": "https://github.com/gazebosim/gz-math.git",
-    "rev": "gz-math9_9.0.0",
-    "hash": "sha256-5SGZtciJF+k0wjjU+O3I8CxAVnI8XpLLOuv4hsagb/4="
+    "rev": "gz-math9_9.1.0",
+    "hash": "sha256-Kc9g5D52+NVygYLpMf+4GFPPn2sTEfXBOC14iw39NlA="
   }
 }

--- a/distros/rolling/hardware-interface-testing/default.nix
+++ b/distros/rolling/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, fmt, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface-testing";
-  version = "6.5.1-r1";
+  version = "6.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/6.5.1-1.tar.gz";
-    name = "6.5.1-1.tar.gz";
-    sha256 = "6ed27cd087b7eddaca0ab5f285cb63dfce32bb11043c4a9dd7f18ce5d3c3f3d6";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/6.7.0-1.tar.gz";
+    name = "6.7.0-1.tar.gz";
+    sha256 = "5ae419cdbc833cf599074fc5c5d4c31a7eccb138039e11c7d1568ed329863b4e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/hardware-interface/default.nix
+++ b/distros/rolling/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, control-msgs, fmt, joint-limits, lifecycle-msgs, pal-statistics, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sdformat-urdf, tinyxml-2, urdf }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface";
-  version = "6.5.1-r1";
+  version = "6.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/6.5.1-1.tar.gz";
-    name = "6.5.1-1.tar.gz";
-    sha256 = "996b5711d7da078c0d8798fc5a562f17b810eb5faa3deb12ff127ce9bcb04b44";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/6.7.0-1.tar.gz";
+    name = "6.7.0-1.tar.gz";
+    sha256 = "9542f9a40e72087c94fdbe2205eb1d44a6802b7daccde010c14447595733e617";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/imu-sensor-broadcaster/default.nix
+++ b/distros/rolling/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, eigen, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-imu-sensor-broadcaster";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "159f16d07bff16c7929780682ff67fede4599af7ce1d532940ce46a54fcf4086";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "cd7ca50ae14a6f9dbff9d957f5426cb91457099f00a46e51f90bb6bfe34b093d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-limits/default.nix
+++ b/distros/rolling/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, fmt, generate-parameter-library, launch-ros, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-limits";
-  version = "6.5.1-r1";
+  version = "6.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/6.5.1-1.tar.gz";
-    name = "6.5.1-1.tar.gz";
-    sha256 = "35ebca38fd18726ed636e05e4424458061e1fd800430af7445e0771114a79954";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/6.7.0-1.tar.gz";
+    name = "6.7.0-1.tar.gz";
+    sha256 = "93acb39bf72ca136fddca8b20a268f78f17c75cd6813af0427e0b63e5dd6e885";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-state-broadcaster/default.nix
+++ b/distros/rolling/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-state-broadcaster";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "49647d9105dee0ca94f7e209b66959f5371cee215ea3c9c820c0c754721bf0f6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "ea3fb1cd90d5a20db7df7ef5402f50206324c3f4ac526d04abcbf6a1ba5d97c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-trajectory-controller/default.nix
+++ b/distros/rolling/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, rsl, tl-expected-nixpkgs, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-trajectory-controller";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "c49759e1fe880e4260feb2bbc5dc6bd087389fb8a19c23454e9018a52779c7bb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "7f372cff336abdccbb77e164a93a1f34afae8efc5391a760693308660883d288";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/kitti-metrics-eval/default.nix
+++ b/distros/rolling/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmath, mrpt-libposes, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-rolling-kitti-metrics-eval";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/kitti_metrics_eval/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "00ed24e58d01edf4a37e4e426dd704170acb0d820efa730946878cc8ce5f10cc";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/kitti_metrics_eval/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "91d06a976d96854030b7d800f8d0747e3bf88e7d6df5c5bdc8695c97030096dc";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mecanum-drive-controller/default.nix
+++ b/distros/rolling/mecanum-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mecanum-drive-controller";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/mecanum_drive_controller/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "99af797eb10e1a41feedae38b7c05f508379da36b49bc451fcd4b6ed0ec5d4f6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/mecanum_drive_controller/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "2564aa69272eb36806697488430648c59392414d5ad81e128f138b683f47b7db";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-bridge-ros2/default.nix
+++ b/distros/rolling/mola-bridge-ros2/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, geographic-msgs, geometry-msgs, gps-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, diagnostic-msgs, geographic-msgs, geometry-msgs, gps-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mola-bridge-ros2";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_bridge_ros2/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "6f402f06161b92ebf6e5c8600b10be0819bdbd6be7cc4d2ebc3d81445d10ca49";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_bridge_ros2/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "ef30612117d05b23aaa01ae7bd8ebb21007446fd3c3a798f0f879755f80471a5";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ros-environment ];
   checkInputs = [ ament-cmake-xmllint ament-lint-auto ament-lint-cmake ];
-  propagatedBuildInputs = [ geographic-msgs geometry-msgs gps-msgs mola-common mola-kernel mola-msgs mrpt-libmaps mrpt-libros-bridge mrpt-nav-interfaces nav-msgs rclcpp sensor-msgs tf2 tf2-geometry-msgs ];
+  propagatedBuildInputs = [ diagnostic-msgs geographic-msgs geometry-msgs gps-msgs mola-common mola-kernel mola-msgs mrpt-libmaps mrpt-libros-bridge mrpt-nav-interfaces nav-msgs rclcpp sensor-msgs tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/rolling/mola-demos/default.nix
+++ b/distros/rolling/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-demos";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_demos/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "a140c4014e9378eb9aae3a5627e95c0dbfed0de7742fb1e66df47d7d9480a2ee";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_demos/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "a5a318e8fba212620c15c2db336050db3c40870d454e773f30306607fb7a0279";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-imu-preintegration/default.nix
+++ b/distros/rolling/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-imu-preintegration";
-  version = "1.15.0-r1";
+  version = "1.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_imu_preintegration-release/archive/release/rolling/mola_imu_preintegration/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "802176b98de955961515044f060c2003cbcff62a2df737edafa9ed10c0cceea7";
+    url = "https://github.com/ros2-gbp/mola_imu_preintegration-release/archive/release/rolling/mola_imu_preintegration/1.16.0-1.tar.gz";
+    name = "1.16.0-1.tar.gz";
+    sha256 = "84c7f9b45283189670566eefe9d9aab9d7eedae08ae250292039833b53937e03";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-euroc-dataset/default.nix
+++ b/distros/rolling/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmath, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-euroc-dataset";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_euroc_dataset/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "2ad53fd686bc2a22e6d4e1857372b87b1d73ddee985f6b11dc3ea8bc045c27d2";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_euroc_dataset/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "76c132031549b5c4be5623e9c05e2c757c17e04c16c1009e0f363002d1e740f7";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-kitti-dataset/default.nix
+++ b/distros/rolling/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-kitti-dataset";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti_dataset/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "6dc3a84125103af332244c92373c6294a7d3ac1fcb22513de4fde087e1e459c8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti_dataset/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "52b118cae1b6b120c0feaacaa980bea06d2ff7774ceeb952c6ce5766fef0ad81";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-kitti360-dataset/default.nix
+++ b/distros/rolling/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-kitti360-dataset";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti360_dataset/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "cd537bf97dec4f8fb8be64d75cb96a33e7c7226fe9fbee3da22473ff23a75661";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti360_dataset/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "e0571962cc848597b19c9ea7a3eae955ab6a09a4d5decb8337d4ed78113f6257";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-lidar-bin-dataset/default.nix
+++ b/distros/rolling/mola-input-lidar-bin-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-lidar-bin-dataset";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_lidar_bin_dataset/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "2dfff2232ca53bd02e8826554f2562d63acc186fb75a3f2a7ff16ea94b7bf3a5";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_lidar_bin_dataset/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "f91370fd3bb432da2a5473a47ca354a247cb1441d7d9b4dccb200102fc543a0a";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-mulran-dataset/default.nix
+++ b/distros/rolling/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-mulran-dataset";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_mulran_dataset/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "f6308524bd68cfbc766c2bb1ae9c72e4a42744a59c0acd9c4d5c24b6928fa73e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_mulran_dataset/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "6cb01f79847bf006420a33c0b4435e3c0cf1ad93c66896ededf2928964d4a8cc";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-paris-luco-dataset/default.nix
+++ b/distros/rolling/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-paris-luco-dataset";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_paris_luco_dataset/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "7176f81ef8bfc9a31db5572ee62fb206e29959610ad60c04777c1c1867b4fe0e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_paris_luco_dataset/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "a1f78ab4fd319e732bf5e5ebd38e2379baaf546f2510dac370612789078571ad";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-rawlog/default.nix
+++ b/distros/rolling/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-rawlog";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rawlog/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "d6dbda0a6ccbc1eb743b01fc4112925e1be3e3316994f52dd957dc7970025ce8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rawlog/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "973e4ebbc3cbc840f2fd0160ffe16d61071a546a11c015e2bddc5329975dd8b5";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-rosbag2/default.nix
+++ b/distros/rolling/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, gps-msgs, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-rosbag2";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rosbag2/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "3a66c5319c5158b2030cfc5e566bdd79291e8af76a657adcbb84a765f8cfe0f9";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rosbag2/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "cba0f3600d6fb4b571aec193db5322290d25900f5d50d66359c741e518122eaf";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-video/default.nix
+++ b/distros/rolling/mola-input-video/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libhwdrivers, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-video";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_video/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "e624f841849084887f3d5e622d2b767f7014b304d7ea5bf0c39c94171c5394af";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_video/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "e039a700046b6196d7f8a4045c0f73141bb6ccdca5376fb78a1badd6c8aafbf5";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-kernel/default.nix
+++ b/distros/rolling/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libgui, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-kernel";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_kernel/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "6dcfd3d8f6e69c7b6fa6dd2097419deb8bd0cfaa52413b168da396f070fd4e62";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_kernel/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "fc08d0bf0662d0f76be6380ee2e04dac65fdcaefeaf11e56e6db4da1915406d7";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-launcher/default.nix
+++ b/distros/rolling/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-xmllint, ament-lint-auto, cmake, mola-kernel, mrpt-libbase, mrpt-libtclap, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-launcher";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_launcher/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "89cdcb006b9e470a7cd4fa38be7af406872ee427e63ed27ead7b1569122efc62";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_launcher/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "6e1029fd1f660d16e390af0bc0ef0abdfb30d1832f5975fc2de05680970d5765";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-metric-maps/default.nix
+++ b/distros/rolling/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mp2p-icp, mrpt-libmaps, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-metric-maps";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_metric_maps/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "ed799f673eaa1f9ad34d74f61f6be54889fde4891f9444be4c4e3048abde0655";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_metric_maps/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "d228b7d7778c5bc346179d0ada695d5c411dda1a0414adb9a6025524b92baee3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-msgs/default.nix
+++ b/distros/rolling/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-mola-msgs";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_msgs/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "608562cf668a6e2cac9a569a032775bf3725bc792a395b6223ad4a04914f9b92";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_msgs/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "61246d527d38e12c87eb8587e3a0dddfecb5fe27918653c6607f80b7f20707c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-pose-list/default.nix
+++ b/distros/rolling/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-rolling-mola-pose-list";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_pose_list/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "206613c60b312d623cec4838887ba1b99c25f57fb3b225f39c848e7415486db3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_pose_list/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "1377d075284ea086b8949146eb351a0775118453775218ab40e5e53e658efec4";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-relocalization/default.nix
+++ b/distros/rolling/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-rolling-mola-relocalization";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_relocalization/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "c7caf3f5197bb5be82cf00512c41f67342803395b64b8adfb1cc45dae05f251c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_relocalization/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "c45e24fd655d21a90b4c4b7b11b50f33af1e3b4dbca76e467245e11b3d558132";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-traj-tools/default.nix
+++ b/distros/rolling/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-rolling-mola-traj-tools";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_traj_tools/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "5c629805fa2cea36e2a735cfa87d5a17967c1be917350cff519bd516044f735a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_traj_tools/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "75f7f0eb29a37f8eaeeb32498da0b0aec62f6d1539c568bf9f4115be4ec3c89f";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-viz/default.nix
+++ b/distros/rolling/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-rolling-mola-viz";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "267abcceef54587d49f69d2215954249195e13d45a40ea8c5c691df02471c95e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "815f247e54199835fe00f64f312a53b1695946c77106b38c00d07b777814ad5d";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-yaml/default.nix
+++ b/distros/rolling/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-rolling-mola-yaml";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_yaml/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "83434cc26b191f7ee6c90cd8e5827da10e6774d7a346ac0f1df3b4c110ee1573";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_yaml/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "29c49ad1a986cf50dda98feaed87ea1d28460462d762317d9a04ac91bb28d437";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola/default.nix
+++ b/distros/rolling/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-input-video, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-rolling-mola";
-  version = "2.6.1-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "c6b47bb780e7756b96c8b8237952f222aa4c3b021081e03c40b1e0727cfa430d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "3895c5ece635fc5d44e39eaf5fb7022c8500750e4d6efe5d1038df4ed8480c9c";
   };
 
   buildType = "cmake";

--- a/distros/rolling/motion-primitives-controllers/default.nix
+++ b/distros/rolling/motion-primitives-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-motion-primitives-controllers";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/motion_primitives_controllers/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "4c2d6af7d2eb3871f488d157c00de6561493b1c9849d391e7942c389414647a1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/motion_primitives_controllers/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "78e066f4aecf7b966bd8efd92b55aaf8bd5089f86f6ff4ef96c675567f4134b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mp2p-icp/default.nix
+++ b/distros/rolling/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mp2p-icp";
-  version = "2.8.1-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "9e109e0b24bb22dba67d46ec0983af55b6cdafb206e874456375ad7ab72d8747";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "800895adf1c33195b464f904a85c60df6bdca40c1c0c9ff00df1a1b9e3625017";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-apps/default.nix
+++ b/distros/rolling/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-apps";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_apps/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "9f4753c87b0c70317139bcc64162fe77c87cfd65b1cf7d240be32e797c99483e";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_apps/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "8cdbefcfe3f877a0d5bcceb6f67ee952d47e04cce3b08c6028c79d0c923c8281";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libapps/default.nix
+++ b/distros/rolling/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libapps";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libapps/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "47ba86143117399df76f3a198188427d654d7e0682aedfe11eac5c33dc7ed0cc";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libapps/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "4c7e4aa311c71da352946a8e84380f0475f9b2007590aa970efa4733eac151e2";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libbase/default.nix
+++ b/distros/rolling/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, onetbb, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib, zstd }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libbase";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libbase/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "766aae44d61500e65c885dbef74670c6501c756c439e7ccd8d385d982ce27bad";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libbase/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "2280489f03baa11e49c4bd7470702766b397e288e1e8a80271c5870e2f36fa94";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libgui/default.nix
+++ b/distros/rolling/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libgui";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libgui/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "7771b39e2b2edb0c2d72413ad98063adc50ea3aae00e9c4e8e47a5590ef7acce";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libgui/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "3fad2088bb3d0a02757fd179a440c3ace57c0783abf2224e9a178bac9d916bd1";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libhwdrivers/default.nix
+++ b/distros/rolling/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libhwdrivers";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libhwdrivers/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "86ddbe28b309be7dfad4cb4ad896bb2bbed38c8b889ab46d2778b6ca3a540749";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libhwdrivers/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "dbad6106018cac6ceb169c8189ae2feaf6100d9047f3fdb2d135663c366b0865";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libmaps/default.nix
+++ b/distros/rolling/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libmaps";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmaps/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "131df8f9d1878cbed1646f60dfbfcef59ec910f0cd1681e498e94bb1e515813f";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmaps/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "6fcd2d4fefc3edf0ed6c13cefcec873a6d0ab5e3d84a0ca4b1bc485faa404b2f";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libmath/default.nix
+++ b/distros/rolling/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libmath";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmath/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "3ee596b699edf373f477b7ee0c8913cbc64d2b91723ffdd71a3288ba341d5fb2";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmath/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "a3a7084eb6a9d91490ca4f27d40ac85b9f2bad9aa9930a01c8ccc33c885dc127";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libnav/default.nix
+++ b/distros/rolling/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libnav";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libnav/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "b203aff0c737e27a94d88cef82eb45278d2ee1d824d0b94d4b525235b9eec41b";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libnav/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "8462d2e5269ef5473dce224b55ceb3a68375db703eeb2752eb891af942c90fc6";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libobs/default.nix
+++ b/distros/rolling/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libobs";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libobs/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "1bbce4932deceaa46e2a4a095f0df2ab2db38deebbbe92ffee976082a85516f0";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libobs/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "74091345d27ac7a0629c8b2bca4674f16e5bc7502e70a3ebb21466bdc6c51d34";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libopengl/default.nix
+++ b/distros/rolling/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libopengl";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libopengl/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "28cc54cba2bcefd17ddcd2ce38a1193163b3791705786cad9fe6f911bc0a9e74";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libopengl/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "4576ec46084c1e714acee19bd0be0e8543174ea0425528a474a1d611e1d5c9c6";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libposes/default.nix
+++ b/distros/rolling/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libposes";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libposes/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "d4b8c2b0bde64de18a8fb31be90c91a716e571868115415e94e320b066bd47ad";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libposes/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "003bfcdb2bd0e94ca43c3dfe57e14a2473f0dd56c91e473f93d8bde7dead6def";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libros-bridge/default.nix
+++ b/distros/rolling/mrpt-libros-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cmake, cv-bridge, geometry-msgs, gps-msgs, mrpt-libmaps, mrpt-libobs, nav-msgs, ros-environment, rosbag2-cpp, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libros-bridge";
-  version = "3.5.1-r1";
+  version = "3.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/rolling/mrpt_libros_bridge/3.5.1-1.tar.gz";
-    name = "3.5.1-1.tar.gz";
-    sha256 = "c4f7d06c8f3150e1c7727ac58ee04d5ed9a8dda9713f7346d896c330b0f0478c";
+    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/rolling/mrpt_libros_bridge/3.5.2-1.tar.gz";
+    name = "3.5.2-1.tar.gz";
+    sha256 = "65c41ea02fdfe2982476165b6cdfe107aefddc6d36fdac09fc14b53a4053fb9f";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libslam/default.nix
+++ b/distros/rolling/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, onetbb, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libslam";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libslam/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "490d29b14a7f5b88095113a0ef388576809f83b6352d6b19520b3af80db6d0e9";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libslam/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "85caf375325162d3ab1fc2cac2c49dab043969b8daa8dbb749246915b69bd0c9";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libtclap/default.nix
+++ b/distros/rolling/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libtclap";
-  version = "2.15.13-r1";
+  version = "2.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libtclap/2.15.13-1.tar.gz";
-    name = "2.15.13-1.tar.gz";
-    sha256 = "acbc50cdd7090ad8090cf9fe4dd5c5a8f6445f237faac87ace41391d4b807a3d";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libtclap/2.15.14-1.tar.gz";
+    name = "2.15.14-1.tar.gz";
+    sha256 = "507a3072ba6b375f2ca7a2f7d0a11a14d7bd44fbecc76d7d07241689ac55c016";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-map-server/default.nix
+++ b/distros/rolling/mrpt-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libros-bridge, mrpt-msgs, mrpt-nav-interfaces, rclcpp-components, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-map-server";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_map_server/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "74cba971da80b3ea5ecf79417220ca8e3f4c314b2b7c99dc781c1e98148e1cc2";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_map_server/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "ca4d5af5187364e6e373398c2378be4b2c2736199dfdbf5ceffc17a1d53f0f62";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mrpt-msgs-bridge/default.nix
+++ b/distros/rolling/mrpt-msgs-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, mrpt-libobs, mrpt-libros-bridge, mrpt-msgs, rclcpp, ros-environment, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-msgs-bridge";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_msgs_bridge/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "cd838f2fb766c6f169e486336391f2a7bf31f09bc80c6d36611ce4ff3a986732";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_msgs_bridge/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "8b50601f1f5677bdc87e4225d5a9c13e8ae2d5e939f16a16af52d0ed7b652011";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mrpt-nav-interfaces/default.nix
+++ b/distros/rolling/mrpt-nav-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, geometry-msgs, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-nav-interfaces";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_nav_interfaces/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "9bfe971b3fb6e072527b512e8693eb7bf80ec77aad776bc1bb92f86dcfe2521d";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_nav_interfaces/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "660761977fb84f5d41df3ba3077601aa60351b13aef2c69beaeb125ed4648753";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mrpt-navigation/default.nix
+++ b/distros/rolling/mrpt-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-map-server, mrpt-msgs-bridge, mrpt-nav-interfaces, mrpt-pf-localization, mrpt-pointcloud-pipeline, mrpt-reactivenav2d, mrpt-tps-astar-planner, mrpt-tutorials }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-navigation";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_navigation/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "d405f85ff0a91fb178a5a459d0ca754663c2f99eae175e07137662d0ae13daed";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_navigation/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "223a2cb0678b4ecc6aa6ae0e48c4cfa66c19fdc7924b249858ce096ca448a898";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mrpt-pf-localization/default.nix
+++ b/distros/rolling/mrpt-pf-localization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, cmake, mola-relocalization, mp2p-icp, mrpt-libgui, mrpt-libros-bridge, mrpt-libslam, mrpt-msgs, mrpt-msgs-bridge, mrpt-tutorials, nav-msgs, pose-cov-ops, rclcpp, rclcpp-components, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-pf-localization";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_pf_localization/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "2f5fb585db8ceb0beddf36d0c8864788e2c4cc4c07b553f61f700aaff406dc78";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_pf_localization/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "8e1bbe5e51bd1b0a6630d0ce0b4a99844325cf35761ed8bacbaf6d7f54df1c0d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mrpt-pointcloud-pipeline/default.nix
+++ b/distros/rolling/mrpt-pointcloud-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, mp2p-icp, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libros-bridge, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-pointcloud-pipeline";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_pointcloud_pipeline/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "3e702adda3514acb54e88de6e7aa87963c414ab4e2b407c34a5b40a088736342";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_pointcloud_pipeline/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "6aab7d08594171666f6c8328a29b154127e5444728a9a2bf1656fe56535fe527";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mrpt-reactivenav2d/default.nix
+++ b/distros/rolling/mrpt-reactivenav2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, mrpt-libnav, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-reactivenav2d";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_reactivenav2d/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "abae944a024928d82d61f17d8f391adb42cfcd20db17d0ed70d8d974b3cf7150";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_reactivenav2d/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "f40ace63a6105abb185ac3dac7a31e4bcbf3168685926f449a0ed8b4d0441658";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mrpt-tps-astar-planner/default.nix
+++ b/distros/rolling/mrpt-tps-astar-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-libgui, mrpt-libmaps, mrpt-libnav, mrpt-libros-bridge, mrpt-msgs, mrpt-nav-interfaces, mrpt-path-planning, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-tps-astar-planner";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_tps_astar_planner/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "2b6ec4db9bdbcf533534077deda854f8e1c06f48f1e33aea7bfe6547039b059e";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_tps_astar_planner/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "424a45b6020578d22832bea775f60ec59baed8c6cdaaffd66f60262d2a4d3a56";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mrpt-tutorials/default.nix
+++ b/distros/rolling/mrpt-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, cmake, mvsim, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-tutorials";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_tutorials/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "19ac690c6b88d13b663ee403b26ed0acc82a3e8cb42ac59e56620ee9f415fcee";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_tutorials/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "ea8a0a1e51add82ab66eb3dd9785e1c6bab6e1d2e648a7ec409e88c1b1e27a7b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/omni-wheel-drive-controller/default.nix
+++ b/distros/rolling/omni-wheel-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, eigen, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-omni-wheel-drive-controller";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/omni_wheel_drive_controller/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "300a23a32513ea90d2af013cb6cb5a29ca7dbac61899e2958bd39b83f4630955";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/omni_wheel_drive_controller/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "9acc611ee992cf46156343542398fc7bfe31b517d57e0c74d2a187ac258fbae5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -32,19 +32,6 @@ in {
     '';
   });
 
-  bag2-to-image = rosSuper.bag2-to-image.overrideAttrs ({
-    patches ? [], ...
-  }: {
-    patches = [
-      # Fix compile error caused by rosidl_buffer introduction
-      # https://github.com/wep21/bag2_to_image/pull/8
-      (self.fetchpatch2 {
-        url = "https://github.com/wep21/bag2_to_image/commit/1c6ff87fa27244db7f15597c9cd6ecad34479208.patch?full_index=1";
-        hash = "sha256-GFPd1MdWgjxnDBqwiO/GKIYLHkY3eGG297HKOAoZacw=";
-      })
-    ];
-  });
-
   battery-state-broadcaster = rosSuper.battery-state-broadcaster.overrideAttrs ({
     patches ? [], ...
   }: {

--- a/distros/rolling/parallel-gripper-controller/default.nix
+++ b/distros/rolling/parallel-gripper-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-parallel-gripper-controller";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/parallel_gripper_controller/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "f83fc158c1c9dd627a7ba73812eaa9fd706d80b69cae0ea26f1fdc39632e3e32";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/parallel_gripper_controller/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "b892c50b45fbad3ff1fea6a604e1281dc2fa6cb159e05134fcb43e265c774031";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pid-controller/default.nix
+++ b/distros/rolling/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-pid-controller";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pid_controller/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "0894e4ac80d71607dbf289857312bbe6e8f870bd33e7f2b92d94295eb4afe654";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pid_controller/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "385d1b752d9c11cbe2f08654f6d26f235333af9e76792a99b2d695841b8849cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pose-broadcaster/default.nix
+++ b/distros/rolling/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-pose-broadcaster";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pose_broadcaster/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "ca70ef6e45fc06b70667d71159b3703df1d1847a277749e090a73434f5e3c3a0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pose_broadcaster/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "10e924db1b32aa9036ae4cde12fd16fbcca841953f870c27b7aa1a382fc6099f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/position-controllers/default.nix
+++ b/distros/rolling/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-position-controllers";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "962552a4869d986bf3e2f9791ac1d643afd9087dc33a8bf68a99d808aa37e617";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "ba3612c1928fb08114699d6c0a531a7695a66a82a06955122f2651f2fb717500";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/python-qt-binding/default.nix
+++ b/distros/rolling/python-qt-binding/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_python3-qt-bindings, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, qt6 }:
+{ lib, buildRosPackage, fetchurl, _unresolved_python3-qt-bindings, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3 }:
 buildRosPackage {
   pname = "ros-rolling-python-qt-binding";
-  version = "2.5.0-r1";
+  version = "2.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/python_qt_binding-release/archive/release/rolling/python_qt_binding/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "a6657e7e59dfe321499dcac3dc915afd929e8c0e6197ce33e43034be8339e951";
+    url = "https://github.com/ros2-gbp/python_qt_binding-release/archive/release/rolling/python_qt_binding/2.5.2-1.tar.gz";
+    name = "2.5.2-1.tar.gz";
+    sha256 = "a74bf620f53f05764e2c9c02671294e6cee220a1a74aa3a45231adea79a09556";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ _unresolved_python3-qt-bindings ament-cmake qt6.qtbase ];
+  buildInputs = [ _unresolved_python3-qt-bindings ament-cmake ];
   checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ python3 ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/qml6-ros2-plugin/default.nix
+++ b/distros/rolling/qml6-ros2-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, example-interfaces, image-transport, qt6, rclcpp, ros-babel-fish, ros-babel-fish-test-msgs, std-srvs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-qml6-ros2-plugin";
-  version = "4.26.40-r1";
+  version = "4.26.42-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qml6_ros2_plugin-release/archive/release/rolling/qml6_ros2_plugin/4.26.40-1.tar.gz";
-    name = "4.26.40-1.tar.gz";
-    sha256 = "1625eb942cd241d67210c2735f4b133c3efb66788f3895f65b8cc94aca4c5659";
+    url = "https://github.com/ros2-gbp/qml6_ros2_plugin-release/archive/release/rolling/qml6_ros2_plugin/4.26.42-1.tar.gz";
+    name = "4.26.42-1.tar.gz";
+    sha256 = "70e15f185eca45ebe27444c09d095a0ce2d24770987b2282d198d5d82c2324a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/range-sensor-broadcaster/default.nix
+++ b/distros/rolling/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-range-sensor-broadcaster";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "28483a5a3ef4c7dc1201dff797d3075bac0e41019bb26b14bdb37894f97763ef";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "eb65072166a1a7f46dc5babf83d80d50d95721b7f0ee4703f880808c107bbbd9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcutils/default.nix
+++ b/distros/rolling/rcutils/default.nix
@@ -5,17 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros-core, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture }:
 buildRosPackage {
   pname = "ros-rolling-rcutils";
-  version = "7.0.9-r1";
+  version = "7.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/rolling/rcutils/7.0.9-1.tar.gz";
-    name = "7.0.9-1.tar.gz";
-    sha256 = "7979e4d733a85c3c47d45292e2b545f7fb639f157c4ce088a5a4ea151d790627";
+    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/rolling/rcutils/7.1.1-1.tar.gz";
+    name = "7.1.1-1.tar.gz";
+    sha256 = "853d00b26f8e529d7a5aaddc0cb9c51f3b279aafe9e57234799a3c6196ad76ff";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-ros-core ];
+  buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common launch launch-testing launch-testing-ament-cmake mimick-vendor osrf-testing-tools-cpp performance-test-fixture ];
+  propagatedBuildInputs = [ ament-cmake-ros-core ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros-core ];
 
   meta = {

--- a/distros/rolling/rmf-demos-assets/default.nix
+++ b/distros/rolling/rmf-demos-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-rmf-demos-assets";
-  version = "2.8.2-r1";
+  version = "2.8.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos_assets/2.8.2-1.tar.gz";
-    name = "2.8.2-1.tar.gz";
-    sha256 = "40b00d776f5f5165ac05013a3c9a5b5146ebcea968cb08ce43ff756fe92c6578";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos_assets/2.8.2-2.tar.gz";
+    name = "2.8.2-2.tar.gz";
+    sha256 = "e7de0e795394a1fe535297dc9edfeb3e455b74f95d87f1a198c9e56716de56b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-demos-bridges/default.nix
+++ b/distros/rolling/rmf-demos-bridges/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages, rmf-building-map-tools, rmf-fleet-msgs, rmf-site-map-msgs, rmf-traffic-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmf-demos-bridges";
-  version = "2.8.2-r1";
+  version = "2.8.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos_bridges/2.8.2-1.tar.gz";
-    name = "2.8.2-1.tar.gz";
-    sha256 = "1ab1fc828e14ecee7f15193fa87020006b06d129d6efd211177f2df48889ffab";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos_bridges/2.8.2-2.tar.gz";
+    name = "2.8.2-2.tar.gz";
+    sha256 = "8a1adab17fb242037bad73e931cfb3547347e547b3d009a4e074dee7ec52b15c";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rmf-demos-fleet-adapter/default.nix
+++ b/distros/rolling/rmf-demos-fleet-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-xml, python3Packages, rclpy, rmf-fleet-adapter-python, rmf-fleet-msgs, rmf-task-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmf-demos-fleet-adapter";
-  version = "2.8.2-r1";
+  version = "2.8.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos_fleet_adapter/2.8.2-1.tar.gz";
-    name = "2.8.2-1.tar.gz";
-    sha256 = "3f1961b347adfa3e394e7a99002d7bc79c5decbe11d67904ad66cae5faab9087";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos_fleet_adapter/2.8.2-2.tar.gz";
+    name = "2.8.2-2.tar.gz";
+    sha256 = "4def719f76d062ae6f5f5a8a27b665d70dcaa96003c2a16e8762e766d4510b11";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rmf-demos-gz/default.nix
+++ b/distros/rolling/rmf-demos-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch-xml, rmf-building-sim-gz-plugins, rmf-demos, rmf-robot-sim-gz-plugins, ros-gz-bridge, ros-gz-sim, ros2launch, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-rolling-rmf-demos-gz";
-  version = "2.8.2-r1";
+  version = "2.8.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos_gz/2.8.2-1.tar.gz";
-    name = "2.8.2-1.tar.gz";
-    sha256 = "e0310b43766fc6e84f496760ffd56c8e6d535a4c775efcf45bb147a818a16b39";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos_gz/2.8.2-2.tar.gz";
+    name = "2.8.2-2.tar.gz";
+    sha256 = "2337b039f3cad92fed31a9552b6e67f85c97d07f2a6ea422396cef7864857129";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-demos-maps/default.nix
+++ b/distros/rolling/rmf-demos-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rmf-building-map-tools, ros2run }:
 buildRosPackage {
   pname = "ros-rolling-rmf-demos-maps";
-  version = "2.8.2-r1";
+  version = "2.8.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos_maps/2.8.2-1.tar.gz";
-    name = "2.8.2-1.tar.gz";
-    sha256 = "b3281b540a5e76b82256129d737baf00c559749321ffa20add14ed2122afb11a";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos_maps/2.8.2-2.tar.gz";
+    name = "2.8.2-2.tar.gz";
+    sha256 = "d365372030e7ee5951b27cafd5987d644c70e23cb282f4a6f4ad09d0ab6a1ed8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-demos-tasks/default.nix
+++ b/distros/rolling/rmf-demos-tasks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, rmf-dispenser-msgs, rmf-fleet-msgs, rmf-lift-msgs, rmf-task-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmf-demos-tasks";
-  version = "2.8.2-r1";
+  version = "2.8.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos_tasks/2.8.2-1.tar.gz";
-    name = "2.8.2-1.tar.gz";
-    sha256 = "5c5117361095523d0da29d3111beff2afe8e3cd42bbb3efe74fbfa5780f54dbf";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos_tasks/2.8.2-2.tar.gz";
+    name = "2.8.2-2.tar.gz";
+    sha256 = "13fbabee6ee22fd6c659ff9316fbcf0c3f01ae15a05fae20556342b70e5e0e90";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rmf-demos/default.nix
+++ b/distros/rolling/rmf-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch-xml, rmf-building-map-tools, rmf-demos-assets, rmf-demos-fleet-adapter, rmf-demos-maps, rmf-demos-tasks, rmf-fleet-adapter, rmf-reservation-node, rmf-task-ros2, rmf-traffic-ros2, rmf-visualization, rviz2 }:
 buildRosPackage {
   pname = "ros-rolling-rmf-demos";
-  version = "2.8.2-r1";
+  version = "2.8.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos/2.8.2-1.tar.gz";
-    name = "2.8.2-1.tar.gz";
-    sha256 = "a6054d9979299bfb65b7f27fd4378ccce690ab656a427ee6e36c8aec1d1e40f7";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos/2.8.2-2.tar.gz";
+    name = "2.8.2-2.tar.gz";
+    sha256 = "13c76abbcde9359494122c8b45be70c9453498e0dd9c700ebd74646d40ac1ecf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-test-fixture-implementation/default.nix
+++ b/distros/rolling/rmw-test-fixture-implementation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros-core, ament-lint-auto, ament-lint-common, python3, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rmw-test-fixture, rpyutils }:
 buildRosPackage {
   pname = "ros-rolling-rmw-test-fixture-implementation";
-  version = "0.15.6-r1";
+  version = "0.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/rolling/rmw_test_fixture_implementation/0.15.6-1.tar.gz";
-    name = "0.15.6-1.tar.gz";
-    sha256 = "37b19a654c0da8f40a1ec7583a80c2cbd9c1977e358d9014478e1432a622cee2";
+    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/rolling/rmw_test_fixture_implementation/0.15.7-1.tar.gz";
+    name = "0.15.7-1.tar.gz";
+    sha256 = "d5605140d9898284052fddbae28ef1047e60bd6900fb5e2073fb1ba65e89198a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-test-fixture/default.nix
+++ b/distros/rolling/rmw-test-fixture/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros-core, ament-lint-auto, ament-lint-common, rmw }:
 buildRosPackage {
   pname = "ros-rolling-rmw-test-fixture";
-  version = "0.15.6-r1";
+  version = "0.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/rolling/rmw_test_fixture/0.15.6-1.tar.gz";
-    name = "0.15.6-1.tar.gz";
-    sha256 = "215235f3ba379a7eee0229dace1b3b3812b225e587e5a27c8e9377ad6f6c0ec2";
+    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/rolling/rmw_test_fixture/0.15.7-1.tar.gz";
+    name = "0.15.7-1.tar.gz";
+    sha256 = "616ada77ba79dae875bb011b7f66658682e90862f5997a75aad090d8c185af32";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-babel-fish-test-msgs/default.nix
+++ b/distros/rolling/ros-babel-fish-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros-babel-fish-test-msgs";
-  version = "4.26.40-r1";
+  version = "4.26.43-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_babel_fish-release/archive/release/rolling/ros_babel_fish_test_msgs/4.26.40-1.tar.gz";
-    name = "4.26.40-1.tar.gz";
-    sha256 = "29c766c9ebf9aadff73923adc31286d43a5a9c412c24d3833883ef798fe38e06";
+    url = "https://github.com/ros2-gbp/ros_babel_fish-release/archive/release/rolling/ros_babel_fish_test_msgs/4.26.43-1.tar.gz";
+    name = "4.26.43-1.tar.gz";
+    sha256 = "d167b2256282027912776172013fbc44cad9cd7c58f9e65b075e628fba5c909d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-babel-fish-tools/default.nix
+++ b/distros/rolling/ros-babel-fish-tools/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, geometry-msgs, rclcpp, ros-babel-fish, ros-babel-fish-test-msgs, std-msgs, yaml-cpp-vendor }:
+buildRosPackage {
+  pname = "ros-rolling-ros-babel-fish-tools";
+  version = "4.26.43-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros_babel_fish-release/archive/release/rolling/ros_babel_fish_tools/4.26.43-1.tar.gz";
+    name = "4.26.43-1.tar.gz";
+    sha256 = "485325f1f087bf4bb47e57c4b2dbd91b09ec16a2c2ebf9a97e0314ab335fb397";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest geometry-msgs ros-babel-fish-test-msgs std-msgs ];
+  propagatedBuildInputs = [ rclcpp ros-babel-fish yaml-cpp-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Tooling for ROS 2 built on ros_babel_fish.
+    Provides header-only JSON and YAML serialization for dynamic messages and a CLI tool to echo topics.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/ros-babel-fish/default.nix
+++ b/distros/rolling/ros-babel-fish/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, example-interfaces, geometry-msgs, rclcpp, rclcpp-action, rcpputils, ros-babel-fish-test-msgs, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros-babel-fish";
-  version = "4.26.40-r1";
+  version = "4.26.43-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_babel_fish-release/archive/release/rolling/ros_babel_fish/4.26.40-1.tar.gz";
-    name = "4.26.40-1.tar.gz";
-    sha256 = "5f6aba02f904afa5ec783c4bce3c9f8d99fd953056778f1a91b7c350ada95f69";
+    url = "https://github.com/ros2-gbp/ros_babel_fish-release/archive/release/rolling/ros_babel_fish/4.26.43-1.tar.gz";
+    name = "4.26.43-1.tar.gz";
+    sha256 = "8ab3222de66218b1df8ef286ec5743d97338d717eb3007fd0f13311087d4ca56";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-workspace/default.nix
+++ b/distros/rolling/ros-workspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-package, cmake }:
 buildRosPackage {
   pname = "ros-rolling-ros-workspace";
-  version = "1.0.3-r6";
+  version = "1.0.3-r7";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_workspace-release/archive/release/rolling/ros_workspace/1.0.3-6.tar.gz";
-    name = "1.0.3-6.tar.gz";
-    sha256 = "ba0888820a591887a17d762f6691aa80a27ce55d8b98096c16c6754fbfdb1beb";
+    url = "https://github.com/ros2-gbp/ros_workspace-release/archive/release/rolling/ros_workspace/1.0.3-7.tar.gz";
+    name = "1.0.3-7.tar.gz";
+    sha256 = "1b128b097438e8b3d6f68b1dacebd72b0047a673b23b8e92a3f7c5409e9513d1";
   };
 
   buildType = "cmake";

--- a/distros/rolling/ros2-control-test-assets/default.nix
+++ b/distros/rolling/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control-test-assets";
-  version = "6.5.1-r1";
+  version = "6.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/6.5.1-1.tar.gz";
-    name = "6.5.1-1.tar.gz";
-    sha256 = "a22f693f9caaec383adfa37dce187a94f54daccae0a690522aef98538410f415";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/6.7.0-1.tar.gz";
+    name = "6.7.0-1.tar.gz";
+    sha256 = "b5cd2a2ad7a91d76c27b8a65c90351adb39375487f0c8d9f627d769189cd51b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control/default.nix
+++ b/distros/rolling/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control";
-  version = "6.5.1-r1";
+  version = "6.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/6.5.1-1.tar.gz";
-    name = "6.5.1-1.tar.gz";
-    sha256 = "ef740f1bf95bf768d632fe79736836195169f9ea321bf0a516d5585ac52e40cf";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/6.7.0-1.tar.gz";
+    name = "6.7.0-1.tar.gz";
+    sha256 = "aeaa3de685482463585da0925253c74c40b9646213e81a8c2cdc91b7293cec77";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-controllers-test-nodes/default.nix
+++ b/distros/rolling/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers-test-nodes";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "38a536c71a3d39544f437740ae1b450c89566d26d6ea60c3105c73b6eb5ff6e7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "81227a8dbc110b159f810791cbffda00c452641bc3f9a26a819cbf3957d11fac";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2-controllers/default.nix
+++ b/distros/rolling/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, chained-filter-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gps-sensor-broadcaster, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, motion-primitives-controllers, omni-wheel-drive-controller, parallel-gripper-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, state-interfaces-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "7cfb4c8195aed2a26cb59f73c8196cc60d40a1a8343b51caef2f95178256dc10";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "6fe22c51fea4ca82b9f7238ac9edfa0f61505f2042f8633a1f959b7163c812f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2controlcli/default.nix
+++ b/distros/rolling/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-rolling-ros2controlcli";
-  version = "6.5.1-r1";
+  version = "6.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/6.5.1-1.tar.gz";
-    name = "6.5.1-1.tar.gz";
-    sha256 = "8154b37567193df74c234188db8cd296ea5f23485c71653cc3d426386cd34c54";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/6.7.0-1.tar.gz";
+    name = "6.7.0-1.tar.gz";
+    sha256 = "d9415e23f0cfab28422447f050bb57cc383dbf6acf848eaba58bdecf7f1a4c39";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosbag2rawlog/default.nix
+++ b/distros/rolling/rosbag2rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, cli11, cmake, cv-bridge, mrpt-libmaps, mrpt-libros-bridge, mrpt-msgs, nav-msgs, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2rawlog";
-  version = "3.5.1-r1";
+  version = "3.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/rolling/rosbag2rawlog/3.5.1-1.tar.gz";
-    name = "3.5.1-1.tar.gz";
-    sha256 = "5f2864e9eda747ab9cae6f7acf9180089b3ec5cea138a96504c9bb4212d7c38d";
+    url = "https://github.com/ros2-gbp/mrpt_ros_bridge-release/archive/release/rolling/rosbag2rawlog/3.5.2-1.tar.gz";
+    name = "3.5.2-1.tar.gz";
+    sha256 = "35a7533247fb6306b04bd869ffd3bf5cd1fb62e83c4a42aa89196c5eb8146a0a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-core-generators/default.nix
+++ b/distros/rolling/rosidl-core-generators/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-generator-py, rosidl-generator-rs, rosidl-typesupport-c, rosidl-typesupport-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-core-generators";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_core-release/archive/release/rolling/rosidl_core_generators/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "ebcf931d3d0f4421a742c5b1269e5968e7fd1df470f0c8d6f9146f62e489506d";
+    url = "https://github.com/ros2-gbp/rosidl_core-release/archive/release/rolling/rosidl_core_generators/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "4d53d53667150d77ccf9fe709abb38c085cbe4b36cfe73cbd0426f57ef2d6fe7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-core-runtime/default.nix
+++ b/distros/rolling/rosidl-core-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-buffer-py, rosidl-generator-py, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-core-runtime";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_core-release/archive/release/rolling/rosidl_core_runtime/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "108b21527bae15ede67b72ffeff2b592793ae15becef6b598baeb4d8ebca65e1";
+    url = "https://github.com/ros2-gbp/rosidl_core-release/archive/release/rolling/rosidl_core_runtime/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "1b0d036fdf717c911aa5b90fe809c7346d22fa28d6604ec36a84c7658ca9b244";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqml-core/default.nix
+++ b/distros/rolling/rqml-core/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, libGL, libGLU, nlohmann_json, qml6-ros2-plugin, qt6, ros-babel-fish-test-msgs, yaml-cpp-vendor }:
+buildRosPackage {
+  pname = "ros-rolling-rqml-core";
+  version = "3.26.42-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqml-release/archive/release/rolling/rqml_core/3.26.42-1.tar.gz";
+    name = "3.26.42-1.tar.gz";
+    sha256 = "d272f0502ce1738ed7fb15b9785689fe139e1a30c3b8cd7181123bba47e6eef8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake libGL libGLU nlohmann_json ];
+  checkInputs = [ ament-lint-auto ros-babel-fish-test-msgs ];
+  propagatedBuildInputs = [ ament-index-cpp qml6-ros2-plugin qt6.qtbase qt6.qtdeclarative yaml-cpp-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "QML-based robotics visualization and control tool for ROS 2.";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/rolling/rqml-default-plugins/default.nix
+++ b/distros/rolling/rqml-default-plugins/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, control-msgs, controller-manager-msgs, geometry-msgs, moveit-msgs, pal-statistics-msgs, qml6-ros2-plugin, qt6, rcl-interfaces, ros-babel-fish-test-msgs, rqml-core, sensor-msgs, tf2-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-rqml-default-plugins";
+  version = "3.26.42-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqml-release/archive/release/rolling/rqml_default_plugins/3.26.42-1.tar.gz";
+    name = "3.26.42-1.tar.gz";
+    sha256 = "318cf0c96f5f7df63527d0091ecd76c9f80d0c7697a5217a9f74381b58e8d53f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto qml6-ros2-plugin rcl-interfaces ros-babel-fish-test-msgs ];
+  propagatedBuildInputs = [ control-msgs controller-manager-msgs geometry-msgs moveit-msgs pal-statistics-msgs qml6-ros2-plugin qt6.qtdeclarative qt6.qtmultimedia rqml-core sensor-msgs tf2-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Default plugins for the QML-based robotics visualization and control tool RQml for ROS 2.";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/rolling/rqml-plugin-example/default.nix
+++ b/distros/rolling/rqml-plugin-example/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, qml6-ros2-plugin, qt6, rqml-core }:
+buildRosPackage {
+  pname = "ros-rolling-rqml-plugin-example";
+  version = "3.26.42-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqml-release/archive/release/rolling/rqml_plugin_example/3.26.42-1.tar.gz";
+    name = "3.26.42-1.tar.gz";
+    sha256 = "db1eea65327297cc2d7c4172b38ee59ea166434a7f67f22cf825e9b26879b0b4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ qml6-ros2-plugin qt6.qtdeclarative rqml-core ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "An example plugin for RQml";
+    license = with lib.licenses; [ "MIT-0" ];
+  };
+}

--- a/distros/rolling/rqml/default.nix
+++ b/distros/rolling/rqml/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rqml-core, rqml-default-plugins }:
+buildRosPackage {
+  pname = "ros-rolling-rqml";
+  version = "3.26.42-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqml-release/archive/release/rolling/rqml/3.26.42-1.tar.gz";
+    name = "3.26.42-1.tar.gz";
+    sha256 = "457ecd95d3e1c914458365972490788c06f8307af1eccb1c075a06cabbd392c9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ rqml-core rqml-default-plugins ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "QML-based robotics visualization and control tool for ROS 2.";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/rolling/rqt-controller-manager/default.nix
+++ b/distros/rolling/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-controller-manager";
-  version = "6.5.1-r1";
+  version = "6.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/6.5.1-1.tar.gz";
-    name = "6.5.1-1.tar.gz";
-    sha256 = "c3fee47c01e70a56ad1e874350f127d30a9c3d73a45f923b3c44759f110e64f8";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/6.7.0-1.tar.gz";
+    name = "6.7.0-1.tar.gz";
+    sha256 = "79ba9d5f2e4132ce5b9d1405bac20ba25ff0197b61f2db0ec93c0081f0690bb3";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-joint-trajectory-controller/default.nix
+++ b/distros/rolling/rqt-joint-trajectory-controller/default.nix
@@ -5,15 +5,16 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-joint-trajectory-controller";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "9ee0752d42fd7d7b9fbda35fa0d1fa8fb2b1ef71d935365373e6000e9bc2bb1e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "1a3ef27780cd00f499d1e120bc72c9d37059fcfa7ee8a243c03974f320b96ff9";
   };
 
   buildType = "ament_python";
+  checkInputs = [ python3Packages.pytest ];
   propagatedBuildInputs = [ control-msgs controller-manager-msgs python-qt-binding python3Packages.rospkg qt-gui rclpy rqt-gui rqt-gui-py trajectory-msgs ];
 
   meta = {

--- a/distros/rolling/rtest/default.nix
+++ b/distros/rolling/rtest/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-clang-tidy, ament-cmake, ament-cmake-copyright, ament-cmake-ros, ament-lint-auto, ament-lint-common, boost, gmock-vendor, gtest, rcl, rcl-action, rclcpp, rclcpp-action, ros-environment }:
+buildRosPackage {
+  pname = "ros-rolling-rtest";
+  version = "0.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rtest-release/archive/release/rolling/rtest/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "40176732f344616853ca1a85d698522a63f67d63754c35166d46ce36d127cca7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-ros boost gtest ros-environment ];
+  checkInputs = [ ament-clang-tidy ament-cmake-copyright ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ action-msgs gmock-vendor rcl rcl-action rclcpp rclcpp-action ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
+
+  meta = {
+    description = "This framework enables writing reliable, fully repeatable tests for C++ ROS 2 implementations.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/rttest/default.nix
+++ b/distros/rolling/rttest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rttest";
-  version = "0.19.2-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_support-release/archive/release/rolling/rttest/0.19.2-1.tar.gz";
-    name = "0.19.2-1.tar.gz";
-    sha256 = "09f49d18584f5f5e7cb465f1afe92b505d8be1fc9a23923fe72b3762a560a075";
+    url = "https://github.com/ros2-gbp/realtime_support-release/archive/release/rolling/rttest/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "f23741e8496d6db5301b52cf6ca1e58c691f0e4b3204a3ea61deece60cff4941";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/state-interfaces-broadcaster/default.nix
+++ b/distros/rolling/state-interfaces-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-state-interfaces-broadcaster";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/state_interfaces_broadcaster/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "7efd1469ab27d505d89b76debfcf181e702673941985f37eca597e147f2d3edb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/state_interfaces_broadcaster/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "e072e27cd3548c13e35aea8c24db76aec5f928c4330a7dc406661f51759b051d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/steering-controllers-library/default.nix
+++ b/distros/rolling/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-steering-controllers-library";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "a8f4023b1915c99c3d924684b3001dd3728266337bb1feff21c755415f59fecd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "ec75f18d3bbfe1d907130b53287c0ffb42882e125c54211209e92a9d9e0f5cd6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tcb-span/default.nix
+++ b/distros/rolling/tcb-span/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-rolling-tcb-span";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/rolling/tcb_span/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "3841e96188e8c951ae7045fd12b56de621f1e53feb6655dd4dde2f9921bd33dc";
+    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/rolling/tcb_span/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "217b3f432a43497701b09295cacbea5a7331552a520d4e42dd480e1e1232efa7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tl-expected/default.nix
+++ b/distros/rolling/tl-expected/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tl-expected-nixpkgs }:
 buildRosPackage {
   pname = "ros-rolling-tl-expected";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/rolling/tl_expected/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "a97f16079bc4ff7c910018efbc1368394242bae8bd4d6ca58b6a571541b01307";
+    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/rolling/tl_expected/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "14c943f3f25ebbd8351b9a7be49991c72eacad027047b7cefcc24de046b67f95";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tlsf-cpp/default.nix
+++ b/distros/rolling/tlsf-cpp/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, rmw, rmw-implementation-cmake, std-msgs, tlsf }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, rcl, rclcpp, rcpputils, rmw, rmw-implementation-cmake, std-msgs, tlsf }:
 buildRosPackage {
   pname = "ros-rolling-tlsf-cpp";
-  version = "0.19.2-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_support-release/archive/release/rolling/tlsf_cpp/0.19.2-1.tar.gz";
-    name = "0.19.2-1.tar.gz";
-    sha256 = "186010a8fc09ee47744302097e60e4a5c57876b6f23d7af3c4a4bdc346d182b2";
+    url = "https://github.com/ros2-gbp/realtime_support-release/archive/release/rolling/tlsf_cpp/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "798143f98a2a3f10e5a25a7dc960db8c9c3b44739bac30b6e8e078ad9f806228";
   };
 
   buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-ros ament-lint-auto ament-lint-common rcpputils rmw-implementation-cmake ];
-  propagatedBuildInputs = [ ament-cmake rclcpp rmw std-msgs tlsf ];
+  propagatedBuildInputs = [ rcl rclcpp rmw std-msgs tlsf ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/topic-tools-interfaces/default.nix
+++ b/distros/rolling/topic-tools-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-topic-tools-interfaces";
-  version = "1.4.3-r1";
+  version = "1.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/rolling/topic_tools_interfaces/1.4.3-1.tar.gz";
-    name = "1.4.3-1.tar.gz";
-    sha256 = "e7a2868ad63776a6a29656dba280e11102ad4c1b33852da0510e765ccf01983b";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/rolling/topic_tools_interfaces/1.4.4-1.tar.gz";
+    name = "1.4.4-1.tar.gz";
+    sha256 = "c9953c12e45032a4b4779ec4ae91f58ff0949f9eefa342c4088df3f6ebfcf3a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/topic-tools/default.nix
+++ b/distros/rolling/topic-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclpy, ros2cli, ros2topic, rosidl-default-generators, rosidl-runtime-py, std-msgs, topic-tools-interfaces }:
 buildRosPackage {
   pname = "ros-rolling-topic-tools";
-  version = "1.4.3-r1";
+  version = "1.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/rolling/topic_tools/1.4.3-1.tar.gz";
-    name = "1.4.3-1.tar.gz";
-    sha256 = "7bff74403fb850e4c85f366e3fcc533c4e9a1b3513ae4faef1fae13695691bf4";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/rolling/topic_tools/1.4.4-1.tar.gz";
+    name = "1.4.4-1.tar.gz";
+    sha256 = "82e6fca0ea388583cd71f943aaef9142ba18a886a999adbc28cbe2e1058dc2ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/transmission-interface/default.nix
+++ b/distros/rolling/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, fmt, hardware-interface, pluginlib, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-transmission-interface";
-  version = "6.5.1-r1";
+  version = "6.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/6.5.1-1.tar.gz";
-    name = "6.5.1-1.tar.gz";
-    sha256 = "392ed226a9e1bbc1da99a9d632d6decbb0c35e4b17e277a6a5fccaf0dec53c72";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/6.7.0-1.tar.gz";
+    name = "6.7.0-1.tar.gz";
+    sha256 = "b43af147d9de09b3946c36429c5e817bd9105e40fc04a2c97fdb680adb7f53c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-controller/default.nix
+++ b/distros/rolling/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-controller";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "b41b0bbde51a4f974823e9c6dfd99ff0b9d03c417e5dbd243fdf2bbef79e392a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "bb9574cc3cbe24e23e625f2aeb87e351f8f4fca252b747607cb09e65cacf0f70";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-steering-controller/default.nix
+++ b/distros/rolling/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-steering-controller";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "0c0c5a8a380c4b0244d15410aa677171fb709f7f3fee09c8da5b585836ff3dbf";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "b22e6c5209da0b6e075247dce510ec9f6f92bd9e9dfaec536076be0889556c73";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-client-library/default.nix
+++ b/distros/rolling/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-rolling-ur-client-library";
-  version = "2.9.0-r1";
+  version = "2.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/rolling/ur_client_library/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "8dc5b05498f28553cdc8f20bf5b17ac8921605444f564135f4b7e567db987816";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/rolling/ur_client_library/2.10.0-1.tar.gz";
+    name = "2.10.0-1.tar.gz";
+    sha256 = "a2f9d22c4fe5e3b9494971855c7d36ddabae5b99584cfc93cde5d75e51961914";
   };
 
   buildType = "cmake";

--- a/distros/rolling/urdfdom-headers/default.nix
+++ b/distros/rolling/urdfdom-headers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-rolling-urdfdom-headers";
-  version = "2.1.1-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/urdfdom_headers-release/archive/release/rolling/urdfdom_headers/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "b68fa9ef07078ab63c37838a5c7fb2155e970a93172a9cfb41bc6861b893b34c";
+    url = "https://github.com/ros2-gbp/urdfdom_headers-release/archive/release/rolling/urdfdom_headers/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "304d482df9a1f4e5de7123b77812d28df0fb85545851fe9724e98188201badc7";
   };
 
   buildType = "cmake";

--- a/distros/rolling/urdfdom/default.nix
+++ b/distros/rolling/urdfdom/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, console-bridge-vendor, python3, tinyxml-2, urdfdom-headers }:
 buildRosPackage {
   pname = "ros-rolling-urdfdom";
-  version = "5.1.1-r1";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/urdfdom-release/archive/release/rolling/urdfdom/5.1.1-1.tar.gz";
-    name = "5.1.1-1.tar.gz";
-    sha256 = "9285ba99589a52bc76c2aeb7621e5d586d7f368ba31b0f7e341dde8f8b063146";
+    url = "https://github.com/ros2-gbp/urdfdom-release/archive/release/rolling/urdfdom/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "a8fe3e6c0a505d0f0d08b423ab1f28436e34dd59ab81ffc7f86a36c9add80ce4";
   };
 
   buildType = "cmake";

--- a/distros/rolling/velocity-controllers/default.nix
+++ b/distros/rolling/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-velocity-controllers";
-  version = "6.5.0-r1";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/6.5.0-1.tar.gz";
-    name = "6.5.0-1.tar.gz";
-    sha256 = "dbf8469f42dd1c81533fd38e59779a839fbc2fca6293121eb1e635eb166aa409";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "ae94e364150f3f664c4bc941c5cf7a7d24e3e28179d80596d1f4fb7a65f6d8fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/warehouse-ros-sqlite/default.nix
+++ b/distros/rolling/warehouse-ros-sqlite/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_sqlite3_vendor, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, warehouse-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite, warehouse-ros }:
 buildRosPackage {
   pname = "ros-rolling-warehouse-ros-sqlite";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/rolling/warehouse_ros_sqlite/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "3de3e4e56187d447368c57a76d2ff48a407e601af5f3b0e01c931bc253b2cda0";
+    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/rolling/warehouse_ros_sqlite/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "3aed7ba939f348e421ca7e06563455cfea3755e582deb5e964f42d2de208a3d7";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake boost ];
   checkInputs = [ ament-cmake-copyright ament-cmake-gtest ament-lint-auto ament-lint-common geometry-msgs ];
-  propagatedBuildInputs = [ _unresolved_sqlite3_vendor class-loader rclcpp warehouse-ros ];
+  propagatedBuildInputs = [ class-loader rclcpp sqlite warehouse-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'kilted', 'rolling'] from nix-ros-overlay commit 4c3c933052113a15b1c2a7fbf3b54c7ffc6e3c8a.
This pull request was generated by running the following command:

```
superflore-gen-nix --dry-run --output-repository-path . --all --tar-archive-dir /home/runner/.ros/tar --upstream-branch develop
```

Changes:
========
Humble Changes:
---------------
* *ackermann-steering-controller 2.53.0-r1 --> 2.53.1-r1*
* *admittance-controller 2.53.0-r1 --> 2.53.1-r1*
* *beluga 2.1.0-r1 --> 2.1.1-r1*
* *beluga-amcl 2.1.0-r1 --> 2.1.1-r1*
* *beluga-ros 2.1.0-r1 --> 2.1.1-r1*
* *bicycle-steering-controller 2.53.0-r1 --> 2.53.1-r1*
* *cloudini-lib 1.0.4-r1 --> 1.1.0-r2*
* *cloudini-ros 1.0.4-r1 --> 1.1.0-r2*
* *compressed-depth-image-transport 2.5.4-r1 --> 2.5.5-r1*
* *compressed-image-transport 2.5.4-r1 --> 2.5.5-r1*
* *diff-drive-controller 2.53.0-r1 --> 2.53.1-r1*
* *effort-controllers 2.53.0-r1 --> 2.53.1-r1*
* *force-torque-sensor-broadcaster 2.53.0-r1 --> 2.53.1-r1*
* *forward-command-controller 2.53.0-r1 --> 2.53.1-r1*
* *gpio-controllers 2.53.0-r1 --> 2.53.1-r1*
* *gripper-controllers 2.53.0-r1 --> 2.53.1-r1*
* *image-transport-plugins 2.5.4-r1 --> 2.5.5-r1*
* *imu-sensor-broadcaster 2.53.0-r1 --> 2.53.1-r1*
* *joint-state-broadcaster 2.53.0-r1 --> 2.53.1-r1*
* *joint-trajectory-controller 2.53.0-r1 --> 2.53.1-r1*
* *kitti-metrics-eval 2.6.1-r1 --> 2.7.0-r1*
* *mecanum-drive-controller 2.53.0-r1 --> 2.53.1-r1*
* *mola 2.6.1-r1 --> 2.7.0-r1*
* *mola-bridge-ros2 2.6.1-r1 --> 2.7.0-r1*
* *mola-demos 2.6.1-r1 --> 2.7.0-r1*
* *mola-imu-preintegration 1.15.0-r1 --> 1.16.0-r1*
* *mola-input-euroc-dataset 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-kitti-dataset 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-kitti360-dataset 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-lidar-bin-dataset 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-mulran-dataset 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-paris-luco-dataset 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-rawlog 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-rosbag2 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-video 2.6.1-r1 --> 2.7.0-r1*
* *mola-kernel 2.6.1-r1 --> 2.7.0-r1*
* *mola-launcher 2.6.1-r1 --> 2.7.0-r1*
* *mola-metric-maps 2.6.1-r1 --> 2.7.0-r1*
* *mola-msgs 2.6.1-r1 --> 2.7.0-r1*
* *mola-pose-list 2.6.1-r1 --> 2.7.0-r1*
* *mola-relocalization 2.6.1-r1 --> 2.7.0-r1*
* *mola-traj-tools 2.6.1-r1 --> 2.7.0-r1*
* *mola-viz 2.6.1-r1 --> 2.7.0-r1*
* *mola-yaml 2.6.1-r1 --> 2.7.0-r1*
* *mp2p-icp 2.8.1-r1 --> 2.9.0-r1*
* *mrpt-apps 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libapps 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libbase 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libgui 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libhwdrivers 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libmaps 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libmath 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libnav 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libobs 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libopengl 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libposes 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libros-bridge 3.5.1-r1 --> 3.5.2-r1*
* *mrpt-libslam 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libtclap 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-map-server 2.3.0-r1 --> 2.4.0-r1*
* *mrpt-msgs-bridge 2.3.0-r1 --> 2.4.0-r1*
* *mrpt-nav-interfaces 2.3.0-r1 --> 2.4.0-r1*
* *mrpt-navigation 2.3.0-r1 --> 2.4.0-r1*
* *mrpt-pf-localization 2.3.0-r1 --> 2.4.0-r1*
* *mrpt-pointcloud-pipeline 2.3.0-r1 --> 2.4.0-r1*
* *mrpt-reactivenav2d 2.3.0-r1 --> 2.4.0-r1*
* *mrpt-tps-astar-planner 2.3.0-r1 --> 2.4.0-r1*
* *mrpt-tutorials 2.3.0-r1 --> 2.4.0-r1*
* *pid-controller 2.53.0-r1 --> 2.53.1-r1*
* *pose-broadcaster 2.53.0-r1 --> 2.53.1-r1*
* *position-controllers 2.53.0-r1 --> 2.53.1-r1*
* *range-sensor-broadcaster 2.53.0-r1 --> 2.53.1-r1*
* *rcl 5.3.12-r1 --> 5.3.13-r1*
* *rcl-action 5.3.12-r1 --> 5.3.13-r1*
* *rcl-lifecycle 5.3.12-r1 --> 5.3.13-r1*
* *rcl-yaml-param-parser 5.3.12-r1 --> 5.3.13-r1*
* *ros2-controllers 2.53.0-r1 --> 2.53.1-r1*
* *ros2-controllers-test-nodes 2.53.0-r1 --> 2.53.1-r1*
* *rosbag2rawlog 3.5.1-r1 --> 3.5.2-r1*
* *rqt-joint-trajectory-controller 2.53.0-r1 --> 2.53.1-r1*
* *steering-controllers-library 2.53.0-r1 --> 2.53.1-r1*
* *tcb-span 1.2.0-r1 --> 1.3.0-r1*
* *theora-image-transport 2.5.4-r1 --> 2.5.5-r1*
* *tl-expected 1.2.0-r1 --> 1.3.0-r1*
* *tricycle-controller 2.53.0-r1 --> 2.53.1-r1*
* *tricycle-steering-controller 2.53.0-r1 --> 2.53.1-r1*
* *ur-client-library 2.9.0-r1 --> 2.10.0-r1*
* *velocity-controllers 2.53.0-r1 --> 2.53.1-r1*

Jazzy Changes:
--------------
* *ackermann-steering-controller 4.39.0-r1 --> 4.40.0-r1*
* *admittance-controller 4.39.0-r1 --> 4.40.0-r1*
* *beluga 2.1.0-r1 --> 2.1.1-r1*
* *beluga-amcl 2.1.0-r1 --> 2.1.1-r1*
* *beluga-ros 2.1.0-r1 --> 2.1.1-r1*
* *bicycle-steering-controller 4.39.0-r1 --> 4.40.0-r1*
* *chained-filter-controller 4.39.0-r1 --> 4.40.0-r1*
* *clearpath-generator-gz 2.9.0-r1 --> 2.9.1-r1*
* *clearpath-gz 2.9.0-r1 --> 2.9.1-r1*
* *clearpath-simulator 2.9.0-r1 --> 2.9.1-r1*
* *cloudini-lib 1.0.4-r1 --> 1.1.0-r1*
* *cloudini-ros 1.0.4-r1 --> 1.1.0-r1*
* *compass-msgs 0.1.1-r1 --> 0.2.0-r1*
* *compressed-depth-image-transport 4.0.6-r1 --> 4.0.7-r1*
* *compressed-image-transport 4.0.6-r1 --> 4.0.7-r1*
* *control-toolbox 4.10.0-r1 --> 4.11.0-r1*
* *controller-interface 4.44.0-r1 --> 4.45.0-r1*
* *controller-manager 4.44.0-r1 --> 4.45.0-r1*
* *controller-manager-msgs 4.44.0-r1 --> 4.45.0-r1*
* *diff-drive-controller 4.39.0-r1 --> 4.40.0-r1*
* *effort-controllers 4.39.0-r1 --> 4.40.0-r1*
* *flir-ptu-description 1.0.1-r1*
* *flir-ptu-driver 1.0.1-r1*
* *flir-ptu-viz 1.0.1-r1*
* *force-torque-sensor-broadcaster 4.39.0-r1 --> 4.40.0-r1*
* *forward-command-controller 4.39.0-r1 --> 4.40.0-r1*
* *fusioncore-core 0.1.1-r1 --> 0.2.0-r1*
* *fusioncore-datasets 0.2.0-r1*
* *fusioncore-gazebo 0.1.1-r1 --> 0.2.0-r1*
* *fusioncore-ros 0.1.1-r1 --> 0.2.0-r1*
* *gpio-controllers 4.39.0-r1 --> 4.40.0-r1*
* *gps-sensor-broadcaster 4.39.0-r1 --> 4.40.0-r1*
* *gripper-controllers 4.39.0-r1 --> 4.40.0-r1*
* *gstreamer-ros-babel-fish 1.26.40-r1*
* *gz-math-vendor 0.0.8-r1 --> 0.0.9-r1*
* *hardware-interface 4.44.0-r1 --> 4.45.0-r1*
* *hardware-interface-testing 4.44.0-r1 --> 4.45.0-r1*
* *image-transport-plugins 4.0.6-r1 --> 4.0.7-r1*
* *imu-sensor-broadcaster 4.39.0-r1 --> 4.40.0-r1*
* *joint-limits 4.44.0-r1 --> 4.45.0-r1*
* *joint-state-broadcaster 4.39.0-r1 --> 4.40.0-r1*
* *joint-trajectory-controller 4.39.0-r1 --> 4.40.0-r1*
* *kitti-metrics-eval 2.6.1-r1 --> 2.7.0-r1*
* *mecanum-drive-controller 4.39.0-r1 --> 4.40.0-r1*
* *mola 2.6.1-r1 --> 2.7.0-r1*
* *mola-bridge-ros2 2.6.1-r1 --> 2.7.0-r1*
* *mola-demos 2.6.1-r1 --> 2.7.0-r1*
* *mola-imu-preintegration 1.15.0-r1 --> 1.16.0-r1*
* *mola-input-euroc-dataset 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-kitti-dataset 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-kitti360-dataset 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-lidar-bin-dataset 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-mulran-dataset 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-paris-luco-dataset 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-rawlog 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-rosbag2 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-video 2.6.1-r1 --> 2.7.0-r1*
* *mola-kernel 2.6.1-r1 --> 2.7.0-r1*
* *mola-launcher 2.6.1-r1 --> 2.7.0-r1*
* *mola-metric-maps 2.6.1-r1 --> 2.7.0-r1*
* *mola-msgs 2.6.1-r1 --> 2.7.0-r1*
* *mola-pose-list 2.6.1-r1 --> 2.7.0-r1*
* *mola-relocalization 2.6.1-r1 --> 2.7.0-r1*
* *mola-traj-tools 2.6.1-r1 --> 2.7.0-r1*
* *mola-viz 2.6.1-r1 --> 2.7.0-r1*
* *mola-yaml 2.6.1-r1 --> 2.7.0-r1*
* *motion-primitives-controllers 4.39.0-r1 --> 4.40.0-r1*
* *mp2p-icp 2.8.1-r1 --> 2.9.0-r1*
* *mrpt-apps 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libapps 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libbase 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libgui 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libhwdrivers 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libmaps 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libmath 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libnav 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libobs 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libopengl 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libposes 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libros-bridge 3.5.1-r1 --> 3.5.2-r1*
* *mrpt-libslam 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libtclap 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-map-server 2.3.1-r1 --> 2.4.0-r1*
* *mrpt-msgs-bridge 2.3.1-r1 --> 2.4.0-r1*
* *mrpt-nav-interfaces 2.3.1-r1 --> 2.4.0-r1*
* *mrpt-navigation 2.3.1-r1 --> 2.4.0-r1*
* *mrpt-pf-localization 2.3.1-r1 --> 2.4.0-r1*
* *mrpt-pointcloud-pipeline 2.3.1-r1 --> 2.4.0-r1*
* *mrpt-reactivenav2d 2.3.1-r1 --> 2.4.0-r1*
* *mrpt-tps-astar-planner 2.3.1-r1 --> 2.4.0-r1*
* *mrpt-tutorials 2.3.1-r1 --> 2.4.0-r1*
* *omni-wheel-drive-controller 4.39.0-r1 --> 4.40.0-r1*
* *parallel-gripper-controller 4.39.0-r1 --> 4.40.0-r1*
* *pid-controller 4.39.0-r1 --> 4.40.0-r1*
* *pose-broadcaster 4.39.0-r1 --> 4.40.0-r1*
* *position-controllers 4.39.0-r1 --> 4.40.0-r1*
* *qml6-ros2-plugin 1.26.31-r1 --> 1.26.41-r1*
* *range-sensor-broadcaster 4.39.0-r1 --> 4.40.0-r1*
* *ros-babel-fish 2.25.111-r1 --> 2.26.40-r1*
* *ros-babel-fish-test-msgs 2.25.111-r1 --> 2.26.40-r1*
* *ros-babel-fish-tools 2.26.40-r1*
* *ros2-control 4.44.0-r1 --> 4.45.0-r1*
* *ros2-control-test-assets 4.44.0-r1 --> 4.45.0-r1*
* *ros2-controllers 4.39.0-r1 --> 4.40.0-r1*
* *ros2-controllers-test-nodes 4.39.0-r1 --> 4.40.0-r1*
* *ros2controlcli 4.44.0-r1 --> 4.45.0-r1*
* *rosbag2rawlog 3.5.1-r1 --> 3.5.2-r1*
* *rosbot 0.18.6-r1 --> 1.0.0-r1*
* *rosbot-bringup 0.18.6-r1 --> 1.0.0-r1*
* *rosbot-controller 0.18.6-r1 --> 1.0.0-r1*
* *rosbot-description 0.18.6-r1 --> 1.0.0-r1*
* *rosbot-gazebo 0.18.6-r1 --> 1.0.0-r1*
* *rosbot-hardware-interfaces 0.18.6-r1 --> 1.0.0-r1*
* *rosbot-joy 0.18.6-r1 --> 1.0.0-r1*
* *rosbot-localization 0.18.6-r1 --> 1.0.0-r1*
* *rosbot-moveit 0.18.6-r1 --> 1.0.0-r1*
* *rosbot-utils 0.18.6-r1 --> 1.0.0-r1*
* *rqml 3.26.41-r1*
* *rqml-core 3.26.41-r1*
* *rqml-default-plugins 3.26.41-r1*
* *rqml-plugin-example 3.26.41-r1*
* *rqt-controller-manager 4.44.0-r1 --> 4.45.0-r1*
* *rqt-joint-trajectory-controller 4.39.0-r1 --> 4.40.0-r1*
* *rtest 0.2.1-r1 --> 0.2.2-r1*
* *state-interfaces-broadcaster 4.39.0-r1 --> 4.40.0-r1*
* *steering-controllers-library 4.39.0-r1 --> 4.40.0-r1*
* *tcb-span 1.2.0-r1 --> 1.3.0-r1*
* *theora-image-transport 4.0.6-r1 --> 4.0.7-r1*
* *tl-expected 1.2.0-r1 --> 1.3.0-r1*
* *transmission-interface 4.44.0-r1 --> 4.45.0-r1*
* *tricycle-controller 4.39.0-r1 --> 4.40.0-r1*
* *tricycle-steering-controller 4.39.0-r1 --> 4.40.0-r1*
* *ur-client-library 2.9.0-r1 --> 2.10.0-r1*
* *velocity-controllers 4.39.0-r1 --> 4.40.0-r1*
* *zstd-image-transport 4.0.6-r1 --> 4.0.7-r1*

Kilted Changes:
---------------
* *ackermann-steering-controller 5.14.0-r1 --> 5.15.0-r1*
* *admittance-controller 5.14.0-r1 --> 5.15.0-r1*
* *beluga 2.1.0-r1 --> 2.1.1-r1*
* *beluga-amcl 2.1.0-r1 --> 2.1.1-r1*
* *beluga-ros 2.1.0-r1 --> 2.1.1-r1*
* *bicycle-steering-controller 5.14.0-r1 --> 5.15.0-r1*
* *chained-filter-controller 5.14.0-r1 --> 5.15.0-r1*
* *cloudini-lib 1.0.4-r1 --> 1.1.0-r1*
* *cloudini-ros 1.0.4-r1 --> 1.1.0-r1*
* *compressed-depth-image-transport 5.1.1-r1 --> 5.1.2-r1*
* *compressed-image-transport 5.1.1-r1 --> 5.1.2-r1*
* *control-toolbox 5.9.1-r1 --> 5.10.0-r1*
* *controller-interface 5.13.0-r1 --> 5.14.0-r1*
* *controller-manager 5.13.0-r1 --> 5.14.0-r1*
* *controller-manager-msgs 5.13.0-r1 --> 5.14.0-r1*
* *diff-drive-controller 5.14.0-r1 --> 5.15.0-r1*
* *effort-controllers 5.14.0-r1 --> 5.15.0-r1*
* *force-torque-sensor-broadcaster 5.14.0-r1 --> 5.15.0-r1*
* *forward-command-controller 5.14.0-r1 --> 5.15.0-r1*
* *gpio-controllers 5.14.0-r1 --> 5.15.0-r1*
* *gps-sensor-broadcaster 5.14.0-r1 --> 5.15.0-r1*
* *gstreamer-ros-babel-fish 1.26.40-r1*
* *gz-math-vendor 0.2.6-r1 --> 0.2.7-r1*
* *hardware-interface 5.13.0-r1 --> 5.14.0-r1*
* *hardware-interface-testing 5.13.0-r1 --> 5.14.0-r1*
* *image-transport-plugins 5.1.1-r1 --> 5.1.2-r1*
* *imu-sensor-broadcaster 5.14.0-r1 --> 5.15.0-r1*
* *joint-limits 5.13.0-r1 --> 5.14.0-r1*
* *joint-state-broadcaster 5.14.0-r1 --> 5.15.0-r1*
* *joint-trajectory-controller 5.14.0-r1 --> 5.15.0-r1*
* *kitti-metrics-eval 2.6.1-r1 --> 2.7.0-r1*
* *mecanum-drive-controller 5.14.0-r1 --> 5.15.0-r1*
* *mola 2.6.1-r1 --> 2.7.0-r1*
* *mola-bridge-ros2 2.6.1-r1 --> 2.7.0-r1*
* *mola-demos 2.6.1-r1 --> 2.7.0-r1*
* *mola-imu-preintegration 1.15.0-r1 --> 1.16.0-r1*
* *mola-input-euroc-dataset 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-kitti-dataset 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-kitti360-dataset 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-lidar-bin-dataset 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-mulran-dataset 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-paris-luco-dataset 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-rawlog 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-rosbag2 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-video 2.6.1-r1 --> 2.7.0-r1*
* *mola-kernel 2.6.1-r1 --> 2.7.0-r1*
* *mola-launcher 2.6.1-r1 --> 2.7.0-r1*
* *mola-metric-maps 2.6.1-r1 --> 2.7.0-r1*
* *mola-msgs 2.6.1-r1 --> 2.7.0-r1*
* *mola-pose-list 2.6.1-r1 --> 2.7.0-r1*
* *mola-relocalization 2.6.1-r1 --> 2.7.0-r1*
* *mola-traj-tools 2.6.1-r1 --> 2.7.0-r1*
* *mola-viz 2.6.1-r1 --> 2.7.0-r1*
* *mola-yaml 2.6.1-r1 --> 2.7.0-r1*
* *motion-primitives-controllers 5.14.0-r1 --> 5.15.0-r1*
* *moveit-task-constructor-capabilities 0.1.4-r2 --> 0.1.5-r1*
* *moveit-task-constructor-core 0.1.4-r2 --> 0.1.5-r1*
* *moveit-task-constructor-demo 0.1.4-r2 --> 0.1.5-r1*
* *moveit-task-constructor-msgs 0.1.4-r2 --> 0.1.5-r1*
* *moveit-task-constructor-visualization 0.1.4-r2 --> 0.1.5-r1*
* *mp2p-icp 2.8.1-r1 --> 2.9.0-r1*
* *mrpt-apps 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libapps 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libbase 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libgui 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libhwdrivers 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libmaps 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libmath 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libnav 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libobs 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libopengl 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libposes 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libros-bridge 3.5.1-r1 --> 3.5.2-r1*
* *mrpt-libslam 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libtclap 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-map-server 2.3.1-r1 --> 2.4.0-r1*
* *mrpt-msgs-bridge 2.3.1-r1 --> 2.4.0-r1*
* *mrpt-nav-interfaces 2.3.1-r1 --> 2.4.0-r1*
* *mrpt-navigation 2.3.1-r1 --> 2.4.0-r1*
* *mrpt-pf-localization 2.3.1-r1 --> 2.4.0-r1*
* *mrpt-pointcloud-pipeline 2.3.1-r1 --> 2.4.0-r1*
* *mrpt-reactivenav2d 2.3.1-r1 --> 2.4.0-r1*
* *mrpt-tps-astar-planner 2.3.1-r1 --> 2.4.0-r1*
* *mrpt-tutorials 2.3.1-r1 --> 2.4.0-r1*
* *omni-wheel-drive-controller 5.14.0-r1 --> 5.15.0-r1*
* *parallel-gripper-controller 5.14.0-r1 --> 5.15.0-r1*
* *pid-controller 5.14.0-r1 --> 5.15.0-r1*
* *pose-broadcaster 5.14.0-r1 --> 5.15.0-r1*
* *position-controllers 5.14.0-r1 --> 5.15.0-r1*
* *qml6-ros2-plugin 2.26.31-r1 --> 2.26.41-r1*
* *range-sensor-broadcaster 5.14.0-r1 --> 5.15.0-r1*
* *ros-babel-fish 3.26.31-r1 --> 3.26.40-r1*
* *ros-babel-fish-test-msgs 3.26.31-r1 --> 3.26.40-r1*
* *ros-babel-fish-tools 3.26.40-r1*
* *ros2-control 5.13.0-r1 --> 5.14.0-r1*
* *ros2-control-test-assets 5.13.0-r1 --> 5.14.0-r1*
* *ros2-controllers 5.14.0-r1 --> 5.15.0-r1*
* *ros2-controllers-test-nodes 5.14.0-r1 --> 5.15.0-r1*
* *ros2controlcli 5.13.0-r1 --> 5.14.0-r1*
* *rosbag2rawlog 3.5.1-r1 --> 3.5.2-r1*
* *rqml 3.26.41-r1*
* *rqml-core 3.26.41-r1*
* *rqml-default-plugins 3.26.41-r1*
* *rqml-plugin-example 3.26.41-r1*
* *rqt-controller-manager 5.13.0-r1 --> 5.14.0-r1*
* *rqt-joint-trajectory-controller 5.14.0-r1 --> 5.15.0-r1*
* *rtest 0.2.1-r1 --> 0.2.2-r1*
* *rviz-marker-tools 0.1.4-r2 --> 0.1.5-r1*
* *state-interfaces-broadcaster 5.14.0-r1 --> 5.15.0-r1*
* *steering-controllers-library 5.14.0-r1 --> 5.15.0-r1*
* *tcb-span 1.2.0-r1 --> 1.3.0-r1*
* *theora-image-transport 5.1.1-r1 --> 5.1.2-r1*
* *tl-expected 1.2.0-r1 --> 1.3.0-r1*
* *transmission-interface 5.13.0-r1 --> 5.14.0-r1*
* *tricycle-controller 5.14.0-r1 --> 5.15.0-r1*
* *tricycle-steering-controller 5.14.0-r1 --> 5.15.0-r1*
* *ur-client-library 2.9.0-r1 --> 2.10.0-r1*
* *velocity-controllers 5.14.0-r1 --> 5.15.0-r1*
* *zstd-image-transport 5.1.1-r1 --> 5.1.2-r1*

Rolling Changes:
----------------
* *ackermann-steering-controller 6.5.0-r1 --> 6.6.0-r1*
* *admittance-controller 6.5.0-r1 --> 6.6.0-r1*
* *ament-cmake-ros 0.15.6-r1 --> 0.15.7-r1*
* *ament-cmake-ros-core 0.15.6-r1 --> 0.15.7-r1*
* *bag2-to-image 0.1.1-r1 --> 0.1.2-r1*
* *bicycle-steering-controller 6.5.0-r1 --> 6.6.0-r1*
* *chained-filter-controller 6.5.0-r1 --> 6.6.0-r1*
* *cloudini-lib 1.0.4-r1 --> 1.1.0-r1*
* *cloudini-ros 1.0.4-r1 --> 1.1.0-r1*
* *control-toolbox 6.2.0-r1 --> 6.3.0-r1*
* *controller-interface 6.5.1-r1 --> 6.7.0-r1*
* *controller-manager 6.5.1-r1 --> 6.7.0-r1*
* *controller-manager-msgs 6.5.1-r1 --> 6.7.0-r1*
* *diff-drive-controller 6.5.0-r1 --> 6.6.0-r1*
* *domain-coordinator 0.15.6-r1 --> 0.15.7-r1*
* *effort-controllers 6.5.0-r1 --> 6.6.0-r1*
* *fastdds 3.6.0-r1 --> 3.6.1-r1*
* *force-torque-sensor-broadcaster 6.5.0-r1 --> 6.6.0-r1*
* *forward-command-controller 6.5.0-r1 --> 6.6.0-r1*
* *gpio-controllers 6.5.0-r1 --> 6.6.0-r1*
* *gps-sensor-broadcaster 6.5.0-r1 --> 6.6.0-r1*
* *gz-cmake-vendor 0.4.3-r1 --> 0.4.4-r1*
* *gz-dartsim-vendor 0.1.2-r1 --> 0.1.3-r1*
* *gz-math-vendor 0.4.2-r1 --> 0.4.3-r1*
* *hardware-interface 6.5.1-r1 --> 6.7.0-r1*
* *hardware-interface-testing 6.5.1-r1 --> 6.7.0-r1*
* *imu-sensor-broadcaster 6.5.0-r1 --> 6.6.0-r1*
* *joint-limits 6.5.1-r1 --> 6.7.0-r1*
* *joint-state-broadcaster 6.5.0-r1 --> 6.6.0-r1*
* *joint-trajectory-controller 6.5.0-r1 --> 6.6.0-r1*
* *kitti-metrics-eval 2.6.1-r1 --> 2.7.0-r1*
* *mecanum-drive-controller 6.5.0-r1 --> 6.6.0-r1*
* *mola 2.6.1-r1 --> 2.7.0-r1*
* *mola-bridge-ros2 2.6.1-r1 --> 2.7.0-r1*
* *mola-demos 2.6.1-r1 --> 2.7.0-r1*
* *mola-imu-preintegration 1.15.0-r1 --> 1.16.0-r1*
* *mola-input-euroc-dataset 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-kitti-dataset 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-kitti360-dataset 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-lidar-bin-dataset 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-mulran-dataset 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-paris-luco-dataset 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-rawlog 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-rosbag2 2.6.1-r1 --> 2.7.0-r1*
* *mola-input-video 2.6.1-r1 --> 2.7.0-r1*
* *mola-kernel 2.6.1-r1 --> 2.7.0-r1*
* *mola-launcher 2.6.1-r1 --> 2.7.0-r1*
* *mola-metric-maps 2.6.1-r1 --> 2.7.0-r1*
* *mola-msgs 2.6.1-r1 --> 2.7.0-r1*
* *mola-pose-list 2.6.1-r1 --> 2.7.0-r1*
* *mola-relocalization 2.6.1-r1 --> 2.7.0-r1*
* *mola-traj-tools 2.6.1-r1 --> 2.7.0-r1*
* *mola-viz 2.6.1-r1 --> 2.7.0-r1*
* *mola-yaml 2.6.1-r1 --> 2.7.0-r1*
* *motion-primitives-controllers 6.5.0-r1 --> 6.6.0-r1*
* *mp2p-icp 2.8.1-r1 --> 2.9.0-r1*
* *mrpt-apps 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libapps 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libbase 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libgui 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libhwdrivers 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libmaps 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libmath 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libnav 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libobs 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libopengl 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libposes 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libros-bridge 3.5.1-r1 --> 3.5.2-r1*
* *mrpt-libslam 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-libtclap 2.15.13-r1 --> 2.15.14-r1*
* *mrpt-map-server 2.3.1-r1 --> 2.4.0-r1*
* *mrpt-msgs-bridge 2.3.1-r1 --> 2.4.0-r1*
* *mrpt-nav-interfaces 2.3.1-r1 --> 2.4.0-r1*
* *mrpt-navigation 2.3.1-r1 --> 2.4.0-r1*
* *mrpt-pf-localization 2.3.1-r1 --> 2.4.0-r1*
* *mrpt-pointcloud-pipeline 2.3.1-r1 --> 2.4.0-r1*
* *mrpt-reactivenav2d 2.3.1-r1 --> 2.4.0-r1*
* *mrpt-tps-astar-planner 2.3.1-r1 --> 2.4.0-r1*
* *mrpt-tutorials 2.3.1-r1 --> 2.4.0-r1*
* *omni-wheel-drive-controller 6.5.0-r1 --> 6.6.0-r1*
* *parallel-gripper-controller 6.5.0-r1 --> 6.6.0-r1*
* *pid-controller 6.5.0-r1 --> 6.6.0-r1*
* *pose-broadcaster 6.5.0-r1 --> 6.6.0-r1*
* *position-controllers 6.5.0-r1 --> 6.6.0-r1*
* *python-qt-binding 2.5.0-r1 --> 2.5.2-r1*
* *qml6-ros2-plugin 4.26.40-r1 --> 4.26.42-r1*
* *range-sensor-broadcaster 6.5.0-r1 --> 6.6.0-r1*
* *rcutils 7.0.9-r1 --> 7.1.1-r1*
* *rmf-demos 2.8.2-r1 --> 2.8.2-r2*
* *rmf-demos-assets 2.8.2-r1 --> 2.8.2-r2*
* *rmf-demos-bridges 2.8.2-r1 --> 2.8.2-r2*
* *rmf-demos-fleet-adapter 2.8.2-r1 --> 2.8.2-r2*
* *rmf-demos-gz 2.8.2-r1 --> 2.8.2-r2*
* *rmf-demos-maps 2.8.2-r1 --> 2.8.2-r2*
* *rmf-demos-tasks 2.8.2-r1 --> 2.8.2-r2*
* *rmw-test-fixture 0.15.6-r1 --> 0.15.7-r1*
* *rmw-test-fixture-implementation 0.15.6-r1 --> 0.15.7-r1*
* *ros-babel-fish 4.26.40-r1 --> 4.26.43-r1*
* *ros-babel-fish-test-msgs 4.26.40-r1 --> 4.26.43-r1*
* *ros-babel-fish-tools 4.26.43-r1*
* *ros-workspace 1.0.3-r6 --> 1.0.3-r7*
* *ros2-control 6.5.1-r1 --> 6.7.0-r1*
* *ros2-control-test-assets 6.5.1-r1 --> 6.7.0-r1*
* *ros2-controllers 6.5.0-r1 --> 6.6.0-r1*
* *ros2-controllers-test-nodes 6.5.0-r1 --> 6.6.0-r1*
* *ros2controlcli 6.5.1-r1 --> 6.7.0-r1*
* *rosbag2rawlog 3.5.1-r1 --> 3.5.2-r1*
* *rosidl-core-generators 0.4.2-r1 --> 0.4.3-r1*
* *rosidl-core-runtime 0.4.2-r1 --> 0.4.3-r1*
* *rqml 3.26.42-r1*
* *rqml-core 3.26.42-r1*
* *rqml-default-plugins 3.26.42-r1*
* *rqml-plugin-example 3.26.42-r1*
* *rqt-controller-manager 6.5.1-r1 --> 6.7.0-r1*
* *rqt-joint-trajectory-controller 6.5.0-r1 --> 6.6.0-r1*
* *rtest 0.2.2-r1*
* *rttest 0.19.2-r1 --> 0.20.0-r1*
* *state-interfaces-broadcaster 6.5.0-r1 --> 6.6.0-r1*
* *steering-controllers-library 6.5.0-r1 --> 6.6.0-r1*
* *tcb-span 2.0.1-r1 --> 2.0.2-r1*
* *tl-expected 2.0.1-r1 --> 2.0.2-r1*
* *tlsf-cpp 0.19.2-r1 --> 0.20.0-r1*
* *topic-tools 1.4.3-r1 --> 1.4.4-r1*
* *topic-tools-interfaces 1.4.3-r1 --> 1.4.4-r1*
* *transmission-interface 6.5.1-r1 --> 6.7.0-r1*
* *tricycle-controller 6.5.0-r1 --> 6.6.0-r1*
* *tricycle-steering-controller 6.5.0-r1 --> 6.6.0-r1*
* *ur-client-library 2.9.0-r1 --> 2.10.0-r1*
* *urdfdom 5.1.1-r1 --> 6.0.0-r1*
* *urdfdom-headers 2.1.1-r1 --> 3.0.0-r1*
* *velocity-controllers 6.5.0-r1 --> 6.6.0-r1*
* *warehouse-ros-sqlite 1.0.6-r1 --> 1.0.7-r1*


No missing dependencies.