### PR TITLE
Run Superflore against rosdistro version locked in flake.lock

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -15,6 +15,17 @@ jobs:
         with:
           name: ros
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+      - name: Configure git
+        run: |
+          git config --local user.email "superflore@github.com"
+          git config --local user.name "Superflore"
+          git config credential.helper '!
+            f() {
+              echo "username=lopsided98"
+              echo "password=${SUPERFLORE_GITHUB_TOKEN}"
+            }; f'
+      - name: Update rosdistro
+        run: nix flake update rosdistro --commit-lock-file
       - name: Install Superflore
         run: |
           nix build .#update-overlay
@@ -31,13 +42,6 @@ jobs:
         env:
           GITHUB_RUNNER_TEMP: ${{ runner.temp }}
         run: |
-          git config --local user.email "superflore@github.com"
-          git config --local user.name "Superflore"
-          git config credential.helper '!
-            f() {
-              echo "username=lopsided98"
-              echo "password=${SUPERFLORE_GITHUB_TOKEN}"
-            }; f'
           nix run .#update-overlay
       - name: Remove untouched files from the cache
         run: "find ~/.ros/tar -atime +1 | tee >(xargs -r ls -lh >&2) | xargs -r rm"

--- a/README.md
+++ b/README.md
@@ -167,10 +167,11 @@ There are thousands of ROS packages, so it is infeasible to make sure every pack
 
 The overlay is updated semi-automatically approximately every few
 weeks. If you want to try a more recent ROS version, you can update
-the whole overlay locally by running the following command from
+the whole overlay locally by running the following commands from
 repository root:
 
 ```
+nix flake update rosdistro
 nix run .#update-overlay
 ```
 
@@ -182,6 +183,13 @@ command line. For example, the following command updates just the
 
 ```
 nix run .#update-overlay -- --dry-run --output-repository-path . --tar-archive-dir .tar --no-branch --ros-distro jazzy
+```
+
+You can also regenerate the overlay from a custom version of the
+rosdistro repository:
+
+```sh
+nix run .#update-overlay --override-input rosdistro /path/to/local/rosdistro
 ```
 
 **Q: Do you provide packages for ROS 1 or Gazebo Classic?**

