### PR TITLE
rosdistro sync, Fri May 22 15:59:36 2026

### DIFF
--- a/distros/humble/agnocast-cie-config-msgs/default.nix
+++ b/distros/humble/agnocast-cie-config-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-agnocast-cie-config-msgs";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/humble/agnocast_cie_config_msgs/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "3ff054587a45521affafff68842834991e6ceeb8bb813433e816ab5a56f5e108";
+    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/humble/agnocast_cie_config_msgs/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "0c74dd15f8603fc5a48edda7208bd29936e95e97b570337dfc3633217e4fa6a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/agnocast-cie-thread-configurator/default.nix
+++ b/distros/humble/agnocast-cie-thread-configurator/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, agnocast-cie-config-msgs, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, yaml-cpp }:
+{ lib, buildRosPackage, fetchurl, agnocast-cie-config-msgs, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rclcpp, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-agnocast-cie-thread-configurator";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/humble/agnocast_cie_thread_configurator/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "ef982dbfdc77822602b99291fb897b8655d8477a8223af23b90bd6b51caacbbb";
+    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/humble/agnocast_cie_thread_configurator/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "9de8863e880a098a4c59401b1c92dd3684ec53944366c5dfeb24c8abd56ff1ee";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ agnocast-cie-config-msgs rclcpp yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/humble/agnocast-components/default.nix
+++ b/distros/humble/agnocast-components/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, agnocast-cie-config-msgs, agnocast-cie-thread-configurator, agnocastlib, ament-cmake, class-loader, glog, launch-testing-ament-cmake, rclcpp, rclcpp-components }:
+{ lib, buildRosPackage, fetchurl, agnocast-cie-config-msgs, agnocast-cie-thread-configurator, agnocastlib, ament-cmake, class-loader, glog, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-humble-agnocast-components";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/humble/agnocast_components/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "bae26928e887299479410d30a28c407864daf51fd9c94a8ae573ae047eaadbdb";
+    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/humble/agnocast_components/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "f786efa6eba62ccbf6794b7844305b70d3a60969c2d2380a9bc4dff6f182b4bc";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ launch-testing-ament-cmake ];
   propagatedBuildInputs = [ agnocast-cie-config-msgs agnocast-cie-thread-configurator agnocastlib class-loader glog rclcpp rclcpp-components ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/humble/agnocast-e2e-test/default.nix
+++ b/distros/humble/agnocast-e2e-test/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, agnocast-components, agnocastlib, ament-cmake, rclcpp, rclcpp-components, std-msgs }:
+{ lib, buildRosPackage, fetchurl, agnocast-cie-config-msgs, agnocast-cie-thread-configurator, agnocast-components, agnocastlib, ament-cmake, launch-testing-ament-cmake, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-agnocast-e2e-test";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/humble/agnocast_e2e_test/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "2c1dd1af4ddf37eab46b45f26737be1aef015edd879719bdd3e8a153e387b9d0";
+    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/humble/agnocast_e2e_test/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "87bb1eff687c50eb2d7fb78dd44e44cb814c6e08b321c15b3d2813b320981a0d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ agnocast-components agnocastlib rclcpp rclcpp-components std-msgs ];
+  checkInputs = [ agnocast-cie-config-msgs launch-testing-ament-cmake ];
+  propagatedBuildInputs = [ agnocast-cie-thread-configurator agnocast-components agnocastlib rclcpp rclcpp-components std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/agnocast-ioctl-wrapper/default.nix
+++ b/distros/humble/agnocast-ioctl-wrapper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-agnocast-ioctl-wrapper";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/humble/agnocast_ioctl_wrapper/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "198fb0bdbf8259d69e56198c28dd6a6d4cf9382ecad5b2bf6b49007d223d62e9";
+    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/humble/agnocast_ioctl_wrapper/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "8def82fa91f481483fdcd941d877bca00bef7088232cb3b22427caa41b3c3f38";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/agnocast-sample-application/default.nix
+++ b/distros/humble/agnocast-sample-application/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, agnocast-components, agnocast-sample-interfaces, agnocastlib, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-humble-agnocast-sample-application";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/humble/agnocast_sample_application/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "acdada074309d8123730ff359a80f84a4bda5f8e2339751c588ee0d245e57d07";
+    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/humble/agnocast_sample_application/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "e9c2a7ead1d545529578c8690d1a505b0c0c8e441007b14796f0de98ccfc695a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/agnocast-sample-interfaces/default.nix
+++ b/distros/humble/agnocast-sample-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-agnocast-sample-interfaces";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/humble/agnocast_sample_interfaces/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "7d4f6895e3e9e1a4925ba3cfa3055c4358a83a9c2cfde8092dfb548993f8ad7f";
+    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/humble/agnocast_sample_interfaces/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "ca3e01d44383d04450b60baaa4748f3e6afe8cacd8451d86f38d3973de978dda";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/agnocast/default.nix
+++ b/distros/humble/agnocast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, agnocast-cie-config-msgs, agnocast-cie-thread-configurator, agnocast-components, agnocast-ioctl-wrapper, agnocast-sample-application, agnocast-sample-interfaces, agnocastlib, ament-cmake, ros2agnocast }:
 buildRosPackage {
   pname = "ros-humble-agnocast";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/humble/agnocast/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "ec47032fd53e6cfa563962b13c0b0bd7a30f9849fdf6f943c4ad36f39b55195a";
+    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/humble/agnocast/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "145973664af60e1a010146764e0a2946628ff3cc6d1b61d4fabca7aef23c865d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/agnocastlib/default.nix
+++ b/distros/humble/agnocastlib/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, agnocast-cie-config-msgs, agnocast-cie-thread-configurator, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, glog, launch-testing-ament-cmake, lttng-ust, message-filters, rcl-yaml-param-parser, rclcpp, rclcpp-components, rosgraph-msgs, std-msgs, tracetools }:
+{ lib, buildRosPackage, fetchurl, agnocast-cie-config-msgs, agnocast-cie-thread-configurator, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, geometry-msgs, glog, launch-testing-ament-cmake, lttng-ust, message-filters, rcl-yaml-param-parser, rclcpp, rclcpp-components, rosgraph-msgs, std-msgs, tf2, tf2-msgs, tf2-ros, tracetools }:
 buildRosPackage {
   pname = "ros-humble-agnocastlib";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/humble/agnocastlib/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "75102c4e958cf48a9487693973293f2a4aabe869c7d1fc04655a15b7d8b70d2f";
+    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/humble/agnocastlib/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "8ca6b2e7f70cde915ab4609e5d99710373a11c28cc2d8ff90b2164ce70036fc8";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common launch-testing-ament-cmake std-msgs ];
-  propagatedBuildInputs = [ agnocast-cie-config-msgs agnocast-cie-thread-configurator ament-index-cpp glog lttng-ust message-filters rcl-yaml-param-parser rclcpp rclcpp-components rosgraph-msgs tracetools ];
+  propagatedBuildInputs = [ agnocast-cie-config-msgs agnocast-cie-thread-configurator ament-index-cpp diagnostic-msgs diagnostic-updater geometry-msgs glog lttng-ust message-filters rcl-yaml-param-parser rclcpp rclcpp-components rosgraph-msgs tf2 tf2-msgs tf2-ros tracetools ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/compass-msgs/default.nix
+++ b/distros/humble/compass-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-compass-msgs";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/compass_msgs/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "8cc41b3bd4d094c0c7148208b7b07ba114c1c5129a9c40cae75beb31ff4ca02d";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/compass_msgs/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "b666a202fb196579c33b91a7f3ffe8462120d179494de90d0fdc7030d74ff465";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/crocoddyl/default.nix
+++ b/distros/humble/crocoddyl/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, cmake, doxygen, eigenpy, ffmpeg, git, ipopt, jrl-cmakemodules, pinocchio, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-crocoddyl";
+  version = "3.2.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crocoddyl-release/archive/release/humble/crocoddyl/3.2.1-2.tar.gz";
+    name = "3.2.1-2.tar.gz";
+    sha256 = "49e17f8a38692211eaccfe8582d7b2bc63abe44982362d8fafa8c32a03c65031";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake doxygen git jrl-cmakemodules ];
+  checkInputs = [ ffmpeg python3Packages.nbconvert python3Packages.notebook python3Packages.scipy ];
+  propagatedBuildInputs = [ ament-cmake boost eigenpy ipopt pinocchio python3 python3Packages.numpy ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Crocoddyl optimal control library";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/depthai-bridge-v3/default.nix
+++ b/distros/humble/depthai-bridge-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-info-manager, composition-interfaces, cv-bridge, depthai-ros-msgs-v3, depthai-v3, ffmpeg-image-transport-msgs, image-transport, nav-msgs, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-bridge-v3";
-  version = "3.1.1-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_bridge_v3/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "7514317ad0bbce098a16477151bd491d8c1bdd9583a69417eda81a5657cebf43";
+    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_bridge_v3/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "f8241e157dfb8ae97f4f1824b4f79eb3cc26df7caca9bc1e5d0ec06ef70b900f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-descriptions-v3/default.nix
+++ b/distros/humble/depthai-descriptions-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-descriptions-v3";
-  version = "3.1.1-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_descriptions_v3/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "fc5598f3dc106c07723689718a22b16b2d216c4a4f3f019d18b69b5ca8165437";
+    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_descriptions_v3/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "5ef85c063e68d2c0c2777aa1aa77af3b924511100b46ce5b948eaddceef8c92f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-examples-v3/default.nix
+++ b/distros/humble/depthai-examples-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, backward-ros, camera-info-manager, cv-bridge, depth-image-proc, depthai-bridge-v3, depthai-descriptions-v3, depthai-ros-msgs-v3, depthai-v3, foxglove-msgs, image-transport, nav-msgs, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-examples-v3";
-  version = "3.1.1-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_examples_v3/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "01390265e5929bd9a0016ec98799498412fc1155889f519404e0525c176a5d44";
+    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_examples_v3/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "4bef5abf542d52f1e93dd437c4251973f2d247a55b233e41f56e1b40c3aa16fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-filters-v3/default.nix
+++ b/distros/humble/depthai-filters-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, depthai-ros-msgs-v3, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-filters-v3";
-  version = "3.1.1-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_filters_v3/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "8c3328fc5332858692a938cd007526b2c57a9a500c3e09d6faee83c12819b3c7";
+    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_filters_v3/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "f85ec0998f77c8587e91d04b7b470d770516f77591c18335111bb07b37d5a63a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros-driver-v3/default.nix
+++ b/distros/humble/depthai-ros-driver-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-python, backward-ros, camera-calibration, camera-info-manager, cv-bridge, depthai-bridge-v3, depthai-descriptions-v3, depthai-ros-msgs-v3, depthai-v3, diagnostic-msgs, diagnostic-updater, ffmpeg-image-transport-msgs, geometry-msgs, image-pipeline, image-transport, image-transport-plugins, nav-msgs, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, tf2-ros, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-driver-v3";
-  version = "3.1.1-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_ros_driver_v3/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "7529c1199c0b1f686c340c59a9583cf6096b5c17a5ecf4e8a7e573f89594de3e";
+    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_ros_driver_v3/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "a455cbac9b00e1f6fcf844845b8f4added41d7885ff984ee7e3b7fe957a733fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros-msgs-v3/default.nix
+++ b/distros/humble/depthai-ros-msgs-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-msgs-v3";
-  version = "3.1.1-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_ros_msgs_v3/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "f8e6878e9be0863968d53f9420bdd0b761231258f97405ebd070fc0a366916b4";
+    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_ros_msgs_v3/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "98e2df1ae8d233e49073912d73f9e8999af461bb1f5240bef593dd67169cf4bd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros-v3/default.nix
+++ b/distros/humble/depthai-ros-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai-bridge-v3, depthai-descriptions-v3, depthai-examples-v3, depthai-filters-v3, depthai-ros-driver-v3, depthai-ros-msgs-v3, depthai-v3 }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-v3";
-  version = "3.1.1-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_ros_v3/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "3b1619715044bb1e54cd8caebeb5167c0ed9c6408851bebaaa554b91de98d5e5";
+    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_ros_v3/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "78e58a73be7359afcd94b6ef575ce2be35d88fd122024d71e05d6f4abfe11dcd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/fusioncore-core/default.nix
+++ b/distros/humble/fusioncore-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module }:
 buildRosPackage {
   pname = "ros-humble-fusioncore-core";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/fusioncore_core/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "a848a5f7a729cf214a7794f81f1f1fab993c6b5d00636b1ae9f099c7e64e8878";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/fusioncore_core/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "f31c29b080a345a13f585840112256d65b40e96e9f85b50a6851634779127e6b";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "Pure C++ UKF sensor fusion library underlying FusionCore. Fuses IMU, wheel encoders and GPS in a 22-state unscented Kalman filter. Includes ECEF GPS conversion, IMU bias estimation, adaptive noise covariance, chi-squared outlier gating, and ZUPT. No ROS dependency, usable standalone.";
+    description = "Pure C++ UKF sensor fusion library underlying FusionCore. Fuses IMU, wheel encoders, GPS, and visual SLAM pose in a 22-state unscented Kalman filter. Includes ECEF GPS conversion, IMU bias estimation, adaptive noise covariance, chi-squared outlier gating, ZUPT, and GPS-denied operation. No ROS dependency, usable standalone.";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/humble/fusioncore-datasets/default.nix
+++ b/distros/humble/fusioncore-datasets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fusioncore-ros, geometry-msgs, nav-msgs, rclpy, robot-localization, rosgraph-msgs, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-fusioncore-datasets";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/fusioncore_datasets/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "4fc23b772307080638507845a6d856a09da3e0a869e72828915073a0ce7305d0";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/fusioncore_datasets/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "7cfe7f7547644c05ac40e8ece6de3f66a96deb79912d733eaa011ae4116a11d0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/fusioncore-gazebo/default.nix
+++ b/distros/humble/fusioncore-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fusioncore-ros, nav-msgs, rclpy, robot-state-publisher, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-fusioncore-gazebo";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/fusioncore_gazebo/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "62222563dbba9e5a63f6a26a85ee671cc36ceda02dea9c9146f101a9c6da9073";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/fusioncore_gazebo/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "a814642a4821dfb1a7c7746f46d71cf47f48912a6b2a9f1c3f994e319c054b5c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/fusioncore-ros/default.nix
+++ b/distros/humble/fusioncore-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, compass-msgs, diagnostic-msgs, eigen3-cmake-module, fusioncore-core, geographic-msgs, geometry-msgs, nav-msgs, proj, rclcpp, rclcpp-lifecycle, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-fusioncore-ros";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/fusioncore_ros/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "b475d543b434063ddf3002afdc299c30ccd9d568e01fec2e0fae91cfba9b509d";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/fusioncore_ros/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "0500dd2afe36c5c311e38f39d298dbb9490401e18ccb746a9afbbf7311a53d71";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {
-    description = "ROS 2 UKF sensor fusion for GPS, IMU and wheel encoders. 22-state filter with ECEF-native GPS handling, automatic IMU bias estimation, adaptive noise covariance, and chi-squared outlier rejection on every sensor. Drop-in robot_localization alternative. Native ROS 2 Jazzy and Humble, benchmarked on 6 NCLT public dataset sequences.";
+    description = "ROS 2 UKF sensor fusion for IMU, wheel encoders, GPS, and visual SLAM pose. 22-state filter with ECEF-native GPS handling, automatic IMU bias estimation, adaptive noise covariance, chi-squared outlier rejection on every sensor, and map reinitialization recovery for GPS-denied operation. Drop-in robot_localization alternative. Native ROS 2 Jazzy, benchmarked on 6 NCLT public dataset sequences.";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -838,6 +838,8 @@ self: super: {
 
  create-robot = self.callPackage ./create-robot {};
 
+ crocoddyl = self.callPackage ./crocoddyl {};
+
  crx-kinematics = self.callPackage ./crx-kinematics {};
 
  cudnn-cmake-module = self.callPackage ./cudnn-cmake-module {};
@@ -1708,6 +1710,8 @@ self: super: {
 
  kinova-gen3-lite-moveit-config = self.callPackage ./kinova-gen3-lite-moveit-config {};
 
+ kitti-metrics-eval = self.callPackage ./kitti-metrics-eval {};
+
  kobuki-core = self.callPackage ./kobuki-core {};
 
  kobuki-ros-interfaces = self.callPackage ./kobuki-ros-interfaces {};
@@ -2042,6 +2046,8 @@ self: super: {
 
  mola = self.callPackage ./mola {};
 
+ mola-academic-datasets = self.callPackage ./mola-academic-datasets {};
+
  mola-bridge-ros2 = self.callPackage ./mola-bridge-ros2 {};
 
  mola-common = self.callPackage ./mola-common {};
@@ -2056,7 +2062,19 @@ self: super: {
 
  mola-imu-preintegration = self.callPackage ./mola-imu-preintegration {};
 
+ mola-input-euroc-dataset = self.callPackage ./mola-input-euroc-dataset {};
+
+ mola-input-kitti360-dataset = self.callPackage ./mola-input-kitti360-dataset {};
+
+ mola-input-kitti-dataset = self.callPackage ./mola-input-kitti-dataset {};
+
  mola-input-lidar-bin-dataset = self.callPackage ./mola-input-lidar-bin-dataset {};
+
+ mola-input-mulran-dataset = self.callPackage ./mola-input-mulran-dataset {};
+
+ mola-input-ouster = self.callPackage ./mola-input-ouster {};
+
+ mola-input-paris-luco-dataset = self.callPackage ./mola-input-paris-luco-dataset {};
 
  mola-input-rawlog = self.callPackage ./mola-input-rawlog {};
 
@@ -2463,6 +2481,8 @@ self: super: {
  novatel-gps-driver = self.callPackage ./novatel-gps-driver {};
 
  novatel-gps-msgs = self.callPackage ./novatel-gps-msgs {};
+
+ novatel-oem6-msgs = self.callPackage ./novatel-oem6-msgs {};
 
  novatel-oem7-driver = self.callPackage ./novatel-oem7-driver {};
 

--- a/distros/humble/kitti-metrics-eval/default.nix
+++ b/distros/humble/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmath, mrpt-libposes, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-humble-kitti-metrics-eval";
-  version = "2.8.0-r1";
+  version = "3.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/kitti_metrics_eval/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "66298fa042ada182ac6755e73d10fb75cdc8833bb0d009cdca0f990bfdac5391";
+    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/humble/kitti_metrics_eval/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "690c5c5ac006e6e3a0a5b65921a5c7fffb853137d99397b022df12ae658837bd";
   };
 
   buildType = "cmake";

--- a/distros/humble/log-view/default.nix
+++ b/distros/humble/log-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ncurses, rcl-interfaces, rclcpp, xclip, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-log-view";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/hatchbed/log_view-release/archive/release/humble/log_view/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "89f2e5dc6bce37b9d54e4f3cf0c89b85a3a05f29805d932a72a0c84a13962c7e";
+    url = "https://github.com/hatchbed/log_view-release/archive/release/humble/log_view/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "1ac96bf8fa982f89aaa80c4c5009dc265e283dea52c5459ed05063d7aefd8c40";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-academic-datasets/default.nix
+++ b/distros/humble/mola-academic-datasets/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, kitti-metrics-eval, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset }:
+buildRosPackage {
+  pname = "ros-humble-mola-academic-datasets";
+  version = "3.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/humble/mola_academic_datasets/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "623ed16ad0b1b70a3e7c2305966624daffb6acbdfc4c6881881308a4ddd9718e";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ kitti-metrics-eval mola-input-euroc-dataset mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Metapackage with all packages supporting reading academic datasets.";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/mola-common/default.nix
+++ b/distros/humble/mola-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-common";
-  version = "0.6.0-r2";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/humble/mola_common/0.6.0-2.tar.gz";
-    name = "0.6.0-2.tar.gz";
-    sha256 = "bb84a4fe7c71163a94adc0eefc63febe30bc8d9749b48b776980b487028752de";
+    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/humble/mola_common/0.6.1-1.tar.gz";
+    name = "0.6.1-1.tar.gz";
+    sha256 = "784dc09a1dfa801a82a63bf03f66a759fa7f6a4dc8549c2007c83179bc19f4b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-input-euroc-dataset/default.nix
+++ b/distros/humble/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmath, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-input-euroc-dataset";
-  version = "2.8.0-r1";
+  version = "3.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_euroc_dataset/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "21eb5928ef8576221c8f61ba07a36a1d58101575c4232b99d36e0744348deaa3";
+    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/humble/mola_input_euroc_dataset/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "4d0730ad97d059765854e5acd74358168b6dfc20d30209fa5b5177209962ef34";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-kitti-dataset/default.nix
+++ b/distros/humble/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-humble-mola-input-kitti-dataset";
-  version = "2.8.0-r1";
+  version = "3.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti_dataset/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "42b7ea6174378a00e7b5f6ee24856765beeac6f1014c5a6b983fa32fec8504fe";
+    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/humble/mola_input_kitti_dataset/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "548efa5c5367ad06a1b2f4c0e116e38d836e4d060f4a8c35abbdd162ffe1a666";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-kitti360-dataset/default.nix
+++ b/distros/humble/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-humble-mola-input-kitti360-dataset";
-  version = "2.8.0-r1";
+  version = "3.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti360_dataset/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "22b14033e06b385d94affc1fd9965e066cb4d9d39893aedb5cf9c655e8df4092";
+    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/humble/mola_input_kitti360_dataset/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "fab162e3ef2e62cbdd5f8825181cdc098692cdf8d3c221e2ed84a1ae39354588";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-mulran-dataset/default.nix
+++ b/distros/humble/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-humble-mola-input-mulran-dataset";
-  version = "2.8.0-r1";
+  version = "3.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_mulran_dataset/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "2ab2e15076529a628938b41e6fdd0e1259baa8b4a0b9a1fc0a56df69c48e13f8";
+    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/humble/mola_input_mulran_dataset/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "dd314ca0138e46a31c517f0399fa7fe84a2ecc36a4a85e1443596756c7253a56";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-ouster/default.nix
+++ b/distros/humble/mola-input-ouster/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, curl, eigen, flatbuffers, libpng, libtins, libzip, mola-kernel, mola-yaml, mrpt-libmaps, mrpt-libobs, openssl, zstd }:
+buildRosPackage {
+  pname = "ros-humble-mola-input-ouster";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_input_ouster-release/archive/release/humble/mola_input_ouster/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "0aa31802d241120f3ac49fec0b1a2e43b2309fd790f6f9c654fdba4d1e46e968";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen flatbuffers libpng libtins libzip openssl zstd ];
+  propagatedBuildInputs = [ curl mola-kernel mola-yaml mrpt-libmaps mrpt-libobs ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "MOLA input module for Ouster LiDAR sensors using the native Ouster C++ SDK.
+    Provides direct sensor connection and PCAP replay without ROS middleware.";
+    license = with lib.licenses; [ "GPL-3.0" ];
+  };
+}

--- a/distros/humble/mola-input-paris-luco-dataset/default.nix
+++ b/distros/humble/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-humble-mola-input-paris-luco-dataset";
-  version = "2.8.0-r1";
+  version = "3.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_paris_luco_dataset/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "128cdc398cce29aac63c95aea1900d7b0ac0aaa6b09367475639328f8090f404";
+    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/humble/mola_input_paris_luco_dataset/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "de29b899a03f03513159e1d081d5826557102966cfb89136b263d9c8609c8f3f";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-lidar-odometry/default.nix
+++ b/distros/humble/mola-lidar-odometry/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_mola_input_kitti360_dataset, _unresolved_mola_input_kitti_dataset, _unresolved_mola_input_mulran_dataset, _unresolved_mola_input_paris_luco_dataset, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-imu-preintegration, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-imu-preintegration, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-humble-mola-lidar-odometry";
   version = "2.2.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-test-datasets rosbag2-storage-mcap ];
-  propagatedBuildInputs = [ _unresolved_mola_input_kitti360_dataset _unresolved_mola_input_kitti_dataset _unresolved_mola_input_mulran_dataset _unresolved_mola_input_paris_luco_dataset mola-common mola-imu-preintegration mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-pose-list mola-state-estimation-simple mola-viz mp2p-icp mrpt-libmaps mrpt-libtclap ];
+  propagatedBuildInputs = [ mola-common mola-imu-preintegration mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-pose-list mola-state-estimation-simple mola-viz mp2p-icp mrpt-libmaps mrpt-libtclap ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/humble/mrpt-apps/default.nix
+++ b/distros/humble/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, mrpt-libapps, mrpt-libnav, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-apps";
-  version = "2.15.17-r1";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_apps/2.15.17-1.tar.gz";
-    name = "2.15.17-1.tar.gz";
-    sha256 = "0ae54a399efc0b783346491f6b7d55d3954ab53c8136b8ca48c9aecb0c01be01";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_apps/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "42a8bd0906606599c6aa2a4920fd029fa937bdc87205de778f9ea2d3bb3cf84d";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-generic-sensor/default.nix
+++ b/distros/humble/mrpt-generic-sensor/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt-sensorlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-msgs, mrpt-sensorlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-mrpt-generic-sensor";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_generic_sensor/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "0cbc98b4f998d06ac5a0f60b209f313a62f48e2b48a77fe1ef2849b59e99e82e";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_generic_sensor/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "d34490f0233b87574202798fca2c9913381cd435f76cec1210971611626bc4b7";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-msgs mrpt-sensorlib rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-msgs mrpt-sensorlib rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/mrpt-libapps/default.nix
+++ b/distros/humble/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libapps";
-  version = "2.15.17-r1";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libapps/2.15.17-1.tar.gz";
-    name = "2.15.17-1.tar.gz";
-    sha256 = "7e5551dd780d5a7d41f78c7d5ed984c19715cab1aa78b5fd072694189fee1152";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libapps/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "f53ea8881fbf2ac0f8a64309633111f4c6c5b7ea1d3c7720f54f8eda47784704";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libbase/default.nix
+++ b/distros/humble/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, onetbb, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, zlib, zstd }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libbase";
-  version = "2.15.17-r1";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libbase/2.15.17-1.tar.gz";
-    name = "2.15.17-1.tar.gz";
-    sha256 = "4abe3cce18d571d6f3fbd9a02e919b3919c6daac53d99b1337f8a4773d8126fe";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libbase/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "7ff8afc74f243243821f3420be613899fc3de0fe03494f91f65fdb7ceb050cad";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libgui/default.nix
+++ b/distros/humble/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, mrpt-libopengl, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libgui";
-  version = "2.15.17-r1";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libgui/2.15.17-1.tar.gz";
-    name = "2.15.17-1.tar.gz";
-    sha256 = "d0292fbd9d555d3a966c2168fcbda4aad3503ca4c81149c422174d6f6c1c48c0";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libgui/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "375dd43e2fac9acbec5ddfac2bcc0b0a0ab83119e94c63bb0c5cbf95edbc4669";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libhwdrivers/default.nix
+++ b/distros/humble/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, mrpt-libgui, mrpt-libmaps, mrpt-libslam, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libhwdrivers";
-  version = "2.15.17-r1";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libhwdrivers/2.15.17-1.tar.gz";
-    name = "2.15.17-1.tar.gz";
-    sha256 = "fcc2058d065e683c777b81ee1fc25b1375d3add0dac7255b4703ca1d826bf24e";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libhwdrivers/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "52a42303e37e25f9d458d29a7d4dd8a2820bca7a3f7af8edf4ed5af3ff860477";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libmaps/default.nix
+++ b/distros/humble/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libmaps";
-  version = "2.15.17-r1";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmaps/2.15.17-1.tar.gz";
-    name = "2.15.17-1.tar.gz";
-    sha256 = "75c3ae23043a33009046791a7565b851663f76cc38ffd29a818d04eb9718c8dd";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmaps/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "661b5924c8a4d3a7e3772ab6593ef2b000118c64880c71ca3d82bf797962faa5";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libmath/default.nix
+++ b/distros/humble/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, mrpt-libbase, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libmath";
-  version = "2.15.17-r1";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmath/2.15.17-1.tar.gz";
-    name = "2.15.17-1.tar.gz";
-    sha256 = "45e3e7833dc87a7c8244562b1cdbdd051e593f871cf2a77d58d301d37603c9f3";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmath/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "686c64db6b14001ab7f78b0b4d13cd42cccf57cff32b2b88852034aace0d70e8";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libnav/default.nix
+++ b/distros/humble/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, mrpt-libmaps, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libnav";
-  version = "2.15.17-r1";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libnav/2.15.17-1.tar.gz";
-    name = "2.15.17-1.tar.gz";
-    sha256 = "44bf1643f3bc7431a1039470aa6066b4659b98ec544fb78b0b368cd22c8d0ba7";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libnav/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "bc74b688c1838e470f9258e4b1846b737ec4c6de1815e584caa38ca266fe1331";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libobs/default.nix
+++ b/distros/humble/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, mrpt-libopengl, mrpt-libposes, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libobs";
-  version = "2.15.17-r1";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libobs/2.15.17-1.tar.gz";
-    name = "2.15.17-1.tar.gz";
-    sha256 = "85f4e33ab0539a701b250765c69d2c34f9b3b474f29a79ce939d15154c95cd20";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libobs/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "a75acc217752d7d77551cbc8823acfcbd32ff43a82e05db99ac8af805c22a701";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libopengl/default.nix
+++ b/distros/humble/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, mrpt-libbase, mrpt-libposes, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libopengl";
-  version = "2.15.17-r1";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libopengl/2.15.17-1.tar.gz";
-    name = "2.15.17-1.tar.gz";
-    sha256 = "004321b490727a78d744f9d25ede752256f1db57df506655cf832ff028b37960";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libopengl/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "58d8174780ba772d254a0a4ad5f8d914e0b5a74c99ad3a74ca7725646d2277a1";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libposes/default.nix
+++ b/distros/humble/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, mrpt-libbase, mrpt-libmath, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libposes";
-  version = "2.15.17-r1";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libposes/2.15.17-1.tar.gz";
-    name = "2.15.17-1.tar.gz";
-    sha256 = "269769b799c6a349b1c535a79203140496c43d4673962cef4b4c4c45a4050347";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libposes/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "0e22a65773da2a705879ba1f99fd4d4e4c0d25545956e5bc19db44776a3b911f";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libslam/default.nix
+++ b/distros/humble/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, mrpt-libmaps, onetbb, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libslam";
-  version = "2.15.17-r1";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libslam/2.15.17-1.tar.gz";
-    name = "2.15.17-1.tar.gz";
-    sha256 = "39ea52a23bb05858d7f67c754f8ae718797cc714a5eeb834811c97d85a01ae3f";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libslam/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "76665fefa4067cbe0d243cf986cf91e7d1ee1d430b401332f85fbab92be106fd";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libtclap/default.nix
+++ b/distros/humble/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, mrpt-libbase, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libtclap";
-  version = "2.15.17-r1";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libtclap/2.15.17-1.tar.gz";
-    name = "2.15.17-1.tar.gz";
-    sha256 = "c06e6f5e440c9abe2390285067e1c69ffac978d3948f132c403ea9e534597d41";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libtclap/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "70827ffbb8bcb3b12385150b884669ef95f9382a7721eb601403cec2cfe8355f";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-sensor-bumblebee-stereo/default.nix
+++ b/distros/humble/mrpt-sensor-bumblebee-stereo/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, rclcpp-components, ros-environment, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-mrpt-sensor-bumblebee-stereo";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_sensor_bumblebee_stereo/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "6abaed5b254b39fbd7a5bbb6187a1048638e9a1ff07c93716c7a0c3e6daf8f9a";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_sensor_bumblebee_stereo/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "57e252ec430886ca6c2e5a6b0de7a29ac68acde94ea0e95b97282ef37304737b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib rclcpp-components tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/mrpt-sensor-gnss-nmea/default.nix
+++ b/distros/humble/mrpt-sensor-gnss-nmea/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nmea-msgs, rclcpp-components, ros-environment, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-mrpt-sensor-gnss-nmea";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_sensor_gnss_nmea/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "4e8578dc81d2bcbdd46364f279451922af4db846d6e311082ad3315a207438eb";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_sensor_gnss_nmea/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "afc972b83123440edb34495854352dfb349d9e4bf2af676a9582551ef6fd3a0b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs nmea-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nmea-msgs rclcpp-components tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/mrpt-sensor-gnss-novatel/default.nix
+++ b/distros/humble/mrpt-sensor-gnss-novatel/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, novatel-oem6-msgs, rclcpp-components, ros-environment, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-mrpt-sensor-gnss-novatel";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_sensor_gnss_novatel/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "f2d343041db9101936234b8a9458f340a21305a2dc792c99ce0008b9d349cae1";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_sensor_gnss_novatel/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "de592b30a634de849c4430a6f192cf27de21d0cb6736ccea45b3ba45ad616122";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib novatel-oem6-msgs rclcpp-components tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/mrpt-sensor-imu-taobotics/default.nix
+++ b/distros/humble/mrpt-sensor-imu-taobotics/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, rclcpp-components, ros-environment, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-mrpt-sensor-imu-taobotics";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_sensor_imu_taobotics/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "f0f91f76e413976918cff37c50e9fd9951a8ef91a1ac6cafaf3722e226132655";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_sensor_imu_taobotics/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "28e3199e72ae287347233cf45fb81201ea73f9d8d355cc55f3dc0c61a4713c47";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib rclcpp-components tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/mrpt-sensorlib/default.nix
+++ b/distros/humble/mrpt-sensorlib/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, diagnostic-updater, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, rclcpp-components, ros-environment, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-mrpt-sensorlib";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_sensorlib/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "813ecb8b3efb6625753bca53e03a12d557569b4eb358d65107caf0fe37f96f30";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_sensorlib/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "54759007524e6fa6348b38428f879139ad055c04c46cfe0d55a37fcb66d7a668";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ diagnostic-updater mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs rclcpp-components tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/mrpt-sensors/default.nix
+++ b/distros/humble/mrpt-sensors/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-generic-sensor, mrpt-sensor-bumblebee-stereo, mrpt-sensor-gnss-nmea, mrpt-sensor-gnss-novatel, mrpt-sensor-imu-taobotics, mrpt-sensorlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-generic-sensor, mrpt-sensor-bumblebee-stereo, mrpt-sensor-gnss-nmea, mrpt-sensor-gnss-novatel, mrpt-sensor-imu-taobotics, mrpt-sensorlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-sensors";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_sensors/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "4de4323ba394db905c4785a7a921e3e9aab1bce63996a2864d9bf6ac095b64f8";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_sensors/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "2ca3814c5fa33b4e6618f45032fe51656c48f8aad1f674bdcf7e9fbe7fbc342c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-generic-sensor mrpt-sensor-bumblebee-stereo mrpt-sensor-gnss-nmea mrpt-sensor-gnss-novatel mrpt-sensor-imu-taobotics mrpt-sensorlib ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-generic-sensor mrpt-sensor-bumblebee-stereo mrpt-sensor-gnss-nmea mrpt-sensor-gnss-novatel mrpt-sensor-imu-taobotics mrpt-sensorlib ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/novatel-oem6-msgs/default.nix
+++ b/distros/humble/novatel-oem6-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-novatel-oem6-msgs";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/novatel_oem6_msgs/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "2180ea055663b2b9e4190cc9787a31480bac5018005af3854bcf261dc28f5500";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-cmake-xmllint ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "ROS messages and services for Novatel OEM6";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/orbbec-camera-msgs/default.nix
+++ b/distros/humble/orbbec-camera-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/orbbec/orbbec_camera_v2-release/archive/release/humble/orbbec_camera_msgs/2.7.6-1.tar.gz";
+    url = "https://github.com/ros2-gbp/orbbec_camera_v2-release/archive/release/humble/orbbec_camera_msgs/2.7.6-1.tar.gz";
     name = "2.7.6-1.tar.gz";
     sha256 = "6f8da5df0061770618ca2ca811d5849b73632ed67426710780f66ba2cd06c50d";
   };

--- a/distros/humble/orbbec-camera/default.nix
+++ b/distros/humble/orbbec-camera/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/orbbec/orbbec_camera_v2-release/archive/release/humble/orbbec_camera/2.7.6-1.tar.gz";
+    url = "https://github.com/ros2-gbp/orbbec_camera_v2-release/archive/release/humble/orbbec_camera/2.7.6-1.tar.gz";
     name = "2.7.6-1.tar.gz";
     sha256 = "ae61263e574aa2c150b673d2711238fe88d9e990244efc25239031509ebe3c9e";
   };

--- a/distros/humble/orbbec-description/default.nix
+++ b/distros/humble/orbbec-description/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/orbbec/orbbec_camera_v2-release/archive/release/humble/orbbec_description/2.7.6-1.tar.gz";
+    url = "https://github.com/ros2-gbp/orbbec_camera_v2-release/archive/release/humble/orbbec_description/2.7.6-1.tar.gz";
     name = "2.7.6-1.tar.gz";
     sha256 = "4b118b714f68277adda61d7f6feb2b00920f0cba8e3c22c44d1d630c108c08b5";
   };

--- a/distros/humble/ros2agnocast/default.nix
+++ b/distros/humble/ros2agnocast/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, agnocast-ioctl-wrapper }:
+{ lib, buildRosPackage, fetchurl, agnocast-ioctl-wrapper, ament-index-python }:
 buildRosPackage {
   pname = "ros-humble-ros2agnocast";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/humble/ros2agnocast/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "183662c3056f7bd975f913666fd775fdab0ed01af60ef8b07f1ba5751e9a6f15";
+    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/humble/ros2agnocast/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "771003b8d533fab0254f0089f86cbf93bd9742bfcb5fd3f991545c148d5b1226";
   };
 
   buildType = "ament_python";
