### PR TITLE
Fix automatic colcon updates

### DIFF
--- a/pkgs/colcon/notification.nix
+++ b/pkgs/colcon/notification.nix
@@ -2,7 +2,7 @@
 
 buildPythonPackage rec {
   pname = "colcon-notification";
-  version = "0.3.0";
+  version = "0.3.1";
 
   src = fetchPypi {
     inherit version;

--- a/pkgs/colcon/notification.nix
+++ b/pkgs/colcon/notification.nix
@@ -5,7 +5,8 @@ buildPythonPackage rec {
   version = "0.3.0";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit version;
+    pname = "colcon_notification";
     hash = "sha256-xFuJgHOo6YxFGDM7dYf56kmsG8Epp7xOE5AFkFcDH7g=";
   };
 

--- a/pkgs/colcon/output.nix
+++ b/pkgs/colcon/output.nix
@@ -2,12 +2,12 @@
 
 buildPythonPackage rec {
   pname = "colcon-output";
-  version = "0.2.13";
+  version = "0.2.14";
 
   src = fetchPypi {
     inherit version;
     pname = "colcon_output";
-    hash = "sha256-RNLTSevbYWiLQeANVl6hoZno/Fwsd68nnPqsdNwBwE0=";
+    hash = "sha256-IetY7i/i33bhIbpI6wIsYFi/JMvW1mtDP709+w+YLEc=";
   };
 
   pyproject = true;

--- a/pkgs/colcon/output.nix
+++ b/pkgs/colcon/output.nix
@@ -5,7 +5,8 @@ buildPythonPackage rec {
   version = "0.2.13";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit version;
+    pname = "colcon_output";
     hash = "sha256-RNLTSevbYWiLQeANVl6hoZno/Fwsd68nnPqsdNwBwE0=";
   };
 

--- a/pkgs/colcon/package-information.nix
+++ b/pkgs/colcon/package-information.nix
@@ -5,7 +5,8 @@ buildPythonPackage rec {
   version = "0.4.0";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit version;
+    pname = "colcon_package_information";
     hash = "sha256-IPUYSuGwXbCnbyRLyFYi9rJeSO9zmPVXhMz+RV1AvPs=";
   };
 

--- a/pkgs/colcon/package-information.nix
+++ b/pkgs/colcon/package-information.nix
@@ -2,7 +2,7 @@
 
 buildPythonPackage rec {
   pname = "colcon-package-information";
-  version = "0.4.0";
+  version = "0.4.1";
 
   src = fetchPypi {
     inherit version;


### PR DESCRIPTION
PyPI changed naming of files to download and we have to update out expressions for automatic updates to work. Without this, updates fail like [here](https://github.com/lopsided98/nix-ros-overlay/actions/runs/25216492908).