### PR TITLE
bloom: 0.13.0 -> 0.14.3

### DIFF
--- a/pkgs/bloom/default.nix
+++ b/pkgs/bloom/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "bloom";
-  version = "0.13.0";
+  version = "0.14.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ros-infrastructure";
     repo = "bloom";
     rev = version;
-    hash = "sha256-sKtLAHCwdzSGCa/jTx6ItImyCJr7ssKQafDkb4ayB8k=";
+    hash = "sha256-gQNk3HbSSsN8yet330x438+HIZBrS48z55kWt6ASBeI=";
   };
 
   patches = [

--- a/pkgs/bloom/default.nix
+++ b/pkgs/bloom/default.nix
@@ -3,7 +3,6 @@
   catkin-pkg,
   empy_3,
   fetchFromGitHub,
-  fetchpatch2,
   lib,
   rosdep,
   rosdistro,
@@ -22,15 +21,6 @@ buildPythonPackage rec {
     rev = version;
     hash = "sha256-gQNk3HbSSsN8yet330x438+HIZBrS48z55kWt6ASBeI=";
   };
-
-  patches = [
-    (fetchpatch2 {
-      # ref. https://github.com/ros-infrastructure/bloom/pull/705
-      name = "debian-architecture-independant.patch";
-      url = "https://github.com/ros-infrastructure/bloom/commit/9e2de64bf1aa286087c70ddad658b0d57339d1fd.patch?full_index=1";
-      hash = "sha256-j9aAX60ydkXPGJasmiRd/h7h9AsEZ/pdqdDfJFSvKcI=";
-    })
-  ];
 
   build-system = [ setuptools ];
 


### PR DESCRIPTION
Hi,

bloom did stop working for me with:
```
==> Generating pull request to distro file located at 'https://raw.githubusercontent.com/ros/rosdistro/master/humble/distribution.yaml'
Unified diff for the ROS distro file located at '/tmp/tmpwvbt2xf2/coal-3.0.3-2.patch':
--- humble/distribution.yaml
+++ humble/distribution.yaml
@@ -1820,7 +1820,7 @@
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/coal-release.git
-      version: 3.0.2-1
+      version: 3.0.3-2
     source:
       type: git
       url: https://github.com/coal-library/coal.git
==> Checking on GitHub for a fork to make the pull request from...
Could not find a fork of ros/rosdistro on the nim65s GitHub account.
Would you like to create one now?
Continue [Y/n]? 
Aborting pull request: HTTP Error 401: Unauthorized (https://api.github.com/repos/ros/rosdistro/forks)
The release of your packages was successful, but the pull request failed.
Please manually open a pull request by editing the file here: 'https://raw.githubusercontent.com/ros/rosdistro/master/humble/distribution.yaml'
❌  No pull request opened.
```

So here is a little update, which did not help at all, because this error was caused by an expired github token in `~/.config/bloom`, even if `$GITHUB_TOKEN` and `gh auth status` were fine…

Anyways, update is done now.

While here I'm removing the patch for  https://github.com/ros-infrastructure/bloom/pull/705, as it turns out ROS buildfarm is not ready for this to work (even with this it still pass `-DCMAKE_INSTALL_LIBDIR=lib/x86_64-linux-gnu`), and I found other ways to fix the issue I had.