-  propagatedBuildInputs = [ agnocast-ioctl-wrapper ];
+  propagatedBuildInputs = [ agnocast-ioctl-wrapper ament-index-python ];
 
   meta = {
     description = "The ROS 2 command line tool extension for Agnocast.";

--- a/distros/humble/sync-tooling-msgs/default.nix
+++ b/distros/humble/sync-tooling-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, protobuf }:
 buildRosPackage {
   pname = "ros-humble-sync-tooling-msgs";
-  version = "0.2.7-r1";
+  version = "0.2.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sync_tooling_msgs-release/archive/release/humble/sync_tooling_msgs/0.2.7-1.tar.gz";
-    name = "0.2.7-1.tar.gz";
-    sha256 = "11e7354cd8c8b64fb21b5db13bc3c70c11e8891b61fb5f4c2330ba182428ef42";
+    url = "https://github.com/ros2-gbp/sync_tooling_msgs-release/archive/release/humble/sync_tooling_msgs/0.2.9-1.tar.gz";
+    name = "0.2.9-1.tar.gz";
+    sha256 = "dbd265944c01f628d30ab9d0fc4678b47aea8372ae7b5f18bc63136a20376977";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/topic-tools-interfaces/default.nix
+++ b/distros/humble/topic-tools-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-topic-tools-interfaces";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/humble/topic_tools_interfaces/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "28fbf6b17d7ceda9b3f1f0b62d449c82c63d35a5728be9f69bba3bf6939e4ca6";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/humble/topic_tools_interfaces/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "3d89940ed0612703f85bdca7d7b1c06e666c04454e62ad0d1b44547c2d0a24d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/topic-tools/default.nix
+++ b/distros/humble/topic-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclpy, ros2cli, rosidl-default-generators, rosidl-runtime-py, std-msgs, topic-tools-interfaces }:
 buildRosPackage {
   pname = "ros-humble-topic-tools";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/humble/topic_tools/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "6b262f27054b6d627f765627eccef88fcfbf25c1dbbd9a56eb26b61f2530e151";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/humble/topic_tools/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "a16332a307c3dbc81212a0ffc44c3c07a546422d21a6b32783a32ed67528152d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-client-library/default.nix
+++ b/distros/humble/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-humble-ur-client-library";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/humble/ur_client_library/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "8d330d8166ddb3eaab7868b5a5248c41ffe7dbde2637d77c443664c54c2f87d3";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/humble/ur_client_library/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "79bbac6b263758552d408f2f09f89f8cb700976038785830f36b1c6df2897466";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/agnocast-cie-config-msgs/default.nix
+++ b/distros/jazzy/agnocast-cie-config-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-agnocast-cie-config-msgs";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/jazzy/agnocast_cie_config_msgs/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "1cd93a4c368ed7f84471d1b251cba39830e667446a1fc93d31968deb1ffe6613";
+    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/jazzy/agnocast_cie_config_msgs/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "0e6d75737b9056ce2fd187c35138e9bd843774b90f4d1f38ed1e6d9e1c39cb71";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/agnocast-cie-thread-configurator/default.nix
+++ b/distros/jazzy/agnocast-cie-thread-configurator/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, agnocast-cie-config-msgs, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, yaml-cpp }:
+{ lib, buildRosPackage, fetchurl, agnocast-cie-config-msgs, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rclcpp, yaml-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-agnocast-cie-thread-configurator";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/jazzy/agnocast_cie_thread_configurator/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "5830ff91c5022f64fa420847abfad9073c75c4f75438ebbeb813712ef3edc5d3";
+    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/jazzy/agnocast_cie_thread_configurator/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "4dc220bfa5cb201ed0e73e938f81e1100e89068cdf280e26a4f451aea0dacebe";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ agnocast-cie-config-msgs rclcpp yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/jazzy/agnocast-components/default.nix
+++ b/distros/jazzy/agnocast-components/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, agnocast-cie-config-msgs, agnocast-cie-thread-configurator, agnocastlib, ament-cmake, class-loader, glog, launch-testing-ament-cmake, rclcpp, rclcpp-components }:
+{ lib, buildRosPackage, fetchurl, agnocast-cie-config-msgs, agnocast-cie-thread-configurator, agnocastlib, ament-cmake, class-loader, glog, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-jazzy-agnocast-components";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/jazzy/agnocast_components/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "e468bdfe68e4828734a60677efcf45103f184bb78bc0c07f856291e70d7121df";
+    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/jazzy/agnocast_components/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "2d4721d6fa1fbb061cc971636039158b581508569cea2a8acf5d751195817749";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ launch-testing-ament-cmake ];
   propagatedBuildInputs = [ agnocast-cie-config-msgs agnocast-cie-thread-configurator agnocastlib class-loader glog rclcpp rclcpp-components ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/jazzy/agnocast-e2e-test/default.nix
+++ b/distros/jazzy/agnocast-e2e-test/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, agnocast-components, agnocastlib, ament-cmake, rclcpp, rclcpp-components, std-msgs }:
+{ lib, buildRosPackage, fetchurl, agnocast-cie-config-msgs, agnocast-cie-thread-configurator, agnocast-components, agnocastlib, ament-cmake, launch-testing-ament-cmake, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-agnocast-e2e-test";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/jazzy/agnocast_e2e_test/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "4de637de3f7af799657b6f11c7d474365d123de963066ce2211862dff8cca491";
+    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/jazzy/agnocast_e2e_test/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "35c127f9d5bdce2b854b913900e0aa142385a50073ddef96fa9b29ef94c6316a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ agnocast-components agnocastlib rclcpp rclcpp-components std-msgs ];
+  checkInputs = [ agnocast-cie-config-msgs launch-testing-ament-cmake ];
+  propagatedBuildInputs = [ agnocast-cie-thread-configurator agnocast-components agnocastlib rclcpp rclcpp-components std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/agnocast-ioctl-wrapper/default.nix
+++ b/distros/jazzy/agnocast-ioctl-wrapper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-agnocast-ioctl-wrapper";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/jazzy/agnocast_ioctl_wrapper/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "84506d4bf7b4359f1b210c0b0e3899ba2d4f3799df52de6ee6b6ec232bd5c338";
+    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/jazzy/agnocast_ioctl_wrapper/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "1913258526d54f068eb0e68004047f64b11833761eb9f9e5c9c01e988588b81d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/agnocast-sample-application/default.nix
+++ b/distros/jazzy/agnocast-sample-application/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, agnocast-components, agnocast-sample-interfaces, agnocastlib, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-jazzy-agnocast-sample-application";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/jazzy/agnocast_sample_application/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "e6978d343c215c2e86f48b7a1e4500bcb9da58243d56d95aabff4216eba628b6";
+    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/jazzy/agnocast_sample_application/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "b2385dbf44c469eb2fb69911db9075b3fd15fc6ad14ddc88a9e13c6588775715";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/agnocast-sample-interfaces/default.nix
+++ b/distros/jazzy/agnocast-sample-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-agnocast-sample-interfaces";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/jazzy/agnocast_sample_interfaces/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "c8533bdce0f0ed37303407014da4ac746eb12b989d1572980a1e4f97efcf9942";
+    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/jazzy/agnocast_sample_interfaces/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "0ef7f4155cec99bd930bfa0cbf991852495812d1fb01028b88f0d1a0bee3b5ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/agnocast/default.nix
+++ b/distros/jazzy/agnocast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, agnocast-cie-config-msgs, agnocast-cie-thread-configurator, agnocast-components, agnocast-ioctl-wrapper, agnocast-sample-application, agnocast-sample-interfaces, agnocastlib, ament-cmake, ros2agnocast }:
 buildRosPackage {
   pname = "ros-jazzy-agnocast";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/jazzy/agnocast/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "cb76fc22409473a49dec9538eeec409d4243ca473b3eb0de07b5fc3179e744b4";
+    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/jazzy/agnocast/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "ad1ebcccd485e690bc06ecc8f21fa8b8aaf3c4ccdfd769f73fe031f039f8a06f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/agnocastlib/default.nix
+++ b/distros/jazzy/agnocastlib/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, agnocast-cie-config-msgs, agnocast-cie-thread-configurator, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, glog, launch-testing-ament-cmake, lttng-ust, message-filters, rcl-yaml-param-parser, rclcpp, rclcpp-components, rosgraph-msgs, std-msgs, tracetools }:
+{ lib, buildRosPackage, fetchurl, agnocast-cie-config-msgs, agnocast-cie-thread-configurator, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, geometry-msgs, glog, launch-testing-ament-cmake, lttng-ust, message-filters, rcl-yaml-param-parser, rclcpp, rclcpp-components, rosgraph-msgs, std-msgs, tf2, tf2-msgs, tf2-ros, tracetools }:
 buildRosPackage {
   pname = "ros-jazzy-agnocastlib";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/jazzy/agnocastlib/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "8e0af7fc8d6b42ffd462ce3724fe3b7704983ddb4384edfdd62bfa2f6175eabd";
+    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/jazzy/agnocastlib/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "f7d6b3c6985bb0bffb73bf0d6f123d05a628f37dae4881ff1830e34f9f2c9007";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common launch-testing-ament-cmake std-msgs ];
-  propagatedBuildInputs = [ agnocast-cie-config-msgs agnocast-cie-thread-configurator ament-index-cpp glog lttng-ust message-filters rcl-yaml-param-parser rclcpp rclcpp-components rosgraph-msgs tracetools ];
+  propagatedBuildInputs = [ agnocast-cie-config-msgs agnocast-cie-thread-configurator ament-index-cpp diagnostic-msgs diagnostic-updater geometry-msgs glog lttng-ust message-filters rcl-yaml-param-parser rclcpp rclcpp-components rosgraph-msgs tf2 tf2-msgs tf2-ros tracetools ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/ament-index-cpp/default.nix
+++ b/distros/jazzy/ament-index-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-jazzy-ament-index-cpp";
-  version = "1.8.3-r1";
+  version = "1.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/jazzy/ament_index_cpp/1.8.3-1.tar.gz";
-    name = "1.8.3-1.tar.gz";
-    sha256 = "fcfa40605ad7d23fa00074eb77fd3ba1c35233425333072fece6df350f0be677";
+    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/jazzy/ament_index_cpp/1.8.4-1.tar.gz";
+    name = "1.8.4-1.tar.gz";
+    sha256 = "31200fbee86690a2cafa76420daf8dc371b013b376d3c7427f70c102ad5228d9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ament-index-python/default.nix
+++ b/distros/jazzy/ament-index-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-ament-index-python";
-  version = "1.8.3-r1";
+  version = "1.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/jazzy/ament_index_python/1.8.3-1.tar.gz";
-    name = "1.8.3-1.tar.gz";
-    sha256 = "f09be43734cf5453b8d9533a2be3e77b89c70ccc470dbe7950a43218c7216a32";
+    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/jazzy/ament_index_python/1.8.4-1.tar.gz";
+    name = "1.8.4-1.tar.gz";
+    sha256 = "f998217ed4a9215efd0a5b4266397fce29ea482557786b013c08bc2de855c23b";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/battery-state-broadcaster/default.nix
+++ b/distros/jazzy/battery-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, pluginlib, realtime-tools, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-battery-state-broadcaster";
-  version = "1.0.2-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_battery_monitoring-release/archive/release/jazzy/battery_state_broadcaster/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "3dcecbebaac2b9b6b57fd8f3ed4d34be5aa83a1e735fffab69dcff1e7d2e1ba6";
+    url = "https://github.com/ros2-gbp/ros_battery_monitoring-release/archive/release/jazzy/battery_state_broadcaster/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "9c8563a61c378ee6822329e5c6263349ed7c9c07f7eabe98ab85854ab08f49a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/battery-state-rviz-overlay/default.nix
+++ b/distros/jazzy/battery-state-rviz-overlay/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmt, rclcpp, rviz-2d-overlay-msgs, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-battery-state-rviz-overlay";
-  version = "1.0.2-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_battery_monitoring-release/archive/release/jazzy/battery_state_rviz_overlay/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "1461324f57aecb947e684d46fc5ab95990dff4c7321c776b5d14bc0e5b79938b";
+    url = "https://github.com/ros2-gbp/ros_battery_monitoring-release/archive/release/jazzy/battery_state_rviz_overlay/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "30eb796ffb520e5b50225c915b243cd251cacc56fd775683fbb5b043d9759aae";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-bms-broadcaster/default.nix
+++ b/distros/jazzy/clearpath-bms-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-bms-broadcaster";
-  version = "2.9.6-r1";
+  version = "2.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bms_broadcaster/2.9.6-1.tar.gz";
-    name = "2.9.6-1.tar.gz";
-    sha256 = "570f689ead6e9ff9bd0e4adc5c53fc4983af5c500cc21d0bb698d6ce8a4f1ad8";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bms_broadcaster/2.9.7-1.tar.gz";
+    name = "2.9.7-1.tar.gz";
+    sha256 = "8f6e4acc588942af7b32c93b4bddb2482993331a70010819a3c9c17422e06fa2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-bt-joy/default.nix
+++ b/distros/jazzy/clearpath-bt-joy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, bluez, joy-linux, python3Packages, twist-mux }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-bt-joy";
-  version = "2.9.6-r1";
+  version = "2.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bt_joy/2.9.6-1.tar.gz";
-    name = "2.9.6-1.tar.gz";
-    sha256 = "87797582c5268cd30c7f7d58c42e532b8ba3486266c1f5a8a1e9e4a1a3e11231";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bt_joy/2.9.7-1.tar.gz";
+    name = "2.9.7-1.tar.gz";
+    sha256 = "7f419a6d15544d520c588a13b54301c167c76c943c8cae8d8332bf9bdfa413d5";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/clearpath-common/default.nix
+++ b/distros/jazzy/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, rmw-zenoh-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-common";
-  version = "2.9.6-r1";
+  version = "2.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_common/2.9.6-1.tar.gz";
-    name = "2.9.6-1.tar.gz";
-    sha256 = "917f3fcf999554dbb2a16196fed5cf2bbe46d4f58b71667507c8ba123b0c88d4";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_common/2.9.7-1.tar.gz";
+    name = "2.9.7-1.tar.gz";
+    sha256 = "91e301c7f9f7b53061a0dee90929d3a62240a50225265aff2cef38d91871d8f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-config/default.nix
+++ b/distros/jazzy/clearpath-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-config";
-  version = "2.9.1-r1";
+  version = "2.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/jazzy/clearpath_config/2.9.1-1.tar.gz";
-    name = "2.9.1-1.tar.gz";
-    sha256 = "340125279df5e6b66e0bb7565094ac2cd490255effa07a4fbc41b2b720912b4f";
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/jazzy/clearpath_config/2.9.2-1.tar.gz";
+    name = "2.9.2-1.tar.gz";
+    sha256 = "6bfa4560306b5fc0a2396c527f780281d35f02da7ace8af065d0fc74857e971d";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/clearpath-control/default.nix
+++ b/distros/jazzy/clearpath-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-bt-joy, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, mecanum-drive-controller, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-control";
-  version = "2.9.6-r1";
+  version = "2.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_control/2.9.6-1.tar.gz";
-    name = "2.9.6-1.tar.gz";
-    sha256 = "2f73fa031ed092cec0cf674568134a402568b4c42a3b4487bc48cf7571a57459";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_control/2.9.7-1.tar.gz";
+    name = "2.9.7-1.tar.gz";
+    sha256 = "23bdd616a18f4eb3aaa407fbcc6f5e5bbfc6ec3a01d23a45c19044bf068300d2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-customization/default.nix
+++ b/distros/jazzy/clearpath-customization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-customization";
-  version = "2.9.6-r1";
+  version = "2.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_customization/2.9.6-1.tar.gz";
-    name = "2.9.6-1.tar.gz";
-    sha256 = "072e23a36e032569f6d3a73b6a40f076754d8dbd0852e42010907c2dd5a88db0";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_customization/2.9.7-1.tar.gz";
+    name = "2.9.7-1.tar.gz";
+    sha256 = "c3872eaeadcdd12e6a181d6f03185901fedc8391b64f102997512215497074da";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-description/default.nix
+++ b/distros/jazzy/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-description";
-  version = "2.9.6-r1";
+  version = "2.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_description/2.9.6-1.tar.gz";
-    name = "2.9.6-1.tar.gz";
-    sha256 = "5ad05fe7a9444fe416c8957376c24b3eecde974d7cbc5b215a6fe95b68ce0bf5";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_description/2.9.7-1.tar.gz";
+    name = "2.9.7-1.tar.gz";
+    sha256 = "b00e8360623583debc9c1d361ee425176bc10c0f474a2991748165da69fa465c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-diagnostics/default.nix
+++ b/distros/jazzy/clearpath-diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-platform-msgs, diagnostic-aggregator, diagnostic-updater, foxglove-bridge, rclcpp, ros2launch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-diagnostics";
-  version = "2.9.6-r1";
+  version = "2.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_diagnostics/2.9.6-1.tar.gz";
-    name = "2.9.6-1.tar.gz";
-    sha256 = "6fddf66b8d6437a97a59665a824615817d96948b9a2d207d8359fc4e65295f6d";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_diagnostics/2.9.7-1.tar.gz";
+    name = "2.9.7-1.tar.gz";
+    sha256 = "99a5ee52eb325af4e297202c89507c44692da21a6d92107ce034b7d4d7914b0e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-generator-common/default.nix
+++ b/distros/jazzy/clearpath-generator-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, _unresolved_python3-apt, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-diagnostics, clearpath-manipulators, moveit-setup-srdf-plugins }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-generator-common";
-  version = "2.9.6-r1";
+  version = "2.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_generator_common/2.9.6-1.tar.gz";
-    name = "2.9.6-1.tar.gz";
-    sha256 = "3032b6efd266fdf0c5cb1da67fad2040c7e2ec6f519da1d24b49993e3e12ae5e";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_generator_common/2.9.7-1.tar.gz";
+    name = "2.9.7-1.tar.gz";
+    sha256 = "700a65d174ab3175161ecd7a062b1a69a429ca96c90ab450457c1a3adf45f860";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-generator-gz/default.nix
+++ b/distros/jazzy/clearpath-generator-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-generator-common, cv-bridge, ptz-action-server-msgs, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-generator-gz";
-  version = "2.9.1-r1";
+  version = "2.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/jazzy/clearpath_generator_gz/2.9.1-1.tar.gz";
-    name = "2.9.1-1.tar.gz";
-    sha256 = "6ef5fa06775338b388e5358f726fbffefd2b55b0b445eb9840b46212d2425869";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/jazzy/clearpath_generator_gz/2.9.2-1.tar.gz";
+    name = "2.9.2-1.tar.gz";
+    sha256 = "c4953b40bc69063ef43f7f0338628705326037a005941d6b7884a58b4ab5ec5e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-gz/default.nix
+++ b/distros/jazzy/clearpath-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-common, clearpath-generator-gz, clearpath-viz, gz-ros2-control, ros-gz }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-gz";
-  version = "2.9.1-r1";
+  version = "2.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/jazzy/clearpath_gz/2.9.1-1.tar.gz";
-    name = "2.9.1-1.tar.gz";
-    sha256 = "89ee73a2736a901da47b5c51281714ac2c5e7d5cc444c8157253d8fa9cda0d20";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/jazzy/clearpath_gz/2.9.2-1.tar.gz";
+    name = "2.9.2-1.tar.gz";
+    sha256 = "d67486e50b66e8cc9544a77a738cb3fe1e6e01b473bf4e66ed355ee0f8627597";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-manipulators-description/default.nix
+++ b/distros/jazzy/clearpath-manipulators-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ewellix-description, robot-state-publisher, robotiq-description, ur-description, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-manipulators-description";
-  version = "2.9.6-r1";
+  version = "2.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators_description/2.9.6-1.tar.gz";
-    name = "2.9.6-1.tar.gz";
-    sha256 = "9b99bebe5f3836060636d24b7c71a642a13b2fbf972fff6b96fe1d023e74deaa";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators_description/2.9.7-1.tar.gz";
+    name = "2.9.7-1.tar.gz";
+    sha256 = "bbf3b7e55fad30b5a8a8e5ee2075b292ed36b22c81435d6310cf21affc22b7ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-manipulators/default.nix
+++ b/distros/jazzy/clearpath-manipulators/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, gripper-controllers, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-warehouse, moveit-setup-srdf-plugins, moveit-simple-controller-manager, position-controllers, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-manipulators";
-  version = "2.9.6-r1";
+  version = "2.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators/2.9.6-1.tar.gz";
-    name = "2.9.6-1.tar.gz";
-    sha256 = "9147a84dc2f0f040d590755efd1d8c6792caa449e9078a53034a4ba2f148c4e1";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators/2.9.7-1.tar.gz";
+    name = "2.9.7-1.tar.gz";
+    sha256 = "7332dbddc8ce631e09038a8a8fff703029d08ef6d11d3ce887ce9b001a8ddca9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-mounts-description/default.nix
+++ b/distros/jazzy/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-mounts-description";
-  version = "2.9.6-r1";
+  version = "2.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_mounts_description/2.9.6-1.tar.gz";
-    name = "2.9.6-1.tar.gz";
-    sha256 = "c5283c90e71dfb59779bad2c5d7e5605f90d09f08083cabd8ee7f08da5c7bb42";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_mounts_description/2.9.7-1.tar.gz";
+    name = "2.9.7-1.tar.gz";
+    sha256 = "d85ba47d91c967135b624c12d800c1f7dff0c0b76913934e599540aa059fca16";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-platform-description/default.nix
+++ b/distros/jazzy/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-platform-description";
-  version = "2.9.6-r1";
+  version = "2.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_platform_description/2.9.6-1.tar.gz";
-    name = "2.9.6-1.tar.gz";
-    sha256 = "18a90a1d91edcef8ecd2757e02f0df656f82406f083945399e116945084d9def";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_platform_description/2.9.7-1.tar.gz";
+    name = "2.9.7-1.tar.gz";
+    sha256 = "36f1d8fce0303ac7bdb4d67702fca31192f1372e9105e454d91c539821a32fef";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-sensors-description/default.nix
+++ b/distros/jazzy/clearpath-sensors-description/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, axis-description, microstrain-inertial-description, realsense2-description, velodyne-description }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, axis-description, flir-ptu-description, microstrain-inertial-description, realsense2-description, velodyne-description, zed-description }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-sensors-description";
-  version = "2.9.6-r1";
+  version = "2.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_sensors_description/2.9.6-1.tar.gz";
-    name = "2.9.6-1.tar.gz";
-    sha256 = "dab3397ae0a168e55d3abe808a83644a0ea50e389c543e4fd16118101ac10cb8";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_sensors_description/2.9.7-1.tar.gz";
+    name = "2.9.7-1.tar.gz";
+    sha256 = "a6bcfb40352657499cc9650ca66ca9fd8571d14e67ee83a01f2da831c67cd347";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ axis-description microstrain-inertial-description realsense2-description velodyne-description ];
+  propagatedBuildInputs = [ axis-description flir-ptu-description microstrain-inertial-description realsense2-description velodyne-description zed-description ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/clearpath-simulator/default.nix
+++ b/distros/jazzy/clearpath-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-generator-gz, clearpath-gz }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-simulator";
-  version = "2.9.1-r1";
+  version = "2.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/jazzy/clearpath_simulator/2.9.1-1.tar.gz";
-    name = "2.9.1-1.tar.gz";
-    sha256 = "bfeda5ccb52238c9f2c0ffe78bdfd12160d77eb4f6f759e021caf63afa55a998";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/jazzy/clearpath_simulator/2.9.2-1.tar.gz";
+    name = "2.9.2-1.tar.gz";
+    sha256 = "f707c953090cc16a7c861ba5bfc7cd475ab81f21b873b16865896965ab65d41a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/compass-msgs/default.nix
+++ b/distros/jazzy/compass-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-compass-msgs";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/compass_msgs/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "26b0a4cbf4fc8cdc5e8c4b255cee2077354ac2b3e2dc68e5af417c7cf6c866e3";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/compass_msgs/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "67f9a2f1f73f5137c25d14e3dd3bf42d075eefe17d84ba83eda9687855c87b77";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/crocoddyl/default.nix
+++ b/distros/jazzy/crocoddyl/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, cmake, doxygen, eigenpy, ffmpeg, git, ipopt, jrl-cmakemodules, pinocchio, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-jazzy-crocoddyl";
+  version = "3.2.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crocoddyl-release/archive/release/jazzy/crocoddyl/3.2.1-2.tar.gz";
+    name = "3.2.1-2.tar.gz";
+    sha256 = "c59f9b53b621d38fe9b69c17bd9ad38dc3eada8ea294225f28aa8c9758ec24e6";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake doxygen git jrl-cmakemodules ];
+  checkInputs = [ ffmpeg python3Packages.nbconvert python3Packages.notebook python3Packages.scipy ];
+  propagatedBuildInputs = [ ament-cmake boost eigenpy ipopt pinocchio python3 python3Packages.numpy ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Crocoddyl optimal control library";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/jazzy/depthai-bridge-v3/default.nix
+++ b/distros/jazzy/depthai-bridge-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-info-manager, composition-interfaces, cv-bridge, depthai-ros-msgs-v3, depthai-v3, ffmpeg-image-transport-msgs, image-transport, nav-msgs, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-bridge-v3";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/jazzy/depthai_bridge_v3/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "b7bac5b9dfef9f5976d8951d5bd6f039c91272d63eeaa00fc850ab8d328bc313";
+    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/jazzy/depthai_bridge_v3/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "378bbaf9490c110e02ef1b4defa065e2f410eaa04bf4dea11c79647b23c52446";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-descriptions-v3/default.nix
+++ b/distros/jazzy/depthai-descriptions-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-descriptions-v3";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/jazzy/depthai_descriptions_v3/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "ffbc530919bbf028001b3a9c2ce5a19ca9272b4785092c2a1f8a6ebce1a61850";
+    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/jazzy/depthai_descriptions_v3/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "a031f70990d2693611e38499a1e13b2ce13d24da5be89db41703758114e375ed";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-examples-v3/default.nix
+++ b/distros/jazzy/depthai-examples-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, backward-ros, camera-info-manager, cv-bridge, depth-image-proc, depthai-bridge-v3, depthai-descriptions-v3, depthai-ros-msgs-v3, depthai-v3, foxglove-msgs, image-transport, nav-msgs, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-examples-v3";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/jazzy/depthai_examples_v3/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "86c5295c9776af09103367d3c81912580224333e11448e2af9f5deaded07b19f";
+    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/jazzy/depthai_examples_v3/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "b96ed05cb7348a77895ea6c928d76042210174779fedd4d816cc0304d0fcb66f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-filters-v3/default.nix
+++ b/distros/jazzy/depthai-filters-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, depthai-ros-msgs-v3, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-filters-v3";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/jazzy/depthai_filters_v3/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "e03358d3e166d7f22e69427ae69100b719e7cd00b2f37f41af04fb577883536a";
+    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/jazzy/depthai_filters_v3/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "300cff53a975cac3a25b9f6b6683dafdfdc2eeb7ef2fb95a35acc463420adb8f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-ros-driver-v3/default.nix
+++ b/distros/jazzy/depthai-ros-driver-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-python, backward-ros, camera-calibration, camera-info-manager, cv-bridge, depthai-bridge-v3, depthai-descriptions-v3, depthai-ros-msgs-v3, depthai-v3, diagnostic-msgs, diagnostic-updater, ffmpeg-image-transport-msgs, geometry-msgs, image-pipeline, image-transport, image-transport-plugins, nav-msgs, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, tf2-ros, vision-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-ros-driver-v3";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/jazzy/depthai_ros_driver_v3/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "be1788c69036cf90e177f5bc474a80c8066edb393b8ced4d2a01a1a3a01dea1d";
+    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/jazzy/depthai_ros_driver_v3/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "3ad47bf3b8e64f1196ff674ddabdb9f793f1c8327ca67fcff41fb4444c65cfbd";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-ros-msgs-v3/default.nix
+++ b/distros/jazzy/depthai-ros-msgs-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-ros-msgs-v3";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/jazzy/depthai_ros_msgs_v3/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "e90b76edd903a1a80b9bd7bc73a20f3746b65dcdf5fe61c1bafb681d12e803ec";
+    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/jazzy/depthai_ros_msgs_v3/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "0e45981b7ee4fedb9c0a5eedda2acf8fff9e2a9a6df76a4db98af0f23935eef6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-ros-v3/default.nix
+++ b/distros/jazzy/depthai-ros-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai-bridge-v3, depthai-descriptions-v3, depthai-examples-v3, depthai-filters-v3, depthai-ros-driver-v3, depthai-ros-msgs-v3, depthai-v3 }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-ros-v3";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/jazzy/depthai_ros_v3/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "1d151922031e20450211f9a560e1e83aa3251fafd90a35f85c71d68e3f9226bd";
+    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/jazzy/depthai_ros_v3/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "a682f823a02150a822fe716a19ef0f48c94e534e85bf678877af3d9496c1a58e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fusioncore-core/default.nix
+++ b/distros/jazzy/fusioncore-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module }:
 buildRosPackage {
   pname = "ros-jazzy-fusioncore-core";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/fusioncore_core/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "356df9863b6bc2a6aa70ba72917cbd81b33205c201089bc60c3c354890eefc9f";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/fusioncore_core/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "e4cb4182081b4b89b167afe03970692ad53298c29704c068a7836c1a7c5501f2";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "Pure C++ UKF sensor fusion library underlying FusionCore. Fuses IMU, wheel encoders and GPS in a 22-state unscented Kalman filter. Includes ECEF GPS conversion, IMU bias estimation, adaptive noise covariance, chi-squared outlier gating, and ZUPT. No ROS dependency, usable standalone.";
+    description = "Pure C++ UKF sensor fusion library underlying FusionCore. Fuses IMU, wheel encoders, GPS, and visual SLAM pose in a 22-state unscented Kalman filter. Includes ECEF GPS conversion, IMU bias estimation, adaptive noise covariance, chi-squared outlier gating, ZUPT, and GPS-denied operation. No ROS dependency, usable standalone.";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/jazzy/fusioncore-datasets/default.nix
+++ b/distros/jazzy/fusioncore-datasets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fusioncore-ros, geometry-msgs, nav-msgs, rclpy, robot-localization, rosgraph-msgs, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-fusioncore-datasets";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/fusioncore_datasets/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "35aed09b135f45d17122d7cf3674db88a0060cd8620371f15cb95d3f92334082";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/fusioncore_datasets/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "9a4d09e1a260d2ef798ac86a6ad1b7fcfaaea3c8d59341e7a1010b8001876a9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fusioncore-gazebo/default.nix
+++ b/distros/jazzy/fusioncore-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fusioncore-ros, nav-msgs, rclpy, robot-state-publisher, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-fusioncore-gazebo";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/fusioncore_gazebo/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "6e621d54fc7eeec3579e21adf9d31d1a823be2ea4c2eb4a984cdcb5c6a4e8cc8";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/fusioncore_gazebo/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "0674575b0f40f82f0e0aa43d3dd8f71a2fca76ce49414dc9fd7241ae7178a07b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fusioncore-ros/default.nix
+++ b/distros/jazzy/fusioncore-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, compass-msgs, diagnostic-msgs, eigen3-cmake-module, fusioncore-core, geographic-msgs, geometry-msgs, nav-msgs, proj, rclcpp, rclcpp-lifecycle, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-fusioncore-ros";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/fusioncore_ros/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "946e04e82bd2c6c8b5f2fff627c7179e486beddea5112b0cb1b98aa04260bffc";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/fusioncore_ros/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "a3a62021b1010835a3c4c90135b8594d3b0f3700c450eb5bd25a53bef9f99629";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {
-    description = "ROS 2 UKF sensor fusion for GPS, IMU and wheel encoders. 22-state filter with ECEF-native GPS handling, automatic IMU bias estimation, adaptive noise covariance, and chi-squared outlier rejection on every sensor. Drop-in robot_localization alternative. Native ROS 2 Jazzy and Humble, benchmarked on 6 NCLT public dataset sequences.";
+    description = "ROS 2 UKF sensor fusion for IMU, wheel encoders, GPS, and visual SLAM pose. 22-state filter with ECEF-native GPS handling, automatic IMU bias estimation, adaptive noise covariance, chi-squared outlier rejection on every sensor, and map reinitialization recovery for GPS-denied operation. Drop-in robot_localization alternative. Native ROS 2 Jazzy, benchmarked on 6 NCLT public dataset sequences.";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -754,6 +754,8 @@ self: super: {
 
  create3-teleop = self.callPackage ./create3-teleop {};
 
+ crocoddyl = self.callPackage ./crocoddyl {};
+
  crx-kinematics = self.callPackage ./crx-kinematics {};
 
  cudnn-cmake-module = self.callPackage ./cudnn-cmake-module {};
@@ -1988,6 +1990,8 @@ self: super: {
 
  mola-input-mulran-dataset = self.callPackage ./mola-input-mulran-dataset {};
 
+ mola-input-ouster = self.callPackage ./mola-input-ouster {};
+
  mola-input-paris-luco-dataset = self.callPackage ./mola-input-paris-luco-dataset {};
 
  mola-input-rawlog = self.callPackage ./mola-input-rawlog {};
@@ -2417,6 +2421,8 @@ self: super: {
  novatel-gps-driver = self.callPackage ./novatel-gps-driver {};
 
  novatel-gps-msgs = self.callPackage ./novatel-gps-msgs {};
+
+ novatel-oem6-msgs = self.callPackage ./novatel-oem6-msgs {};
 
  novatel-oem7-driver = self.callPackage ./novatel-oem7-driver {};
 

--- a/distros/jazzy/kitti-metrics-eval/default.nix
+++ b/distros/jazzy/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmath, mrpt-libposes, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-jazzy-kitti-metrics-eval";
-  version = "3.0.0-r1";
+  version = "3.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/jazzy/kitti_metrics_eval/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "629ed32b55407d9d8b9b562476e7e8f4cf79bbffe988fda842811bf09f72bf85";
+    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/jazzy/kitti_metrics_eval/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "f255311be61f0002e035a1b4a10efdc522b2b33a73cb493ca5177e93ff9565a3";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/leo-bringup/default.nix
+++ b/distros/jazzy/leo-bringup/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-index-python, ament-lint-auto, geometry-msgs, image-proc, launch, launch-ros, leo-description, leo-filters, leo-fw, leo-msgs, python3Packages, robot-state-publisher, rosapi, rosbridge-server, sensor-msgs, web-video-server, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-index-python, ament-lint-auto, geometry-msgs, image-proc, launch, launch-ros, leo-description, leo-filters, leo-fw, leo-msgs, python3Packages, rclpy, robot-state-publisher, rosapi, rosbridge-server, sensor-msgs, tf-transformations, web-video-server, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-leo-bringup";
-  version = "2.5.1-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/jazzy/leo_bringup/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "879efd17545e56e7eb537832fce9d15df106e4575cf0bc5025d8d91d46662b60";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/jazzy/leo_bringup/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "5bdcb7b799c7ba92bec6628c0daed3919878f2e406f92856aef579d7f6d5a7a2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-black ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ ament-index-python geometry-msgs image-proc launch launch-ros leo-description leo-filters leo-fw leo-msgs python3Packages.smbus2 robot-state-publisher rosapi rosbridge-server sensor-msgs web-video-server xacro ];
+  propagatedBuildInputs = [ ament-index-python geometry-msgs image-proc launch launch-ros leo-description leo-filters leo-fw leo-msgs python3Packages.smbus2 rclpy robot-state-publisher rosapi rosbridge-server sensor-msgs tf-transformations web-video-server xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/leo-filters/default.nix
+++ b/distros/jazzy/leo-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, generate-parameter-library, geometry-msgs, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, std-srvs, tf2, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-leo-filters";
-  version = "2.5.1-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/jazzy/leo_filters/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "4dcab6d5add1cdd262388441cdcfbee55f37d0fc980717f15354bfc9928d936d";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/jazzy/leo_filters/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "1e3e01d2fde6ce49c29bf781a08a6ce1c01dd284cd95bcefc04ccce7b342c2e8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/leo-fw/default.nix
+++ b/distros/jazzy/leo-fw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-pep257, ament-cmake-python, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-python, ament-lint-auto, geometry-msgs, leo-msgs, nav-msgs, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, ros2cli, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-leo-fw";
-  version = "2.5.1-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/jazzy/leo_fw/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "1bb42dfe9f649394ca89625b172844cbe3dfc7d9a7797eeb601a8982e4d5f179";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/jazzy/leo_fw/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "561c3dc14fdcb597ee8a040aef28ccc66619961b50f143876e9254862ef1f916";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/leo-robot/default.nix
+++ b/distros/jazzy/leo-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, leo, leo-bringup, leo-filters, leo-fw }:
 buildRosPackage {
   pname = "ros-jazzy-leo-robot";
-  version = "2.5.1-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/jazzy/leo_robot/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "624254b8827bfd0cc00e50700dcda07401cb623e81612bb8d766246702968f6d";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/jazzy/leo_robot/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "186b99ad42d05c6b5ee1fb7c6e6044b27ab8d8cd07ff3ae506b009a578fb22ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/log-view/default.nix
+++ b/distros/jazzy/log-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ncurses, rcl-interfaces, rclcpp, xclip, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-log-view";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/log_view-release/archive/release/jazzy/log_view/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "3aeb0e3650f07e349b27a0b9c069fcce3837372457862f3bcaeb83c3bb545742";
+    url = "https://github.com/ros2-gbp/log_view-release/archive/release/jazzy/log_view/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "104f5379404b1572ea8cf97cc320dfabe2000804ecbc7178bb6666d7bccad0a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-academic-datasets/default.nix
+++ b/distros/jazzy/mola-academic-datasets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, kitti-metrics-eval, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset }:
 buildRosPackage {
   pname = "ros-jazzy-mola-academic-datasets";
-  version = "3.0.0-r1";
+  version = "3.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/jazzy/mola_academic_datasets/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "2a01efe724ba87afdcbf37651252ffc1cd915d4693bc2b37a339fffe43bbd414";
+    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/jazzy/mola_academic_datasets/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "a9e5671b28c410bff01c188ddd578cb098f082aacdcfaa7474e7494152fa88b7";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-common/default.nix
+++ b/distros/jazzy/mola-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-common";
-  version = "0.6.0-r2";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/jazzy/mola_common/0.6.0-2.tar.gz";
-    name = "0.6.0-2.tar.gz";
-    sha256 = "8f0ccbd3b37bb1c27afb5b9908650e82f6c9ef354ca6ade4b5011f28b8ae698a";
+    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/jazzy/mola_common/0.6.1-1.tar.gz";
+    name = "0.6.1-1.tar.gz";
+    sha256 = "21018537b4e97275d9fb1404abfec116921d43b2731ac244f1e11c317a048160";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-input-euroc-dataset/default.nix
+++ b/distros/jazzy/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmath, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-euroc-dataset";
-  version = "3.0.0-r1";
+  version = "3.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/jazzy/mola_input_euroc_dataset/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "dfd977cccc9edd5f6ad2f0991309295d7dfe99d6958ec164fe9029ae69a08a11";
+    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/jazzy/mola_input_euroc_dataset/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "05ae054c05160d001ed73ecf4ae99a87bfa55932fb9ff13b87fe10d3800c93c4";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-kitti-dataset/default.nix
+++ b/distros/jazzy/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-kitti-dataset";
-  version = "3.0.0-r1";
+  version = "3.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/jazzy/mola_input_kitti_dataset/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "09b4280bae126f748df2653878e7ecc583b3921f406f2801584b453b38c598eb";
+    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/jazzy/mola_input_kitti_dataset/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "5b12bb82be150bd7fb35867c48564203e9bb917a413a0956d6d310b16c4497ab";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-kitti360-dataset/default.nix
+++ b/distros/jazzy/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-kitti360-dataset";
-  version = "3.0.0-r1";
+  version = "3.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/jazzy/mola_input_kitti360_dataset/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "54b7f28980002b8e13a6d9cbc568946a031bc6095637ae5937824300ddc7a76c";
+    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/jazzy/mola_input_kitti360_dataset/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "9913f8ea4fce2bda559f52ce4c7f7233126a3e7b810ce97d36c1251aa84d087d";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-mulran-dataset/default.nix
+++ b/distros/jazzy/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-mulran-dataset";
-  version = "3.0.0-r1";
+  version = "3.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/jazzy/mola_input_mulran_dataset/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "24d15340805583243e33f0989e12a3f527923c4ef513c3174b346fef64238aa6";
+    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/jazzy/mola_input_mulran_dataset/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "fa687aa1d1bc31bf1041e441ec568025a4a7b9dbc6578e81aaa6903d5463e0ba";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-ouster/default.nix
+++ b/distros/jazzy/mola-input-ouster/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, curl, eigen, flatbuffers, libpng, libtins, libzip, mola-kernel, mola-yaml, mrpt-libmaps, mrpt-libobs, openssl, zstd }:
+buildRosPackage {
+  pname = "ros-jazzy-mola-input-ouster";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_input_ouster-release/archive/release/jazzy/mola_input_ouster/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "99f2888756bc78ea6170546ec50680426150a5dc6114457afdf3866c51cb8d96";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen flatbuffers libpng libtins libzip openssl zstd ];
+  propagatedBuildInputs = [ curl mola-kernel mola-yaml mrpt-libmaps mrpt-libobs ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "MOLA input module for Ouster LiDAR sensors using the native Ouster C++ SDK.
+    Provides direct sensor connection and PCAP replay without ROS middleware.";
+    license = with lib.licenses; [ "GPL-3.0" ];
+  };
+}

--- a/distros/jazzy/mola-input-paris-luco-dataset/default.nix
+++ b/distros/jazzy/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-paris-luco-dataset";
-  version = "3.0.0-r1";
+  version = "3.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/jazzy/mola_input_paris_luco_dataset/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "10fe11307e9aec58fa9a0d121acdbcf5bc48a4ccdb62818efe8b6e982944b4f1";
+    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/jazzy/mola_input_paris_luco_dataset/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "5826ef39aec5425daccdb3c33d08b9c850ae285778cc569f9d401a6f92dee6de";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-generic-sensor/default.nix
+++ b/distros/jazzy/mrpt-generic-sensor/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt-sensorlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-msgs, mrpt-sensorlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-generic-sensor";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_generic_sensor/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "0f21cdd404e601d70e164b2e91041377d31bdf908f90d029c22e8a0b87fb7bde";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_generic_sensor/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "467cee5fbeb47d4105bbcaac0578a5835f92695a88c9b6d19b76cd083e881001";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-msgs mrpt-sensorlib rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-msgs mrpt-sensorlib rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/mrpt-sensor-bumblebee-stereo/default.nix
+++ b/distros/jazzy/mrpt-sensor-bumblebee-stereo/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, rclcpp-components, ros-environment, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-sensor-bumblebee-stereo";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_sensor_bumblebee_stereo/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "b8d7784201a83ebbaebce3da68f80c9761d9e155e2b036933ff9edae886b678a";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_sensor_bumblebee_stereo/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "bf52c82f6b762086f4696e9e89fb25a0d72d0a74c29771e949b0f490d03a114d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib rclcpp-components tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/mrpt-sensor-gnss-nmea/default.nix
+++ b/distros/jazzy/mrpt-sensor-gnss-nmea/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nmea-msgs, rclcpp-components, ros-environment, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-sensor-gnss-nmea";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_sensor_gnss_nmea/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "27cba2f36bc3aaefb580f18ae4e4d9b00a0cf8b993aac8a40485d3bb5f76f6bd";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_sensor_gnss_nmea/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "3bf10c765e972b65a15806cb5b69e5654f08ccd6745f13e50d7f23d5fe30e6a2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs nmea-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nmea-msgs rclcpp-components tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/mrpt-sensor-gnss-novatel/default.nix
+++ b/distros/jazzy/mrpt-sensor-gnss-novatel/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, novatel-oem6-msgs, rclcpp-components, ros-environment, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-sensor-gnss-novatel";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_sensor_gnss_novatel/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "12b5809e4bc8fca3980c413694bf18abf113245089c9658ce81cf064bcfd5600";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_sensor_gnss_novatel/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "b520a65ea751b216b49dc9a89c3d184c11b9a92ed95afbebd95fdf2c35747ce9";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib novatel-oem6-msgs rclcpp-components tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/mrpt-sensor-imu-taobotics/default.nix
+++ b/distros/jazzy/mrpt-sensor-imu-taobotics/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, rclcpp-components, ros-environment, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-sensor-imu-taobotics";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_sensor_imu_taobotics/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "e47dd33ca1f5961f8f51bb1adcddae2b295493f4c3c7dee065615f52076aa802";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_sensor_imu_taobotics/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "efa33fe3b14ccbb852497e7e28f08214ef97b81196cfa1a7ba7b943a3e8ac31d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib rclcpp-components tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/mrpt-sensorlib/default.nix
+++ b/distros/jazzy/mrpt-sensorlib/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, diagnostic-updater, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, rclcpp-components, ros-environment, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-sensorlib";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_sensorlib/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "4ae320de739a56a00b785da1015ede7e159acbdf711642b4883f274bbebc5669";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_sensorlib/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "004ff3a8288ea9b164261a027d3bf35df1188004e3d8f3cba9cf097cbd0eb043";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ diagnostic-updater mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs rclcpp-components tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/mrpt-sensors/default.nix
+++ b/distros/jazzy/mrpt-sensors/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-generic-sensor, mrpt-sensor-bumblebee-stereo, mrpt-sensor-gnss-nmea, mrpt-sensor-gnss-novatel, mrpt-sensor-imu-taobotics, mrpt-sensorlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-generic-sensor, mrpt-sensor-bumblebee-stereo, mrpt-sensor-gnss-nmea, mrpt-sensor-gnss-novatel, mrpt-sensor-imu-taobotics, mrpt-sensorlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-sensors";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_sensors/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "2d63b464c5221840a9dcfe76712ddb57038562ec6e4dd6b00a24d655bf673888";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_sensors/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "585eb486106ae0d144d4e6c30c033ebdf874c9644ca9a834edca29c44aacf796";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-generic-sensor mrpt-sensor-bumblebee-stereo mrpt-sensor-gnss-nmea mrpt-sensor-gnss-novatel mrpt-sensor-imu-taobotics mrpt-sensorlib ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-generic-sensor mrpt-sensor-bumblebee-stereo mrpt-sensor-gnss-nmea mrpt-sensor-gnss-novatel mrpt-sensor-imu-taobotics mrpt-sensorlib ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/novatel-oem6-msgs/default.nix
+++ b/distros/jazzy/novatel-oem6-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-novatel-oem6-msgs";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/novatel_oem6_msgs/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "9be82f900c46af60afccf3bdcfcace2ad85a70cd7f6fa1137303d8584200bee0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-cmake-xmllint ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "ROS messages and services for Novatel OEM6";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/orbbec-camera-msgs/default.nix
+++ b/distros/jazzy/orbbec-camera-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/orbbec/orbbec_camera_v2-release/archive/release/jazzy/orbbec_camera_msgs/2.7.6-1.tar.gz";
+    url = "https://github.com/ros2-gbp/orbbec_camera_v2-release/archive/release/jazzy/orbbec_camera_msgs/2.7.6-1.tar.gz";
     name = "2.7.6-1.tar.gz";
     sha256 = "8bc411a8b5ad355d702b9f1859677bec41aba09d7d27a5942cf32d1806a60d17";
   };

--- a/distros/jazzy/orbbec-camera/default.nix
+++ b/distros/jazzy/orbbec-camera/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/orbbec/orbbec_camera_v2-release/archive/release/jazzy/orbbec_camera/2.7.6-1.tar.gz";
+    url = "https://github.com/ros2-gbp/orbbec_camera_v2-release/archive/release/jazzy/orbbec_camera/2.7.6-1.tar.gz";
     name = "2.7.6-1.tar.gz";
     sha256 = "2df015003035fb51ee0bfad94b0c9346cf035ea18f631223f93227b905890702";
   };

