### PR TITLE
CI: Add lyrical

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,7 @@ jobs:
           - humble
           - jazzy
           - kilted
+          - lyrical
           - rolling
         system:
           - x86_64-linux


### PR DESCRIPTION
I forgot to add this when I added Lyrical. Without this, lyrical binaries are not built and uploaded to the binary cache. This causes our Superflore runs to timeout in "Update ament_vendor info" step, because it needs to build many packages from source instead of fetching them from the cache.