--- a/flake.lock
+++ b/flake.lock
@@ -37,7 +37,24 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rosdistro": "rosdistro"
+      }
+    },
+    "rosdistro": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1777588030,
+        "narHash": "sha256-2rUTgWkEhSKOUxF8jNqVtt5OOUbONeRWpeVBK9O/XZU=",
+        "owner": "ros",
+        "repo": "rosdistro",
+        "rev": "cbeafda93a5adcc1168fec90474a08761b98b0ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ros",
+        "repo": "rosdistro",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,10 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    rosdistro = { url = "github:ros/rosdistro"; flake = false; };
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils, rosdistro }:
     with nixpkgs.lib;
     with flake-utils.lib;
     eachSystem systems.flakeExposed (system: let
@@ -23,7 +24,9 @@
     in {
       legacyPackages = (intersectAttrs (self.overlays.default null pkgs) pkgs)
                        // pkgs.rosPackages; # for backward compatibility
-      packages.update-overlay = pkgs.callPackage ./maintainers/scripts/update-overlay.nix { };
+      packages.update-overlay = pkgs.callPackage ./maintainers/scripts/update-overlay.nix {
+        inherit rosdistro;
+      };
 
       devShells = {
         example-turtlebot3-gazebo = import ./examples/turtlebot3-gazebo.nix { inherit pkgs; };

--- a/maintainers/scripts/update-overlay.nix
+++ b/maintainers/scripts/update-overlay.nix
@@ -1,24 +1,98 @@
 {
-  curl,
+  python3,
   python3Packages,
+  rosdistro,
+  stdenv,
   superflore,
   writeShellApplication,
+  yq-go,
 }:
+let
+  rosdistro-offline = stdenv.mkDerivation {
+    pname = "rosdistro";
+    version = rosdistro.lastModifiedDate;
+    src = rosdistro;
+    postPatch = ''
+      substituteInPlace rosdep/sources.list.d/20-default.list \
+        --replace-fail https://raw.githubusercontent.com/ros/rosdistro/master/ file://${placeholder "out"}/
+    '';
+    postInstall = ''
+      mkdir -p $out
+      cp -r * $out
+    '';
+  };
+  rosdep-unwrapped = python3Packages.rosdep.overrideAttrs ({ postPatch ? "", ...}: {
+    postPatch = postPatch + ''
+      substituteInPlace src/rosdep2/rep3.py \
+        --replace-fail https://raw.githubusercontent.com/ros/rosdistro/master/ file://${rosdistro}/
+    '';
+  });
+  rosdep-cache = stdenv.mkDerivation {
+    pname = "rosdep-cache";
+    version = rosdistro.lastModifiedDate;
+    nativeBuildInputs = [
+      rosdep-unwrapped
+    ];
+    ROSDEP_SOURCE_PATH = "${rosdistro-offline}/rosdep/sources.list.d";
+    ROSDISTRO_INDEX_URL = "file://${rosdistro-offline}/index-v4.yaml";
+    ROS_HOME = placeholder "out";
+    buildCommand = ''
+      mkdir -p $out
+      rosdep update
+    '';
+  };
+in
 writeShellApplication {
   name = "update-overlay";
 
   runtimeInputs = [
-    curl
     superflore
-    python3Packages.rosdep
+    yq-go
+    (python3.withPackages (p: [ p.rosdistro ]))
   ];
 
   runtimeEnv = {
+    ROS_HOME = rosdep-cache;
+    ROSDISTRO_INDEX_URL = "file://${rosdistro-offline}/index-v4.yaml";
     ROS_OS_OVERRIDE = "nixos";
-    ROSDEP_SOURCE_PATH = "rosdep-sources";
+    ROSDEP_SOURCE_PATH = "${rosdistro-offline}/rosdep/sources.list.d";
   };
 
   text = ''
+    ################################################################
+    # Build rosdistro cache corresponding to locked rosdistro commit
+
+    # This requires network access to fetch package.xml files so we
+    # perform it here instead of in a separate derivation like
+    # rosdep-cache.
+    mapfile -t DISTROS < <(python -c "
+    import rosdistro
+    index = rosdistro.get_index(rosdistro.get_index_url())
+    def should_generate(distro):
+      return index.distributions[distro]['distribution_status'] in ['active', 'pre-release', 'rolling']
+    print('\n'.join([distro for distro in index.distributions.keys() if should_generate(distro)]))
+    ")
+    cache_dir=''${XDG_CACHE_HOME:-~/.cache}/rosdistro-cache/${rosdistro.rev}
+    if [[ ! -d "$cache_dir" ]]; then
+      mkdir -p "$(dirname "$cache_dir")"
+      cache_tmp=$(mktemp --directory "''${cache_dir}.XXXXXX")
+      (
+        cd "$cache_tmp"
+        rosdistro_build_cache "$ROSDISTRO_INDEX_URL" "''${DISTROS[@]}"
+        cp ${rosdistro-offline}/index-v4.yaml .
+        chmod +w index-v4.yaml
+        for distro in "''${DISTROS[@]}"; do
+          yq -i ".distributions.$distro.distribution_cache = \"$distro-cache.yaml\"" index-v4.yaml
+        done
+      )
+      mv "$cache_tmp" "$cache_dir"
+    fi
+    echo "Using rosdistro cache in $cache_dir"
+    ROSDISTRO_INDEX_URL="file://$cache_dir/index-v4.yaml"
+
+    ################################################################
+    # Run Superflore
+    mkdir -p ~/.ros/tar
     if [[ $# -eq 0 ]]; then
       echo "No superflore parameters specified, using defaults."
       if [[ ''${GITHUB_ACTION:-} ]]; then
@@ -30,9 +104,6 @@ writeShellApplication {
       fi
     fi
     set -x
-    mkdir -p "$ROSDEP_SOURCE_PATH"
-    curl https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/sources.list.d/20-default.list -o "$ROSDEP_SOURCE_PATH/20-default.list"
-    rosdep update
     superflore-gen-nix "$@"
   '';
 }


### PR DESCRIPTION
Previously, updating the overlay used the latest rosdistro version available at time of running the command. This worked well, except that it was not reproducible.

Now, we use the same "trick" as ros2nix, which locks rosdistro in `flake.lock` and makes the underlying tooling use that version by setting several environment variables.

The advantages of this approach are the following:
- The results or running the update command are reproducible.
- It is possible to test rosdistro and rosdep updates locally by regenerating overlay from a local rosdistro version.
- It simplifies experimenting with changes to Superflore, because the output does not depend on online state.

Compared to ros2nix, which uses just the rosdep database, Superflore needs the full rosdistro database. The problem with rosdistro database is that it normally uses an online cache, which is built by the official ROS buildfarm. For Nix, we would like to build the cache via pure computation in Nix derivation (like we do with rosdep cache), but this is not possible. The cache contains the content of `package.xml` files of all ROS packages and these need to be fetched from the internet. To do that in Nix, we would need to use impure-derivation experimental feature, which is not enabled by default and is not available in all Nix implementations. Therefore, we build the cache outside of Nix (via `nix run`) and store it between invocations under `~/.cache/rosdistro-cache`.