--- a/distros/jazzy/orbbec-description/default.nix
+++ b/distros/jazzy/orbbec-description/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/orbbec/orbbec_camera_v2-release/archive/release/jazzy/orbbec_description/2.7.6-1.tar.gz";
+    url = "https://github.com/ros2-gbp/orbbec_camera_v2-release/archive/release/jazzy/orbbec_description/2.7.6-1.tar.gz";
     name = "2.7.6-1.tar.gz";
     sha256 = "64c13f5f8e4a4fc9a65f66795607f0a07c8de2429bd667e998b62c103335f35a";
   };

--- a/distros/jazzy/ros2agnocast/default.nix
+++ b/distros/jazzy/ros2agnocast/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, agnocast-ioctl-wrapper }:
+{ lib, buildRosPackage, fetchurl, agnocast-ioctl-wrapper, ament-index-python }:
 buildRosPackage {
   pname = "ros-jazzy-ros2agnocast";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/jazzy/ros2agnocast/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "d72ae1a5297c6601a0904c8a8e88ffda445dbceabf8ebef63fe7a7153f28c9c3";
+    url = "https://github.com/ros2-gbp/agnocast-release/archive/release/jazzy/ros2agnocast/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "d5674d156bc4b39fabbf0b474644fbeb2d9207bca692f21bbaed49a0a5eee435";
   };
 
   buildType = "ament_python";
-  propagatedBuildInputs = [ agnocast-ioctl-wrapper ];
+  propagatedBuildInputs = [ agnocast-ioctl-wrapper ament-index-python ];
 
   meta = {
     description = "The ROS 2 command line tool extension for Agnocast.";

--- a/distros/jazzy/sync-tooling-msgs/default.nix
+++ b/distros/jazzy/sync-tooling-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, protobuf }:
 buildRosPackage {
   pname = "ros-jazzy-sync-tooling-msgs";
-  version = "0.2.7-r1";
+  version = "0.2.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sync_tooling_msgs-release/archive/release/jazzy/sync_tooling_msgs/0.2.7-1.tar.gz";
-    name = "0.2.7-1.tar.gz";
-    sha256 = "ffafefe6766b0fe77815bf36c86ee27e03b6ddb417e8855b58b8bf8d3b8ef118";
+    url = "https://github.com/ros2-gbp/sync_tooling_msgs-release/archive/release/jazzy/sync_tooling_msgs/0.2.9-1.tar.gz";
+    name = "0.2.9-1.tar.gz";
+    sha256 = "aed487313161a6921070dc21794bf98f630ce8eee855fe56631a1fdeabf3d302";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/topic-tools-interfaces/default.nix
+++ b/distros/jazzy/topic-tools-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-topic-tools-interfaces";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/jazzy/topic_tools_interfaces/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "9a123f2a8f13f7e0512bbe0930f06a5eba56c61aa2916c6870d0b3ea13ed2a3c";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/jazzy/topic_tools_interfaces/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "c6d7d7e46a7548926c2d925532a2bf7e0648bcb6060ea61903b2201f6989a406";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/topic-tools/default.nix
+++ b/distros/jazzy/topic-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclpy, ros2cli, rosidl-default-generators, rosidl-runtime-py, std-msgs, topic-tools-interfaces }:
 buildRosPackage {
   pname = "ros-jazzy-topic-tools";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/jazzy/topic_tools/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "9b2616f1093bfd2e0965f7783b95ecf90d09f4b2de8635bcbeea83a1b88d1cc8";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/jazzy/topic_tools/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "c2d80cf026e8058e08dce1606697462a7042a0a0765f36f6e24821c3d759d6bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-client-library/default.nix
+++ b/distros/jazzy/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-jazzy-ur-client-library";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/jazzy/ur_client_library/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "3a350021fdc6374d8effbca573928cb5f8c197ef562547e1b8a4ac81fb550071";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/jazzy/ur_client_library/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "8ac0e14ce1fa33d42b63a2a8dc71f98b443f95ff70503ae1b5af287b7bad4f2e";
   };
 
   buildType = "cmake";

