### PR TITLE
workflows: Fix removal of untouched tarballs from the cache

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -27,6 +27,8 @@ jobs:
           restore-keys: tars
           path: |
             ~/.ros/tar
+      - name: Mark all cached files as untouched
+        run: "touch --date=@0 ~/.ros/tar/*"
       - name: Update overlay
         env:
           GITHUB_RUNNER_TEMP: ${{ runner.temp }}
@@ -40,7 +42,7 @@ jobs:
             }; f'
           nix run .#update-overlay
       - name: Remove untouched files from the cache
-        run: "find ~/.ros/tar -atime +1 | tee >(xargs -r ls -lh >&2) | xargs -r rm"
+        run: "find ~/.ros/tar -atime +1 | xargs -r rm -v"
       - name: Save ROS tarball cache
         uses: actions/cache/save@v4
         with:


### PR DESCRIPTION
We need to touch the files with old date (`@0`) to see, which files were actually used by Superflore.

When removing the unneeded files, we should not print them with "ls" while removing them at the same time.