--- a/distros/kilted/ament-index-cpp/default.nix
+++ b/distros/kilted/ament-index-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-kilted-ament-index-cpp";
-  version = "1.11.3-r1";
+  version = "1.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/kilted/ament_index_cpp/1.11.3-1.tar.gz";
-    name = "1.11.3-1.tar.gz";
-    sha256 = "32b9226b412bcfb0e2047f0703f938156c6f2af33b1b49db9d3eb7d6b5956d23";
+    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/kilted/ament_index_cpp/1.11.4-1.tar.gz";
+    name = "1.11.4-1.tar.gz";
+    sha256 = "20728d8f69455d55a943f3e9719e10fd4fab6303d046fac4b11ad79b7aa33789";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ament-index-python/default.nix
+++ b/distros/kilted/ament-index-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-kilted-ament-index-python";
-  version = "1.11.3-r1";
+  version = "1.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/kilted/ament_index_python/1.11.3-1.tar.gz";
-    name = "1.11.3-1.tar.gz";
-    sha256 = "6def3d1eeddc3815a86857823242c183b1185d3a5e99b9e8269a11737a58cf3d";
+    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/kilted/ament_index_python/1.11.4-1.tar.gz";
+    name = "1.11.4-1.tar.gz";
+    sha256 = "1e28ee784d767cbf8023e5184d1b0cd8107708f1732874b12a5617e2094f2a2e";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/crocoddyl/default.nix
+++ b/distros/kilted/crocoddyl/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, cmake, doxygen, eigenpy, ffmpeg, git, ipopt, jrl-cmakemodules, pinocchio, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-kilted-crocoddyl";
+  version = "3.2.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crocoddyl-release/archive/release/kilted/crocoddyl/3.2.1-2.tar.gz";
+    name = "3.2.1-2.tar.gz";
+    sha256 = "f46df6ed20f2f0279e2d3cefb87a8effcb9b1fd13afd22da688e669b79a7c4d7";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake doxygen git jrl-cmakemodules ];
+  checkInputs = [ ffmpeg python3Packages.nbconvert python3Packages.notebook python3Packages.scipy ];
+  propagatedBuildInputs = [ ament-cmake boost eigenpy ipopt pinocchio python3 python3Packages.numpy ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Crocoddyl optimal control library";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/kilted/depthai-bridge/default.nix
+++ b/distros/kilted/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-info-manager, composition-interfaces, cv-bridge, depthai, depthai-ros-msgs, ffmpeg-image-transport-msgs, image-transport, nav-msgs, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-kilted-depthai-bridge";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_bridge/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "54b63680f18176934e684f20df62d7eb58c78184a69c607297afa26c0dc17553";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_bridge/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "f23e0c3a8828c0b11cf3aa4ce2f41e54f4310a45266f0200c8bd3c064ed42d2d";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/depthai-descriptions/default.nix
+++ b/distros/kilted/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-kilted-depthai-descriptions";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_descriptions/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "803c164f24e6990c5bfafa1f4ab2c06037e7cf1bbe1e023d0d0c805095af2bea";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_descriptions/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "f343204edc52a9cc3180289b8f416c3f735c8ac8da44be6275253eddf2ce0651";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/depthai-examples/default.nix
+++ b/distros/kilted/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, backward-ros, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, nav-msgs, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-kilted-depthai-examples";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_examples/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "7a38d8fefbc39cb7ea916dc8801d502855c1d2e902485389b197cec8ea235be2";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_examples/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "4c5e13b0797a29570702d202b564d30b2a4ef78a01286493ec93a68c59074af8";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/depthai-filters/default.nix
+++ b/distros/kilted/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, depthai-ros-msgs, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-depthai-filters";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_filters/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "29b7ea736c3b192a883eaf5f3e7b62e3cd3676d6720c332dc7e3b360f29e2b3b";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_filters/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "8911468120d12521067039560865249d580b48d770e36d4e20b36f3f1d547413";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/depthai-ros-driver/default.nix
+++ b/distros/kilted/depthai-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-python, backward-ros, camera-calibration, camera-info-manager, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, ffmpeg-image-transport-msgs, geometry-msgs, image-pipeline, image-transport, image-transport-plugins, nav-msgs, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, tf2-ros, vision-msgs }:
 buildRosPackage {
   pname = "ros-kilted-depthai-ros-driver";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_ros_driver/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "2fd16ee2bbcdc340061de65cc6dcc27bd4a432097682cd3fe9d2a67f97d84c33";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_ros_driver/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "d788f50d5a9f7e3957f5d17d087f24e01fc2a270648ccd571d919b1cbdc5134e";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/depthai-ros-msgs/default.nix
+++ b/distros/kilted/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-kilted-depthai-ros-msgs";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_ros_msgs/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "725cfdb8f442e40c2db286441248888360188e68997c4c26e3f2fe70a0b4801e";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_ros_msgs/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "2428cebdd00bdf59e121b5fd7293dc0a3ce4a628f32425deb9437ae19685e10a";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/depthai-ros/default.nix
+++ b/distros/kilted/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-kilted-depthai-ros";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai-ros/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "77a87f83413234f56814ead6e5be309b490f0187c967e4d64d35e0544671ca61";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai-ros/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "109a75818c20ac267f71c18fa08e2c0383bfa3fea9d1a010c57bd72d58bb05c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/flexbe-behavior-engine/default.nix
+++ b/distros/kilted/flexbe-behavior-engine/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, flexbe-core, flexbe-input, flexbe-mirror, flexbe-msgs, flexbe-onboard, flexbe-states, flexbe-testing, flexbe-widget }:
 buildRosPackage {
   pname = "ros-kilted-flexbe-behavior-engine";
-  version = "4.1.3-r1";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/kilted/flexbe_behavior_engine/4.1.3-1.tar.gz";
-    name = "4.1.3-1.tar.gz";
-    sha256 = "1196e51fe830d87c36d5881da1a88ad2fab93f565ca53cfadbeaae36f7d924f7";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/kilted/flexbe_behavior_engine/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "ef5809f85f143d60155d24c033ec1c7d1fba080f2eec5951e3ec1b061f422355";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/flexbe-core/default.nix
+++ b/distros/kilted/flexbe-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-msgs, launch-ros, launch-testing, python3Packages, rclpy, std-msgs, std-srvs, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-kilted-flexbe-core";
-  version = "4.1.3-r1";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/kilted/flexbe_core/4.1.3-1.tar.gz";
-    name = "4.1.3-1.tar.gz";
-    sha256 = "a4d0e54ad241fe6ab607fddf77249f3eac7af77a919450e0c79c58044f02a9a7";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/kilted/flexbe_core/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "e32ac6cb588df2d36c4c3560742f91f1500e11c06f49ba5df4c66b38dd49e26a";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/flexbe-input/default.nix
+++ b/distros/kilted/flexbe-input/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-kilted-flexbe-input";
-  version = "4.1.3-r1";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/kilted/flexbe_input/4.1.3-1.tar.gz";
-    name = "4.1.3-1.tar.gz";
-    sha256 = "93aacace4ee9c55a844bb1e7f64db02d404ea44471befe484caf25ac6daee7fe";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/kilted/flexbe_input/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "f1ac74342da2c6779cc7759370db87878c30e3d34ad88423c097dc5654482dfe";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/flexbe-mirror/default.nix
+++ b/distros/kilted/flexbe-mirror/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-kilted-flexbe-mirror";
-  version = "4.1.3-r1";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/kilted/flexbe_mirror/4.1.3-1.tar.gz";
-    name = "4.1.3-1.tar.gz";
-    sha256 = "a31471a1548bc20438a979894cc99564545bbe1927043b56d6a09c1ef04920e4";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/kilted/flexbe_mirror/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "7a151d1abde83d75d8cd5ad03d628467252eca919e05ba3e363ab6e1f7fab504";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/flexbe-msgs/default.nix
+++ b/distros/kilted/flexbe-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-flexbe-msgs";
-  version = "4.1.3-r1";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/kilted/flexbe_msgs/4.1.3-1.tar.gz";
-    name = "4.1.3-1.tar.gz";
-    sha256 = "87327df7b1e325382549e5d5744e7881570e430a316e275875f369ee0cf573db";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/kilted/flexbe_msgs/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "ff5e317bf3b959f3d24f8312458a55b6fdc9aaecdf1b2cbd538ef7d9ca3c7367";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/flexbe-onboard/default.nix
+++ b/distros/kilted/flexbe-onboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, flexbe-states, launch-ros, launch-testing, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-kilted-flexbe-onboard";
-  version = "4.1.3-r1";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/kilted/flexbe_onboard/4.1.3-1.tar.gz";
-    name = "4.1.3-1.tar.gz";
-    sha256 = "1ff0f585825f26e9c405a257a155974813ed5e562856e877d058e74424555f73";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/kilted/flexbe_onboard/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "0588ed964d54f84a614129abcfd970d8b8e9faf07da4f1b725f1cc55207eeacb";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/flexbe-states/default.nix
+++ b/distros/kilted/flexbe-states/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, flexbe-testing, geometry-msgs, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-kilted-flexbe-states";
-  version = "4.1.3-r1";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/kilted/flexbe_states/4.1.3-1.tar.gz";
-    name = "4.1.3-1.tar.gz";
-    sha256 = "c06ea96443c272b93f8fa40487c19b0c1a76ca61bf7b5f9e379ab930053f13f5";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/kilted/flexbe_states/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "d0c45ca1d08ce97d31978002461b129a620046f16364171085b8b3f0e0f1c772";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/flexbe-testing/default.nix
+++ b/distros/kilted/flexbe-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-copyright, ament-flake8, ament-index-python, ament-pep257, flexbe-core, flexbe-msgs, launch-ros, launch-testing, python3Packages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-flexbe-testing";
-  version = "4.1.3-r1";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/kilted/flexbe_testing/4.1.3-1.tar.gz";
-    name = "4.1.3-1.tar.gz";
-    sha256 = "e6833ecbd7d45573fa2e779a016765f382d327a9d786a388250a3fb382d222f6";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/kilted/flexbe_testing/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "37f1e97a04a7f84753b8b666a93e8655c2423606804fea4b53e4da4206b4cfb6";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/flexbe-widget/default.nix
+++ b/distros/kilted/flexbe-widget/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-mirror, flexbe-msgs, flexbe-onboard, launch-ros, python3Packages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-flexbe-widget";
-  version = "4.1.3-r1";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/kilted/flexbe_widget/4.1.3-1.tar.gz";
-    name = "4.1.3-1.tar.gz";
-    sha256 = "c7a66995c97e0c5d0d1942d5693bc7fb1fff4fad96c5541dcd6c5d45e19a9cff";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/kilted/flexbe_widget/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "d1eee053a68b55e3d8f2bdbbfb32387d45d1b89018209510c2174216c3dee7d9";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/generated.nix
+++ b/distros/kilted/generated.nix
@@ -438,6 +438,8 @@ self: super: {
 
  cras-topic-tools = self.callPackage ./cras-topic-tools {};
 
+ crocoddyl = self.callPackage ./crocoddyl {};
+
  crx-kinematics = self.callPackage ./crx-kinematics {};
 
  cudnn-cmake-module = self.callPackage ./cudnn-cmake-module {};
@@ -1194,8 +1196,6 @@ self: super: {
 
  kinematics-interface-pinocchio = self.callPackage ./kinematics-interface-pinocchio {};
 
- kitti-metrics-eval = self.callPackage ./kitti-metrics-eval {};
-
  kobuki-core = self.callPackage ./kobuki-core {};
 
  kobuki-ros-interfaces = self.callPackage ./kobuki-ros-interfaces {};
@@ -1438,17 +1438,9 @@ self: super: {
 
  mola-imu-preintegration = self.callPackage ./mola-imu-preintegration {};
 
- mola-input-euroc-dataset = self.callPackage ./mola-input-euroc-dataset {};
-
- mola-input-kitti360-dataset = self.callPackage ./mola-input-kitti360-dataset {};
-
- mola-input-kitti-dataset = self.callPackage ./mola-input-kitti-dataset {};
-
  mola-input-lidar-bin-dataset = self.callPackage ./mola-input-lidar-bin-dataset {};
 
- mola-input-mulran-dataset = self.callPackage ./mola-input-mulran-dataset {};
-
- mola-input-paris-luco-dataset = self.callPackage ./mola-input-paris-luco-dataset {};
+ mola-input-ouster = self.callPackage ./mola-input-ouster {};
 
  mola-input-rawlog = self.callPackage ./mola-input-rawlog {};
 
@@ -1483,6 +1475,8 @@ self: super: {
  mola-traj-tools = self.callPackage ./mola-traj-tools {};
 
  mola-viz = self.callPackage ./mola-viz {};
+
+ mola-viz-imgui = self.callPackage ./mola-viz-imgui {};
 
  mola-yaml = self.callPackage ./mola-yaml {};
 
@@ -1817,6 +1811,8 @@ self: super: {
  novatel-gps-driver = self.callPackage ./novatel-gps-driver {};
 
  novatel-gps-msgs = self.callPackage ./novatel-gps-msgs {};
+
+ novatel-oem6-msgs = self.callPackage ./novatel-oem6-msgs {};
 
  novatel-oem7-driver = self.callPackage ./novatel-oem7-driver {};
 

--- a/distros/kilted/leo-bringup/default.nix
+++ b/distros/kilted/leo-bringup/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-index-python, ament-lint-auto, geometry-msgs, image-proc, launch, launch-ros, leo-description, leo-filters, leo-fw, leo-msgs, python3Packages, robot-state-publisher, rosapi, rosbridge-server, sensor-msgs, web-video-server, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-index-python, ament-lint-auto, geometry-msgs, image-proc, launch, launch-ros, leo-description, leo-filters, leo-fw, leo-msgs, python3Packages, rclpy, robot-state-publisher, rosapi, rosbridge-server, sensor-msgs, tf-transformations, web-video-server, xacro }:
 buildRosPackage {
   pname = "ros-kilted-leo-bringup";
-  version = "2.5.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/kilted/leo_bringup/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "da6289b46e3ab26a17fd96861a53782b5f2c2e14606843181ad29895e1e804b8";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/kilted/leo_bringup/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "b95acf83d90d6ed2d3b9eda685f9dad9d06f6a96dac6e3a62f24c217e8b2d550";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-black ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ ament-index-python geometry-msgs image-proc launch launch-ros leo-description leo-filters leo-fw leo-msgs python3Packages.smbus2 robot-state-publisher rosapi rosbridge-server sensor-msgs web-video-server xacro ];
+  propagatedBuildInputs = [ ament-index-python geometry-msgs image-proc launch launch-ros leo-description leo-filters leo-fw leo-msgs python3Packages.smbus2 rclpy robot-state-publisher rosapi rosbridge-server sensor-msgs tf-transformations web-video-server xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/leo-filters/default.nix
+++ b/distros/kilted/leo-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, generate-parameter-library, geometry-msgs, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, std-srvs, tf2, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-kilted-leo-filters";
-  version = "2.5.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/kilted/leo_filters/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "b7a4872c751febdce2a235f14a5de0659ac091f641fd55935e52498cd404ea22";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/kilted/leo_filters/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "b2a4393d1938c98c28444fdfe51330c0f02d66a87b0c13f4afc756c426d93831";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/leo-fw/default.nix
+++ b/distros/kilted/leo-fw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-pep257, ament-cmake-python, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-python, ament-lint-auto, geometry-msgs, leo-msgs, nav-msgs, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, ros2cli, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kilted-leo-fw";
-  version = "2.5.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/kilted/leo_fw/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "1b7963dacade77d52e53a2f1f8bbe67bb5840c05550d7c3ca96ea6abf3ee16cf";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/kilted/leo_fw/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "7cdf4acf495523b5a81afe81e449d66fab99167d0879eb02c9fa3797acee69f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/leo-robot/default.nix
+++ b/distros/kilted/leo-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, leo, leo-bringup, leo-filters, leo-fw }:
 buildRosPackage {
   pname = "ros-kilted-leo-robot";
-  version = "2.5.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/kilted/leo_robot/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "c8ccfc5f56024e8bc3d7829662830d303ff93b411c2a43f5ca09ce079937902a";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/kilted/leo_robot/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "64ccc6d71f55a9756f5900bddfec84e9c27e500a8907a15ee057bedf042bab72";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mola-bridge-ros2/default.nix
+++ b/distros/kilted/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, diagnostic-msgs, geographic-msgs, geometry-msgs, gps-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mola-bridge-ros2";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_bridge_ros2/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "d6d150137fa9077d687e878cb33315e17c3f90d421c7e2da1f93c36fe3c15792";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_bridge_ros2/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "c30a63763a69ea482893182b98b9d4ee8b3b7ff1ba28c5bd50d63d6302c15a73";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mola-common/default.nix
+++ b/distros/kilted/mola-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-kilted-mola-common";
-  version = "0.6.0-r1";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/kilted/mola_common/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "65bc7967b4e447b74a497950bfb9e483cf98a8fd265d52c4be4be8a75265bafb";
+    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/kilted/mola_common/0.6.1-1.tar.gz";
+    name = "0.6.1-1.tar.gz";
+    sha256 = "01e493db43d91be6b0143368f0372562df7ec2ba61a6b37de615b8e5cb8ba925";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mola-demos/default.nix
+++ b/distros/kilted/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-kilted-mola-demos";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_demos/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "52857c2c61cea877173705ca88d52fdfac81db7115f3ceaf989851c35c21d06d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_demos/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "aad52f4483a4daf24476617cce23a4b7fe6fa40447ee1232672f4b428c9eedb0";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mola-input-lidar-bin-dataset/default.nix
+++ b/distros/kilted/mola-input-lidar-bin-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-kilted-mola-input-lidar-bin-dataset";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_lidar_bin_dataset/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "70d6f612d1a1867170e83a5cf941f19c0a493824b15455315f0e2da4af92a451";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_lidar_bin_dataset/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "713c7ef3df8f80fdecf5b0974a976225ee9ea867f49ccd2d73619334fa66c6be";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-input-ouster/default.nix
+++ b/distros/kilted/mola-input-ouster/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, curl, eigen, flatbuffers, libpng, libtins, libzip, mola-kernel, mola-yaml, mrpt-libmaps, mrpt-libobs, openssl, zstd }:
+buildRosPackage {
+  pname = "ros-kilted-mola-input-ouster";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_input_ouster-release/archive/release/kilted/mola_input_ouster/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "de0886117255db6719e39a620eb4911f3fb0c475b8241dd8cd8089ecf720c495";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen flatbuffers libpng libtins libzip openssl zstd ];
+  propagatedBuildInputs = [ curl mola-kernel mola-yaml mrpt-libmaps mrpt-libobs ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "MOLA input module for Ouster LiDAR sensors using the native Ouster C++ SDK.
+    Provides direct sensor connection and PCAP replay without ROS middleware.";
+    license = with lib.licenses; [ "GPL-3.0" ];
+  };
+}

--- a/distros/kilted/mola-input-rawlog/default.nix
+++ b/distros/kilted/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-kilted-mola-input-rawlog";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_rawlog/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "f6a4a7442e53f9f722f5693a726ae4c33157a6275a9e3dd3e500b0f1d1758a33";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_rawlog/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "97bc0dea266f88e31ee0630be76892569b7f3dc8fadb13c88cdcee1775f9a674";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-input-rosbag2/default.nix
+++ b/distros/kilted/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, gps-msgs, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-mola-input-rosbag2";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_rosbag2/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "a1b8ae977d94643f5e8d23118fb9fa411f63af7c0f195330b55a0865c6760f23";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_rosbag2/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "1bf851ffc0bc19b16fbb00aec5cca05cdfb1476364d30d58e20357c649e9961a";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-input-video/default.nix
+++ b/distros/kilted/mola-input-video/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libhwdrivers, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-kilted-mola-input-video";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_video/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "b43067ba96e4da6baede6dcc6339802b3ca422fbf65e1146e4d6b4e745c7cfbf";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_input_video/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "aec3d32d41af64cba1ab519faf56106352f243a93e04f4b293a53f67148dfbe3";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-kernel/default.nix
+++ b/distros/kilted/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libgui, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-kilted-mola-kernel";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_kernel/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "eea286942b3399290fdb707011cb5d70999ebcfedd87e75a15e3a30ad9e57f3f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_kernel/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "ce487fb39f3284629799fab5392cc1be527cdd6c5399648351a4753f5f2b37a0";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-launcher/default.nix
+++ b/distros/kilted/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-xmllint, ament-lint-auto, cmake, mola-kernel, mrpt-libbase, mrpt-libtclap, ros-environment }:
 buildRosPackage {
   pname = "ros-kilted-mola-launcher";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_launcher/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "b695ea84ce3f3401e8c90a0d237705955b61a321490e95f05e5b02e83d22f722";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_launcher/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "4da9f8cfcad12a5035a8fcec59f093cf80aa44d9e6431c80825e519ab72ab2ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mola-lidar-odometry/default.nix
+++ b/distros/kilted/mola-lidar-odometry/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-imu-preintegration, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
+{ lib, buildRosPackage, fetchurl, _unresolved_mola_input_kitti360_dataset, _unresolved_mola_input_kitti_dataset, _unresolved_mola_input_mulran_dataset, _unresolved_mola_input_paris_luco_dataset, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-imu-preintegration, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-kilted-mola-lidar-odometry";
   version = "2.1.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-test-datasets rosbag2-storage-mcap ];
-  propagatedBuildInputs = [ mola-common mola-imu-preintegration mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-pose-list mola-state-estimation-simple mola-viz mp2p-icp mrpt-libmaps mrpt-libtclap ];
+  propagatedBuildInputs = [ _unresolved_mola_input_kitti360_dataset _unresolved_mola_input_kitti_dataset _unresolved_mola_input_mulran_dataset _unresolved_mola_input_paris_luco_dataset mola-common mola-imu-preintegration mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-pose-list mola-state-estimation-simple mola-viz mp2p-icp mrpt-libmaps mrpt-libtclap ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/kilted/mola-metric-maps/default.nix
+++ b/distros/kilted/mola-metric-maps/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mp2p-icp, mrpt-libmaps, onetbb, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mola-kernel, mp2p-icp, mrpt-libmaps, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-kilted-mola-metric-maps";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_metric_maps/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "2f8f953755dd9f62ae664dee53ff669ad9526a91157a8e8f6859ef7aa9e97456";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_metric_maps/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "2d6ff4fd6555e4624fca91eae260bcb60947b739d0b60760ff8e6bfc0ddfbcd1";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ mola-common mp2p-icp mrpt-libmaps onetbb ];
+  propagatedBuildInputs = [ mola-common mola-kernel mp2p-icp mrpt-libmaps onetbb ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/kilted/mola-msgs/default.nix
+++ b/distros/kilted/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-kilted-mola-msgs";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_msgs/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "8b2c4c9dc6b4dfb33e5d75aa7e5f0d716bf785dfc96f69ad36b3b16598ae0d55";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_msgs/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "acd0b837f536a638b53f05c6df8c6e073d85923676a67f1892c12ec74e473185";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mola-pose-list/default.nix
+++ b/distros/kilted/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-kilted-mola-pose-list";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_pose_list/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "a42a39be9b0d0c1b72f5ab31f14b61b15891f940c2bf14ec922f018daacb0c58";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_pose_list/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "e15820ab5ec6f1b15c1bf4c2752f5146698af7ea94528c1e2d7afa1ce3a44515";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-relocalization/default.nix
+++ b/distros/kilted/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-kilted-mola-relocalization";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_relocalization/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "42d9c099921d01a14c544ca6c4462942b3949957e2a22b8548c5fbd60d309cab";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_relocalization/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "b4d2f93ff930621663eab252603b8c7e9971e2ab3b45976f95af5221f662b493";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-traj-tools/default.nix
+++ b/distros/kilted/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-kilted-mola-traj-tools";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_traj_tools/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "1d0fdd4c3674aed00811103a6a4ebfd3fbcd558cb47755639ab4c1a60399d043";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_traj_tools/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "7d9ff65540991c71d2992b9a604b07885e0c0ead5134a78f0c76f3bfb31e2d43";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-viz-imgui/default.nix
+++ b/distros/kilted/mola-viz-imgui/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, freeglut, glfw3, libGL, libGLU, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libopengl }:
+buildRosPackage {
+  pname = "ros-kilted-mola-viz-imgui";
+  version = "2.9.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_viz_imgui/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "4b824b161f56a55dae23409eeae4793c38c527e05ab797061582a7da06ab0151";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ freeglut glfw3 libGL libGLU mola-kernel mrpt-libgui mrpt-libmaps mrpt-libobs mrpt-libopengl ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Dear ImGui (docking branch) GUI backend for MOLA";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/kilted/mola-viz/default.nix
+++ b/distros/kilted/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-kilted-mola-viz";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_viz/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "48a4c2b162c1bdb55ac38fb5b001167f01462ce43b79c7992af1b94b95e90105";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_viz/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "82cb8a3ca99c3a026c138e513523964b3574702a0aed61ee8e8efe9e6349bba0";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-yaml/default.nix
+++ b/distros/kilted/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-kilted-mola-yaml";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_yaml/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "de59c339111e457754aabe9e40711eafd260f08cd82fd72e5c0b46695e5066ee";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola_yaml/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "c0dec0688e5003400dec2dcefadb7ca2b4f5daeaacbc81d6253afd603edd17fa";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola/default.nix
+++ b/distros/kilted/mola/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-input-video, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
+{ lib, buildRosPackage, fetchurl, cmake, mola-bridge-ros2, mola-demos, mola-input-rawlog, mola-input-rosbag2, mola-input-video, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-kilted-mola";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "f2c7f59ed12a81ee71f59a02012fa858abdf2b4b32ce3167370c40d450e2dac1";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/kilted/mola/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "1ef23c4b8d40a77e849974c9c22112c79963954b964250b551f9f2ff917697dd";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
-  propagatedBuildInputs = [ kitti-metrics-eval mola-bridge-ros2 mola-demos mola-input-euroc-dataset mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-input-video mola-kernel mola-launcher mola-metric-maps mola-pose-list mola-relocalization mola-traj-tools mola-viz mola-yaml ];
+  propagatedBuildInputs = [ mola-bridge-ros2 mola-demos mola-input-rawlog mola-input-rosbag2 mola-input-video mola-kernel mola-launcher mola-metric-maps mola-pose-list mola-relocalization mola-traj-tools mola-viz mola-yaml ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/kilted/mrpt-generic-sensor/default.nix
+++ b/distros/kilted/mrpt-generic-sensor/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt-sensorlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-msgs, mrpt-sensorlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-generic-sensor";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/kilted/mrpt_generic_sensor/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "d2f0f879b21fabe643527884001f201c2b19d5435493d5e0a43dcce0de944d65";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/kilted/mrpt_generic_sensor/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "2915874cf08f7aaf2ac73bf7b1a743435c32ca974c3741b60283205deae6c8a4";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-msgs mrpt-sensorlib rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-msgs mrpt-sensorlib rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/mrpt-sensor-bumblebee-stereo/default.nix
+++ b/distros/kilted/mrpt-sensor-bumblebee-stereo/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, rclcpp-components, ros-environment, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-sensor-bumblebee-stereo";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/kilted/mrpt_sensor_bumblebee_stereo/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "45372f42f1322ad7c29f036438ec02584ffe10ecb5d9cadc7c81be91d2b25abb";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/kilted/mrpt_sensor_bumblebee_stereo/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "3b1e402b5fe37aaa112178ccc52a398e628de15caa47cd5f4f1179c708133591";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib rclcpp-components tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/mrpt-sensor-gnss-nmea/default.nix
+++ b/distros/kilted/mrpt-sensor-gnss-nmea/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nmea-msgs, rclcpp-components, ros-environment, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-sensor-gnss-nmea";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/kilted/mrpt_sensor_gnss_nmea/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "ee8da1a1a1d515d4071c1386ed9d007e44d1cfb885cf0d3dfb5aa417748fdb10";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/kilted/mrpt_sensor_gnss_nmea/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "648884fc5c5cf62bc3477526f23e0308a56ead49f617b14e4228317c9c256827";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs nmea-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nmea-msgs rclcpp-components tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/mrpt-sensor-gnss-novatel/default.nix
+++ b/distros/kilted/mrpt-sensor-gnss-novatel/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, novatel-oem6-msgs, rclcpp-components, ros-environment, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-sensor-gnss-novatel";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/kilted/mrpt_sensor_gnss_novatel/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "d8c9b543af8561ff182e300c20440debed69e73e609b42c4ab9e7df72acf4088";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/kilted/mrpt_sensor_gnss_novatel/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "e0a89816a57a38db99227fac6abd8948aae641aea5418c590b253487848dce83";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib novatel-oem6-msgs rclcpp-components tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/mrpt-sensor-imu-taobotics/default.nix
+++ b/distros/kilted/mrpt-sensor-imu-taobotics/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, rclcpp-components, ros-environment, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-sensor-imu-taobotics";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/kilted/mrpt_sensor_imu_taobotics/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "35133c4d13777bbc2ad048f4c41bd2bcc54063e4239c8e58fa3dd877adf3a21a";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/kilted/mrpt_sensor_imu_taobotics/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "638bc0dfa1ffbcaca409accda5f7fb055779d9fac5a2c90aae30406d0c261db1";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib rclcpp-components tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/mrpt-sensorlib/default.nix
+++ b/distros/kilted/mrpt-sensorlib/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, diagnostic-updater, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, rclcpp-components, ros-environment, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-sensorlib";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/kilted/mrpt_sensorlib/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "2f1ccb91314a90d230fd5e3e84aec1b895d36b0feed6f7204e0c162612732ee9";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/kilted/mrpt_sensorlib/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "a1724660349fe5b01e60bb2f9f01645e92aa64aa5be1c9c20a5cc7bb38253ec2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ diagnostic-updater mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs rclcpp-components tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/mrpt-sensors/default.nix
+++ b/distros/kilted/mrpt-sensors/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-generic-sensor, mrpt-sensor-bumblebee-stereo, mrpt-sensor-gnss-nmea, mrpt-sensor-gnss-novatel, mrpt-sensor-imu-taobotics, mrpt-sensorlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-generic-sensor, mrpt-sensor-bumblebee-stereo, mrpt-sensor-gnss-nmea, mrpt-sensor-gnss-novatel, mrpt-sensor-imu-taobotics, mrpt-sensorlib }:
 buildRosPackage {
   pname = "ros-kilted-mrpt-sensors";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/kilted/mrpt_sensors/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "1c55640dadb62371a2e939413e3f78b979a044c096d9c1fbca89d6782d751357";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/kilted/mrpt_sensors/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "937094f96cb0560f6da6483d4405544c209970802a1b47a18981cd265c4173f3";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-generic-sensor mrpt-sensor-bumblebee-stereo mrpt-sensor-gnss-nmea mrpt-sensor-gnss-novatel mrpt-sensor-imu-taobotics mrpt-sensorlib ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-generic-sensor mrpt-sensor-bumblebee-stereo mrpt-sensor-gnss-nmea mrpt-sensor-gnss-novatel mrpt-sensor-imu-taobotics mrpt-sensorlib ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/novatel-oem6-msgs/default.nix
+++ b/distros/kilted/novatel-oem6-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-novatel-oem6-msgs";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/kilted/novatel_oem6_msgs/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "562ecafc2a445363919a2797f58884af886f71de63e8968fbe28b18bf3a4bce9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-cmake-xmllint ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "ROS messages and services for Novatel OEM6";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/topic-tools-interfaces/default.nix
+++ b/distros/kilted/topic-tools-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-kilted-topic-tools-interfaces";
-  version = "1.4.2-r2";
+  version = "1.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/kilted/topic_tools_interfaces/1.4.2-2.tar.gz";
-    name = "1.4.2-2.tar.gz";
-    sha256 = "43d14f2513b3f6a0b2507bdddbcc73cbefc3ab320e67557c905dd0fcf26a9808";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/kilted/topic_tools_interfaces/1.4.5-1.tar.gz";
+    name = "1.4.5-1.tar.gz";
+    sha256 = "e777f375e4a2bb4c7f186a000fcbe1c407cb2d5d4eb2df4968ca6208402970c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/topic-tools/default.nix
+++ b/distros/kilted/topic-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclpy, ros2cli, rosidl-default-generators, rosidl-runtime-py, std-msgs, topic-tools-interfaces }:
 buildRosPackage {
   pname = "ros-kilted-topic-tools";
-  version = "1.4.2-r2";
+  version = "1.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/kilted/topic_tools/1.4.2-2.tar.gz";
-    name = "1.4.2-2.tar.gz";
-    sha256 = "50dadbf5e412b7442f46e90b9bc38613fdb39756450a1147936ab9e9ca67cfa7";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/kilted/topic_tools/1.4.5-1.tar.gz";
+    name = "1.4.5-1.tar.gz";
+    sha256 = "58d61358496cf05d9e1c5a8e67f4bf9037e6607a69ec441758c2b8d7877b2ffd";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ur-client-library/default.nix
+++ b/distros/kilted/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-kilted-ur-client-library";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/kilted/ur_client_library/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "9548a9515f2a1bf26514666ca825eb7473b4cfaefdc03c3006bb3ca27a9cc290";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/kilted/ur_client_library/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "97b1922f4bf32bbb6e02b8fc269e419f9f70db60c4368e6cb3cf5012d2c1e7d1";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/action-msgs/default.nix
+++ b/distros/lyrical/action-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-core-generators, rosidl-core-runtime, service-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-action-msgs";
-  version = "2.4.4-r3";
+  version = "2.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/lyrical/action_msgs/2.4.4-3.tar.gz";
-    name = "2.4.4-3.tar.gz";
-    sha256 = "edccfb85e2022dc1c35fbc4cce54fbe202ec5380cc977973579b25e90becb04d";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/lyrical/action_msgs/2.4.5-1.tar.gz";
+    name = "2.4.5-1.tar.gz";
+    sha256 = "96625d9f572ff7a5d4dab32e4ee6895856b813daa6f480c50ed5ab85aa4fb172";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ament-clang-format/default.nix
+++ b/distros/lyrical/ament-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, clang, python3Packages }:
 buildRosPackage {
   pname = "ros-lyrical-ament-clang-format";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_clang_format/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "f6482d96cd35421ba22e843718215116bb5d2e466dbb8a3a62e25e28d5f4211e";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_clang_format/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "dfdbb417fa1c387355f1dd71b47dc14beb108cbb3f4b72cd1efcaddf719cb6ae";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/ament-clang-tidy/default.nix
+++ b/distros/lyrical/ament-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, clang, python3Packages }:
 buildRosPackage {
   pname = "ros-lyrical-ament-clang-tidy";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_clang_tidy/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "44e482366c94de7ab0fe928c3430a60c60dba2fe526febf94e5cba282249832e";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_clang_tidy/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "8082f96121a17d13058850286dd646ae08c80277779032b1b4772907f46f35cf";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/ament-cmake-clang-format/default.nix
+++ b/distros/lyrical/ament-cmake-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-lyrical-ament-cmake-clang-format";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_clang_format/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "d8aa334d0814b119dc2810cadb5faea3461dc6f1eaee5934a2a9b5510702f552";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_clang_format/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "de07035e994b51702b245cc11e9467520def015637236f42b4c2eb5e84d23f8f";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ament-cmake-clang-tidy/default.nix
+++ b/distros/lyrical/ament-cmake-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-tidy, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-lyrical-ament-cmake-clang-tidy";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_clang_tidy/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "89663e174bf896a04263eb388fbd08a7904ae6dd68d551bf26ecca8cd65e8659";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_clang_tidy/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "7d1706161df773d4480eebed14241957ba98e80207db05ff5532c4e271e41055";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ament-cmake-copyright/default.nix
+++ b/distros/lyrical/ament-cmake-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-copyright }:
 buildRosPackage {
   pname = "ros-lyrical-ament-cmake-copyright";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_copyright/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "abe2250f54dd0632d83cfab6c10f208d92ae6c61bc8348b6b9d37798f140c975";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_copyright/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "e3cc4e3b414f8d50a25626db7592681f7bf17d86e18768cf3bd9225fc3e4ed40";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ament-cmake-cppcheck/default.nix
+++ b/distros/lyrical/ament-cmake-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cppcheck }:
 buildRosPackage {
   pname = "ros-lyrical-ament-cmake-cppcheck";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_cppcheck/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "3c634cbda02ced6e66cb1923a4833b3a8b28c10a824f7b8333c21bb22f5202c5";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_cppcheck/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "e685439858537998425b69621e42b6f5f3873c96defac3f214d1a22edadfbae0";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ament-cmake-cpplint/default.nix
+++ b/distros/lyrical/ament-cmake-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cpplint }:
 buildRosPackage {
   pname = "ros-lyrical-ament-cmake-cpplint";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_cpplint/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "328fa00f770689e5a30e18f98a4af168917b674ba416a3d0c5f1d2d715874275";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_cpplint/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "234cea2d2d98797e2dd83600e1c61da987307a4ab2e3c4d3ba873c2994404bef";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ament-cmake-flake8/default.nix
+++ b/distros/lyrical/ament-cmake-flake8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-flake8 }:
 buildRosPackage {
   pname = "ros-lyrical-ament-cmake-flake8";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_flake8/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "4ce7302abb44508d40227bc8ae15f7b9ffb44ba5b172002e053f2e30d301942f";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_flake8/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "3daf37a48f24b1034974bcee55c976c6301cae7dd15a4fd48aa0d51201a4ba9f";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ament-cmake-lint-cmake/default.nix
+++ b/distros/lyrical/ament-cmake-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, ament-lint-cmake }:
 buildRosPackage {
   pname = "ros-lyrical-ament-cmake-lint-cmake";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_lint_cmake/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "26229286cd63ea4d75fb5583090bdaa680264f4e65f298afaea081587c6c7159";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_lint_cmake/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "50994875d28e381c0f1b214bb1b030b23c979b03a2f680f7151ad4742e9f88c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ament-cmake-mypy/default.nix
+++ b/distros/lyrical/ament-cmake-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-mypy }:
 buildRosPackage {
   pname = "ros-lyrical-ament-cmake-mypy";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_mypy/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "a1391ea6cf3f89c4dcf4eb2468cd9d1f573315ab89b031d9b3bcdf47833a399e";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_mypy/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "385a7d913dffba60920c835df719009bdc346a27066844639e68dee83144e632";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ament-cmake-pclint/default.nix
+++ b/distros/lyrical/ament-cmake-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pclint }:
 buildRosPackage {
   pname = "ros-lyrical-ament-cmake-pclint";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_pclint/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "090ce923603254daf3bcccf2f48441de6d44b147e398c75f2231dbd17a49c27c";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_pclint/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "9b989a06f9c38e682523f7e4b371acc28d5b7a556f4c33bcea84aee10bbdb849";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ament-cmake-pep257/default.nix
+++ b/distros/lyrical/ament-cmake-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pep257 }:
 buildRosPackage {
   pname = "ros-lyrical-ament-cmake-pep257";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_pep257/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "bda4725c7d609a6d6aae70c92ff5f1b404140cfc9bf3826595d33b54736c846a";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_pep257/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "3ec7ce95be07b09f68746883b9a689415efab2e097bae3aa3594af510f214dfc";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ament-cmake-pycodestyle/default.nix
+++ b/distros/lyrical/ament-cmake-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pycodestyle }:
 buildRosPackage {
   pname = "ros-lyrical-ament-cmake-pycodestyle";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_pycodestyle/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "a3f2f6a8cd4a23a37c63f1745dc49499221ecd1b937e38a9e810c78878817bfe";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_pycodestyle/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "1d5d0ae97bcd26a776af0583c34b718a118f6cc718c851a5c6b31ae8ab8606db";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ament-cmake-pyflakes/default.nix
+++ b/distros/lyrical/ament-cmake-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pyflakes }:
 buildRosPackage {
   pname = "ros-lyrical-ament-cmake-pyflakes";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_pyflakes/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "a8b478a58cf54c81b10d4ca55b85810a4e0e549184c01e49b109e0d1a17e1c0e";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_pyflakes/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "fd676ae2c76a6a31306709ea6cd07526f6a5198105ef6f8130b058f73c3b28bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ament-cmake-uncrustify/default.nix
+++ b/distros/lyrical/ament-cmake-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-uncrustify }:
 buildRosPackage {
   pname = "ros-lyrical-ament-cmake-uncrustify";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_uncrustify/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "fd0a7c583502c465f1dedf20827b9b90cf5232f565cb086a9f3de0e225b0bfeb";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_uncrustify/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "c496cbf599d38765c6c809a4ba492e13e5ad9c8487aa97e26fd5fea6f8892c0b";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ament-cmake-xmllint/default.nix
+++ b/distros/lyrical/ament-cmake-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-xmllint }:
 buildRosPackage {
   pname = "ros-lyrical-ament-cmake-xmllint";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_xmllint/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "12266e74756a25879451dc97b7e4c8d3d25cca82a2c6392c8d6654ad232cc287";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cmake_xmllint/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "926dd18f987652418dcab7ad79ff6bd6cce0f36a92a339adad4134e3ef536047";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ament-copyright/default.nix
+++ b/distros/lyrical/ament-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-lyrical-ament-copyright";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_copyright/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "816c53254698537862a4f02c67dd7fddee01a59eb64feb03e7a1e51aa1837a4b";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_copyright/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "48bb5c0bb394db57b22f551562976503b95872a50947754dada3118f33c52a6a";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/ament-cppcheck/default.nix
+++ b/distros/lyrical/ament-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-pycodestyle, ament-xmllint, cppcheck, python3Packages }:
 buildRosPackage {
   pname = "ros-lyrical-ament-cppcheck";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cppcheck/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "fc9cae91bd1a88c3e9146d1e6ace15b86b36601ac8ee64b75f6fff8b67cf506a";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cppcheck/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "55e5a59481c8fb0083f99df64ff0787b02eed65358376e8f187c7736b100552d";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/ament-cpplint/default.nix
+++ b/distros/lyrical/ament-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-lyrical-ament-cpplint";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cpplint/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "d5f975c3ac2760378e95d32cfe5df33188fbe17636c77cd42865ec75f533c5f1";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_cpplint/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "bcd5752cf6737c5314e6e559faf90f8395493abe93d25312a1579a57bf21ff8d";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/ament-flake8/default.nix
+++ b/distros/lyrical/ament-flake8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint, python3Packages }:
 buildRosPackage {
   pname = "ros-lyrical-ament-flake8";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_flake8/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "7a07458bd1a8af0a52e8163a47760ad8f87dc85793654f7695faa3e07e1e317e";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_flake8/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "98295cd2004217c30745a643e8697615809abe1420ccb6584aaeb2b2bcc21729";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/ament-lint-auto/default.nix
+++ b/distros/lyrical/ament-lint-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-lyrical-ament-lint-auto";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_lint_auto/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "73af12c532f6c5aa1d518330f9e5c115be309f87335f3f595139e83e8f2f4cf8";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_lint_auto/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "60ad02c10596fb064e836addb21d9cd85065699d3a4c230529306de1080b1ffe";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ament-lint-cmake/default.nix
+++ b/distros/lyrical/ament-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-lyrical-ament-lint-cmake";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_lint_cmake/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "7a75d34d0506f78424e7c68c5d09570898e28e36bb32377d5db96c960e49c4bd";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_lint_cmake/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "d992f5a4de7b7289ee2ef8201fde16728c2673147b4942ebf6b35e4fd3d64d6a";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/ament-lint-common/default.nix
+++ b/distros/lyrical/ament-lint-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-export-dependencies, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-lyrical-ament-lint-common";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_lint_common/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "b6abea0cab08a65700899808a3a836cfb584e31e7478ff6be86aa8b73dc02f32";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_lint_common/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "01a1ebcc3e9d8cd8abcbfed20b84122be858a8f6d6c07af65603f70f0dbe0287";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ament-lint/default.nix
+++ b/distros/lyrical/ament-lint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages }:
 buildRosPackage {
   pname = "ros-lyrical-ament-lint";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_lint/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "2a193c124da3cc76b205d1bfcec07188a1714991831fd4590e3b8cb1435e6405";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_lint/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "effb2e0b4668d0d566603d6e7579acf6de5c217290d8fea35e3e308700b77910";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/ament-mypy/default.nix
+++ b/distros/lyrical/ament-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-lyrical-ament-mypy";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_mypy/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "85146e3149b7dad8e123ff1d931ddf4520a5eeed67505779c0563d86313b1d4b";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_mypy/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "fc2c2e11df9d8ce2ae8a1426d3e8764eb76169d4cef0bb20a187f7603a6a5f47";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/ament-pclint/default.nix
+++ b/distros/lyrical/ament-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-lyrical-ament-pclint";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_pclint/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "07c4189f0feb1b4a8beab44524420647b84afcae3a37fdb9cb07be42d54eb15a";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_pclint/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "3a44a2dabcab32e4b4df476b1f7018f4cadeadfbb3c79db09f939b94113fe7ab";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/ament-pep257/default.nix
+++ b/distros/lyrical/ament-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, python3Packages }:
 buildRosPackage {
   pname = "ros-lyrical-ament-pep257";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_pep257/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "4b5a5cd13a0de4bb528ff2d9e926f3c64637a190f409437d25341088a825c38a";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_pep257/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "3fb57cf76fac3f565e6ecba77820b6c9983d8bbf75848ee376ca756aae2ad890";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/ament-pycodestyle/default.nix
+++ b/distros/lyrical/ament-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-lyrical-ament-pycodestyle";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_pycodestyle/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "a029211b768c42529132e84a4d95e03bb10b9355b62e40aa922dc97ac0e3ec7d";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_pycodestyle/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "8982bea4e2353bee71ae6ae71cf669146928b7e307b259caade1cf2cdf25c335";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/ament-pyflakes/default.nix
+++ b/distros/lyrical/ament-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-pycodestyle, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-lyrical-ament-pyflakes";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_pyflakes/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "4b6fb910fe109358dd37219a1962926583a27ee4c92796b2448513807a0409ff";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_pyflakes/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "f54259ebdc878bc94c745895153823f23ca0f89d911b65f8a233d104af987209";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/ament-uncrustify/default.nix
+++ b/distros/lyrical/ament-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-pycodestyle, ament-xmllint, python3Packages, uncrustify-vendor }:
 buildRosPackage {
   pname = "ros-lyrical-ament-uncrustify";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_uncrustify/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "55f7196fc218e30aae8740073131c3d78068101a01b8dbfc816b6732532ad6e7";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_uncrustify/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "f8f169445fdb06bbff857936ab041335ec3a5929a55e94ddf5c6f4ae52249bbc";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/ament-xmllint/default.nix
+++ b/distros/lyrical/ament-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-lint, ament-pep257, libxml2, python3Packages }:
 buildRosPackage {
   pname = "ros-lyrical-ament-xmllint";
-  version = "0.20.5-r4";
+  version = "0.20.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_xmllint/0.20.5-4.tar.gz";
-    name = "0.20.5-4.tar.gz";
-    sha256 = "6ac9b63c7678ff37ac53280748d4413d636baa8a0843c405ecb1932aa081b4f1";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/lyrical/ament_xmllint/0.20.6-1.tar.gz";
+    name = "0.20.6-1.tar.gz";
+    sha256 = "84a7f217c39fd72653732914ee26ddd2d8ef1d1fef78d81f8a6354cf8002c860";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/builtin-interfaces/default.nix
+++ b/distros/lyrical/builtin-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-core-generators, rosidl-core-runtime }:
 buildRosPackage {
   pname = "ros-lyrical-builtin-interfaces";
-  version = "2.4.4-r3";
+  version = "2.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/lyrical/builtin_interfaces/2.4.4-3.tar.gz";
-    name = "2.4.4-3.tar.gz";
-    sha256 = "194c04afaf4142abdad330cad56c7d4e3fc522c6a059b8fa0686a1e8a9f89bbc";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/lyrical/builtin_interfaces/2.4.5-1.tar.gz";
+    name = "2.4.5-1.tar.gz";
+    sha256 = "61ac3dff250aec653ef35a54807236fe988df94d18cf656042e5c3475c689bb5";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/cm-topic-hardware-component/default.nix
+++ b/distros/lyrical/cm-topic-hardware-component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pal-statistics-msgs, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-lyrical-cm-topic-hardware-component";
-  version = "1.0.0-r3";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_based_hardware-release/archive/release/lyrical/cm_topic_hardware_component/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "749abc2a960c6353bfb3cb108cdc29c0bd6ebf5139448029f14e4bfd550fceb3";
+    url = "https://github.com/ros2-gbp/topic_based_hardware-release/archive/release/lyrical/cm_topic_hardware_component/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "0e07efed1758f5de3dcbd56914d7c340678a191a1ed2849ff0b4f6cf8c3cbf7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/composition-interfaces/default.nix
+++ b/distros/lyrical/composition-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-lyrical-composition-interfaces";
-  version = "2.4.4-r3";
+  version = "2.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/lyrical/composition_interfaces/2.4.4-3.tar.gz";
-    name = "2.4.4-3.tar.gz";
-    sha256 = "95953c57033082014db38264fa83aedf29747772ae0922f66e5da3ad8683e26b";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/lyrical/composition_interfaces/2.4.5-1.tar.gz";
+    name = "2.4.5-1.tar.gz";
+    sha256 = "ecb34e91bcb93fde2014fb7a2492966f537482dede50d1669240f28df1ca7aa9";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/compressed-depth-image-transport/default.nix
+++ b/distros/lyrical/compressed-depth-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, opencv, pluginlib, rcl-interfaces, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-compressed-depth-image-transport";
-  version = "6.2.4-r3";
+  version = "6.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/lyrical/compressed_depth_image_transport/6.2.4-3.tar.gz";
-    name = "6.2.4-3.tar.gz";
-    sha256 = "c1d0e965d497aeb5302d78fe6e89f107a05467d2490632482251ed1436c1fabb";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/lyrical/compressed_depth_image_transport/6.2.5-1.tar.gz";
+    name = "6.2.5-1.tar.gz";
+    sha256 = "01df40b847a4865101aed85c78279277f822aa793235c7b0bd8251115d5f3bbd";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/compressed-image-transport/default.nix
+++ b/distros/lyrical/compressed-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-lyrical-compressed-image-transport";
-  version = "6.2.4-r3";
+  version = "6.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/lyrical/compressed_image_transport/6.2.4-3.tar.gz";
-    name = "6.2.4-3.tar.gz";
-    sha256 = "3e24847c21c3d579e648dc09bc394ebf97ca3b5826d8967b6ec5ea9debdbc7e2";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/lyrical/compressed_image_transport/6.2.5-1.tar.gz";
+    name = "6.2.5-1.tar.gz";
+    sha256 = "ba2eb2a029817cbb2c9441bdbaafc2531d3e5cdbd6d0ca947b7b6ca970382684";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/cuda-buffer-backend-msgs/default.nix
+++ b/distros/lyrical/cuda-buffer-backend-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-lyrical-cuda-buffer-backend-msgs";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/lyrical/cuda_buffer_backend_msgs/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "984ccf49d945fc1ba8b32e18b464baba6cf01d90684731ff23ce4ae762281be7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "CUDA buffer descriptor messages for rosidl::Buffer backend serialization.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/cuda-buffer-backend/default.nix
+++ b/distros/lyrical/cuda-buffer-backend/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cuda-buffer, cuda-buffer-backend-msgs, launch-ros, launch-testing, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-components, rcutils, rosidl-buffer-backend, rosidl-buffer-backend-registry, rosidl-runtime-cpp, rosidl-typesupport-cpp, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-cuda-buffer-backend";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/lyrical/cuda_buffer_backend/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "aa077ce9aac5ccb09864355bbfd6fb075fb92521c4431a22499b701cb1acb6f4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common launch-ros launch-testing launch-testing-ament-cmake rclcpp rclcpp-components sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ cuda-buffer cuda-buffer-backend-msgs pluginlib rcutils rosidl-buffer-backend rosidl-buffer-backend-registry rosidl-runtime-cpp rosidl-typesupport-cpp ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = "Pluginlib backend for CUDA-backed rosidl::Buffer transport,
+  using CUDA IPC when available and CPU fallback otherwise.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/cuda-buffer/default.nix
+++ b/distros/lyrical/cuda-buffer/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, _unresolved_nvidia-cuda, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cuda-buffer-backend-msgs, rcutils, rmw, rosidl-buffer }:
+buildRosPackage {
+  pname = "ros-lyrical-cuda-buffer";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/lyrical/cuda_buffer/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "53ff6ea45f8166b2c3f2385da29cd0c9f2fcb8e1efc8d33ce07c0dec7637e772";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ _unresolved_nvidia-cuda cuda-buffer-backend-msgs rcutils rmw rosidl-buffer ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "CUDA-backed rosidl::Buffer storage and synchronization utilities,
+  including memory pooling, CUDA IPC support, and same-host endpoint locality
+  discovery for rosidl::Buffer backends.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/event-camera-tools/default.nix
+++ b/distros/lyrical/event-camera-tools/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-black, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, event-camera-codecs, event-camera-msgs, opencv, rclcpp, rclcpp-components, ros-environment, rosbag2-cpp, rosbag2-storage, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-black, ament-cmake-clang-format, ament-cmake-ros, ament-cmake-test, ament-lint-auto, ament-lint-common, event-camera-codecs, event-camera-msgs, opencv, rclcpp, rclcpp-components, ros-environment, rosbag2-cpp, rosbag2-storage, sensor-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-event-camera-tools";
-  version = "3.1.2-r3";
+  version = "3.1.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/event_camera_tools-release/archive/release/lyrical/event_camera_tools/3.1.2-3.tar.gz";
-    name = "3.1.2-3.tar.gz";
-    sha256 = "63a51292990411d7aa46d16136a9c30206269ba7e2a35d9459be3cd1241bb078";
+    url = "https://github.com/ros2-gbp/event_camera_tools-release/archive/release/lyrical/event_camera_tools/3.1.5-2.tar.gz";
+    name = "3.1.5-2.tar.gz";
+    sha256 = "d7840217a8128899d98ca86d7ca6cd340fdea3988f3c1d270f1fb44e971bd001";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ros-environment ];
-  checkInputs = [ ament-cmake-black ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-black ament-cmake-clang-format ament-cmake-test ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ event-camera-codecs event-camera-msgs opencv opencv.cxxdev rclcpp rclcpp-components rosbag2-cpp rosbag2-storage sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ros-environment ];
 

--- a/distros/lyrical/feetech-ros2-driver/default.nix
+++ b/distros/lyrical/feetech-ros2-driver/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_libserial-dev, ament-cmake, fmt, hardware-interface, pkg-config, pluginlib, range-v3, rclcpp, spdlog, tl-expected }:
+{ lib, buildRosPackage, fetchurl, _unresolved_libserial-dev, _unresolved_tl_expected, ament-cmake, fmt, hardware-interface, pkg-config, pluginlib, range-v3, rclcpp, spdlog }:
 buildRosPackage {
   pname = "ros-lyrical-feetech-ros2-driver";
   version = "0.2.1-r3";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ _unresolved_libserial-dev fmt hardware-interface pkg-config pluginlib range-v3 rclcpp spdlog tl-expected ];
+  propagatedBuildInputs = [ _unresolved_libserial-dev _unresolved_tl_expected fmt hardware-interface pkg-config pluginlib range-v3 rclcpp spdlog ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/lyrical/flexbe-behavior-engine/default.nix
+++ b/distros/lyrical/flexbe-behavior-engine/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, flexbe-core, flexbe-input, flexbe-mirror, flexbe-msgs, flexbe-onboard, flexbe-states, flexbe-testing, flexbe-widget }:
 buildRosPackage {
   pname = "ros-lyrical-flexbe-behavior-engine";
-  version = "4.0.3-r3";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/lyrical/flexbe_behavior_engine/4.0.3-3.tar.gz";
-    name = "4.0.3-3.tar.gz";
-    sha256 = "7082e3355603940a226a341a2340046147e7f085c3a527f761d365694d443e94";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/lyrical/flexbe_behavior_engine/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "7633e3f2847f9b811206cb68b40a7db91ad18dc49b3e6e620844d8fc65f21b41";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/flexbe-core/default.nix
+++ b/distros/lyrical/flexbe-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-msgs, launch-ros, launch-testing, python3Packages, rclpy, std-msgs, std-srvs, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-lyrical-flexbe-core";
-  version = "4.0.3-r3";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/lyrical/flexbe_core/4.0.3-3.tar.gz";
-    name = "4.0.3-3.tar.gz";
-    sha256 = "5ef8e7ab12aa7e8cc2e6b426c9c9a30fdbcb4b945bc21084188e089743ff3689";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/lyrical/flexbe_core/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "34ec2f3cc2454832b7febebf2fa486b51b228c675d43477ae080cfdb763d5b96";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/flexbe-input/default.nix
+++ b/distros/lyrical/flexbe-input/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-lyrical-flexbe-input";
-  version = "4.0.3-r3";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/lyrical/flexbe_input/4.0.3-3.tar.gz";
-    name = "4.0.3-3.tar.gz";
-    sha256 = "92fce9fe7beb8a499a045c9cb1bd06d9566076125acced60a8db9c17fc677cea";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/lyrical/flexbe_input/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "824f6ca5f97dfedd6f946acd803efd346622930ffe60135d16bc8ee01c6ab8ec";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/flexbe-mirror/default.nix
+++ b/distros/lyrical/flexbe-mirror/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-lyrical-flexbe-mirror";
-  version = "4.0.3-r3";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/lyrical/flexbe_mirror/4.0.3-3.tar.gz";
-    name = "4.0.3-3.tar.gz";
-    sha256 = "41e952a0182e545bac44db693e7dec555b8ffafbd06ff1c1b06885fcfa8b2f3a";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/lyrical/flexbe_mirror/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "ed4acb039c5823dcbb7cc1946112e2ec8e335fa11b8ffb5c71fcffe5d829cb09";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/flexbe-msgs/default.nix
+++ b/distros/lyrical/flexbe-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-flexbe-msgs";
-  version = "4.0.3-r3";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/lyrical/flexbe_msgs/4.0.3-3.tar.gz";
-    name = "4.0.3-3.tar.gz";
-    sha256 = "9756edbed233fdce9208aee676ba16ae8ade5e6236c8bfee7609fad4dac70631";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/lyrical/flexbe_msgs/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "9b2069ef7dcea49253fa33ffa3fab388c47d4ad4296dbddfc8d6101904954f96";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/flexbe-onboard/default.nix
+++ b/distros/lyrical/flexbe-onboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, flexbe-states, launch-ros, launch-testing, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-lyrical-flexbe-onboard";
-  version = "4.0.3-r3";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/lyrical/flexbe_onboard/4.0.3-3.tar.gz";
-    name = "4.0.3-3.tar.gz";
-    sha256 = "da376cea8034b70a7b2dc6410ad9bfe4ffb846ce218cdad0a70c086cc16e9390";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/lyrical/flexbe_onboard/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "b3003672cf1b43e65748b11c209dfe3ad56309ed0920485b08d8902ba9ed1a31";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/flexbe-states/default.nix
+++ b/distros/lyrical/flexbe-states/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, flexbe-testing, geometry-msgs, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-lyrical-flexbe-states";
-  version = "4.0.3-r3";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/lyrical/flexbe_states/4.0.3-3.tar.gz";
-    name = "4.0.3-3.tar.gz";
-    sha256 = "f2340fa27b5c7fc6c4873ca7167df712221d00ffa13722369b074f4f999ed1bb";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/lyrical/flexbe_states/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "26e67687ada0109174fee76acb3e9049a382efe6e9a1c3085e97cf5613a3c8d6";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/flexbe-testing/default.nix
+++ b/distros/lyrical/flexbe-testing/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, launch-ros, launch-testing, python3Packages, rclpy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-copyright, ament-flake8, ament-index-python, ament-pep257, flexbe-core, flexbe-msgs, launch-ros, launch-testing, python3Packages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-flexbe-testing";
-  version = "4.0.3-r3";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/lyrical/flexbe_testing/4.0.3-3.tar.gz";
-    name = "4.0.3-3.tar.gz";
-    sha256 = "efbdaf4c2c8a26018cf0a40197893b4f4e7a982218c8287e4c7a0905e05c1403";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/lyrical/flexbe_testing/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "b69e1b9d3d7aa2fcf57f177fdbf8400986f0f56e5d17e73e2dddab5f34591969";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-cmake-pytest ament-copyright ament-flake8 ament-pep257 launch-testing python3Packages.pytest std-msgs ];
-  propagatedBuildInputs = [ flexbe-core flexbe-msgs launch-ros rclpy ];
+  propagatedBuildInputs = [ ament-index-python flexbe-core flexbe-msgs launch-ros rclpy ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/lyrical/flexbe-widget/default.nix
+++ b/distros/lyrical/flexbe-widget/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-mirror, flexbe-msgs, flexbe-onboard, launch-ros, python3Packages, rclpy }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-mirror, flexbe-msgs, flexbe-onboard, launch-ros, python3Packages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-flexbe-widget";
-  version = "4.0.3-r3";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/lyrical/flexbe_widget/4.0.3-3.tar.gz";
-    name = "4.0.3-3.tar.gz";
-    sha256 = "9cf74dd5eff326dbaabd22cdeba15e9f63d2b205aac75c5e8f6fea82f61c8354";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/lyrical/flexbe_widget/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "c9085afc59d40c5ce75f4974c7a4855850c79b1d9c9b3830b03602ee1d15145f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
-  propagatedBuildInputs = [ flexbe-core flexbe-mirror flexbe-msgs flexbe-onboard launch-ros rclpy ];
+  propagatedBuildInputs = [ flexbe-core flexbe-mirror flexbe-msgs flexbe-onboard launch-ros rclpy std-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/lyrical/frequency-cam/default.nix
+++ b/distros/lyrical/frequency-cam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, cv-bridge, event-camera-codecs, event-camera-msgs, image-transport, rclcpp, rclcpp-components, rosbag2-cpp, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-frequency-cam";
-  version = "3.1.0-r3";
+  version = "3.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/frequency_cam-release/archive/release/lyrical/frequency_cam/3.1.0-3.tar.gz";
-    name = "3.1.0-3.tar.gz";
-    sha256 = "ab09144008f0de703e45ff3f4d97dc64f0c241e8c59c2b02ccfe7b279377d028";
+    url = "https://github.com/ros2-gbp/frequency_cam-release/archive/release/lyrical/frequency_cam/3.1.2-2.tar.gz";
+    name = "3.1.2-2.tar.gz";
+    sha256 = "c89d3a589a17883e0d0d7a78dcbe7c3183daa1d66980914c26f6c68fcd0c6e58";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/fuse-constraints/default.nix
+++ b/distros/lyrical/fuse-constraints/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ceres-solver, eigen, fuse-core, fuse-graphs, fuse-variables, gbenchmark, geometry-msgs, gtest-vendor, pluginlib, rclcpp, suitesparse }:
 buildRosPackage {
   pname = "ros-lyrical-fuse-constraints";
-  version = "1.3.1-r3";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_constraints/1.3.1-3.tar.gz";
-    name = "1.3.1-3.tar.gz";
-    sha256 = "eb8014956df59134206166559c67d2425380e12fd232488f140e6696619e95db";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_constraints/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "31b87f8dc069602d3cb8e3342320584673442f7bc2a5f6937f738e2d086acc68";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/fuse-core/default.nix
+++ b/distros/lyrical/fuse-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, boost, ceres-solver, eigen, fuse-msgs, geometry-msgs, glog, gtest-vendor, launch, launch-pytest, pluginlib, rcl-interfaces, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-lyrical-fuse-core";
-  version = "1.3.1-r3";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_core/1.3.1-3.tar.gz";
-    name = "1.3.1-3.tar.gz";
-    sha256 = "c15e5dbfd8a5831a7b5a35782abe46f56847e75c60cb8c392aa4ec8103d6a141";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_core/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "f6b80dfa67dab7d9eb330e0af758b4b92b9c35ea8192c9b601ccc59191507edc";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/fuse-doc/default.nix
+++ b/distros/lyrical/fuse-doc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, gtest-vendor }:
 buildRosPackage {
   pname = "ros-lyrical-fuse-doc";
-  version = "1.3.1-r3";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_doc/1.3.1-3.tar.gz";
-    name = "1.3.1-3.tar.gz";
-    sha256 = "cba469d4a967e1353a7133101f4d2318c846151e8b6260dc53bbca1cb0a4ebf5";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_doc/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "700e94889b12cb0f0412ca0737d410961233f8df1ad1871070637aea989f500c";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/fuse-graphs/default.nix
+++ b/distros/lyrical/fuse-graphs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ceres-solver, fuse-core, gbenchmark, gtest-vendor, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-lyrical-fuse-graphs";
-  version = "1.3.1-r3";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_graphs/1.3.1-3.tar.gz";
-    name = "1.3.1-3.tar.gz";
-    sha256 = "cb9c6d4ab8e5a398582c7b26549bb70a3575236e76bb4c1c8c5237f51e28b8ab";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_graphs/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "7108ab40085e0804d754a8ccfe6f4e3d2f8d081e80fec36f6cf86f9ca49f154b";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/fuse-loss/default.nix
+++ b/distros/lyrical/fuse-loss/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ceres-solver, fuse-core, gtest-vendor, libsForQt5, pluginlib, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-lyrical-fuse-loss";
-  version = "1.3.1-r3";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_loss/1.3.1-3.tar.gz";
-    name = "1.3.1-3.tar.gz";
-    sha256 = "4160550f6412af6e769f179a6ede6a05452cb6080ddd5a052611b5f18d5b5eab";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_loss/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "8c4ec94c3b874d538fc9d2c7e6d22664be2821015900dc835673998e99f6729d";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/fuse-models/default.nix
+++ b/distros/lyrical/fuse-models/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, boost, ceres-solver, eigen, fuse-constraints, fuse-core, fuse-graphs, fuse-msgs, fuse-publishers, fuse-variables, gbenchmark, geometry-msgs, gtest-vendor, nav-msgs, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-srvs, tf2, tf2-2d, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-lyrical-fuse-models";
-  version = "1.3.1-r3";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_models/1.3.1-3.tar.gz";
-    name = "1.3.1-3.tar.gz";
-    sha256 = "3586b748a37e60104f93ae3fce5c7279436dad7bab34dd17713d536c12f86ca7";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_models/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "ac0cea4a3673dc376e3319b014c84e8251843101b1cce6f8c152b9809f0640ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/fuse-msgs/default.nix
+++ b/distros/lyrical/fuse-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, geometry-msgs, gtest-vendor, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-fuse-msgs";
-  version = "1.3.1-r3";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_msgs/1.3.1-3.tar.gz";
-    name = "1.3.1-3.tar.gz";
-    sha256 = "5e17234827dfe38ca68a317a4836c8d361cfdc62493abff843aedd596f64c8b2";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_msgs/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "4e9ef65a3cc683fd692a4b263fb62043d3020ca874e0bb9e8957d9416d14c85b";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/fuse-optimizers/default.nix
+++ b/distros/lyrical/fuse-optimizers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, boost, ceres-solver, diagnostic-updater, eigen, fuse-constraints, fuse-core, fuse-graphs, fuse-models, fuse-msgs, fuse-variables, geometry-msgs, gtest-vendor, launch, launch-pytest, launch-ros, nav-msgs, pluginlib, rclcpp, rclcpp-components, std-srvs }:
 buildRosPackage {
   pname = "ros-lyrical-fuse-optimizers";
-  version = "1.3.1-r3";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_optimizers/1.3.1-3.tar.gz";
-    name = "1.3.1-3.tar.gz";
-    sha256 = "b313536a43331f781dcbb84d683944dc396f9183f66e72b8208706b4c8be9404";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_optimizers/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "3b2a7a9de47ab75a93e41af32de7f99eed2d91b4a75932ecffb3688e0f69dcd2";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/fuse-publishers/default.nix
+++ b/distros/lyrical/fuse-publishers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fuse-constraints, fuse-core, fuse-graphs, fuse-msgs, fuse-variables, geometry-msgs, gtest-vendor, nav-msgs, pluginlib, rclcpp, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-lyrical-fuse-publishers";
-  version = "1.3.1-r3";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_publishers/1.3.1-3.tar.gz";
-    name = "1.3.1-3.tar.gz";
-    sha256 = "f025c5777eded202329226f360b8632a2eff5bbf5c98e2f6e063288ef810e470";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_publishers/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "780eaa980bf891c39f86a6b321f77c7f678b0031b2652ae78a4897b296d0e84f";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/fuse-tutorials/default.nix
+++ b/distros/lyrical/fuse-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fuse-constraints, fuse-core, fuse-models, fuse-optimizers, fuse-publishers, fuse-variables, gtest-vendor, nav-msgs, rclcpp, rviz2, sensor-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-fuse-tutorials";
-  version = "1.3.1-r3";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_tutorials/1.3.1-3.tar.gz";
-    name = "1.3.1-3.tar.gz";
-    sha256 = "00f506137ba6e10fbf2a456f45663db30043defc5c8b78edb244a1d31c5534b8";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_tutorials/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "beef551a26b6c576fafcb6132c149cd7bdba1523d27cacfe8d1e2dbdb186de89";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/fuse-variables/default.nix
+++ b/distros/lyrical/fuse-variables/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ceres-solver, fuse-core, fuse-graphs, gtest-vendor, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-lyrical-fuse-variables";
-  version = "1.3.1-r3";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_variables/1.3.1-3.tar.gz";
-    name = "1.3.1-3.tar.gz";
-    sha256 = "7f69538f46c6d5da447377c4e4752a7116407e57cab5202fbb95f124cc8b2436";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_variables/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "d6a632735f34ab293f27df1c640c29322374ebd7a0ed0a7bf79ceda3abf7d673";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/fuse-viz/default.nix
+++ b/distros/lyrical/fuse-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, eigen, fuse-constraints, fuse-core, fuse-msgs, fuse-variables, geometry-msgs, gtest-vendor, qt5, rviz-common, rviz-rendering, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-fuse-viz";
-  version = "1.3.1-r3";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_viz/1.3.1-3.tar.gz";
-    name = "1.3.1-3.tar.gz";
-    sha256 = "aeffbd08cb3ceae4e4b448286cb96221fc783c44c398ecf2ac5217ec02b49627";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_viz/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "5e6c71ad126e1627e6c7496f32361c82a3a0559c131d8e4bd1236cc5f8d9fc24";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/fuse/default.nix
+++ b/distros/lyrical/fuse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, fuse-constraints, fuse-core, fuse-doc, fuse-graphs, fuse-models, fuse-msgs, fuse-optimizers, fuse-publishers, fuse-variables, fuse-viz, gtest-vendor }:
 buildRosPackage {
   pname = "ros-lyrical-fuse";
-  version = "1.3.1-r3";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse/1.3.1-3.tar.gz";
-    name = "1.3.1-3.tar.gz";
-    sha256 = "fd89ac382430ff1b24500ccac9d925155d32a7af4cac6f178767adfaef186835";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "d8e3f815d4424318bb72a506863874ddd2af38603a52d6e92a19e7b2eb41c0b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/generate-parameter-library-py/default.nix
+++ b/distros/lyrical/generate-parameter-library-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-lyrical-generate-parameter-library-py";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/lyrical/generate_parameter_library_py/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "e856cd6149b1edcae3f9eaf867817631ae615484e525ec354f280882dc583ddb";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/lyrical/generate_parameter_library_py/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "9b221851d81d73136ea78d019edca2376cdded025fe640818d8462fe0cb5e94f";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/generate-parameter-library/default.nix
+++ b/distros/lyrical/generate-parameter-library/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, fmt, generate-parameter-library-py, rclcpp, rclcpp-lifecycle, rclpy, rsl, tcb-span, tl-expected, tl-expected-nixpkgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, fmt, generate-parameter-library-py, rclcpp, rclcpp-lifecycle, rclpy, rsl, tcb-span, tl-expected-nixpkgs }:
 buildRosPackage {
   pname = "ros-lyrical-generate-parameter-library";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/lyrical/generate_parameter_library/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "935d4f6efc33a41181db494969e346ca389327d0331ccd24be007d937f0ed696";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/lyrical/generate_parameter_library/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "1ed91d540f684130a2532a970b10afbb04ea4b0082a9808fa3779b9a4b035f63";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
-  propagatedBuildInputs = [ fmt generate-parameter-library-py rclcpp rclcpp-lifecycle rclpy rsl tcb-span tl-expected tl-expected-nixpkgs ];
+  propagatedBuildInputs = [ fmt generate-parameter-library-py rclcpp rclcpp-lifecycle rclpy rsl tcb-span tl-expected-nixpkgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python generate-parameter-library-py ];
 
   meta = {

--- a/distros/lyrical/generated.nix
+++ b/distros/lyrical/generated.nix
@@ -438,6 +438,12 @@ self: super: {
 
  crx-kinematics = self.callPackage ./crx-kinematics {};
 
+ cuda-buffer = self.callPackage ./cuda-buffer {};
+
+ cuda-buffer-backend = self.callPackage ./cuda-buffer-backend {};
+
+ cuda-buffer-backend-msgs = self.callPackage ./cuda-buffer-backend-msgs {};
+
  cudnn-cmake-module = self.callPackage ./cudnn-cmake-module {};
 
  cv-bridge = self.callPackage ./cv-bridge {};
@@ -1153,6 +1159,8 @@ self: super: {
  librealsense2 = self.callPackage ./librealsense2 {};
 
  libstatistics-collector = self.callPackage ./libstatistics-collector {};
+
+ libtorch-vendor = self.callPackage ./libtorch-vendor {};
 
  libyaml-vendor = self.callPackage ./libyaml-vendor {};
 
@@ -2086,6 +2094,8 @@ self: super: {
 
  rmw-zenoh-cpp = self.callPackage ./rmw-zenoh-cpp {};
 
+ robot-arm-demo = self.callPackage ./robot-arm-demo {};
+
  robot-calibration = self.callPackage ./robot-calibration {};
 
  robot-calibration-msgs = self.callPackage ./robot-calibration-msgs {};
@@ -2652,6 +2662,8 @@ self: super: {
 
  teleop-twist-keyboard = self.callPackage ./teleop-twist-keyboard {};
 
+ tensor-msgs = self.callPackage ./tensor-msgs {};
+
  tensorrt-cmake-module = self.callPackage ./tensorrt-cmake-module {};
 
  test-apex-test-tools = self.callPackage ./test-apex-test-tools {};
@@ -2702,8 +2714,6 @@ self: super: {
 
  tinyxml-vendor = self.callPackage ./tinyxml-vendor {};
 
- tl-expected = self.callPackage ./tl-expected {};
-
  tlsf = self.callPackage ./tlsf {};
 
  tlsf-cpp = self.callPackage ./tlsf-cpp {};
@@ -2717,6 +2727,8 @@ self: super: {
  topic-tools-interfaces = self.callPackage ./topic-tools-interfaces {};
 
  toppra = self.callPackage ./toppra {};
+
+ torch-conversions = self.callPackage ./torch-conversions {};
 
  trac-ik = self.callPackage ./trac-ik {};
 

--- a/distros/lyrical/gz-ros2-control-demos/default.nix
+++ b/distros/lyrical/gz-ros2-control-demos/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_effort_controllers, _unresolved_velocity_controllers, ackermann-steering-controller, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, diff-drive-controller, force-torque-sensor-broadcaster, geometry-msgs, gz-ros2-control, gz-sim-vendor, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, mecanum-drive-controller, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2-control-cmake, ros2controlcli, ros2launch, std-msgs, tricycle-steering-controller, xacro }:
+{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, diff-drive-controller, force-torque-sensor-broadcaster, forward-command-controller, geometry-msgs, gz-ros2-control, gz-sim-vendor, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, mecanum-drive-controller, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2-control-cmake, ros2controlcli, ros2launch, std-msgs, tricycle-steering-controller, xacro }:
 buildRosPackage {
   pname = "ros-lyrical-gz-ros2-control-demos";
-  version = "3.0.7-r3";
+  version = "3.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/lyrical/gz_ros2_control_demos/3.0.7-3.tar.gz";
-    name = "3.0.7-3.tar.gz";
-    sha256 = "058b581acd753fb28dbc28e7761d209e52e2fa0d146724582ceb2fa361c01eac";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/lyrical/gz_ros2_control_demos/3.0.8-1.tar.gz";
+    name = "3.0.8-1.tar.gz";
+    sha256 = "4cbd98e774176bc7177a3af27da7b9ad1ec6e5735b6421bfc61e5fe910491e4f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake pluginlib rclcpp-action ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ _unresolved_effort_controllers _unresolved_velocity_controllers ackermann-steering-controller ament-index-python control-msgs control-toolbox diff-drive-controller force-torque-sensor-broadcaster geometry-msgs gz-ros2-control gz-sim-vendor hardware-interface imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller launch launch-ros mecanum-drive-controller rclcpp rclcpp-lifecycle robot-state-publisher ros-gz-bridge ros-gz-sim ros2-control-cmake ros2controlcli ros2launch std-msgs tricycle-steering-controller xacro ];
+  propagatedBuildInputs = [ ackermann-steering-controller ament-index-python control-msgs control-toolbox diff-drive-controller force-torque-sensor-broadcaster forward-command-controller geometry-msgs gz-ros2-control gz-sim-vendor hardware-interface imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller launch launch-ros mecanum-drive-controller rclcpp rclcpp-lifecycle robot-state-publisher ros-gz-bridge ros-gz-sim ros2-control-cmake ros2controlcli ros2launch std-msgs tricycle-steering-controller xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/lyrical/gz-ros2-control/default.nix
+++ b/distros/lyrical/gz-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, gz-plugin-vendor, gz-sim-vendor, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-lyrical-gz-ros2-control";
-  version = "3.0.7-r3";
+  version = "3.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/lyrical/gz_ros2_control/3.0.7-3.tar.gz";
-    name = "3.0.7-3.tar.gz";
-    sha256 = "6eebfaab508ddf9a3bed6db61952eecf90ae6451556f5e34b5e54f60fbfd49dd";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/lyrical/gz_ros2_control/3.0.8-1.tar.gz";
+    name = "3.0.8-1.tar.gz";
+    sha256 = "f5d0ffd063f3ded7f3a61ffc471552d61be52f21d2a3259202992f597ce619a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/image-transport-plugins/default.nix
+++ b/distros/lyrical/image-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, compressed-depth-image-transport, compressed-image-transport, theora-image-transport, zstd-image-transport }:
 buildRosPackage {
   pname = "ros-lyrical-image-transport-plugins";
-  version = "6.2.4-r3";
+  version = "6.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/lyrical/image_transport_plugins/6.2.4-3.tar.gz";
-    name = "6.2.4-3.tar.gz";
-    sha256 = "6fa3f555a2075c37f94406b5e0a9655a274497bd1821546fea784ffa51eb45ac";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/lyrical/image_transport_plugins/6.2.5-1.tar.gz";
+    name = "6.2.5-1.tar.gz";
+    sha256 = "a10d382334d5fb99427e296c2c772847322bc26abf1067398dc9825a27e617a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/joint-state-topic-hardware-interface/default.nix
+++ b/distros/lyrical/joint-state-topic-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-ros, angles, control-msgs, controller-manager, forward-command-controller, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, launch-testing, launch-testing-ament-cmake, rclcpp, rclpy, robot-state-publisher, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, topic-tools, xacro }:
 buildRosPackage {
   pname = "ros-lyrical-joint-state-topic-hardware-interface";
-  version = "1.0.0-r3";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_based_hardware-release/archive/release/lyrical/joint_state_topic_hardware_interface/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "a33a4d1fa1ef0f2152e395ab1eaec8cd2b651c2b1d0c5a2a1c1bb66052bd07e6";
+    url = "https://github.com/ros2-gbp/topic_based_hardware-release/archive/release/lyrical/joint_state_topic_hardware_interface/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "1c37d809f8191bb41b945e95af6f616dde1f21345842c6db574a2074653fa2cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/kinematics-interface-kdl/default.nix
+++ b/distros/lyrical/kinematics-interface-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, eigen, eigen3-cmake-module, kdl-parser, kinematics-interface, pluginlib, ros2-control-cmake, tf2-eigen-kdl }:
 buildRosPackage {
   pname = "ros-lyrical-kinematics-interface-kdl";
-  version = "2.4.0-r4";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/lyrical/kinematics_interface_kdl/2.4.0-4.tar.gz";
-    name = "2.4.0-4.tar.gz";
-    sha256 = "db52aa3695c4fecf4f53fb4b7f4d6dd5ae9c4e4fb22f37036ab4a66713018eac";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/lyrical/kinematics_interface_kdl/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "c0725b7dac0dbb03380258b3391b848890fb73fadcb2ab25249d0f2a4f48954b";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/kinematics-interface-pinocchio/default.nix
+++ b/distros/lyrical/kinematics-interface-pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, eigen, eigen3-cmake-module, kinematics-interface, pinocchio, pluginlib, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-lyrical-kinematics-interface-pinocchio";
-  version = "2.4.0-r4";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/lyrical/kinematics_interface_pinocchio/2.4.0-4.tar.gz";
-    name = "2.4.0-4.tar.gz";
-    sha256 = "d764a63be0745adf74770107dbfe516414db485329f86897eca76a07c25025f2";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/lyrical/kinematics_interface_pinocchio/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "41e15c68bbc25ec2b4073dec307bcfc1490ddbb1b851a215c91b3546d482888f";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/kinematics-interface/default.nix
+++ b/distros/lyrical/kinematics-interface/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, eigen, pluginlib, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, eigen, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-lyrical-kinematics-interface";
-  version = "2.4.0-r4";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/lyrical/kinematics_interface/2.4.0-4.tar.gz";
-    name = "2.4.0-4.tar.gz";
-    sha256 = "a26588aa19b1785b79ef70423b2b179dd22d8590d1d4d73951c5a6a4abb6af1d";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/lyrical/kinematics_interface/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "b57b07da8eae25a137314b49c22abfc9a3e627702f23d9bb5d49c06cf85724cf";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock pluginlib ros2-control-test-assets ];
-  propagatedBuildInputs = [ backward-ros eigen rclcpp-lifecycle ];
+  propagatedBuildInputs = [ backward-ros eigen rclcpp rclcpp-lifecycle ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/lyrical/libtorch-vendor/default.nix
+++ b/distros/lyrical/libtorch-vendor/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-lyrical-libtorch-vendor";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/lyrical/libtorch_vendor/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "4be2495cd5214d91ddb6671389a4d42448d765b9e2ed2eb9326bcf8d53f219cc";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-vendor-package ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package ];
+
+  meta = {
+    description = "Vendor package that downloads and installs the pre-built
+  LibTorch C++ distribution for torch_conversions and other packages.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/lifecycle-msgs/default.nix
+++ b/distros/lyrical/lifecycle-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-lyrical-lifecycle-msgs";
-  version = "2.4.4-r3";
+  version = "2.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/lyrical/lifecycle_msgs/2.4.4-3.tar.gz";
-    name = "2.4.4-3.tar.gz";
-    sha256 = "cca1dee710719018da875570b0e846ce7468fa54a285830a327301f5a8cbdafe";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/lyrical/lifecycle_msgs/2.4.5-1.tar.gz";
+    name = "2.4.5-1.tar.gz";
+    sha256 = "0462d11f54bbc7c9792105ae7a785def0ed5c12aa92c80e3b9f47e7ccbf89081";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/message-filters/default.nix
+++ b/distros/lyrical/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, rclcpp, rclcpp-lifecycle, rclpy, rcutils, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-message-filters";
-  version = "7.4.0-r1";
+  version = "7.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/lyrical/message_filters/7.4.0-1.tar.gz";
-    name = "7.4.0-1.tar.gz";
-    sha256 = "0b286d06db4aee178d1fb380ba38909c1a595cb60c512c73ccd9e81fc1d1b363";
+    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/lyrical/message_filters/7.4.1-1.tar.gz";
+    name = "7.4.1-1.tar.gz";
+    sha256 = "ed08c73e507407bc90829aa455b1e866f68c2434ec3ce72d422cf334e5ca6542";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/mola-common/default.nix
+++ b/distros/lyrical/mola-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-lyrical-mola-common";
-  version = "0.6.0-r2";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/lyrical/mola_common/0.6.0-2.tar.gz";
-    name = "0.6.0-2.tar.gz";
-    sha256 = "f29ecf7295db9d5d2a76a873773aa79f0978575ad424beefa5319c3a04fec270";
+    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/lyrical/mola_common/0.6.1-1.tar.gz";
+    name = "0.6.1-1.tar.gz";
+    sha256 = "b21bc729664be9e92a081f91d49287f010a6c2c393b9a18a2d783b65dee6cfcf";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/mrpt-apps/default.nix
+++ b/distros/lyrical/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, mrpt-libapps, mrpt-libnav, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, zlib }:
 buildRosPackage {
   pname = "ros-lyrical-mrpt-apps";
-  version = "2.15.17-r2";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_apps/2.15.17-2.tar.gz";
-    name = "2.15.17-2.tar.gz";
-    sha256 = "c4834c5510e8586e644bb2b3aa2225b947f49e29cf69d563530d4cc9c475edb6";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_apps/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "6f6dbc35b853b4ba59140b2904816344157defbecd6d4525d918b5a9e7a02cf5";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mrpt-libapps/default.nix
+++ b/distros/lyrical/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, zlib }:
 buildRosPackage {
   pname = "ros-lyrical-mrpt-libapps";
-  version = "2.15.17-r2";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_libapps/2.15.17-2.tar.gz";
-    name = "2.15.17-2.tar.gz";
-    sha256 = "fe4d2db5275df03ed2997890d634ef494b7bdcf34a7e8e69e9b95ef2ef68e414";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_libapps/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "ebfe2f7a78a412d5079258cc020a7cd807c0c43413ca105c11d50919b4f34722";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mrpt-libbase/default.nix
+++ b/distros/lyrical/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, onetbb, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, zlib, zstd }:
 buildRosPackage {
   pname = "ros-lyrical-mrpt-libbase";
-  version = "2.15.17-r2";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_libbase/2.15.17-2.tar.gz";
-    name = "2.15.17-2.tar.gz";
-    sha256 = "ecf76f45e31fec942c0a649133867984c69680a288c8907fc057c04fc802aadb";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_libbase/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "d457dbab327579094ca797ed4739d0b3fc36a2ddc917d695b8f4ad8bdf711440";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mrpt-libgui/default.nix
+++ b/distros/lyrical/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, mrpt-libopengl, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, zlib }:
 buildRosPackage {
   pname = "ros-lyrical-mrpt-libgui";
-  version = "2.15.17-r2";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_libgui/2.15.17-2.tar.gz";
-    name = "2.15.17-2.tar.gz";
-    sha256 = "4e2723d8eb3bfdfa75d0fff58b31e1faa8340a8f5db798a016ba87d2968d4323";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_libgui/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "85c3b39505505da619356ade7dc881059e410cb4eb3948ad09ee974e6035c7f9";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mrpt-libhwdrivers/default.nix
+++ b/distros/lyrical/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, mrpt-libgui, mrpt-libmaps, mrpt-libslam, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, zlib }:
 buildRosPackage {
   pname = "ros-lyrical-mrpt-libhwdrivers";
-  version = "2.15.17-r2";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_libhwdrivers/2.15.17-2.tar.gz";
-    name = "2.15.17-2.tar.gz";
-    sha256 = "4a1c4d2739a889e931621d26c160aeafa5d7f281a672ec65cbc2f2f5038ecc8c";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_libhwdrivers/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "87a23e10e1beb1c3fe547b2f4b2f693d2ce62c8501267a92ec116c22899758cb";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mrpt-libmaps/default.nix
+++ b/distros/lyrical/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, zlib }:
 buildRosPackage {
   pname = "ros-lyrical-mrpt-libmaps";
-  version = "2.15.17-r2";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_libmaps/2.15.17-2.tar.gz";
-    name = "2.15.17-2.tar.gz";
-    sha256 = "6e244eb0ff15c83b25b4c2af2d9a3f280e148df9b8b885ef87554444b19d4017";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_libmaps/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "7f78bf0cb78ec4a2b95ce7e59fb6078c66a6da30d62d94261a5d47cfae34f1ae";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mrpt-libmath/default.nix
+++ b/distros/lyrical/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, mrpt-libbase, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, zlib }:
 buildRosPackage {
   pname = "ros-lyrical-mrpt-libmath";
-  version = "2.15.17-r2";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_libmath/2.15.17-2.tar.gz";
-    name = "2.15.17-2.tar.gz";
-    sha256 = "0e7799e1f1f143634ed2243d1a401169be0159d18b411582bbd3117f3476397d";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_libmath/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "5e43c19d902ee40c34c9b4c7412e35742a846feeca3c97a6ec53cfaa40964f69";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mrpt-libnav/default.nix
+++ b/distros/lyrical/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, mrpt-libmaps, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, zlib }:
 buildRosPackage {
   pname = "ros-lyrical-mrpt-libnav";
-  version = "2.15.17-r2";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_libnav/2.15.17-2.tar.gz";
-    name = "2.15.17-2.tar.gz";
-    sha256 = "088cde4b2603ac9b5381fda84f5b36fcf776108906487407c230cdfceb02ed64";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_libnav/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "71e0f397bb41c98e92373d20c2d8d02d299dbb5012fa1ca4089e74194f6d317b";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mrpt-libobs/default.nix
+++ b/distros/lyrical/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, mrpt-libopengl, mrpt-libposes, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, zlib }:
 buildRosPackage {
   pname = "ros-lyrical-mrpt-libobs";
-  version = "2.15.17-r2";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_libobs/2.15.17-2.tar.gz";
-    name = "2.15.17-2.tar.gz";
-    sha256 = "ee9a2bfbb3cacac4aba90d95e2830527c26912f13c414f39d402c76be07cefdd";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_libobs/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "5b00b29aa328a8938b627e313708001f27dd8e8d01c0ccce6018aed8149fd9d9";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mrpt-libopengl/default.nix
+++ b/distros/lyrical/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, mrpt-libbase, mrpt-libposes, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, zlib }:
 buildRosPackage {
   pname = "ros-lyrical-mrpt-libopengl";
-  version = "2.15.17-r2";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_libopengl/2.15.17-2.tar.gz";
-    name = "2.15.17-2.tar.gz";
-    sha256 = "297d00a90160143164881541a351c8afcd3c4e24355d1973527c1e50f96ecfb3";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_libopengl/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "f4497b6fa323153179fcd1826f6e1db4dc76e08413d95eee0e0498271a9ccea9";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mrpt-libposes/default.nix
+++ b/distros/lyrical/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, mrpt-libbase, mrpt-libmath, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, zlib }:
 buildRosPackage {
   pname = "ros-lyrical-mrpt-libposes";
-  version = "2.15.17-r2";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_libposes/2.15.17-2.tar.gz";
-    name = "2.15.17-2.tar.gz";
-    sha256 = "523cc7fbc3819fa851dcdec4c6b11babe8a9d637c3ca1ba67333fc9a4ef7c999";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_libposes/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "ef8bac455cbfaf2ea74c1b4ddb1f67f097f6662fb3901e1add05277bd67d0790";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mrpt-libslam/default.nix
+++ b/distros/lyrical/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, mrpt-libmaps, onetbb, opencv, openni2, pkg-config, python3Packages, tinyxml-2, udev, wxGTK32, zlib }:
 buildRosPackage {
   pname = "ros-lyrical-mrpt-libslam";
-  version = "2.15.17-r2";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_libslam/2.15.17-2.tar.gz";
-    name = "2.15.17-2.tar.gz";
-    sha256 = "09f4d50c777b1d42c3f5464b30c9d708e4eda1b40f338fb281438827306f055e";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_libslam/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "b88aef2d0ae972b6c48fa526f67ec828ae5edd7c6193d8ad08de9ab612de5c43";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mrpt-libtclap/default.nix
+++ b/distros/lyrical/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, libxrandr, libxxf86vm, mrpt-libbase, opencv, openni2, pkg-config, python3Packages, suitesparse, tinyxml-2, udev, wxGTK32, zlib }:
 buildRosPackage {
   pname = "ros-lyrical-mrpt-libtclap";
-  version = "2.15.17-r2";
+  version = "2.15.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_libtclap/2.15.17-2.tar.gz";
-    name = "2.15.17-2.tar.gz";
-    sha256 = "2325c9b24791d681cf7a69f2e94235e2e222e34b6a4654e08d2e2dd55cc977f8";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/lyrical/mrpt_libtclap/2.15.18-1.tar.gz";
+    name = "2.15.18-1.tar.gz";
+    sha256 = "dc97073815a7cf6ff9a9a143efa88db9db6b334eaefd21a7b78794d9f315bb2a";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/om-gravity-compensation-controller/default.nix
+++ b/distros/lyrical/om-gravity-compensation-controller/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, angles, backward-ros, control-msgs, control-toolbox, controller-interface, generate-parameter-library, hardware-interface, kdl-parser, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, rsl, tl-expected, urdf }:
+{ lib, buildRosPackage, fetchurl, _unresolved_tl_expected, ament-cmake, angles, backward-ros, control-msgs, control-toolbox, controller-interface, generate-parameter-library, hardware-interface, kdl-parser, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, rsl, urdf }:
 buildRosPackage {
   pname = "ros-lyrical-om-gravity-compensation-controller";
   version = "4.1.2-r3";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ angles backward-ros control-msgs control-toolbox controller-interface generate-parameter-library hardware-interface kdl-parser pluginlib rclcpp rclcpp-lifecycle realtime-tools rsl tl-expected urdf ];
+  propagatedBuildInputs = [ _unresolved_tl_expected angles backward-ros control-msgs control-toolbox controller-interface generate-parameter-library hardware-interface kdl-parser pluginlib rclcpp rclcpp-lifecycle realtime-tools rsl urdf ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -96,20 +96,6 @@ in {
       '';
   });
 
-  fuse-core = rosSuper.fuse-core.overrideAttrs ({
-    patches ? [], ...
-  }: {
-    patches = patches ++ [
-      # Don't fail with boost >= 1.86
-      # https://github.com/locusrobotics/fuse/pull/423
-      (self.fetchpatch2 {
-        url = "https://github.com/wentasah/fuse/commit/037b417d9db394b3d5154a800283c30d0ae30cee.patch?full_index=1";
-        hash = "sha256-ShWKk5H/6eaViWfAOL0T+ynCps2FgsPWtAZDoUjvR50=";
-        stripLen = 1;
-      })
-    ];
-  });
-
   gazebo = self.gazebo_11;
 
   geometric-shapes = rosSuper.geometric-shapes.overrideAttrs({

--- a/distros/lyrical/persist-parameter-server/default.nix
+++ b/distros/lyrical/persist-parameter-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, boost, launch, launch-ros, rclcpp, rclcpp-components, rcutils, rmw, rmw-implementation-cmake, std-msgs, std-srvs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-lyrical-persist-parameter-server";
-  version = "1.0.5-r3";
+  version = "4.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/persist_parameter_server-release/archive/release/lyrical/persist_parameter_server/1.0.5-3.tar.gz";
-    name = "1.0.5-3.tar.gz";
-    sha256 = "ece31fcd2e6e03888abf7687fecca8646077a410deb2a50fb8593bd8a4a63908";
+    url = "https://github.com/ros2-gbp/persist_parameter_server-release/archive/release/lyrical/persist_parameter_server/4.0.0-2.tar.gz";
+    name = "4.0.0-2.tar.gz";
+    sha256 = "d088bec905bfec5a98e8e4d20bffee49f7161139690e3c8013bfa3e6097750af";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/pick-ik/default.nix
+++ b/distros/lyrical/pick-ik/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, fmt, generate-parameter-library, moveit-core, moveit-resources-panda-moveit-config, pluginlib, range-v3, rclcpp, rsl, tf2-geometry-msgs, tf2-kdl, tl-expected }:
+{ lib, buildRosPackage, fetchurl, _unresolved_tl_expected, ament-cmake-ros, fmt, generate-parameter-library, moveit-core, moveit-resources-panda-moveit-config, pluginlib, range-v3, rclcpp, rsl, tf2-geometry-msgs, tf2-kdl }:
 buildRosPackage {
   pname = "ros-lyrical-pick-ik";
   version = "1.1.1-r3";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ moveit-resources-panda-moveit-config ];
-  propagatedBuildInputs = [ fmt generate-parameter-library moveit-core pluginlib range-v3 rclcpp rsl tf2-geometry-msgs tf2-kdl tl-expected ];
+  propagatedBuildInputs = [ _unresolved_tl_expected fmt generate-parameter-library moveit-core pluginlib range-v3 rclcpp rsl tf2-geometry-msgs tf2-kdl ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/lyrical/plotjuggler/default.nix
+++ b/distros/lyrical/plotjuggler/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, data-tamer-cpp, fmt, lua, lz4, nlohmann_json, protobuf, qt5, rclcpp, zstd }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, data-tamer-cpp, fmt, lua, lz4, nlohmann_json, protobuf, qt5, zstd }:
 buildRosPackage {
   pname = "ros-lyrical-plotjuggler";
-  version = "3.14.4-r3";
+  version = "3.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/lyrical/plotjuggler/3.14.4-3.tar.gz";
-    name = "3.14.4-3.tar.gz";
-    sha256 = "e01fbaf42260d3f9abe12397ee73d1f5f7271926fbf87def386a106f2813e659";
+    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/lyrical/plotjuggler/3.17.2-1.tar.gz";
+    name = "3.17.2-1.tar.gz";
+    sha256 = "1c043f801cf86cda24e8af178da96558daafbb202e5641c1cce9b81168efd76c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-index-cpp binutils boost cppzmq data-tamer-cpp fmt lua lz4 nlohmann_json protobuf qt5.qtbase qt5.qtsvg qt5.qtwebsockets qt5.qtx11extras rclcpp zstd ];
+  propagatedBuildInputs = [ ament-index-cpp binutils boost cppzmq data-tamer-cpp fmt lua lz4 nlohmann_json protobuf qt5.qtbase qt5.qtsvg qt5.qtwebsockets qt5.qtx11extras zstd ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/lyrical/rcl-interfaces/default.nix
+++ b/distros/lyrical/rcl-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-lyrical-rcl-interfaces";
-  version = "2.4.4-r3";
+  version = "2.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/lyrical/rcl_interfaces/2.4.4-3.tar.gz";
-    name = "2.4.4-3.tar.gz";
-    sha256 = "0c3091d021a3be1a7bdf0cd87aa25896ba2e431107c5813733eb4c419d1ca1cc";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/lyrical/rcl_interfaces/2.4.5-1.tar.gz";
+    name = "2.4.5-1.tar.gz";
+    sha256 = "7ec27c9c9d8e4e1365e786018577daaf109e02818c72e1e6ab23b33ff4ffd290";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rmw-fastrtps-cpp/default.nix
+++ b/distros/lyrical/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros-core, ament-lint-auto, ament-lint-common, fastcdr, fastdds, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-buffer-backend-registry, rosidl-dynamic-typesupport, rosidl-dynamic-typesupport-fastrtps, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-lyrical-rmw-fastrtps-cpp";
-  version = "9.4.7-r3";
+  version = "9.4.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/lyrical/rmw_fastrtps_cpp/9.4.7-3.tar.gz";
-    name = "9.4.7-3.tar.gz";
-    sha256 = "2c48e8b347e090009b852e0e71fdca3c34fab596a65d5bdaed4551ca682fc17d";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/lyrical/rmw_fastrtps_cpp/9.4.8-1.tar.gz";
+    name = "9.4.8-1.tar.gz";
+    sha256 = "f55c526d23edb050234fccfc0f1091aec9bbd3ce34430af279cbb7a492bf2cd6";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/lyrical/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros-core, ament-lint-auto, ament-lint-common, fastcdr, fastdds, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-buffer, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-lyrical-rmw-fastrtps-dynamic-cpp";
-  version = "9.4.7-r3";
+  version = "9.4.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/lyrical/rmw_fastrtps_dynamic_cpp/9.4.7-3.tar.gz";
-    name = "9.4.7-3.tar.gz";
-    sha256 = "3bc374615af0f08e831587f0cead2f97dbecb94ee3a2786ff6ae1683f02cdd21";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/lyrical/rmw_fastrtps_dynamic_cpp/9.4.8-1.tar.gz";
+    name = "9.4.8-1.tar.gz";
+    sha256 = "5ac3135db378e616ce5602556860b6f20bc1e634cd9a034590dabe59cbc831a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/lyrical/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros-core, ament-lint-auto, ament-lint-common, fastcdr, fastdds, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-security-common, rosidl-buffer-backend-registry, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-lyrical-rmw-fastrtps-shared-cpp";
-  version = "9.4.7-r3";
+  version = "9.4.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/lyrical/rmw_fastrtps_shared_cpp/9.4.7-3.tar.gz";
-    name = "9.4.7-3.tar.gz";
-    sha256 = "f1e78ad6a894cbe879c9d6a74134e3d8b080dc7c5bae4cc03ede09fc6bc887bb";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/lyrical/rmw_fastrtps_shared_cpp/9.4.8-1.tar.gz";
+    name = "9.4.8-1.tar.gz";
+    sha256 = "e765c6029bce516596388c668135594afd7be807d10fec5c3fa62e59c8fe2434";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/robot-arm-demo/default.nix
+++ b/distros/lyrical/robot-arm-demo/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, SDL2, _unresolved_nvidia-cuda-dev, ament-cmake, ament-lint-auto, ament-lint-common, glew, libGL, libGLU, libtorch-vendor, libx11, rclcpp, rclcpp-components, tensor-msgs, torch-conversions }:
+buildRosPackage {
+  pname = "ros-lyrical-robot-arm-demo";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosidl_buffer_backends_tutorials-release/archive/release/lyrical/robot_arm_demo/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "0e74f84f8f24f06ee19ebbb638b570b5e6cf4b80d17bdc98d8afa82323141397";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ SDL2 _unresolved_nvidia-cuda-dev glew libGL libGLU libtorch-vendor libx11 rclcpp rclcpp-components tensor-msgs torch-conversions ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "GPU-rendered frames published as tensor_msgs/ExperimentalTensor and
+    delivered via the cuda_buffer_backend zero-copy transport, received
+    and displayed by a second node using torch_conversions.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/rosgraph-msgs/default.nix
+++ b/distros/lyrical/rosgraph-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-lyrical-rosgraph-msgs";
-  version = "2.4.4-r3";
+  version = "2.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/lyrical/rosgraph_msgs/2.4.4-3.tar.gz";
-    name = "2.4.4-3.tar.gz";
-    sha256 = "6b7678a1a2f6174e193214d984f12b757a52d517a2ae46e93cfa8f5d1e1beecb";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/lyrical/rosgraph_msgs/2.4.5-1.tar.gz";
+    name = "2.4.5-1.tar.gz";
+    sha256 = "9712cc0973fd66b62316758b97d461a32dc10ec572e81e038be74b72ef250b16";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rqt-bag-plugins/default.nix
+++ b/distros/lyrical/rqt-bag-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, builtin-interfaces, geometry-msgs, python3Packages, rclpy, rosbag2, rqt-bag, rqt-gui, rqt-gui-py, rqt-plot, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-rqt-bag-plugins";
-  version = "2.2.2-r3";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/lyrical/rqt_bag_plugins/2.2.2-3.tar.gz";
-    name = "2.2.2-3.tar.gz";
-    sha256 = "57c774772c5f884e8f0c07c2eb772c406134bb619b6e72d6a18967bb583d2fe1";
+    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/lyrical/rqt_bag_plugins/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "74b9815bea9ca6f302e57b4ff44b287751539ec7874885f4d03d92bd71ea0aa5";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/rqt-bag/default.nix
+++ b/distros/lyrical/rqt-bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, builtin-interfaces, python-qt-binding, python3Packages, rclpy, rosbag2-py, rosidl-runtime-py, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-lyrical-rqt-bag";
-  version = "2.2.2-r3";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/lyrical/rqt_bag/2.2.2-3.tar.gz";
-    name = "2.2.2-3.tar.gz";
-    sha256 = "251fd83aa9f7dd118e94d349ab34b23044ee2952d64cefb2c1cff2c571f938fb";
+    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/lyrical/rqt_bag/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "468b365e3deba5155d120e8bb1616f819756e5e9b735767cc30cc6e580f8e1bf";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/rqt-topic/default.nix
+++ b/distros/lyrical/rqt-topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-xmllint, python-qt-binding, python3Packages, rclpy, ros2topic, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-lyrical-rqt-topic";
-  version = "2.1.0-r3";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_topic-release/archive/release/lyrical/rqt_topic/2.1.0-3.tar.gz";
-    name = "2.1.0-3.tar.gz";
-    sha256 = "7df03d97a5ebb9475dd0fe11517e5851ade4dcd199383ea3a7e95fc9487913f7";
+    url = "https://github.com/ros2-gbp/rqt_topic-release/archive/release/lyrical/rqt_topic/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "699bd8441b6f63cfc21447a372f37104fcf962279f64141ff0aef440aa9dc28f";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/rviz-common/default.nix
+++ b/distros/lyrical/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, message-filters, pluginlib, qt6, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml-2, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-lyrical-rviz-common";
-  version = "15.2.2-r3";
+  version = "15.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/lyrical/rviz_common/15.2.2-3.tar.gz";
-    name = "15.2.2-3.tar.gz";
-    sha256 = "1218f700e6a89ee37c824df14285b10932cecf8b37aa9bbeda88b8e942b6d337";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/lyrical/rviz_common/15.2.3-1.tar.gz";
+    name = "15.2.3-1.tar.gz";
+    sha256 = "5dad80072d6eadf0607bfcdb65e42c85e7900dfd0dbb210cea43b483af39f4f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rviz-default-plugins/default.nix
+++ b/distros/lyrical/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, gz-math-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt6, rclcpp, resource-retriever, resource-retriever-service-plugin, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-rviz-default-plugins";
-  version = "15.2.2-r3";
+  version = "15.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/lyrical/rviz_default_plugins/15.2.2-3.tar.gz";
-    name = "15.2.2-3.tar.gz";
-    sha256 = "736c52b123f7aa5e55c67b1faedfef6b9646ea8e210697a0d444a15883b83a40";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/lyrical/rviz_default_plugins/15.2.3-1.tar.gz";
+    name = "15.2.3-1.tar.gz";
+    sha256 = "ed52af64096a6a75ec88ade30f84aab50c02bab99bb45a639130649144f60f7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rviz-ogre-vendor/default.nix
+++ b/distros/lyrical/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, glew, libGL, libGLU, libx11, libxaw, libxrandr }:
 buildRosPackage {
   pname = "ros-lyrical-rviz-ogre-vendor";
-  version = "15.2.2-r3";
+  version = "15.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/lyrical/rviz_ogre_vendor/15.2.2-3.tar.gz";
-    name = "15.2.2-3.tar.gz";
-    sha256 = "8dbc64ff6b3549bf1d2bef356da57f7c0dae5f2a414825f4e624dda93b195c4b";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/lyrical/rviz_ogre_vendor/15.2.3-1.tar.gz";
+    name = "15.2.3-1.tar.gz";
+    sha256 = "ce27385c093022860253dff8ef5ede6afbaf4532e4fd4c3ac01e9c641c181fdc";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rviz-rendering-tests/default.nix
+++ b/distros/lyrical/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, qt6, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-lyrical-rviz-rendering-tests";
-  version = "15.2.2-r3";
+  version = "15.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/lyrical/rviz_rendering_tests/15.2.2-3.tar.gz";
-    name = "15.2.2-3.tar.gz";
-    sha256 = "00c3cc2fa74b8b1e2287c6f1c92980418f4a86fa02cdf610062d81956b679ae5";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/lyrical/rviz_rendering_tests/15.2.3-1.tar.gz";
+    name = "15.2.3-1.tar.gz";
+    sha256 = "20425dbb923478fd788ee133359d60c224fb509ff5a960a3e4c539b6c1a2695e";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rviz-rendering/default.nix
+++ b/distros/lyrical/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, assimp, eigen, eigen3-cmake-module, qt6, resource-retriever, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-lyrical-rviz-rendering";
-  version = "15.2.2-r3";
+  version = "15.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/lyrical/rviz_rendering/15.2.2-3.tar.gz";
-    name = "15.2.2-3.tar.gz";
-    sha256 = "8fcab18f2b4668fe933d5a1d8000c770bb0a6b71727d7a9cf5ea760b0405c0a1";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/lyrical/rviz_rendering/15.2.3-1.tar.gz";
+    name = "15.2.3-1.tar.gz";
+    sha256 = "e5ea7c03e1176def313b4c7f9d8936c93f15da625fb0d1056a3fd8a84b250c9f";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rviz-visual-testing-framework/default.nix
+++ b/distros/lyrical/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, qt6, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-lyrical-rviz-visual-testing-framework";
-  version = "15.2.2-r3";
+  version = "15.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/lyrical/rviz_visual_testing_framework/15.2.2-3.tar.gz";
-    name = "15.2.2-3.tar.gz";
-    sha256 = "f715b808af7703597f9c53183d6e62d0b788876025e0b3d3ce37e2a0595ef2b2";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/lyrical/rviz_visual_testing_framework/15.2.3-1.tar.gz";
+    name = "15.2.3-1.tar.gz";
+    sha256 = "87d80241d76a9cc5bad8c15305604a0d6d8c2f859cc971544c1fe6131afe63a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rviz2/default.nix
+++ b/distros/lyrical/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, python3, python3Packages, qt6, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-rviz2";
-  version = "15.2.2-r3";
+  version = "15.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/lyrical/rviz2/15.2.2-3.tar.gz";
-    name = "15.2.2-3.tar.gz";
-    sha256 = "5e6c3c9bc9581026adbc233b3cb466f64b338e6eac6429b2facda25745283260";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/lyrical/rviz2/15.2.3-1.tar.gz";
+    name = "15.2.3-1.tar.gz";
+    sha256 = "1be603e6968b9a2581b97231333af33282283cb718db3f6bc0986b9a75788a30";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/service-msgs/default.nix
+++ b/distros/lyrical/service-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-core-generators, rosidl-core-runtime }:
 buildRosPackage {
   pname = "ros-lyrical-service-msgs";
-  version = "2.4.4-r3";
+  version = "2.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/lyrical/service_msgs/2.4.4-3.tar.gz";
-    name = "2.4.4-3.tar.gz";
-    sha256 = "3d36da0f7dd425f09cc4630ad788e7e7e127880d3149f6f1cb02676c9f4ef3e8";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/lyrical/service_msgs/2.4.5-1.tar.gz";
+    name = "2.4.5-1.tar.gz";
+    sha256 = "3aaf85fdd6e5280ff3470a0178a624ef467795358a103536580c91586cea6f41";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/statistics-msgs/default.nix
+++ b/distros/lyrical/statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-lyrical-statistics-msgs";
-  version = "2.4.4-r3";
+  version = "2.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/lyrical/statistics_msgs/2.4.4-3.tar.gz";
-    name = "2.4.4-3.tar.gz";
-    sha256 = "0217d5353945640569e3dfdc0e5c7f8e3d612857162f93c5673f0b9b10f26d4b";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/lyrical/statistics_msgs/2.4.5-1.tar.gz";
+    name = "2.4.5-1.tar.gz";
+    sha256 = "eb4adac4ddb877174858197e23816da465249c8e187fca2bb673ad28e2df487e";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/tcb-span/default.nix
+++ b/distros/lyrical/tcb-span/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-lyrical-tcb-span";
-  version = "2.0.2-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/lyrical/tcb_span/2.0.2-3.tar.gz";
-    name = "2.0.2-3.tar.gz";
-    sha256 = "b01425bb3efea6b1b5136871418e0f3168999eb7d935c5b38dcd6593976d5c0d";
+    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/lyrical/tcb_span/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "0468cb21fcb0192757f96818ec7cb57b72373dd601b79fdda74f58a2d85c7f88";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/tensor-msgs/default.nix
+++ b/distros/lyrical/tensor-msgs/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-lyrical-tensor-msgs";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/lyrical/tensor_msgs/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "d94e08eb97808693d0d9bb5c684f947cedde3615e22a88f02d73e4446e97b436";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "DLPack-compatible Tensor message for publishing / subscribing to tensors.
+  Currently exposes only ExperimentalTensor (used internally; schema may change
+  before stabilization).";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/test-msgs/default.nix
+++ b/distros/lyrical/test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-mypy, ament-lint-auto, ament-lint-common, builtin-interfaces, python3Packages, rosidl-default-generators, rosidl-default-runtime, test-interface-files }:
 buildRosPackage {
   pname = "ros-lyrical-test-msgs";
-  version = "2.4.4-r3";
+  version = "2.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/lyrical/test_msgs/2.4.4-3.tar.gz";
-    name = "2.4.4-3.tar.gz";
-    sha256 = "9757e12cd61ef2c26ab11c1789e18acdd91787e872ff89e9731f6e7e2053c7e1";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/lyrical/test_msgs/2.4.5-1.tar.gz";
+    name = "2.4.5-1.tar.gz";
+    sha256 = "0896f5c4761131289e526a7726d25c5e8cdaba3a5136cae3eaf3aac035e53796";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/theora-image-transport/default.nix
+++ b/distros/lyrical/theora-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, libogg, libtheora, opencv, pkg-config, pluginlib, rclcpp, rcutils, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-theora-image-transport";
-  version = "6.2.4-r3";
+  version = "6.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/lyrical/theora_image_transport/6.2.4-3.tar.gz";
-    name = "6.2.4-3.tar.gz";
-    sha256 = "ae352deea1129b4b3aaca1f35312233a4560c30612cf1902e6b82de0f192d883";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/lyrical/theora_image_transport/6.2.5-1.tar.gz";
+    name = "6.2.5-1.tar.gz";
+    sha256 = "5fccf45b0b7bdaf7a651198b09248518416cf9cfa4f3c8c3a7207e9c52071b9f";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/topic-tools-interfaces/default.nix
+++ b/distros/lyrical/topic-tools-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-lyrical-topic-tools-interfaces";
-  version = "1.4.4-r3";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/lyrical/topic_tools_interfaces/1.4.4-3.tar.gz";
-    name = "1.4.4-3.tar.gz";
-    sha256 = "25c9a62ba352a958875e03311f561bc4fdb215e948cbde4c82cccec2c6ee139a";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/lyrical/topic_tools_interfaces/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "3994332a5d71ca017b87a46543a1b27e08d46a06e52bfe08aabccc4b5abcc36c";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/topic-tools/default.nix
+++ b/distros/lyrical/topic-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclpy, ros2cli, ros2topic, rosidl-default-generators, rosidl-runtime-py, std-msgs, topic-tools-interfaces }:
 buildRosPackage {
   pname = "ros-lyrical-topic-tools";
-  version = "1.4.4-r3";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/lyrical/topic_tools/1.4.4-3.tar.gz";
-    name = "1.4.4-3.tar.gz";
-    sha256 = "9a414e01ffae8be04cbb345da02aa59d6740b6e892b90a98d763ceaf8e4d2ce0";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/lyrical/topic_tools/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "f618bffc745bd18c6569fc70bd8a910e413c142266e1ab9490b525d64ae8b3ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/torch-conversions/default.nix
+++ b/distros/lyrical/torch-conversions/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-testing-ament-cmake, libtorch-vendor, rclcpp, rclcpp-components, rcutils, rmw, rosidl-buffer, std-msgs, tensor-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-torch-conversions";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/lyrical/torch_conversions/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "0cfa5c633e187ab8140353c71c9f62b3b0e01cf5d1be6509ce6d32828f058fc3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common launch-testing-ament-cmake rclcpp rclcpp-components std-msgs ];
+  propagatedBuildInputs = [ libtorch-vendor rcutils rmw rosidl-buffer tensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Header-only helper library that converts between a
+  tensor_msgs/ExperimentalTensor message and an at::Tensor backed by rosidl::Buffer storage.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/type-description-interfaces/default.nix
+++ b/distros/lyrical/type-description-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-core-generators, rosidl-core-runtime, service-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-type-description-interfaces";
-  version = "2.4.4-r3";
+  version = "2.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/lyrical/type_description_interfaces/2.4.4-3.tar.gz";
-    name = "2.4.4-3.tar.gz";
-    sha256 = "13adf8f64d8715656a1e16e998d336c6be1a483a52b7f3a40866c0eb9e3a3aa4";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/lyrical/type_description_interfaces/2.4.5-1.tar.gz";
+    name = "2.4.5-1.tar.gz";
+    sha256 = "4ff80de4ca7c8ea70912837eff1a147e429eb4386710d243875d6d8c5ed7dd54";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ur-calibration/default.nix
+++ b/distros/lyrical/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-lyrical-ur-calibration";
-  version = "5.0.0-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/lyrical/ur_calibration/5.0.0-3.tar.gz";
-    name = "5.0.0-3.tar.gz";
-    sha256 = "f46e21b10981ee2778c77dd0762eb1b9dd9f46177a76ef36f8d80aa45ff3240a";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/lyrical/ur_calibration/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "b1e9318b34f8135b583ec4e8dbcbe60742fbe754b9a4931cfac2a31e0075c859";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ur-controllers/default.nix
+++ b/distros/lyrical/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, angles, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, trajectory-msgs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-ur-controllers";
-  version = "5.0.0-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/lyrical/ur_controllers/5.0.0-3.tar.gz";
-    name = "5.0.0-3.tar.gz";
-    sha256 = "a3d70ecfb4e3171c793d98ee47787d3bb4412cf7f1d5be52e0ae8827ac8818cd";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/lyrical/ur_controllers/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "2d239dd99b363d599023c3ca3d1b63f7aec96835aee6fc6b68822f8c78f37486";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ur-dashboard-msgs/default.nix
+++ b/distros/lyrical/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-lyrical-ur-dashboard-msgs";
-  version = "5.0.0-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/lyrical/ur_dashboard_msgs/5.0.0-3.tar.gz";
-    name = "5.0.0-3.tar.gz";
-    sha256 = "d888e498e0c78e79f1f5b7934a9fe8074cc459efff48a6e193f19fb6cc9d66da";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/lyrical/ur_dashboard_msgs/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "796379e8f4c95bd70818ba2f41776a37ead5c19eb439fc2a8b395ec2b925432b";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ur-moveit-config/default.nix
+++ b/distros/lyrical/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, ur-description, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-lyrical-ur-moveit-config";
-  version = "5.0.0-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/lyrical/ur_moveit_config/5.0.0-3.tar.gz";
-    name = "5.0.0-3.tar.gz";
-    sha256 = "6f0a7dbcff3a991eba49856d0b703b9973e7d5b30bf67172d543610509722589";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/lyrical/ur_moveit_config/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "c1a7fb034490d77a884b889fc5694f7bbfefcef6bc22ff30e18cc4151f1d02aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ur-robot-driver/default.nix
+++ b/distros/lyrical/ur-robot-driver/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_effort_controllers, _unresolved_position_controllers, _unresolved_velocity_controllers, ament-cmake, ament-cmake-python, backward-ros, control-msgs, controller-manager, controller-manager-msgs, force-torque-sensor-broadcaster, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, motion-primitives-controllers, pluginlib, pose-broadcaster, rclcpp, rclcpp-lifecycle, rclpy, robot-state-publisher, ros2-controllers-test-nodes, ros2run, rviz2, socat, std-msgs, std-srvs, tf2-geometry-msgs, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs, urdf, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, backward-ros, control-msgs, controller-manager, controller-manager-msgs, force-torque-sensor-broadcaster, forward-command-controller, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, motion-primitives-controllers, pluginlib, pose-broadcaster, rclcpp, rclcpp-lifecycle, rclpy, robot-state-publisher, ros2-controllers-test-nodes, ros2run, rviz2, socat, std-msgs, std-srvs, tf2-geometry-msgs, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs, urdf, xacro }:
 buildRosPackage {
   pname = "ros-lyrical-ur-robot-driver";
-  version = "5.0.0-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/lyrical/ur_robot_driver/5.0.0-3.tar.gz";
-    name = "5.0.0-3.tar.gz";
-    sha256 = "82fcbe30e84ec5c9bea8df57f1731ebeabfb50d86512a724eef1ed779b91a367";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/lyrical/ur_robot_driver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "52ec69f3de924ab3c4ca647763e0db6ecf0c1407c67f10c3c5c9c101302a39ea";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ launch-testing-ament-cmake ros2run ];
-  propagatedBuildInputs = [ _unresolved_effort_controllers _unresolved_position_controllers _unresolved_velocity_controllers backward-ros control-msgs controller-manager controller-manager-msgs force-torque-sensor-broadcaster geometry-msgs hardware-interface joint-state-broadcaster joint-state-publisher joint-trajectory-controller launch launch-ros motion-primitives-controllers pluginlib pose-broadcaster rclcpp rclcpp-lifecycle rclpy robot-state-publisher ros2-controllers-test-nodes rviz2 socat std-msgs std-srvs tf2-geometry-msgs ur-client-library ur-controllers ur-dashboard-msgs ur-description ur-msgs urdf xacro ];
+  propagatedBuildInputs = [ backward-ros control-msgs controller-manager controller-manager-msgs force-torque-sensor-broadcaster forward-command-controller geometry-msgs hardware-interface joint-state-broadcaster joint-state-publisher joint-trajectory-controller launch launch-ros motion-primitives-controllers pluginlib pose-broadcaster rclcpp rclcpp-lifecycle rclpy robot-state-publisher ros2-controllers-test-nodes rviz2 socat std-msgs std-srvs tf2-geometry-msgs ur-client-library ur-controllers ur-dashboard-msgs ur-description ur-msgs urdf xacro ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/lyrical/ur/default.nix
+++ b/distros/lyrical/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-lyrical-ur";
-  version = "5.0.0-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/lyrical/ur/5.0.0-3.tar.gz";
-    name = "5.0.0-3.tar.gz";
-    sha256 = "68dfc5172348a16886fac93b59eccd88132c0009ec9c660d4587c8ddb292a0ac";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/lyrical/ur/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "d437f35a8439355ba4b0ed6eef58817e547e22269978acb232b702dae17f3f39";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/zstd-image-transport/default.nix
+++ b/distros/lyrical/zstd-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, image-transport, zlib }:
 buildRosPackage {
   pname = "ros-lyrical-zstd-image-transport";
-  version = "6.2.4-r3";
+  version = "6.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/lyrical/zstd_image_transport/6.2.4-3.tar.gz";
-    name = "6.2.4-3.tar.gz";
-    sha256 = "efc597b18cb7e1efbfd961695462a513d0f9d053c3eef1011f47e6c2646a2c3f";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/lyrical/zstd_image_transport/6.2.5-1.tar.gz";
+    name = "6.2.5-1.tar.gz";
+    sha256 = "3c0285f12e1a632dd9f85c6e5d456b0e0753d8ad4fcd2f24108ffcef16909690";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-clang-format/default.nix
+++ b/distros/rolling/ament-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, clang, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-clang-format";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_format/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "3301a6c8781414bfbdbc359b4cfdf63b72029f74bd6c413de95112c1fe5eb00f";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_format/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "a56d6bc7869fba9eac5bb3a5098cd23b10a16022f566dd5244ef4a0ff55597dc";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-clang-tidy/default.nix
+++ b/distros/rolling/ament-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, clang, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-clang-tidy";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_tidy/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "9b8c5b3dd0c92e987e3ffae5b67673710e2dbc693cdd0814f10e833ae9559483";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_tidy/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "e5bf979e7ae0bd9a63f9b04836cc6716f96a4195be55874687fbfa2fb099fbdd";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-cmake-clang-format/default.nix
+++ b/distros/rolling/ament-cmake-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-clang-format";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_format/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "cfc0b68558ce888a947d2e042bc0a679f3817a95b4bb6ec35677ba230700965c";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_format/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "964f6aada73d47b3350f680cd052fb26dd62b916878a5dd2fe24226d060231d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-clang-tidy/default.nix
+++ b/distros/rolling/ament-cmake-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-tidy, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-clang-tidy";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_tidy/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "1149853b1f2623bd297bb40d6b3a53468ddc71cfe6afa7926247ad59e0549d0d";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_tidy/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "8a93eeca21676c5b3cac6551d4095d48a6cfffb5416b80bd65cce6ae724adc19";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-copyright/default.nix
+++ b/distros/rolling/ament-cmake-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-copyright }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-copyright";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_copyright/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "653fb3380c01c3956232463deb942c22362593427ae30f77979b13e8aca6f399";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_copyright/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "67b66f6fed3cda482f08e5f30fc6011da4a7e29551d73460e3c5b346dfdadad6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-cppcheck/default.nix
+++ b/distros/rolling/ament-cmake-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cppcheck }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-cppcheck";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cppcheck/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "495c284e3963f28c8037bdc32ce8a5936b0b6ba133d3d558e3b9364093a707c2";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cppcheck/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "87f3c238c112400269988798500ba20db6ef698392b5d4088665d1685d79d694";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-cpplint/default.nix
+++ b/distros/rolling/ament-cmake-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cpplint }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-cpplint";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cpplint/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "11ba9d76d6aa68e8ca0a18c466840ba06242a3d5907582ee73443d94d4397f02";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cpplint/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "3b7061746663eff46b37d1917d5ce1ca39ef5f68bfc17f4e7d273791ae4653c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-flake8/default.nix
+++ b/distros/rolling/ament-cmake-flake8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-flake8 }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-flake8";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_flake8/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "bb7eeb96cb967980c8a6c52ab33626bb5a10e11464567b61790bd64c16d65356";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_flake8/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "e35b0f7a6bca7d70eee7a42b1bbc0b3c4b860a846055658ef6eadc4e3e394d9b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-lint-cmake/default.nix
+++ b/distros/rolling/ament-cmake-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, ament-lint-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-lint-cmake";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_lint_cmake/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "959e946d6fc3cfdeb7be3a3c4a58e18c7a7476c53cd5538cc8f2408b62f01a03";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_lint_cmake/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "ac020a15cbce2f34f746281959265acc1e6f2af3e2a22847eac65aa28a956239";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-mypy/default.nix
+++ b/distros/rolling/ament-cmake-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-mypy }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-mypy";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_mypy/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "143db1d998f24dcb407d6a6641f87ec4b6eee2578d6dae3fdea2405545b12d08";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_mypy/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "d0132b2f0175af42734590e077497b05811ef99a15f5cb54f23c01ce4d161c6b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pclint/default.nix
+++ b/distros/rolling/ament-cmake-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pclint }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pclint";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pclint/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "80f34e0787b1181efef6f960e915d2aa722c76fe4844135f06f3f9570a40fee5";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pclint/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "779383d3899c413ce82fbfe02627bdffcf9bf3a3e17272054c1d35e4ea345f82";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pep257/default.nix
+++ b/distros/rolling/ament-cmake-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pep257 }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pep257";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pep257/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "5c3a11305567995e0fedf39006ae6df34d490d931fd7fba2c801846924531928";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pep257/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "5e4cd25cbb5463629cfd803c1f1c654656260792aef65afa64f0da134375ba57";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pycodestyle/default.nix
+++ b/distros/rolling/ament-cmake-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pycodestyle }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pycodestyle";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pycodestyle/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "f7fa51ce27c46e567f4ed709a8c6e5c9cf3b386e6a72eea8a81e59e934c5aed1";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pycodestyle/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "830f99160d6b232f236136f6bd3c023914a7249b1c8bf582ce876490d12b8b1f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pyflakes/default.nix
+++ b/distros/rolling/ament-cmake-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pyflakes }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pyflakes";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pyflakes/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "bd653c226b4bca012102c8ca8a14ac4499dac65b6ee1bc6b557da473a3993295";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pyflakes/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "859947379e2c36d534ffc823f2ff287eba77cfc38b00083ae6dcba30289e21fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-uncrustify/default.nix
+++ b/distros/rolling/ament-cmake-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-uncrustify }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-uncrustify";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_uncrustify/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "0fb9dc99edbeb8ae15fcfeb21b194d8944cb4ce941c5a841318108bd5d49c980";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_uncrustify/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "c57bd68ae70280b1e8a51ef02fccfa76b75d5161e080b81d8e4544d6cde748f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-xmllint/default.nix
+++ b/distros/rolling/ament-cmake-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-xmllint }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-xmllint";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_xmllint/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "05209024df110f661dbe2599932f1d4c8a04aa60e43ac9aca4f5f2bb498ae046";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_xmllint/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "f73c7b23fe976a02867dfcc32ac1942447ad3297c79c2955637499c61824a718";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-copyright/default.nix
+++ b/distros/rolling/ament-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-copyright";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_copyright/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "63f107d169e5c454c740e6443524cdd2bda00310e2cce13b49b2822f18a14b60";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_copyright/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "1d5b51877c25c3bfe819264d28bd56df1d4e24acc7378017de59954d12cf1950";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-cppcheck/default.nix
+++ b/distros/rolling/ament-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-pycodestyle, ament-xmllint, cppcheck, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-cppcheck";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cppcheck/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "0eaf15b2a33d326eccc0890bb618bd51c4ac93d7fa4d8dac26a8e040d376275b";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cppcheck/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "9c1b3dd5aeac6bf43b9e2077e82a8cee5a07f1138e8aeb688d41638e4c887206";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-cpplint/default.nix
+++ b/distros/rolling/ament-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-cpplint";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cpplint/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "e245672b6594fa1ad53f3480c392a04421cf8c0a85c3c70c79a891fda216e714";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cpplint/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "784d360c83b2c08f0d54dbd1fcf4d170f4eb4c5602b14d8c605e1cb49e20a7b7";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-flake8/default.nix
+++ b/distros/rolling/ament-flake8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-flake8";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_flake8/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "b8da457b6c40ac7649a3b3cdc55b0f5c98fb8c93c840c0fc53d0fb808b214321";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_flake8/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "439b2c5fe73b6060056bb70c68dad2a53f6c150299116f2305a264180353e19e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-lint-auto/default.nix
+++ b/distros/rolling/ament-lint-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint-auto";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_auto/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "a568c2113e59625729c882539a0cd5d60b1a96c4d3e322eba493a9507dffb9be";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_auto/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "064ac839dbeb8c3f921538abd764c1bcf1a0b8a470577270fa00ce06ab7a1ae3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-lint-cmake/default.nix
+++ b/distros/rolling/ament-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint-cmake";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_cmake/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "1a311bf3cace31577237322b6ba45cd1bbe76fb9699a0c4defbd178478153f96";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_cmake/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "7af20072ee7a6630cf37e79c5aba3b64a4b6a5e92ea770785b83f8a32fdadc22";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-lint-common/default.nix
+++ b/distros/rolling/ament-lint-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-export-dependencies, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint-common";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_common/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "4b83a4afd7318d151d3c214c9d63f85e848ea2b539a5aecc46debdc42098b831";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_common/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "5b90b300d3e0f7c13b54c260923dc75226db4227018e661ce53a72e8d1ccdb1a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-lint/default.nix
+++ b/distros/rolling/ament-lint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "c1744c31a06fbb6f41ad2ae074a80032a76fc1e1f5ae2ec8067d448a530e280b";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "37dc60de73f0f4bd5d181de8bfca441857f5cb44fb5c59a06529f54ace067bf6";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-mypy/default.nix
+++ b/distros/rolling/ament-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-mypy";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_mypy/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "63d428ed4f3db41876dffa6df565df37a9685752c3f46e44c257975ae75d513e";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_mypy/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "05f04cfeb0c33f798812683feab8d10daaf076d51e0b311cf085227b608ba3c5";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-pclint/default.nix
+++ b/distros/rolling/ament-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pclint";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pclint/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "a27029974b9bcccb080a5aec3b21b8ac1562d2fe1b74695c63f18414d235eca7";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pclint/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "e6ac1501c387daf3d4796ed4548c02dffe23ca2e1882a7134e7f609df352f3df";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-pep257/default.nix
+++ b/distros/rolling/ament-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pep257";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pep257/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "0b1ab40b822a41ddf9eb12a447663e3e5f884b74d83c4c87cd30b6a3746e8276";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pep257/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "7bcfcec9ef48a60fd450638cd8aa998724dc4dfdd1e9bdf787557d256fe979cf";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-pycodestyle/default.nix
+++ b/distros/rolling/ament-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pycodestyle";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pycodestyle/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "51264efe3029b68a9f63b5e52b752555df3feae7f62cea787ca6c03f9756460b";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pycodestyle/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "7bf00ca192016fe12cf7854d8e7170ffb7bcfc96f840ab73007c2d28908cc842";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-pyflakes/default.nix
+++ b/distros/rolling/ament-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-pycodestyle, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pyflakes";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pyflakes/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "8d47981686c1bf68b2faf58b336eef4da6361fadcb2eda8464f51056ca93bed9";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pyflakes/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "8bf258889fbe1ba454883ef35a0e7f5cfb4f93b9264786d8130d3055022f6191";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-uncrustify/default.nix
+++ b/distros/rolling/ament-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-pycodestyle, ament-xmllint, python3Packages, uncrustify-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ament-uncrustify";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_uncrustify/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "7c1acfbc0c6f341dc1071f8c46d7bfdc9e07beb3cf0256e626b8631d2af888a3";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_uncrustify/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "46e5a0d2ea09da72780085aca7b7fdc94653c19dad4a7ff13a0d17c30b8a5f5b";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-xmllint/default.nix
+++ b/distros/rolling/ament-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-lint, ament-pep257, libxml2, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-xmllint";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_xmllint/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "f9f682d31802890a446cdeefd16842dae0d87b7ec60b9b20b55a7353d635a5f8";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_xmllint/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "4f86c006cc71a3d11a1d810f27ff37e6f8b22a41767a471b97ae7ba575b6d6fe";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/cuda-buffer-backend-msgs/default.nix
+++ b/distros/rolling/cuda-buffer-backend-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-cuda-buffer-backend-msgs";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/rolling/cuda_buffer_backend_msgs/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "8d2ccdc58b5b99892fe5dc20bc7d62e265f1e91e3836fed371e3c0cf6cfe19af";
+    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/rolling/cuda_buffer_backend_msgs/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "97748df74b5742055f1129d5b533a352122b2bb74711ab3c550e2a0986f91c70";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/cuda-buffer-backend/default.nix
+++ b/distros/rolling/cuda-buffer-backend/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cuda-buffer, cuda-buffer-backend-msgs, launch-ros, launch-testing, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-components, rcutils, rosidl-buffer-backend, rosidl-buffer-backend-registry, rosidl-runtime-cpp, rosidl-typesupport-cpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-cuda-buffer-backend";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/rolling/cuda_buffer_backend/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "703805ddeb49ba6236c57729ae2f4d2f7b4e586481737b5360938c778753cb46";
+    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/rolling/cuda_buffer_backend/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "f24403e3cc17f52872340c7fd8aace1cc8c6ac8ee740b42229f9a3d5d15a8aa8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/cuda-buffer/default.nix
+++ b/distros/rolling/cuda-buffer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, _unresolved_nvidia-cuda, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cuda-buffer-backend-msgs, rcutils, rmw, rosidl-buffer }:
 buildRosPackage {
   pname = "ros-rolling-cuda-buffer";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/rolling/cuda_buffer/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "12bac4cc09a19de9ed58e142e1caf2827ba4fc6026b68d5fa1fb87bf8dbe9179";
+    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/rolling/cuda_buffer/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "5e1a4549566804dfa83dbc96c99a17b17eb096b513cf64f5a08c37cefba0682a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/flexbe-behavior-engine/default.nix
+++ b/distros/rolling/flexbe-behavior-engine/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, flexbe-core, flexbe-input, flexbe-mirror, flexbe-msgs, flexbe-onboard, flexbe-states, flexbe-testing, flexbe-widget }:
 buildRosPackage {
   pname = "ros-rolling-flexbe-behavior-engine";
-  version = "4.0.3-r2";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/rolling/flexbe_behavior_engine/4.0.3-2.tar.gz";
-    name = "4.0.3-2.tar.gz";
-    sha256 = "72b49832330fbfd309d46b562c13df145fd5fe87d20348e0725d65ca8b145c1a";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/rolling/flexbe_behavior_engine/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "7e364614760e7a565a624d8547c4068bc2c66ec49093af6c261a86d281db1f23";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/flexbe-core/default.nix
+++ b/distros/rolling/flexbe-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-msgs, launch-ros, launch-testing, python3Packages, rclpy, std-msgs, std-srvs, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-flexbe-core";
-  version = "4.0.3-r2";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/rolling/flexbe_core/4.0.3-2.tar.gz";
-    name = "4.0.3-2.tar.gz";
-    sha256 = "5c91b26d43c2463df750b1cc4ab90a3595ffd663240b3376c34b7f4ca6522abb";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/rolling/flexbe_core/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "b1e1054a50eb8f20630dfe789f57726ce9484e6fb38bc502014609788eda6b69";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/flexbe-input/default.nix
+++ b/distros/rolling/flexbe-input/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-flexbe-input";
-  version = "4.0.3-r2";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/rolling/flexbe_input/4.0.3-2.tar.gz";
-    name = "4.0.3-2.tar.gz";
-    sha256 = "0c98ad4dcc511149ddbc072293612cac5d645cbc6e5c0bc5f8f011dd0d041c8d";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/rolling/flexbe_input/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "ea2c52eae5c778e6feeb16e95d07f11ebbce8d3c602960bf0636aa0579724f67";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/flexbe-mirror/default.nix
+++ b/distros/rolling/flexbe-mirror/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-flexbe-mirror";
-  version = "4.0.3-r2";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/rolling/flexbe_mirror/4.0.3-2.tar.gz";
-    name = "4.0.3-2.tar.gz";
-    sha256 = "1916c4d1e64d48872cdcc6b9aff5e7f7f52cf3631d7cf9243cec0cbdc5296c7d";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/rolling/flexbe_mirror/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "d19ecd78f6e79f39cf186ed972fd3bcfa1fd4a731ed83f70bbb10c4cc260e2bc";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/flexbe-msgs/default.nix
+++ b/distros/rolling/flexbe-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-flexbe-msgs";
-  version = "4.0.3-r2";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/rolling/flexbe_msgs/4.0.3-2.tar.gz";
-    name = "4.0.3-2.tar.gz";
-    sha256 = "8a69a7eb545e60405200411bc2731b706e4c08684990c64226ac35a2057cc942";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/rolling/flexbe_msgs/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "ac8852e84ab01352352147fc9e030599caa6ec79a7bdac2b70ac4b59b236aba8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/flexbe-onboard/default.nix
+++ b/distros/rolling/flexbe-onboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, flexbe-states, launch-ros, launch-testing, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-flexbe-onboard";
-  version = "4.0.3-r2";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/rolling/flexbe_onboard/4.0.3-2.tar.gz";
-    name = "4.0.3-2.tar.gz";
-    sha256 = "3ba94492bda4e2bcdbcd6181a271541161611db1522540d2645e52821d2410b7";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/rolling/flexbe_onboard/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "ad835f34cbfe1d5772b6311056b54351c820758610e7cb8db30974df4ea4a3c4";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/flexbe-states/default.nix
+++ b/distros/rolling/flexbe-states/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, flexbe-testing, geometry-msgs, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-flexbe-states";
-  version = "4.0.3-r2";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/rolling/flexbe_states/4.0.3-2.tar.gz";
-    name = "4.0.3-2.tar.gz";
-    sha256 = "ed9afaca7ef592ccb3e65074082a6a432da8ec9169d2209c285efcde3d65f60b";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/rolling/flexbe_states/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "33f62be96403683a9f293f028bd53adbacaac5c93c75fa5f62415607dbda8a85";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/flexbe-testing/default.nix
+++ b/distros/rolling/flexbe-testing/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, launch-ros, launch-testing, python3Packages, rclpy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-copyright, ament-flake8, ament-index-python, ament-pep257, flexbe-core, flexbe-msgs, launch-ros, launch-testing, python3Packages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-flexbe-testing";
-  version = "4.0.3-r2";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/rolling/flexbe_testing/4.0.3-2.tar.gz";
-    name = "4.0.3-2.tar.gz";
-    sha256 = "8db05a68c02aca9de6f6d75599d989ea56c14cb40d6f967a554ca70920415c44";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/rolling/flexbe_testing/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "db0f164426ebd44793e0b5db6fd3e94e6e080b5a1dca3a629912546775ae0fb2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-cmake-pytest ament-copyright ament-flake8 ament-pep257 launch-testing python3Packages.pytest std-msgs ];
-  propagatedBuildInputs = [ flexbe-core flexbe-msgs launch-ros rclpy ];
+  propagatedBuildInputs = [ ament-index-python flexbe-core flexbe-msgs launch-ros rclpy ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/rolling/flexbe-widget/default.nix
+++ b/distros/rolling/flexbe-widget/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-mirror, flexbe-msgs, flexbe-onboard, launch-ros, python3Packages, rclpy }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-mirror, flexbe-msgs, flexbe-onboard, launch-ros, python3Packages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-flexbe-widget";
-  version = "4.0.3-r2";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/rolling/flexbe_widget/4.0.3-2.tar.gz";
-    name = "4.0.3-2.tar.gz";
-    sha256 = "8e29c5bd39fccc2023608bd1734f3985f89ba5b396da0c6f0fd70e3ead41f6d8";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/rolling/flexbe_widget/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "5ae552223a0c8ec55228c78442c89c587dd9dd0371bd97d486c156cc02f7a96c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
-  propagatedBuildInputs = [ flexbe-core flexbe-mirror flexbe-msgs flexbe-onboard launch-ros rclpy ];
+  propagatedBuildInputs = [ flexbe-core flexbe-mirror flexbe-msgs flexbe-onboard launch-ros rclpy std-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -22,8 +22,6 @@ self: super: {
 
  actuator-msgs = self.callPackage ./actuator-msgs {};
 
- adaptive-component = self.callPackage ./adaptive-component {};
-
  admittance-controller = self.callPackage ./admittance-controller {};
 
  ament-acceleration = self.callPackage ./ament-acceleration {};
@@ -394,8 +392,6 @@ self: super: {
 
  coin-d4-driver = self.callPackage ./coin-d4-driver {};
 
- color-names = self.callPackage ./color-names {};
-
  color-util = self.callPackage ./color-util {};
 
  common-interfaces = self.callPackage ./common-interfaces {};
@@ -539,8 +535,6 @@ self: super: {
  dummy-robot-bringup = self.callPackage ./dummy-robot-bringup {};
 
  dummy-sensors = self.callPackage ./dummy-sensors {};
-
- dynamixel-hardware = self.callPackage ./dynamixel-hardware {};
 
  dynamixel-hardware-interface = self.callPackage ./dynamixel-hardware-interface {};
 
@@ -980,8 +974,6 @@ self: super: {
 
  imu-transformer = self.callPackage ./imu-transformer {};
 
- interactive-marker-twist-server = self.callPackage ./interactive-marker-twist-server {};
-
  interactive-markers = self.callPackage ./interactive-markers {};
 
  intra-process-demo = self.callPackage ./intra-process-demo {};
@@ -1246,8 +1238,6 @@ self: super: {
 
  message-filters = self.callPackage ./message-filters {};
 
- message-tf-frame-transformer = self.callPackage ./message-tf-frame-transformer {};
-
  metavision-driver = self.callPackage ./metavision-driver {};
 
  micro-ros-diagnostic-bridge = self.callPackage ./micro-ros-diagnostic-bridge {};
@@ -1297,6 +1287,8 @@ self: super: {
  mola-input-lidar-bin-dataset = self.callPackage ./mola-input-lidar-bin-dataset {};
 
  mola-input-mulran-dataset = self.callPackage ./mola-input-mulran-dataset {};
+
+ mola-input-ouster = self.callPackage ./mola-input-ouster {};
 
  mola-input-paris-luco-dataset = self.callPackage ./mola-input-paris-luco-dataset {};
 
@@ -1580,6 +1572,8 @@ self: super: {
 
  novatel-gps-msgs = self.callPackage ./novatel-gps-msgs {};
 
+ novatel-oem6-msgs = self.callPackage ./novatel-oem6-msgs {};
+
  ntpd-driver = self.callPackage ./ntpd-driver {};
 
  ntrip-client = self.callPackage ./ntrip-client {};
@@ -1749,10 +1743,6 @@ self: super: {
  pick-ik = self.callPackage ./pick-ik {};
 
  picknik-ament-copyright = self.callPackage ./picknik-ament-copyright {};
-
- picknik-reset-fault-controller = self.callPackage ./picknik-reset-fault-controller {};
-
- picknik-twist-controller = self.callPackage ./picknik-twist-controller {};
 
  pid-controller = self.callPackage ./pid-controller {};
 
@@ -2220,8 +2210,6 @@ self: super: {
 
  ros-gz-sim-demos = self.callPackage ./ros-gz-sim-demos {};
 
- ros-image-to-qimage = self.callPackage ./ros-image-to-qimage {};
-
  ros-industrial-cmake-boilerplate = self.callPackage ./ros-industrial-cmake-boilerplate {};
 
  ros-testing = self.callPackage ./ros-testing {};
@@ -2380,10 +2368,6 @@ self: super: {
 
  rosx-introspection = self.callPackage ./rosx-introspection {};
 
- rot-conv = self.callPackage ./rot-conv {};
-
- rplidar-ros = self.callPackage ./rplidar-ros {};
-
  rpyutils = self.callPackage ./rpyutils {};
 
  rqml = self.callPackage ./rqml {};
@@ -2466,12 +2450,6 @@ self: super: {
 
  rslidar-msg = self.callPackage ./rslidar-msg {};
 
- rt-manipulators-cpp = self.callPackage ./rt-manipulators-cpp {};
-
- rt-manipulators-examples = self.callPackage ./rt-manipulators-examples {};
-
- rt-usb-9axisimu-driver = self.callPackage ./rt-usb-9axisimu-driver {};
-
  rtabmap = self.callPackage ./rtabmap {};
 
  rtcm-msgs = self.callPackage ./rtcm-msgs {};
@@ -2507,8 +2485,6 @@ self: super: {
  rviz-rendering-tests = self.callPackage ./rviz-rendering-tests {};
 
  rviz-visual-testing-framework = self.callPackage ./rviz-visual-testing-framework {};
-
- rviz-visual-tools = self.callPackage ./rviz-visual-tools {};
 
  sdformat-test-files = self.callPackage ./sdformat-test-files {};
 
@@ -2921,8 +2897,6 @@ self: super: {
  velodyne-pointcloud = self.callPackage ./velodyne-pointcloud {};
 
  vision-msgs = self.callPackage ./vision-msgs {};
-
- vision-msgs-layers = self.callPackage ./vision-msgs-layers {};
 
  vision-msgs-rviz-plugins = self.callPackage ./vision-msgs-rviz-plugins {};
 

--- a/distros/rolling/geodesy/default.nix
+++ b/distros/rolling/geodesy/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, angles, geographic-msgs, geometry-msgs, python3Packages, sensor-msgs, unique-identifier-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, angles, geographic-msgs, geometry-msgs, python3Packages, sensor-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-geodesy";
-  version = "1.0.6-r2";
+  version = "1.0.7-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geographic_info-release/archive/release/rolling/geodesy/1.0.6-2.tar.gz";
-    name = "1.0.6-2.tar.gz";
-    sha256 = "3f5890f3d64be315441b2300136d3cc7cb1733bf55e8c52d4cad0b92eda78c83";
+    url = "https://github.com/ros2-gbp/geographic_info-release/archive/release/rolling/geodesy/1.0.7-4.tar.gz";
+    name = "1.0.7-4.tar.gz";
+    sha256 = "92b12f2fc7a8e3083544b5e81d8df61f1008ecaacdc3574341c36ba5a1367984";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake python3Packages.catkin-pkg ];
+  checkInputs = [ ament-cmake-gtest ];
   propagatedBuildInputs = [ angles geographic-msgs geometry-msgs python3Packages.pyproj sensor-msgs unique-identifier-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/geographic-info/default.nix
+++ b/distros/rolling/geographic-info/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geodesy, geographic-msgs }:
 buildRosPackage {
   pname = "ros-rolling-geographic-info";
-  version = "1.0.6-r2";
+  version = "1.0.7-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geographic_info-release/archive/release/rolling/geographic_info/1.0.6-2.tar.gz";
-    name = "1.0.6-2.tar.gz";
-    sha256 = "d97b43e57f2166650dea04fd34df297251e587ed6598ee81bfcfdf1a7423f758";
+    url = "https://github.com/ros2-gbp/geographic_info-release/archive/release/rolling/geographic_info/1.0.7-4.tar.gz";
+    name = "1.0.7-4.tar.gz";
+    sha256 = "85cfaff3725af7768e7a99853eb66a64aaa2ea0a08fb8c56b531046f51a4a559";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/geographic-msgs/default.nix
+++ b/distros/rolling/geographic-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-geographic-msgs";
-  version = "1.0.6-r2";
+  version = "1.0.7-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geographic_info-release/archive/release/rolling/geographic_msgs/1.0.6-2.tar.gz";
-    name = "1.0.6-2.tar.gz";
-    sha256 = "66650367848609ab5045a1febc01a71cea3665e9a26b556d0c0452c27676d222";
+    url = "https://github.com/ros2-gbp/geographic_info-release/archive/release/rolling/geographic_msgs/1.0.7-4.tar.gz";
+    name = "1.0.7-4.tar.gz";
+    sha256 = "0f10f4a2e126dc63db782bce455875b113086f4d2c236e931dce7623a41adf8d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/kinova-gen3-6dof-robotiq-2f-85-moveit-config/default.nix
+++ b/distros/rolling/kinova-gen3-6dof-robotiq-2f-85-moveit-config/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, joint-state-publisher, joint-state-publisher-gui, joint-trajectory-controller, kortex-description, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, picknik-reset-fault-controller, picknik-twist-controller, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, tf2-ros, xacro }:
+{ lib, buildRosPackage, fetchurl, _unresolved_picknik_reset_fault_controller, _unresolved_picknik_twist_controller, ament-cmake, controller-manager, joint-state-publisher, joint-state-publisher-gui, joint-trajectory-controller, kortex-description, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-rolling-kinova-gen3-6dof-robotiq-2f-85-moveit-config";
   version = "0.2.5-r2";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ controller-manager joint-state-publisher joint-state-publisher-gui joint-trajectory-controller kortex-description moveit-configs-utils moveit-kinematics moveit-planners moveit-ros-move-group moveit-ros-visualization moveit-ros-warehouse moveit-setup-assistant moveit-simple-controller-manager picknik-reset-fault-controller picknik-twist-controller robot-state-publisher rviz-common rviz-default-plugins rviz2 tf2-ros xacro ];
+  propagatedBuildInputs = [ _unresolved_picknik_reset_fault_controller _unresolved_picknik_twist_controller controller-manager joint-state-publisher joint-state-publisher-gui joint-trajectory-controller kortex-description moveit-configs-utils moveit-kinematics moveit-planners moveit-ros-move-group moveit-ros-visualization moveit-ros-warehouse moveit-setup-assistant moveit-simple-controller-manager robot-state-publisher rviz-common rviz-default-plugins rviz2 tf2-ros xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/kinova-gen3-7dof-robotiq-2f-85-moveit-config/default.nix
+++ b/distros/rolling/kinova-gen3-7dof-robotiq-2f-85-moveit-config/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, joint-state-publisher, joint-state-publisher-gui, joint-trajectory-controller, kortex-description, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, picknik-reset-fault-controller, picknik-twist-controller, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, tf2-ros, xacro }:
+{ lib, buildRosPackage, fetchurl, _unresolved_picknik_reset_fault_controller, _unresolved_picknik_twist_controller, ament-cmake, controller-manager, joint-state-publisher, joint-state-publisher-gui, joint-trajectory-controller, kortex-description, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-rolling-kinova-gen3-7dof-robotiq-2f-85-moveit-config";
   version = "0.2.5-r2";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ controller-manager joint-state-publisher joint-state-publisher-gui joint-trajectory-controller kortex-description moveit-configs-utils moveit-kinematics moveit-planners moveit-ros-move-group moveit-ros-visualization moveit-ros-warehouse moveit-setup-assistant moveit-simple-controller-manager picknik-reset-fault-controller picknik-twist-controller robot-state-publisher rviz-common rviz-default-plugins rviz2 tf2-ros xacro ];
+  propagatedBuildInputs = [ _unresolved_picknik_reset_fault_controller _unresolved_picknik_twist_controller controller-manager joint-state-publisher joint-state-publisher-gui joint-trajectory-controller kortex-description moveit-configs-utils moveit-kinematics moveit-planners moveit-ros-move-group moveit-ros-visualization moveit-ros-warehouse moveit-setup-assistant moveit-simple-controller-manager robot-state-publisher rviz-common rviz-default-plugins rviz2 tf2-ros xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/kinova-gen3-lite-moveit-config/default.nix
+++ b/distros/rolling/kinova-gen3-lite-moveit-config/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, joint-state-publisher, joint-state-publisher-gui, kortex-description, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, picknik-reset-fault-controller, picknik-twist-controller, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, tf2-ros, xacro }:
+{ lib, buildRosPackage, fetchurl, _unresolved_picknik_reset_fault_controller, _unresolved_picknik_twist_controller, ament-cmake, controller-manager, joint-state-publisher, joint-state-publisher-gui, kortex-description, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-rolling-kinova-gen3-lite-moveit-config";
   version = "0.2.5-r2";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ controller-manager joint-state-publisher joint-state-publisher-gui kortex-description moveit-configs-utils moveit-kinematics moveit-planners moveit-ros-move-group moveit-ros-visualization moveit-ros-warehouse moveit-setup-assistant moveit-simple-controller-manager picknik-reset-fault-controller picknik-twist-controller robot-state-publisher rviz-common rviz-default-plugins rviz2 tf2-ros xacro ];
+  propagatedBuildInputs = [ _unresolved_picknik_reset_fault_controller _unresolved_picknik_twist_controller controller-manager joint-state-publisher joint-state-publisher-gui kortex-description moveit-configs-utils moveit-kinematics moveit-planners moveit-ros-move-group moveit-ros-visualization moveit-ros-warehouse moveit-setup-assistant moveit-simple-controller-manager robot-state-publisher rviz-common rviz-default-plugins rviz2 tf2-ros xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/kitti-metrics-eval/default.nix
+++ b/distros/rolling/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmath, mrpt-libposes, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-rolling-kitti-metrics-eval";
-  version = "3.0.0-r1";
+  version = "3.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/rolling/kitti_metrics_eval/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "d7b830cd98bf2651ccf70370b6a9cc095c49121bd2778d38a4ebd5210956ae94";
+    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/rolling/kitti_metrics_eval/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "a06ac311e2fbd5d33c5896a26124edde7299056ba8252b74792e0603a4adb64e";
   };
 
   buildType = "cmake";

--- a/distros/rolling/kortex-description/default.nix
+++ b/distros/rolling/kortex-description/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, gz-ros2-control, joint-state-publisher, joint-state-publisher-gui, joint-trajectory-controller, parallel-gripper-controller, picknik-reset-fault-controller, picknik-twist-controller, robot-state-publisher, robotiq-description, rviz2 }:
+{ lib, buildRosPackage, fetchurl, _unresolved_picknik_reset_fault_controller, _unresolved_picknik_twist_controller, ament-cmake, gz-ros2-control, joint-state-publisher, joint-state-publisher-gui, joint-trajectory-controller, parallel-gripper-controller, robot-state-publisher, robotiq-description, rviz2 }:
 buildRosPackage {
   pname = "ros-rolling-kortex-description";
   version = "0.2.5-r2";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ gz-ros2-control joint-state-publisher joint-state-publisher-gui joint-trajectory-controller parallel-gripper-controller picknik-reset-fault-controller picknik-twist-controller robot-state-publisher robotiq-description rviz2 ];
+  propagatedBuildInputs = [ _unresolved_picknik_reset_fault_controller _unresolved_picknik_twist_controller gz-ros2-control joint-state-publisher joint-state-publisher-gui joint-trajectory-controller parallel-gripper-controller robot-state-publisher robotiq-description rviz2 ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/leo-bringup/default.nix
+++ b/distros/rolling/leo-bringup/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-index-python, ament-lint-auto, geometry-msgs, image-proc, launch, launch-ros, leo-description, leo-filters, leo-fw, leo-msgs, python3Packages, robot-state-publisher, rosapi, rosbridge-server, sensor-msgs, web-video-server, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-index-python, ament-lint-auto, geometry-msgs, image-proc, launch, launch-ros, leo-description, leo-filters, leo-fw, leo-msgs, python3Packages, rclpy, robot-state-publisher, rosapi, rosbridge-server, sensor-msgs, tf-transformations, web-video-server, xacro }:
 buildRosPackage {
   pname = "ros-rolling-leo-bringup";
-  version = "2.5.0-r2";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/rolling/leo_bringup/2.5.0-2.tar.gz";
-    name = "2.5.0-2.tar.gz";
-    sha256 = "51fd69cacac1b998ad0598e9d448fafbbb4a6a37a0eccbfde34e74cbacb4967e";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/rolling/leo_bringup/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "617bcee5b9b8bf5ba07b27aeeab38bdd9cf174f0aa1cff667676edacafcdfdf2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-black ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ ament-index-python geometry-msgs image-proc launch launch-ros leo-description leo-filters leo-fw leo-msgs python3Packages.smbus2 robot-state-publisher rosapi rosbridge-server sensor-msgs web-video-server xacro ];
+  propagatedBuildInputs = [ ament-index-python geometry-msgs image-proc launch launch-ros leo-description leo-filters leo-fw leo-msgs python3Packages.smbus2 rclpy robot-state-publisher rosapi rosbridge-server sensor-msgs tf-transformations web-video-server xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/leo-filters/default.nix
+++ b/distros/rolling/leo-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, generate-parameter-library, geometry-msgs, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, std-srvs, tf2, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-leo-filters";
-  version = "2.5.0-r2";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/rolling/leo_filters/2.5.0-2.tar.gz";
-    name = "2.5.0-2.tar.gz";
-    sha256 = "ac66cdf547ac6484ea1047c5d45c357f9e12e302ad5ab8e55966a5a7c8f7810d";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/rolling/leo_filters/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "13d8613a8cef726bd402296384682174094e7e8fb933814f237cdde924a2dfdb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/leo-fw/default.nix
+++ b/distros/rolling/leo-fw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-pep257, ament-cmake-python, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-python, ament-lint-auto, geometry-msgs, leo-msgs, nav-msgs, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, ros2cli, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-leo-fw";
-  version = "2.5.0-r2";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/rolling/leo_fw/2.5.0-2.tar.gz";
-    name = "2.5.0-2.tar.gz";
-    sha256 = "473bc184b77be3d62f87e0ad80a695846ffec8bb1c187eafc714b26e5e367bbd";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/rolling/leo_fw/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "95efe6a8f93c5666a3576ba9638ed437fe43923a6e8e032ee059f379bccb0811";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/leo-robot/default.nix
+++ b/distros/rolling/leo-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, leo, leo-bringup, leo-filters, leo-fw }:
 buildRosPackage {
   pname = "ros-rolling-leo-robot";
-  version = "2.5.0-r2";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/rolling/leo_robot/2.5.0-2.tar.gz";
-    name = "2.5.0-2.tar.gz";
-    sha256 = "8e26031cab517f61b08ded4194b8eebaeb8f850a62a2d6236d829d7897de4946";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/rolling/leo_robot/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "3074fae107f73fe4dbe23a8c5690818107c46cf1d4d258e9be8dac906808e705";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/libtorch-vendor/default.nix
+++ b/distros/rolling/libtorch-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-libtorch-vendor";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/rolling/libtorch_vendor/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "ecb5de6e9a6dbe74b767091e7fee3a89ecf2a819e40821963062aa8068dbcc7e";
+    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/rolling/libtorch_vendor/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "ccc56928fed6cfa585d70a2417a5003f364e757e23d5be75e99384a3053de637";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/log-view/default.nix
+++ b/distros/rolling/log-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ncurses, rcl-interfaces, rclcpp, xclip, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-log-view";
-  version = "0.3.2-r1";
+  version = "0.3.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/log_view-release/archive/release/rolling/log_view/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "680ce50fa2c611e55eddcfcb6a267bb460a47b59069d66d808286b156c5ae804";
+    url = "https://github.com/ros2-gbp/log_view-release/archive/release/rolling/log_view/0.3.3-2.tar.gz";
+    name = "0.3.3-2.tar.gz";
+    sha256 = "58ade36ba2364d9b1b185bc2306fb3d89790ff7d8f704e068edd932c7e67d35c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-academic-datasets/default.nix
+++ b/distros/rolling/mola-academic-datasets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, kitti-metrics-eval, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset }:
 buildRosPackage {
   pname = "ros-rolling-mola-academic-datasets";
-  version = "3.0.0-r1";
+  version = "3.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/rolling/mola_academic_datasets/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "2401adccabea9c57da1014ac81489cf2df4b48d2f3276c3143b94dcbc91d2af3";
+    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/rolling/mola_academic_datasets/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "0d463f87d88d65db7eb4dc8b10fe6b82a7ac4d519119bc11a6bca31f93144af5";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-common/default.nix
+++ b/distros/rolling/mola-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-common";
-  version = "0.6.0-r2";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/rolling/mola_common/0.6.0-2.tar.gz";
-    name = "0.6.0-2.tar.gz";
-    sha256 = "5b5562b43be5c9bdba0a4d9aceb73e850fe718d62c3881a8a5f2fb0c464f8ef5";
+    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/rolling/mola_common/0.6.1-1.tar.gz";
+    name = "0.6.1-1.tar.gz";
+    sha256 = "7b513bbf406bf643cf9e530de47168a333bf84878327fa455e1baa598495c30c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-input-euroc-dataset/default.nix
+++ b/distros/rolling/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmath, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-euroc-dataset";
-  version = "3.0.0-r1";
+  version = "3.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/rolling/mola_input_euroc_dataset/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "78ccbdbad8bda9e19e22a560c51f63c1f09f30e649ba95982ec16ffba53625a9";
+    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/rolling/mola_input_euroc_dataset/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "df830766d237dd623ce951eced01824647908c5b10a9d84f4d0d30f2be139489";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-kitti-dataset/default.nix
+++ b/distros/rolling/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-kitti-dataset";
-  version = "3.0.0-r1";
+  version = "3.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/rolling/mola_input_kitti_dataset/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "4789e496dbbd946bade1bcb1ee11309542d0a414fefbbd59f102e508a0d6b54c";
+    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/rolling/mola_input_kitti_dataset/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "0744162fb2e92c07569006905e32263789c0c985f1f01110750dea3eda540504";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-kitti360-dataset/default.nix
+++ b/distros/rolling/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-kitti360-dataset";
-  version = "3.0.0-r1";
+  version = "3.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/rolling/mola_input_kitti360_dataset/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "68f18dc82044bc624171270cccd4e9afbb7d140358939e26edbe64cc1e112733";
+    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/rolling/mola_input_kitti360_dataset/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "f3acfd9c857089b0ed3e0dc7c649093a9e54924ce5a237777d85c6a1d5b05191";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-mulran-dataset/default.nix
+++ b/distros/rolling/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-mulran-dataset";
-  version = "3.0.0-r1";
+  version = "3.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/rolling/mola_input_mulran_dataset/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "a35fc6721913ad32e1b430951abf7ca8002301fdcc36d5208e497f01186ca66f";
+    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/rolling/mola_input_mulran_dataset/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "1b80b7a499bc8ccac27e3a9b8f646633469d6091ee70d80269941e4b286fc0fb";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-ouster/default.nix
+++ b/distros/rolling/mola-input-ouster/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, curl, eigen, flatbuffers, libpng, libtins, libzip, mola-kernel, mola-yaml, mrpt-libmaps, mrpt-libobs, openssl, zstd }:
+buildRosPackage {
+  pname = "ros-rolling-mola-input-ouster";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_input_ouster-release/archive/release/rolling/mola_input_ouster/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "f7bcc78693096e33a6f8c9659177c75391c159e234a6e64e0477161c79fa3fa5";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen flatbuffers libpng libtins libzip openssl zstd ];
+  propagatedBuildInputs = [ curl mola-kernel mola-yaml mrpt-libmaps mrpt-libobs ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "MOLA input module for Ouster LiDAR sensors using the native Ouster C++ SDK.
+    Provides direct sensor connection and PCAP replay without ROS middleware.";
+    license = with lib.licenses; [ "GPL-3.0" ];
+  };
+}

--- a/distros/rolling/mola-input-paris-luco-dataset/default.nix
+++ b/distros/rolling/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-paris-luco-dataset";
-  version = "3.0.0-r1";
+  version = "3.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/rolling/mola_input_paris_luco_dataset/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "5f9b2f16ed848bd1c6820c33ce3c866c38320750b1ed7729669981229f9dd2d6";
+    url = "https://github.com/ros2-gbp/mola_academic_datasets-release/archive/release/rolling/mola_input_paris_luco_dataset/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "f53dea536aa9f89ab1949fb1d1fcf3c6f26142f003f69a70e94be7a1611e1310";
   };
 
   buildType = "cmake";

--- a/distros/rolling/moveit-visual-tools/default.nix
+++ b/distros/rolling/moveit-visual-tools/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, graph-msgs, moveit-common, moveit-core, moveit-ros-planning, rclcpp, rviz-visual-tools, std-msgs, tf2-eigen, tf2-ros, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, _unresolved_rviz_visual_tools, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, graph-msgs, moveit-common, moveit-core, moveit-ros-planning, rclcpp, std-msgs, tf2-eigen, tf2-ros, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-visual-tools";
   version = "4.1.2-r2";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs graph-msgs moveit-common moveit-core moveit-ros-planning rclcpp rviz-visual-tools std-msgs tf2-eigen tf2-ros trajectory-msgs visualization-msgs ];
+  propagatedBuildInputs = [ _unresolved_rviz_visual_tools geometry-msgs graph-msgs moveit-common moveit-core moveit-ros-planning rclcpp std-msgs tf2-eigen tf2-ros trajectory-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/mrpt-generic-sensor/default.nix
+++ b/distros/rolling/mrpt-generic-sensor/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt-sensorlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-msgs, mrpt-sensorlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-generic-sensor";
-  version = "0.2.4-r2";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_generic_sensor/0.2.4-2.tar.gz";
-    name = "0.2.4-2.tar.gz";
-    sha256 = "e00f9fd95ddcc5ddbed07cd9436565822706e689b653d87eb312e573687129b1";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_generic_sensor/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "62f49feb0f740f8c2b43c3e70a211318be840012d05b69f2f2dfa7ba2387c090";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-msgs mrpt-sensorlib rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-msgs mrpt-sensorlib rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/mrpt-sensor-bumblebee-stereo/default.nix
+++ b/distros/rolling/mrpt-sensor-bumblebee-stereo/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, rclcpp-components, ros-environment, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-sensor-bumblebee-stereo";
-  version = "0.2.4-r2";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_sensor_bumblebee_stereo/0.2.4-2.tar.gz";
-    name = "0.2.4-2.tar.gz";
-    sha256 = "9d3e3e95c5f0053d4af6b9e71eb15782310e3499309809e48c1f6c163790c3ee";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_sensor_bumblebee_stereo/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "ad3f8dd033dfd3f1613fdb4581403bfa35ed79b99cc92e3750a2d9dedebd130b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib rclcpp-components tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/mrpt-sensor-gnss-nmea/default.nix
+++ b/distros/rolling/mrpt-sensor-gnss-nmea/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nmea-msgs, rclcpp-components, ros-environment, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-sensor-gnss-nmea";
-  version = "0.2.4-r2";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_sensor_gnss_nmea/0.2.4-2.tar.gz";
-    name = "0.2.4-2.tar.gz";
-    sha256 = "527611c954d1c49e5a01aecc7424d575178e743bd992d7206e5494852ba97e11";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_sensor_gnss_nmea/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "b99e4e01fa29496eee13a28cffe8f5241d2e55c52ee19d1a139907c747c71740";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs nmea-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nmea-msgs rclcpp-components tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/mrpt-sensor-gnss-novatel/default.nix
+++ b/distros/rolling/mrpt-sensor-gnss-novatel/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, novatel-oem6-msgs, rclcpp-components, ros-environment, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-sensor-gnss-novatel";
-  version = "0.2.4-r2";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_sensor_gnss_novatel/0.2.4-2.tar.gz";
-    name = "0.2.4-2.tar.gz";
-    sha256 = "68188111fb3b885b09530417c542a2b4c294a81f402cbc55e3643693ad16e94c";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_sensor_gnss_novatel/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "323d23afd5a34597a2cc18ce0b6e75d9214ef4354cc0ec1372437fcd691ac30b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib novatel-oem6-msgs rclcpp-components tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/mrpt-sensor-imu-taobotics/default.nix
+++ b/distros/rolling/mrpt-sensor-imu-taobotics/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, rclcpp-components, ros-environment, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-sensor-imu-taobotics";
-  version = "0.2.4-r2";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_sensor_imu_taobotics/0.2.4-2.tar.gz";
-    name = "0.2.4-2.tar.gz";
-    sha256 = "15d403a1070fea006988becec69d12f9ec7937a2caa53831dc2181992102ae33";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_sensor_imu_taobotics/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "9080952ab22cc7ec93011c736877c02bb41aca2d58d2223ae26374042da35188";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib rclcpp-components tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/mrpt-sensorlib/default.nix
+++ b/distros/rolling/mrpt-sensorlib/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, diagnostic-updater, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, rclcpp-components, ros-environment, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-sensorlib";
-  version = "0.2.4-r2";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_sensorlib/0.2.4-2.tar.gz";
-    name = "0.2.4-2.tar.gz";
-    sha256 = "4040c1979b8859765b5053f64614db2ad602e05d0724da1d0381787d8cabc5c3";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_sensorlib/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "0b1bbc425913e2c05724dcce56d1c8d3c0ce8bd649b8e683816c7859959417eb";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ diagnostic-updater mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs rclcpp-components tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/mrpt-sensors/default.nix
+++ b/distros/rolling/mrpt-sensors/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-generic-sensor, mrpt-sensor-bumblebee-stereo, mrpt-sensor-gnss-nmea, mrpt-sensor-gnss-novatel, mrpt-sensor-imu-taobotics, mrpt-sensorlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-generic-sensor, mrpt-sensor-bumblebee-stereo, mrpt-sensor-gnss-nmea, mrpt-sensor-gnss-novatel, mrpt-sensor-imu-taobotics, mrpt-sensorlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-sensors";
-  version = "0.2.4-r2";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_sensors/0.2.4-2.tar.gz";
-    name = "0.2.4-2.tar.gz";
-    sha256 = "1950d135f48781b85e90eca4098ba960de8606bdb44b9757677ca5e4808fc81a";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_sensors/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "3833bbc8f49cb3894bbdfb62cc77a1e951a483e9cdba5ffa320057c267482e7a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-generic-sensor mrpt-sensor-bumblebee-stereo mrpt-sensor-gnss-nmea mrpt-sensor-gnss-novatel mrpt-sensor-imu-taobotics mrpt-sensorlib ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-generic-sensor mrpt-sensor-bumblebee-stereo mrpt-sensor-gnss-nmea mrpt-sensor-gnss-novatel mrpt-sensor-imu-taobotics mrpt-sensorlib ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/novatel-oem6-msgs/default.nix
+++ b/distros/rolling/novatel-oem6-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-novatel-oem6-msgs";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/novatel_oem6_msgs/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "1ca0c1e44c1829baaa8786597a641a1c3c1925217542552252f5d86f5bebc5db";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-cmake-xmllint ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "ROS messages and services for Novatel OEM6";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/rosidlcpp-generator-c/default.nix
+++ b/distros/rolling/rosidlcpp-generator-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-ros-core, fmt, nlohmann_json, rcutils, ros-environment, rosidl-cmake, rosidl-generator-type-description, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp-generator-c";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_generator_c/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "c46b17c6f4dcc064ad06267cd8ff563727d3a0c633f66b86e0e95f2d4e954816";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_generator_c/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "f875ad173bc1d1ad7a0e96497dacd75c5bd3f25ce28d45eeb07e0eb0bd0e7f83";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidlcpp-generator-core/default.nix
+++ b/distros/rolling/rosidlcpp-generator-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, fmt, nlohmann_json, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp-generator-core";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_generator_core/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "18a8f8e1e3c2fa5ad0016ed437b4da0134be6e0649b98eb82ad8a34d2f50d4a7";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_generator_core/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "9c7b079c1d5b3466e0d774575743047dad87daa012a5edc8926e4f1283b448c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidlcpp-generator-cpp/default.nix
+++ b/distros/rolling/rosidlcpp-generator-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, fmt, nlohmann_json, rcutils, rosidl-cmake, rosidl-generator-type-description, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp-generator-cpp";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_generator_cpp/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "7017951c1023160869ca95c3b2c43d50fbb03cb1f33be5c32f6a0e82855c4fc6";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_generator_cpp/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "9bd434482fbd5147883293982ec1183fcd2790f8b369df4d1d75dd51a940ebc0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidlcpp-generator-py/default.nix
+++ b/distros/rolling/rosidlcpp-generator-py/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, fmt, nlohmann_json, python-cmake-module, rmw, rosidl-generator-c, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-c, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, fmt, nlohmann_json, rmw, rosidl-generator-c, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-c, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp-generator-py";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_generator_py/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "4d63b6f52878f54b655f349f1f00b73e6fb6be66b6c396d48f0d76d947fa93b4";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_generator_py/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "5e1044eec76490f35658c3d44be190e28cef5165f5af15c9d0e26e7ec57ac3ba";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ rosidl-runtime-c ];
-  propagatedBuildInputs = [ ament-cmake ament-index-python fmt nlohmann_json python-cmake-module rmw rosidl-generator-c rosidl-pycommon rosidl-typesupport-c rosidl-typesupport-interface rosidlcpp-generator-core rosidlcpp-parser ];
-  nativeBuildInputs = [ ament-cmake ament-index-python python-cmake-module rosidl-generator-c rosidl-pycommon rosidl-typesupport-c rosidl-typesupport-interface ];
+  propagatedBuildInputs = [ ament-cmake ament-index-python fmt nlohmann_json rmw rosidl-generator-c rosidl-pycommon rosidl-typesupport-c rosidl-typesupport-interface rosidlcpp-generator-core rosidlcpp-parser ];
+  nativeBuildInputs = [ ament-cmake ament-index-python rosidl-generator-c rosidl-pycommon rosidl-typesupport-c rosidl-typesupport-interface ];
 
   meta = {
     description = "Generate the ROS interfaces in Python.";

--- a/distros/rolling/rosidlcpp-generator-type-description/default.nix
+++ b/distros/rolling/rosidlcpp-generator-type-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, fmt, nlohmann_json, rcutils, rosidl-runtime-c, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp-generator-type-description";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_generator_type_description/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "0a86cb82f09938ff190fafd26447d7e5a71ad1b9bb8fc4e52ee26ae01ce0cf2c";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_generator_type_description/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "2b99c91511fcf44d81ba0d537bd0dfe794c9efa2baba672c87a4c50f989b68df";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidlcpp-parser/default.nix
+++ b/distros/rolling/rosidlcpp-parser/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, fmt, nlohmann_json }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, fmt, nlohmann_json, rosidl-pycommon }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp-parser";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_parser/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "193beda046eae5fab17d66590a764660ee3d5943f0cded80a16ea796efce2d7d";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_parser/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "165f2bf7464904945435c6c7f7dd8d12489884fe2a4dc5ce9c5e67da3ed6a44d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake fmt nlohmann_json ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-pycommon ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/rosidlcpp-typesupport-c/default.nix
+++ b/distros/rolling/rosidlcpp-typesupport-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-ros-core, ament-index-python, fmt, nlohmann_json, rcpputils, rcutils, ros-environment, rosidl-cli, rosidl-generator-c, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-c, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp-typesupport-c";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_typesupport_c/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "d1422093956e4c06d02f5b566538590cd54c4e844bcb20dd76a2aaf042d757dd";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_typesupport_c/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "a0016d7a9422a8422d7b410a445c5f024713bf50bd620bc4fffb9aba8beee0bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidlcpp-typesupport-cpp/default.nix
+++ b/distros/rolling/rosidlcpp-typesupport-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-ros-core, ament-index-python, fmt, nlohmann_json, rcpputils, rcutils, ros-environment, rosidl-cli, rosidl-generator-c, rosidl-generator-type-description, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-cpp, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp-typesupport-cpp";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_typesupport_cpp/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "2e9b8458372725149101161949a7448227fc96559449c66d34f4c6eb9e577134";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_typesupport_cpp/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "98b2c71dd6c25d17922ecfb6d54b071d6e074468bf3b094c4b2d4874af671b72";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidlcpp-typesupport-fastrtps-c/default.nix
+++ b/distros/rolling/rosidlcpp-typesupport-fastrtps-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-cmake-ros, fastcdr, fmt, nlohmann_json, rmw, rosidl-generator-c, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp-typesupport-fastrtps-c";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_typesupport_fastrtps_c/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "ad1b67d3a68c297300f37714c50371d3cf30f20162dfd7290bc14a0ce949eae0";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_typesupport_fastrtps_c/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "962c29cb96503c9673f48ade0ad9a663324cab85dff884910ea780390b2a177c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidlcpp-typesupport-fastrtps-cpp/default.nix
+++ b/distros/rolling/rosidlcpp-typesupport-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-cmake-ros, fastcdr, fmt, nlohmann_json, rmw, rosidl-generator-c, rosidl-generator-cpp, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp-typesupport-fastrtps-cpp";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_typesupport_fastrtps_cpp/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "e62e303f34159d759070446cfae1ada74ffd1e48f0c759192cd0ead803b3edd7";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_typesupport_fastrtps_cpp/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "6390246f7a9401424eb696b3a0ca960949ff81d57bc5ca9490c037aa99b85a0e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidlcpp-typesupport-introspection-c/default.nix
+++ b/distros/rolling/rosidlcpp-typesupport-introspection-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros-core, ament-index-python, fmt, nlohmann_json, ros-environment, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp-typesupport-introspection-c";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_typesupport_introspection_c/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "90a0e621fa041e92cc99a7f61d393cc76ff772cf5b0e8f7df059eb2cb9ee8573";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_typesupport_introspection_c/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "5f0d6979ff7d335dfa64630ddae367c40df3f316c88812f230d517f8f7f04fcc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidlcpp-typesupport-introspection-cpp/default.nix
+++ b/distros/rolling/rosidlcpp-typesupport-introspection-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros-core, ament-index-python, fmt, nlohmann_json, ros-environment, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidl-typesupport-introspection-c, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp-typesupport-introspection-cpp";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_typesupport_introspection_cpp/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "296e16738d94739cf3241e4c050de48c105a6262440b953f97db26028b25cfae";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp_typesupport_introspection_cpp/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "3b2544a16848f96b481f8d08f39e4416ab5371aed2b821a5c61cd6c6517237ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidlcpp/default.nix
+++ b/distros/rolling/rosidlcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, rosidlcpp-generator-c, rosidlcpp-generator-cpp, rosidlcpp-generator-py, rosidlcpp-generator-type-description, rosidlcpp-typesupport-c, rosidlcpp-typesupport-cpp, rosidlcpp-typesupport-fastrtps-c, rosidlcpp-typesupport-fastrtps-cpp, rosidlcpp-typesupport-introspection-c, rosidlcpp-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosidlcpp";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "d26ba0c18f4222b2e0387b215e2855942fad8314ce3d5fdf69d0383c75692d83";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/rolling/rosidlcpp/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "6dbd587f232a57ea55e643e26690ace4c30906d696ad041326ee2ce50f3617c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-image-overlay/default.nix
+++ b/distros/rolling/rqt-image-overlay/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, compressed-image-transport, image-transport, pluginlib, qt5, rclcpp, ros-image-to-qimage, rqt-gui, rqt-gui-cpp, rqt-image-overlay-layer, std-msgs }:
+{ lib, buildRosPackage, fetchurl, _unresolved_ros_image_to_qimage, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, compressed-image-transport, image-transport, pluginlib, qt5, rclcpp, rqt-gui, rqt-gui-cpp, rqt-image-overlay-layer, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-image-overlay";
   version = "0.5.0-r2";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common compressed-image-transport std-msgs ];
-  propagatedBuildInputs = [ image-transport pluginlib qt5.qtbase rclcpp ros-image-to-qimage rqt-gui rqt-gui-cpp rqt-image-overlay-layer ];
+  propagatedBuildInputs = [ _unresolved_ros_image_to_qimage image-transport pluginlib qt5.qtbase rclcpp rqt-gui rqt-gui-cpp rqt-image-overlay-layer ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/rqt-topic/default.nix
+++ b/distros/rolling/rqt-topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-xmllint, python-qt-binding, python3Packages, rclpy, ros2topic, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-rolling-rqt-topic";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_topic-release/archive/release/rolling/rqt_topic/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "9286b4665cc306fbf413969adfb86c000f9480ed091554b6a7591ea3cefb4643";
+    url = "https://github.com/ros2-gbp/rqt_topic-release/archive/release/rolling/rqt_topic/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "a42043c2dbe8618d29940594c3f62d9165a4f97198b64b9b0348b78b67a933f6";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/tensor-msgs/default.nix
+++ b/distros/rolling/tensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-tensor-msgs";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/rolling/tensor_msgs/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "ed41d42afa2406fa0e79542ed799d3e120f7db3318bed9f93c29ddd71929d608";
+    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/rolling/tensor_msgs/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "b36a6019de9e0f40bfa311f3549cdb3f857e077e1cbf72d8ab46c6adc132d570";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/topic-tools-interfaces/default.nix
+++ b/distros/rolling/topic-tools-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-topic-tools-interfaces";
-  version = "1.4.4-r2";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/rolling/topic_tools_interfaces/1.4.4-2.tar.gz";
-    name = "1.4.4-2.tar.gz";
-    sha256 = "550db312749dd661e7b555c3d3e2fdca5895f14f92ce6d2be5f4304df17b7032";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/rolling/topic_tools_interfaces/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "922e42b5a8a3157fb3be1bc1987680580187f55475d69315138e2d790cb3f08d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/topic-tools/default.nix
+++ b/distros/rolling/topic-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclpy, ros2cli, ros2topic, rosidl-default-generators, rosidl-runtime-py, std-msgs, topic-tools-interfaces }:
 buildRosPackage {
   pname = "ros-rolling-topic-tools";
-  version = "1.4.4-r2";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/rolling/topic_tools/1.4.4-2.tar.gz";
-    name = "1.4.4-2.tar.gz";
-    sha256 = "ae0e11e56d1deec4316bc90f9a5139a3444cdd75796be0f6d59655f004d8436b";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/rolling/topic_tools/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "fd5d71c266da9a53a29cc971e445caa3b9dcf4dafcb9a2c668ac76f4f85c38b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/torch-conversions/default.nix
+++ b/distros/rolling/torch-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-testing-ament-cmake, libtorch-vendor, rclcpp, rclcpp-components, rcutils, rmw, rosidl-buffer, std-msgs, tensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-torch-conversions";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/rolling/torch_conversions/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "41891b696c55b84b845419c58d1f6a8a922ffcec8bc9f59c0521651faf0911f7";
+    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/rolling/torch_conversions/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "3d6a24c7771aa14d9c55995f97a5f85d5c1ae32ddfbf6aebe91c20670f7a16b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-client-library/default.nix
+++ b/distros/rolling/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-rolling-ur-client-library";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/rolling/ur_client_library/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "dd424b8c1ab2da90c3aae1a07e5d64566736f85a9e05bd2637f0fb04a32a7a0e";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/rolling/ur_client_library/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "77d82408ed38e2fde2097baa111cdabdfee4f1958897dc8b8b23d79b42d619a2";
   };
 
   buildType = "cmake";

--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
     "rosdistro": {
       "flake": false,
       "locked": {
-        "lastModified": 1778803943,
-        "narHash": "sha256-yC8eCVZrBr4/qqXamjEWWhUGAd5L9MdmJy+2XYi+mQU=",
+        "lastModified": 1779440547,
+        "narHash": "sha256-zwkFhi7/rGJ1DPykUsulXnAJXFxbR5YQO10GuFUEBfo=",
         "owner": "ros",
         "repo": "rosdistro",
-        "rev": "d0289235417ac482484d84136074d6344ac9d2bc",
+        "rev": "7111412b11e86fbb1751db4c4955d798f95e5cf3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'kilted', 'lyrical', 'rolling'] from nix-ros-overlay commit baf83478983da4a828e07d1179c2e76e46c4632c.
This pull request was generated by running the following command:

```
superflore-gen-nix --dry-run --output-repository-path . --all --tar-archive-dir /home/runner/.ros/tar --upstream-branch develop
```

Changes:
========
Humble Changes:
---------------
* *agnocast 2.3.3-r1 --> 2.3.4-r1*
* *agnocast-cie-config-msgs 2.3.3-r1 --> 2.3.4-r1*
* *agnocast-cie-thread-configurator 2.3.3-r1 --> 2.3.4-r1*
* *agnocast-components 2.3.3-r1 --> 2.3.4-r1*
* *agnocast-e2e-test 2.3.3-r1 --> 2.3.4-r1*
* *agnocast-ioctl-wrapper 2.3.3-r1 --> 2.3.4-r1*
* *agnocast-sample-application 2.3.3-r1 --> 2.3.4-r1*
* *agnocast-sample-interfaces 2.3.3-r1 --> 2.3.4-r1*
* *agnocastlib 2.3.3-r1 --> 2.3.4-r1*
* *compass-msgs 0.2.3-r1 --> 0.2.4-r1*
* *crocoddyl 3.2.1-r2*
* *depthai-bridge-v3 3.1.1-r1 --> 3.2.1-r1*
* *depthai-descriptions-v3 3.1.1-r1 --> 3.2.1-r1*
* *depthai-examples-v3 3.1.1-r1 --> 3.2.1-r1*
* *depthai-filters-v3 3.1.1-r1 --> 3.2.1-r1*
* *depthai-ros-driver-v3 3.1.1-r1 --> 3.2.1-r1*
* *depthai-ros-msgs-v3 3.1.1-r1 --> 3.2.1-r1*
* *depthai-ros-v3 3.1.1-r1 --> 3.2.1-r1*
* *fusioncore-core 0.2.3-r1 --> 0.2.4-r1*
* *fusioncore-datasets 0.2.3-r1 --> 0.2.4-r1*
* *fusioncore-gazebo 0.2.3-r1 --> 0.2.4-r1*
* *fusioncore-ros 0.2.3-r1 --> 0.2.4-r1*
* *kitti-metrics-eval 2.8.0-r1 --> 3.0.0-r2*
* *log-view 0.3.2-r1 --> 0.3.3-r1*
* *mola-academic-datasets 3.0.0-r2*
* *mola-common 0.6.0-r2 --> 0.6.1-r1*
* *mola-input-euroc-dataset 2.8.0-r1 --> 3.0.0-r2*
* *mola-input-kitti-dataset 2.8.0-r1 --> 3.0.0-r2*
* *mola-input-kitti360-dataset 2.8.0-r1 --> 3.0.0-r2*
* *mola-input-mulran-dataset 2.8.0-r1 --> 3.0.0-r2*
* *mola-input-ouster 0.1.0-r1*
* *mola-input-paris-luco-dataset 2.8.0-r1 --> 3.0.0-r2*
* *mrpt-apps 2.15.17-r1 --> 2.15.18-r1*
* *mrpt-generic-sensor 0.2.4-r1 --> 0.3.0-r1*
* *mrpt-libapps 2.15.17-r1 --> 2.15.18-r1*
* *mrpt-libbase 2.15.17-r1 --> 2.15.18-r1*
* *mrpt-libgui 2.15.17-r1 --> 2.15.18-r1*
* *mrpt-libhwdrivers 2.15.17-r1 --> 2.15.18-r1*
* *mrpt-libmaps 2.15.17-r1 --> 2.15.18-r1*
* *mrpt-libmath 2.15.17-r1 --> 2.15.18-r1*
* *mrpt-libnav 2.15.17-r1 --> 2.15.18-r1*
* *mrpt-libobs 2.15.17-r1 --> 2.15.18-r1*
* *mrpt-libopengl 2.15.17-r1 --> 2.15.18-r1*
* *mrpt-libposes 2.15.17-r1 --> 2.15.18-r1*
* *mrpt-libslam 2.15.17-r1 --> 2.15.18-r1*
* *mrpt-libtclap 2.15.17-r1 --> 2.15.18-r1*
* *mrpt-sensor-bumblebee-stereo 0.2.4-r1 --> 0.3.0-r1*
* *mrpt-sensor-gnss-nmea 0.2.4-r1 --> 0.3.0-r1*
* *mrpt-sensor-gnss-novatel 0.2.4-r1 --> 0.3.0-r1*
* *mrpt-sensor-imu-taobotics 0.2.4-r1 --> 0.3.0-r1*
* *mrpt-sensorlib 0.2.4-r1 --> 0.3.0-r1*
* *mrpt-sensors 0.2.4-r1 --> 0.3.0-r1*
* *novatel-oem6-msgs 0.3.0-r1*
* *ros2agnocast 2.3.3-r1 --> 2.3.4-r1*
* *sync-tooling-msgs 0.2.7-r1 --> 0.2.9-r1*
* *topic-tools 1.1.1-r1 --> 1.1.2-r1*
* *topic-tools-interfaces 1.1.1-r1 --> 1.1.2-r1*
* *ur-client-library 2.11.0-r1 --> 2.12.0-r1*

Jazzy Changes:
--------------
* *agnocast 2.3.3-r1 --> 2.3.4-r1*
* *agnocast-cie-config-msgs 2.3.3-r1 --> 2.3.4-r1*
* *agnocast-cie-thread-configurator 2.3.3-r1 --> 2.3.4-r1*
* *agnocast-components 2.3.3-r1 --> 2.3.4-r1*
* *agnocast-e2e-test 2.3.3-r1 --> 2.3.4-r1*
* *agnocast-ioctl-wrapper 2.3.3-r1 --> 2.3.4-r1*
* *agnocast-sample-application 2.3.3-r1 --> 2.3.4-r1*
* *agnocast-sample-interfaces 2.3.3-r1 --> 2.3.4-r1*
* *agnocastlib 2.3.3-r1 --> 2.3.4-r1*
* *ament-index-cpp 1.8.3-r1 --> 1.8.4-r1*
* *ament-index-python 1.8.3-r1 --> 1.8.4-r1*
* *battery-state-broadcaster 1.0.2-r1 --> 1.2.0-r1*
* *battery-state-rviz-overlay 1.0.2-r1 --> 1.2.0-r1*
* *clearpath-bms-broadcaster 2.9.6-r1 --> 2.9.7-r1*
* *clearpath-bt-joy 2.9.6-r1 --> 2.9.7-r1*
* *clearpath-common 2.9.6-r1 --> 2.9.7-r1*
* *clearpath-config 2.9.1-r1 --> 2.9.2-r1*
* *clearpath-control 2.9.6-r1 --> 2.9.7-r1*
* *clearpath-customization 2.9.6-r1 --> 2.9.7-r1*
* *clearpath-description 2.9.6-r1 --> 2.9.7-r1*
* *clearpath-diagnostics 2.9.6-r1 --> 2.9.7-r1*
* *clearpath-generator-common 2.9.6-r1 --> 2.9.7-r1*
* *clearpath-generator-gz 2.9.1-r1 --> 2.9.2-r1*
* *clearpath-gz 2.9.1-r1 --> 2.9.2-r1*
* *clearpath-manipulators 2.9.6-r1 --> 2.9.7-r1*
* *clearpath-manipulators-description 2.9.6-r1 --> 2.9.7-r1*
* *clearpath-mounts-description 2.9.6-r1 --> 2.9.7-r1*
* *clearpath-platform-description 2.9.6-r1 --> 2.9.7-r1*
* *clearpath-sensors-description 2.9.6-r1 --> 2.9.7-r1*
* *clearpath-simulator 2.9.1-r1 --> 2.9.2-r1*
* *compass-msgs 0.2.3-r1 --> 0.2.4-r1*
* *crocoddyl 3.2.1-r2*
* *depthai-bridge-v3 3.2.0-r1 --> 3.2.1-r1*
* *depthai-descriptions-v3 3.2.0-r1 --> 3.2.1-r1*
* *depthai-examples-v3 3.2.0-r1 --> 3.2.1-r1*
* *depthai-filters-v3 3.2.0-r1 --> 3.2.1-r1*
* *depthai-ros-driver-v3 3.2.0-r1 --> 3.2.1-r1*
* *depthai-ros-msgs-v3 3.2.0-r1 --> 3.2.1-r1*
* *depthai-ros-v3 3.2.0-r1 --> 3.2.1-r1*
* *fusioncore-core 0.2.3-r1 --> 0.2.4-r1*
* *fusioncore-datasets 0.2.3-r1 --> 0.2.4-r1*
* *fusioncore-gazebo 0.2.3-r1 --> 0.2.4-r1*
* *fusioncore-ros 0.2.3-r1 --> 0.2.4-r1*
* *kitti-metrics-eval 3.0.0-r1 --> 3.0.0-r2*
* *leo-bringup 2.5.1-r1 --> 2.6.1-r1*
* *leo-filters 2.5.1-r1 --> 2.6.1-r1*
* *leo-fw 2.5.1-r1 --> 2.6.1-r1*
* *leo-robot 2.5.1-r1 --> 2.6.1-r1*
* *log-view 0.3.2-r1 --> 0.3.3-r1*
* *mola-academic-datasets 3.0.0-r1 --> 3.0.0-r2*
* *mola-common 0.6.0-r2 --> 0.6.1-r1*
* *mola-input-euroc-dataset 3.0.0-r1 --> 3.0.0-r2*
* *mola-input-kitti-dataset 3.0.0-r1 --> 3.0.0-r2*
* *mola-input-kitti360-dataset 3.0.0-r1 --> 3.0.0-r2*
* *mola-input-mulran-dataset 3.0.0-r1 --> 3.0.0-r2*
* *mola-input-ouster 0.1.0-r1*
* *mola-input-paris-luco-dataset 3.0.0-r1 --> 3.0.0-r2*
* *mrpt-generic-sensor 0.2.4-r1 --> 0.3.0-r1*
* *mrpt-sensor-bumblebee-stereo 0.2.4-r1 --> 0.3.0-r1*
* *mrpt-sensor-gnss-nmea 0.2.4-r1 --> 0.3.0-r1*
* *mrpt-sensor-gnss-novatel 0.2.4-r1 --> 0.3.0-r1*
* *mrpt-sensor-imu-taobotics 0.2.4-r1 --> 0.3.0-r1*
* *mrpt-sensorlib 0.2.4-r1 --> 0.3.0-r1*
* *mrpt-sensors 0.2.4-r1 --> 0.3.0-r1*
* *novatel-oem6-msgs 0.3.0-r1*
* *ros2agnocast 2.3.3-r1 --> 2.3.4-r1*
* *sync-tooling-msgs 0.2.7-r1 --> 0.2.9-r1*
* *topic-tools 1.3.3-r1 --> 1.3.4-r1*
* *topic-tools-interfaces 1.3.3-r1 --> 1.3.4-r1*
* *ur-client-library 2.11.0-r1 --> 2.12.0-r1*

Kilted Changes:
---------------
* *ament-index-cpp 1.11.3-r1 --> 1.11.4-r1*
* *ament-index-python 1.11.3-r1 --> 1.11.4-r1*
* *crocoddyl 3.2.1-r2*
* *depthai-bridge 3.2.0-r1 --> 3.2.1-r1*
* *depthai-descriptions 3.2.0-r1 --> 3.2.1-r1*
* *depthai-examples 3.2.0-r1 --> 3.2.1-r1*
* *depthai-filters 3.2.0-r1 --> 3.2.1-r1*
* *depthai-ros 3.2.0-r1 --> 3.2.1-r1*
* *depthai-ros-driver 3.2.0-r1 --> 3.2.1-r1*
* *depthai-ros-msgs 3.2.0-r1 --> 3.2.1-r1*
* *flexbe-behavior-engine 4.1.3-r1 --> 4.1.4-r1*
* *flexbe-core 4.1.3-r1 --> 4.1.4-r1*
* *flexbe-input 4.1.3-r1 --> 4.1.4-r1*
* *flexbe-mirror 4.1.3-r1 --> 4.1.4-r1*
* *flexbe-msgs 4.1.3-r1 --> 4.1.4-r1*
* *flexbe-onboard 4.1.3-r1 --> 4.1.4-r1*
* *flexbe-states 4.1.3-r1 --> 4.1.4-r1*
* *flexbe-testing 4.1.3-r1 --> 4.1.4-r1*
* *flexbe-widget 4.1.3-r1 --> 4.1.4-r1*
* *leo-bringup 2.5.0-r1 --> 2.6.1-r1*
* *leo-filters 2.5.0-r1 --> 2.6.1-r1*
* *leo-fw 2.5.0-r1 --> 2.6.1-r1*
* *leo-robot 2.5.0-r1 --> 2.6.1-r1*
* *mola 2.8.0-r1 --> 2.9.0-r1*
* *mola-bridge-ros2 2.8.0-r1 --> 2.9.0-r1*
* *mola-common 0.6.0-r1 --> 0.6.1-r1*
* *mola-demos 2.8.0-r1 --> 2.9.0-r1*
* *mola-input-lidar-bin-dataset 2.8.0-r1 --> 2.9.0-r1*
* *mola-input-ouster 0.1.0-r1*
* *mola-input-rawlog 2.8.0-r1 --> 2.9.0-r1*
* *mola-input-rosbag2 2.8.0-r1 --> 2.9.0-r1*
* *mola-input-video 2.8.0-r1 --> 2.9.0-r1*
* *mola-kernel 2.8.0-r1 --> 2.9.0-r1*
* *mola-launcher 2.8.0-r1 --> 2.9.0-r1*
* *mola-metric-maps 2.8.0-r1 --> 2.9.0-r1*
* *mola-msgs 2.8.0-r1 --> 2.9.0-r1*
* *mola-pose-list 2.8.0-r1 --> 2.9.0-r1*
* *mola-relocalization 2.8.0-r1 --> 2.9.0-r1*
* *mola-traj-tools 2.8.0-r1 --> 2.9.0-r1*
* *mola-viz 2.8.0-r1 --> 2.9.0-r1*
* *mola-viz-imgui 2.9.0-r1*
* *mola-yaml 2.8.0-r1 --> 2.9.0-r1*
* *mrpt-generic-sensor 0.2.4-r1 --> 0.3.0-r1*
* *mrpt-sensor-bumblebee-stereo 0.2.4-r1 --> 0.3.0-r1*
* *mrpt-sensor-gnss-nmea 0.2.4-r1 --> 0.3.0-r1*
* *mrpt-sensor-gnss-novatel 0.2.4-r1 --> 0.3.0-r1*
* *mrpt-sensor-imu-taobotics 0.2.4-r1 --> 0.3.0-r1*
* *mrpt-sensorlib 0.2.4-r1 --> 0.3.0-r1*
* *mrpt-sensors 0.2.4-r1 --> 0.3.0-r1*
* *novatel-oem6-msgs 0.3.0-r1*
* *topic-tools 1.4.2-r2 --> 1.4.5-r1*
* *topic-tools-interfaces 1.4.2-r2 --> 1.4.5-r1*
* *ur-client-library 2.11.0-r1 --> 2.12.0-r1*

Lyrical Changes:
----------------
* *action-msgs 2.4.4-r3 --> 2.4.5-r1*
* *ament-clang-format 0.20.5-r4 --> 0.20.6-r1*
* *ament-clang-tidy 0.20.5-r4 --> 0.20.6-r1*
* *ament-cmake-clang-format 0.20.5-r4 --> 0.20.6-r1*
* *ament-cmake-clang-tidy 0.20.5-r4 --> 0.20.6-r1*
* *ament-cmake-copyright 0.20.5-r4 --> 0.20.6-r1*
* *ament-cmake-cppcheck 0.20.5-r4 --> 0.20.6-r1*
* *ament-cmake-cpplint 0.20.5-r4 --> 0.20.6-r1*
* *ament-cmake-flake8 0.20.5-r4 --> 0.20.6-r1*
* *ament-cmake-lint-cmake 0.20.5-r4 --> 0.20.6-r1*
* *ament-cmake-mypy 0.20.5-r4 --> 0.20.6-r1*
* *ament-cmake-pclint 0.20.5-r4 --> 0.20.6-r1*
* *ament-cmake-pep257 0.20.5-r4 --> 0.20.6-r1*
* *ament-cmake-pycodestyle 0.20.5-r4 --> 0.20.6-r1*
* *ament-cmake-pyflakes 0.20.5-r4 --> 0.20.6-r1*
* *ament-cmake-uncrustify 0.20.5-r4 --> 0.20.6-r1*
* *ament-cmake-xmllint 0.20.5-r4 --> 0.20.6-r1*
* *ament-copyright 0.20.5-r4 --> 0.20.6-r1*
* *ament-cppcheck 0.20.5-r4 --> 0.20.6-r1*
* *ament-cpplint 0.20.5-r4 --> 0.20.6-r1*
* *ament-flake8 0.20.5-r4 --> 0.20.6-r1*
* *ament-lint 0.20.5-r4 --> 0.20.6-r1*
* *ament-lint-auto 0.20.5-r4 --> 0.20.6-r1*
* *ament-lint-cmake 0.20.5-r4 --> 0.20.6-r1*
* *ament-lint-common 0.20.5-r4 --> 0.20.6-r1*
* *ament-mypy 0.20.5-r4 --> 0.20.6-r1*
* *ament-pclint 0.20.5-r4 --> 0.20.6-r1*
* *ament-pep257 0.20.5-r4 --> 0.20.6-r1*
* *ament-pycodestyle 0.20.5-r4 --> 0.20.6-r1*
* *ament-pyflakes 0.20.5-r4 --> 0.20.6-r1*
* *ament-uncrustify 0.20.5-r4 --> 0.20.6-r1*
* *ament-xmllint 0.20.5-r4 --> 0.20.6-r1*
* *builtin-interfaces 2.4.4-r3 --> 2.4.5-r1*
* *cm-topic-hardware-component 1.0.0-r3 --> 1.1.0-r1*
* *composition-interfaces 2.4.4-r3 --> 2.4.5-r1*
* *compressed-depth-image-transport 6.2.4-r3 --> 6.2.5-r1*
* *compressed-image-transport 6.2.4-r3 --> 6.2.5-r1*
* *cuda-buffer 0.1.1-r1*
* *cuda-buffer-backend 0.1.1-r1*
* *cuda-buffer-backend-msgs 0.1.1-r1*
* *event-camera-tools 3.1.2-r3 --> 3.1.5-r2*
* *flexbe-behavior-engine 4.0.3-r3 --> 4.1.4-r1*
* *flexbe-core 4.0.3-r3 --> 4.1.4-r1*
* *flexbe-input 4.0.3-r3 --> 4.1.4-r1*
* *flexbe-mirror 4.0.3-r3 --> 4.1.4-r1*
* *flexbe-msgs 4.0.3-r3 --> 4.1.4-r1*
* *flexbe-onboard 4.0.3-r3 --> 4.1.4-r1*
* *flexbe-states 4.0.3-r3 --> 4.1.4-r1*
* *flexbe-testing 4.0.3-r3 --> 4.1.4-r1*
* *flexbe-widget 4.0.3-r3 --> 4.1.4-r1*
* *frequency-cam 3.1.0-r3 --> 3.1.2-r2*
* *fuse 1.3.1-r3 --> 1.3.3-r1*
* *fuse-constraints 1.3.1-r3 --> 1.3.3-r1*
* *fuse-core 1.3.1-r3 --> 1.3.3-r1*
* *fuse-doc 1.3.1-r3 --> 1.3.3-r1*
* *fuse-graphs 1.3.1-r3 --> 1.3.3-r1*
* *fuse-loss 1.3.1-r3 --> 1.3.3-r1*
* *fuse-models 1.3.1-r3 --> 1.3.3-r1*
* *fuse-msgs 1.3.1-r3 --> 1.3.3-r1*
* *fuse-optimizers 1.3.1-r3 --> 1.3.3-r1*
* *fuse-publishers 1.3.1-r3 --> 1.3.3-r1*
* *fuse-tutorials 1.3.1-r3 --> 1.3.3-r1*
* *fuse-variables 1.3.1-r3 --> 1.3.3-r1*
* *fuse-viz 1.3.1-r3 --> 1.3.3-r1*
* *generate-parameter-library 1.0.1-r1 --> 1.1.0-r1*
* *generate-parameter-library-py 1.0.1-r1 --> 1.1.0-r1*
* *gz-ros2-control 3.0.7-r3 --> 3.0.8-r1*
* *gz-ros2-control-demos 3.0.7-r3 --> 3.0.8-r1*
* *image-transport-plugins 6.2.4-r3 --> 6.2.5-r1*
* *joint-state-topic-hardware-interface 1.0.0-r3 --> 1.1.0-r1*
* *kinematics-interface 2.4.0-r4 --> 2.4.2-r1*
* *kinematics-interface-kdl 2.4.0-r4 --> 2.4.2-r1*
* *kinematics-interface-pinocchio 2.4.0-r4 --> 2.4.2-r1*
* *libtorch-vendor 0.1.1-r1*
* *lifecycle-msgs 2.4.4-r3 --> 2.4.5-r1*
* *message-filters 7.4.0-r1 --> 7.4.1-r1*
* *mola-common 0.6.0-r2 --> 0.6.1-r1*
* *mrpt-apps 2.15.17-r2 --> 2.15.18-r1*
* *mrpt-libapps 2.15.17-r2 --> 2.15.18-r1*
* *mrpt-libbase 2.15.17-r2 --> 2.15.18-r1*
* *mrpt-libgui 2.15.17-r2 --> 2.15.18-r1*
* *mrpt-libhwdrivers 2.15.17-r2 --> 2.15.18-r1*
* *mrpt-libmaps 2.15.17-r2 --> 2.15.18-r1*
* *mrpt-libmath 2.15.17-r2 --> 2.15.18-r1*
* *mrpt-libnav 2.15.17-r2 --> 2.15.18-r1*
* *mrpt-libobs 2.15.17-r2 --> 2.15.18-r1*
* *mrpt-libopengl 2.15.17-r2 --> 2.15.18-r1*
* *mrpt-libposes 2.15.17-r2 --> 2.15.18-r1*
* *mrpt-libslam 2.15.17-r2 --> 2.15.18-r1*
* *mrpt-libtclap 2.15.17-r2 --> 2.15.18-r1*
* *persist-parameter-server 1.0.5-r3 --> 4.0.0-r2*
* *plotjuggler 3.14.4-r3 --> 3.17.2-r1*
* *rcl-interfaces 2.4.4-r3 --> 2.4.5-r1*
* *rmw-fastrtps-cpp 9.4.7-r3 --> 9.4.8-r1*
* *rmw-fastrtps-dynamic-cpp 9.4.7-r3 --> 9.4.8-r1*
* *rmw-fastrtps-shared-cpp 9.4.7-r3 --> 9.4.8-r1*
* *robot-arm-demo 0.1.0-r1*
* *rosgraph-msgs 2.4.4-r3 --> 2.4.5-r1*
* *rqt-bag 2.2.2-r3 --> 2.2.3-r1*
* *rqt-bag-plugins 2.2.2-r3 --> 2.2.3-r1*
* *rqt-topic 2.1.0-r3 --> 2.1.1-r1*
* *rviz-common 15.2.2-r3 --> 15.2.3-r1*
* *rviz-default-plugins 15.2.2-r3 --> 15.2.3-r1*
* *rviz-ogre-vendor 15.2.2-r3 --> 15.2.3-r1*
* *rviz-rendering 15.2.2-r3 --> 15.2.3-r1*
* *rviz-rendering-tests 15.2.2-r3 --> 15.2.3-r1*
* *rviz-visual-testing-framework 15.2.2-r3 --> 15.2.3-r1*
* *rviz2 15.2.2-r3 --> 15.2.3-r1*
* *service-msgs 2.4.4-r3 --> 2.4.5-r1*
* *statistics-msgs 2.4.4-r3 --> 2.4.5-r1*
* *tcb-span 2.0.2-r3 --> 2.0.3-r1*
* *tensor-msgs 0.1.1-r1*
* *test-msgs 2.4.4-r3 --> 2.4.5-r1*
* *theora-image-transport 6.2.4-r3 --> 6.2.5-r1*
* *topic-tools 1.4.4-r3 --> 1.5.0-r1*
* *topic-tools-interfaces 1.4.4-r3 --> 1.5.0-r1*
* *torch-conversions 0.1.1-r1*
* *type-description-interfaces 2.4.4-r3 --> 2.4.5-r1*
* *ur 5.0.0-r3 --> 6.0.0-r1*
* *ur-calibration 5.0.0-r3 --> 6.0.0-r1*
* *ur-controllers 5.0.0-r3 --> 6.0.0-r1*
* *ur-dashboard-msgs 5.0.0-r3 --> 6.0.0-r1*
* *ur-moveit-config 5.0.0-r3 --> 6.0.0-r1*
* *ur-robot-driver 5.0.0-r3 --> 6.0.0-r1*
* *zstd-image-transport 6.2.4-r3 --> 6.2.5-r1*

Rolling Changes:
----------------
* *ament-clang-format 0.21.0-r1 --> 0.21.1-r1*
* *ament-clang-tidy 0.21.0-r1 --> 0.21.1-r1*
* *ament-cmake-clang-format 0.21.0-r1 --> 0.21.1-r1*
* *ament-cmake-clang-tidy 0.21.0-r1 --> 0.21.1-r1*
* *ament-cmake-copyright 0.21.0-r1 --> 0.21.1-r1*
* *ament-cmake-cppcheck 0.21.0-r1 --> 0.21.1-r1*
* *ament-cmake-cpplint 0.21.0-r1 --> 0.21.1-r1*
* *ament-cmake-flake8 0.21.0-r1 --> 0.21.1-r1*
* *ament-cmake-lint-cmake 0.21.0-r1 --> 0.21.1-r1*
* *ament-cmake-mypy 0.21.0-r1 --> 0.21.1-r1*
* *ament-cmake-pclint 0.21.0-r1 --> 0.21.1-r1*
* *ament-cmake-pep257 0.21.0-r1 --> 0.21.1-r1*
* *ament-cmake-pycodestyle 0.21.0-r1 --> 0.21.1-r1*
* *ament-cmake-pyflakes 0.21.0-r1 --> 0.21.1-r1*
* *ament-cmake-uncrustify 0.21.0-r1 --> 0.21.1-r1*
* *ament-cmake-xmllint 0.21.0-r1 --> 0.21.1-r1*
* *ament-copyright 0.21.0-r1 --> 0.21.1-r1*
* *ament-cppcheck 0.21.0-r1 --> 0.21.1-r1*
* *ament-cpplint 0.21.0-r1 --> 0.21.1-r1*
* *ament-flake8 0.21.0-r1 --> 0.21.1-r1*
* *ament-lint 0.21.0-r1 --> 0.21.1-r1*
* *ament-lint-auto 0.21.0-r1 --> 0.21.1-r1*
* *ament-lint-cmake 0.21.0-r1 --> 0.21.1-r1*
* *ament-lint-common 0.21.0-r1 --> 0.21.1-r1*
* *ament-mypy 0.21.0-r1 --> 0.21.1-r1*
* *ament-pclint 0.21.0-r1 --> 0.21.1-r1*
* *ament-pep257 0.21.0-r1 --> 0.21.1-r1*
* *ament-pycodestyle 0.21.0-r1 --> 0.21.1-r1*
* *ament-pyflakes 0.21.0-r1 --> 0.21.1-r1*
* *ament-uncrustify 0.21.0-r1 --> 0.21.1-r1*
* *ament-xmllint 0.21.0-r1 --> 0.21.1-r1*
* *cuda-buffer 0.1.0-r1 --> 0.1.1-r1*
* *cuda-buffer-backend 0.1.0-r1 --> 0.1.1-r1*
* *cuda-buffer-backend-msgs 0.1.0-r1 --> 0.1.1-r1*
* *flexbe-behavior-engine 4.0.3-r2 --> 4.1.4-r1*
* *flexbe-core 4.0.3-r2 --> 4.1.4-r1*
* *flexbe-input 4.0.3-r2 --> 4.1.4-r1*
* *flexbe-mirror 4.0.3-r2 --> 4.1.4-r1*
* *flexbe-msgs 4.0.3-r2 --> 4.1.4-r1*
* *flexbe-onboard 4.0.3-r2 --> 4.1.4-r1*
* *flexbe-states 4.0.3-r2 --> 4.1.4-r1*
* *flexbe-testing 4.0.3-r2 --> 4.1.4-r1*
* *flexbe-widget 4.0.3-r2 --> 4.1.4-r1*
* *geodesy 1.0.6-r2 --> 1.0.7-r4*
* *geographic-info 1.0.6-r2 --> 1.0.7-r4*
* *geographic-msgs 1.0.6-r2 --> 1.0.7-r4*
* *kitti-metrics-eval 3.0.0-r1 --> 3.0.0-r2*
* *leo-bringup 2.5.0-r2 --> 2.6.1-r1*
* *leo-filters 2.5.0-r2 --> 2.6.1-r1*
* *leo-fw 2.5.0-r2 --> 2.6.1-r1*
* *leo-robot 2.5.0-r2 --> 2.6.1-r1*
* *libtorch-vendor 0.1.0-r1 --> 0.1.1-r1*
* *log-view 0.3.2-r1 --> 0.3.3-r2*
* *mola-academic-datasets 3.0.0-r1 --> 3.0.0-r2*
* *mola-common 0.6.0-r2 --> 0.6.1-r1*
* *mola-input-euroc-dataset 3.0.0-r1 --> 3.0.0-r2*
* *mola-input-kitti-dataset 3.0.0-r1 --> 3.0.0-r2*
* *mola-input-kitti360-dataset 3.0.0-r1 --> 3.0.0-r2*
* *mola-input-mulran-dataset 3.0.0-r1 --> 3.0.0-r2*
* *mola-input-ouster 0.1.0-r1*
* *mola-input-paris-luco-dataset 3.0.0-r1 --> 3.0.0-r2*
* *mrpt-generic-sensor 0.2.4-r2 --> 0.3.0-r1*
* *mrpt-sensor-bumblebee-stereo 0.2.4-r2 --> 0.3.0-r1*
* *mrpt-sensor-gnss-nmea 0.2.4-r2 --> 0.3.0-r1*
* *mrpt-sensor-gnss-novatel 0.2.4-r2 --> 0.3.0-r1*
* *mrpt-sensor-imu-taobotics 0.2.4-r2 --> 0.3.0-r1*
* *mrpt-sensorlib 0.2.4-r2 --> 0.3.0-r1*
* *mrpt-sensors 0.2.4-r2 --> 0.3.0-r1*
* *novatel-oem6-msgs 0.3.0-r1*
* *rosidlcpp 0.5.0-r2 --> 0.6.0-r1*
* *rosidlcpp-generator-c 0.5.0-r2 --> 0.6.0-r1*
* *rosidlcpp-generator-core 0.5.0-r2 --> 0.6.0-r1*
* *rosidlcpp-generator-cpp 0.5.0-r2 --> 0.6.0-r1*
* *rosidlcpp-generator-py 0.5.0-r2 --> 0.6.0-r1*
* *rosidlcpp-generator-type-description 0.5.0-r2 --> 0.6.0-r1*
* *rosidlcpp-parser 0.5.0-r2 --> 0.6.0-r1*
* *rosidlcpp-typesupport-c 0.5.0-r2 --> 0.6.0-r1*
* *rosidlcpp-typesupport-cpp 0.5.0-r2 --> 0.6.0-r1*
* *rosidlcpp-typesupport-fastrtps-c 0.5.0-r2 --> 0.6.0-r1*
* *rosidlcpp-typesupport-fastrtps-cpp 0.5.0-r2 --> 0.6.0-r1*
* *rosidlcpp-typesupport-introspection-c 0.5.0-r2 --> 0.6.0-r1*
* *rosidlcpp-typesupport-introspection-cpp 0.5.0-r2 --> 0.6.0-r1*
* *rqt-topic 3.0.0-r1 --> 3.0.1-r1*
* *tensor-msgs 0.1.0-r1 --> 0.1.1-r1*
* *topic-tools 1.4.4-r2 --> 1.6.0-r1*
* *topic-tools-interfaces 1.4.4-r2 --> 1.6.0-r1*
* *torch-conversions 0.1.0-r1 --> 0.1.1-r1*
* *ur-client-library 2.11.0-r1 --> 2.12.0-r1*


No missing dependencies.