### PR TITLE
Address some TODOs from the past

### DIFF
--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -260,7 +260,7 @@ in with lib; {
   };
 
   foxglove-bridge = rosSuper.foxglove-bridge.overrideAttrs({
-    postPatch ? "", cmakeFlags ? [], ...
+    postPatch ? "", ...
   }: {
     postPatch = let
       # SDK version from
@@ -288,11 +288,6 @@ in with lib; {
           'https://github.com/foxglove/foxglove-sdk/releases/download/sdk%2Fv''${FOXGLOVE_SDK_VERSION}/foxglove-v''${FOXGLOVE_SDK_VERSION}-cpp-''${FOXGLOVE_SDK_PLATFORM}.zip' \
           ${sdk}
       '';
-    cmakeFlags = cmakeFlags ++  [
-      # Prevent: stl_algobase.h:452:30: error: 'void* __builtin_memmove(void*, const void*, long unsigned int)' forming offset 8 is out of the bounds [0, 8] [-Werror=array-bounds=]
-      # TODO: Remove this after we move to newer libstdc++
-      "-DCMAKE_CXX_FLAGS=-Wno-error=array-bounds"
-    ];
   });
 
   fusioncore-ros = rosSuper.fusioncore-ros.overrideAttrs ({

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -4,17 +4,6 @@ self:
 rosSelf: rosSuper: let
   inherit (rosSelf) lib;
 in with lib; {
-
-  # TODO: Remove after https://github.com/autowarefoundation/agnocast/pull/1188
-  # appears in ROS release
-  agnocastlib = rosSuper.agnocastlib.overrideAttrs ({
-    propagatedBuildInputs ? [], ...
-  }: {
-    propagatedBuildInputs = propagatedBuildInputs ++ [
-      rosSelf.message-filters
-    ];
-  });
-
   autoware-adapi-adaptors = rosSuper.autoware-adapi-adaptors.overrideAttrs ({
     postPatch ? "", ...
   }: {

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -4,16 +4,6 @@ self:
 rosSelf: rosSuper: let
   inherit (rosSelf) lib;
 in {
-  # TODO: Remove after https://github.com/autowarefoundation/agnocast/pull/1188
-  # appears in ROS release
-  agnocastlib = rosSuper.agnocastlib.overrideAttrs ({
-    propagatedBuildInputs ? [], ...
-  }: {
-    propagatedBuildInputs = propagatedBuildInputs ++ [
-      rosSelf.message-filters
-    ];
-  });
-
   async-web-server-cpp = rosSuper.async-web-server-cpp.overrideAttrs ({
     patches ? [], ...
   }: {

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -473,14 +473,6 @@ in {
     ];
   });
 
-  # rqt is broken in rolling due to unfinished qt6 migration.
-  # TODO: Remove this once rqt works in rolling.
-  ros-gz-sim-demos = rosSuper.ros-gz-sim-demos.override {
-    rqt-image-view = null;
-    rqt-plot = null;
-    rqt-topic  = null;
-  };
-
   rqt-robot-monitor = rosSuper.rqt-robot-monitor.overrideAttrs ({
     nativeBuildInputs ? [], ...
   }: {

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -472,14 +472,6 @@ in {
     ];
   });
 
-  # rqt is broken in rolling due to unfinished qt6 migration.
-  # TODO: Remove this once rqt works in rolling.
-  ros-gz-sim-demos = rosSuper.ros-gz-sim-demos.override {
-    rqt-image-view = null;
-    rqt-plot = null;
-    rqt-topic  = null;
-  };
-
   rqt-robot-monitor = rosSuper.rqt-robot-monitor.overrideAttrs ({
     nativeBuildInputs ? [], ...
   }: {

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,6 @@
         inherit system;
         overlays = [ self.overlays.default ];
       };
-      genAttrs' = xs: f: listToAttrs (map f xs); # TODO remove after we're at newer nixpkgs
       exampleForDistro = exampleName: rosDistro:
         nameValuePair "example-${exampleName}-${rosDistro}" (
           import ./examples/${exampleName}.nix { inherit pkgs rosDistro; }


### PR DESCRIPTION
### Hydra build and evaluation statistics
<details>
<summary>✅ Still succeeding builds: 7762</summary>


[Hydra comparison](https://hydra.iid.ciirc.cvut.cz/eval/10330?compare=10322)
</details>

<details>
<summary>✅ Still unbuilt attributes: 20</summary>


[Hydra comparison](https://hydra.iid.ciirc.cvut.cz/eval/10330?compare=10322)
</details>

<details>
<summary>⚠️ Still present eval errors: 329</summary>


  | Reason | Attributes |
  |--------|------------|
  | Unrecognized eval error | [humble.buildRosPackage](https://index.ros.org/p/buildRosPackage/#humble), [jazzy.buildRosPackage](https://index.ros.org/p/buildRosPackage/#jazzy), [kilted.buildRosPackage](https://index.ros.org/p/buildRosPackage/#kilted), [lyrical.buildRosPackage](https://index.ros.org/p/buildRosPackage/#lyrical), [rolling.buildRosPackage](https://index.ros.org/p/buildRosPackage/#rolling) |
  | ``` callPackageWith: Function called without required argument "_unresolved_ament_python" ``` | [humble.trackdlo-bringup](https://index.ros.org/p/trackdlo_bringup/#humble), [humble.trackdlo-segmentation](https://index.ros.org/p/trackdlo_segmentation/#humble), [humble.trackdlo-utils](https://index.ros.org/p/trackdlo_utils/#humble), [jazzy.trackdlo-bringup](https://index.ros.org/p/trackdlo_bringup/#jazzy), [jazzy.trackdlo-segmentation](https://index.ros.org/p/trackdlo_segmentation/#jazzy), [jazzy.trackdlo-utils](https://index.ros.org/p/trackdlo_utils/#jazzy) |
  | ``` callPackageWith: Function called without required argument "_unresolved_catkin" ``` | [kilted.novatel-oem7-driver](https://index.ros.org/p/novatel_oem7_driver/#kilted), [kilted.novatel-oem7-msgs](https://index.ros.org/p/novatel_oem7_msgs/#kilted) |
  | ``` callPackageWith: Function called without required argument "_unresolved_gazebo_ros_pkgs" ``` | [jazzy.dolly](https://index.ros.org/p/dolly/#jazzy), [jazzy.dolly-gazebo](https://index.ros.org/p/dolly_gazebo/#jazzy) |
  | ``` callPackageWith: Function called without required argument "_unresolved_gurumdds-3" ``` | [humble.gurumdds-cmake-module](https://index.ros.org/p/gurumdds_cmake_module/#humble), [humble.rmw-gurumdds-cpp](https://index.ros.org/p/rmw_gurumdds_cpp/#humble), [jazzy.gurumdds-cmake-module](https://index.ros.org/p/gurumdds_cmake_module/#jazzy), [jazzy.rmw-gurumdds-cpp](https://index.ros.org/p/rmw_gurumdds_cpp/#jazzy), [kilted.gurumdds-cmake-module](https://index.ros.org/p/gurumdds_cmake_module/#kilted), [kilted.rmw-gurumdds-cpp](https://index.ros.org/p/rmw_gurumdds_cpp/#kilted) |
  | ``` callPackageWith: Function called without required argument "_unresolved_gz-plugin" ``` | [humble.leo-gz-bringup](https://index.ros.org/p/leo_gz_bringup/#humble), [humble.leo-gz-plugins](https://index.ros.org/p/leo_gz_plugins/#humble), [humble.leo-simulator](https://index.ros.org/p/leo_simulator/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_gz-sensors6" ``` | [humble.pmb2-gazebo](https://index.ros.org/p/pmb2_gazebo/#humble), [humble.pmb2-simulation](https://index.ros.org/p/pmb2_simulation/#humble), [humble.tiago-gazebo](https://index.ros.org/p/tiago_gazebo/#humble), [humble.tiago-simulation](https://index.ros.org/p/tiago_simulation/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_husarion_gz_worlds" ``` | [jazzy.rosbot-gazebo](https://index.ros.org/p/rosbot_gazebo/#jazzy) |
  | ``` callPackageWith: Function called without required argument "_unresolved_husarion_mecanum_drive_controller" ``` | [jazzy.rosbot](https://index.ros.org/p/rosbot/#jazzy), [jazzy.rosbot-controller](https://index.ros.org/p/rosbot_controller/#jazzy) |
  | ``` callPackageWith: Function called without required argument "_unresolved_ignition-common4" ``` | [humble.irobot-create-ignition-plugins](https://index.ros.org/p/irobot_create_ignition_plugins/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_ignition-fortress" ``` | [humble.rmf-building-sim-gz-plugins](https://index.ros.org/p/rmf_building_sim_gz_plugins/#humble), [humble.rmf-robot-sim-gz-plugins](https://index.ros.org/p/rmf_robot_sim_gz_plugins/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_ignition-fuel-tools7" ``` | [humble.rmf-building-map-tools](https://index.ros.org/p/rmf_building_map_tools/#humble), [humble.rmf-dev](https://index.ros.org/p/rmf_dev/#humble), [humble.rmf-traffic-editor-test-maps](https://index.ros.org/p/rmf_traffic_editor_test_maps/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_ignition-gazebo6" ``` | [humble.aerostack2](https://index.ros.org/p/aerostack2/#humble), [humble.andino-gz](https://index.ros.org/p/andino_gz/#humble), [humble.as2-gazebo-assets](https://index.ros.org/p/as2_gazebo_assets/#humble), [humble.as2-platform-gazebo](https://index.ros.org/p/as2_platform_gazebo/#humble), [humble.as2-visualization](https://index.ros.org/p/as2_visualization/#humble), [humble.clearpath-gz](https://index.ros.org/p/clearpath_gz/#humble), [humble.clearpath-simulator](https://index.ros.org/p/clearpath_simulator/#humble), [humble.desktop-full](https://index.ros.org/p/desktop_full/#humble), [humble.dolly-ignition](https://index.ros.org/p/dolly_ignition/#humble), [humble.ewellix-sim](https://index.ros.org/p/ewellix_sim/#humble), [humble.franka-gazebo-bringup](https://index.ros.org/p/franka_gazebo_bringup/#humble), [humble.franka-ign-ros2-control](https://index.ros.org/p/franka_ign_ros2_control/#humble), [humble.franka-ros2](https://index.ros.org/p/franka_ros2/#humble), [humble.gz-ros2-control](https://index.ros.org/p/gz_ros2_control/#humble), [humble.gz-ros2-control-demos](https://index.ros.org/p/gz_ros2_control_demos/#humble), [humble.ign-ros2-control](https://index.ros.org/p/ign_ros2_control/#humble), [humble.ign-ros2-control-demos](https://index.ros.org/p/ign_ros2_control_demos/#humble), [humble.iiqka-moveit-example](https://index.ros.org/p/iiqka_moveit_example/#humble), [humble.irobot-create-ignition-bringup](https://index.ros.org/p/irobot_create_ignition_bringup/#humble), [humble.irobot-create-ignition-sim](https://index.ros.org/p/irobot_create_ignition_sim/#humble), [humble.kuka-agilus-support](https://index.ros.org/p/kuka_agilus_support/#humble), [humble.kuka-drivers](https://index.ros.org/p/kuka_drivers/#humble), [humble.kuka-fortec-support](https://index.ros.org/p/kuka_fortec_support/#humble), [humble.kuka-gazebo](https://index.ros.org/p/kuka_gazebo/#humble), [humble.kuka-iiqka-eac-driver](https://index.ros.org/p/kuka_iiqka_eac_driver/#humble), [humble.kuka-iontec-support](https://index.ros.org/p/kuka_iontec_support/#humble), [humble.kuka-lbr-iisy-support](https://index.ros.org/p/kuka_lbr_iisy_support/#humble), [humble.kuka-quantec-support](https://index.ros.org/p/kuka_quantec_support/#humble), [humble.kuka-robot-descriptions](https://index.ros.org/p/kuka_robot_descriptions/#humble), [humble.kuka-rsi-driver](https://index.ros.org/p/kuka_rsi_driver/#humble), [humble.nicla-vision-ros2](https://index.ros.org/p/nicla_vision_ros2/#humble), [humble.raspimouse-description](https://index.ros.org/p/raspimouse_description/#humble), [humble.raspimouse-gazebo](https://index.ros.org/p/raspimouse_gazebo/#humble), [humble.raspimouse-navigation](https://index.ros.org/p/raspimouse_navigation/#humble), [humble.raspimouse-sim](https://index.ros.org/p/raspimouse_sim/#humble), [humble.raspimouse-slam](https://index.ros.org/p/raspimouse_slam/#humble), [humble.raspimouse-slam-navigation](https://index.ros.org/p/raspimouse_slam_navigation/#humble), [humble.ros-gz](https://index.ros.org/p/ros_gz/#humble), [humble.ros-gz-sim](https://index.ros.org/p/ros_gz_sim/#humble), [humble.ros-gz-sim-demos](https://index.ros.org/p/ros_gz_sim_demos/#humble), [humble.ros-ign](https://index.ros.org/p/ros_ign/#humble), [humble.ros-ign-gazebo](https://index.ros.org/p/ros_ign_gazebo/#humble), [humble.ros-ign-gazebo-demos](https://index.ros.org/p/ros_ign_gazebo_demos/#humble), [humble.simulation](https://index.ros.org/p/simulation/#humble), [humble.turtlebot4-ignition-bringup](https://index.ros.org/p/turtlebot4_ignition_bringup/#humble), [humble.turtlebot4-simulator](https://index.ros.org/p/turtlebot4_simulator/#humble), [humble.ur-simulation-gz](https://index.ros.org/p/ur_simulation_gz/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_ignition-gui6" ``` | [humble.turtlebot4-ignition-gui-plugins](https://index.ros.org/p/turtlebot4_ignition_gui_plugins/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_ignition-plugin" ``` | [humble.bcr-arm](https://index.ros.org/p/bcr_arm/#humble), [humble.bcr-arm-gazebo](https://index.ros.org/p/bcr_arm_gazebo/#humble), [humble.bcr-arm-ros2](https://index.ros.org/p/bcr_arm_ros2/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_libopen3d-dev" ``` | [humble.open3d-conversions](https://index.ros.org/p/open3d_conversions/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_libpointmatcher" ``` | [lyrical.rtabmap](https://index.ros.org/p/rtabmap/#lyrical), [rolling.rtabmap](https://index.ros.org/p/rtabmap/#rolling) |
  | ``` callPackageWith: Function called without required argument "_unresolved_libserial-dev" ``` | [humble.andino-apps](https://index.ros.org/p/andino_apps/#humble), [humble.andino-base](https://index.ros.org/p/andino_base/#humble), [humble.andino-bringup](https://index.ros.org/p/andino_bringup/#humble), [humble.andino-control](https://index.ros.org/p/andino_control/#humble), [humble.andino-gz-classic](https://index.ros.org/p/andino_gz_classic/#humble), [humble.feetech-ros2-driver](https://index.ros.org/p/feetech_ros2_driver/#humble), [jazzy.feetech-ros2-driver](https://index.ros.org/p/feetech_ros2_driver/#jazzy), [kilted.feetech-ros2-driver](https://index.ros.org/p/feetech_ros2_driver/#kilted), [lyrical.feetech-ros2-driver](https://index.ros.org/p/feetech_ros2_driver/#lyrical), [rolling.feetech-ros2-driver](https://index.ros.org/p/feetech_ros2_driver/#rolling) |
  | ``` callPackageWith: Function called without required argument "_unresolved_micro_ros_agent" ``` | [jazzy.rosbot-bringup](https://index.ros.org/p/rosbot_bringup/#jazzy) |
  | ``` callPackageWith: Function called without required argument "_unresolved_mola_input_kitti360_dataset" ``` | [kilted.mola-lidar-odometry](https://index.ros.org/p/mola_lidar_odometry/#kilted) |
  | ``` callPackageWith: Function called without required argument "_unresolved_nvidia-cuda" ``` | [lyrical.cuda-buffer](https://index.ros.org/p/cuda_buffer/#lyrical), [lyrical.cuda-buffer-backend](https://index.ros.org/p/cuda_buffer_backend/#lyrical), [rolling.cuda-buffer](https://index.ros.org/p/cuda_buffer/#rolling), [rolling.cuda-buffer-backend](https://index.ros.org/p/cuda_buffer_backend/#rolling) |
  | ``` callPackageWith: Function called without required argument "_unresolved_nvidia-cuda-dev" ``` | [lyrical.robot-arm-demo](https://index.ros.org/p/robot_arm_demo/#lyrical), [rolling.robot-arm-demo](https://index.ros.org/p/robot_arm_demo/#rolling) |
  | ``` callPackageWith: Function called without required argument "_unresolved_parameter_traits" ``` | [lyrical.linear-feedback-controller](https://index.ros.org/p/linear_feedback_controller/#lyrical), [rolling.linear-feedback-controller](https://index.ros.org/p/linear_feedback_controller/#rolling) |
  | ``` callPackageWith: Function called without required argument "_unresolved_picknik_reset_fault_controller" ``` | [rolling.kinova-gen3-6dof-robotiq-2f-85-moveit-config](https://index.ros.org/p/kinova_gen3_6dof_robotiq_2f_85_moveit_config/#rolling), [rolling.kinova-gen3-7dof-robotiq-2f-85-moveit-config](https://index.ros.org/p/kinova_gen3_7dof_robotiq_2f_85_moveit_config/#rolling), [rolling.kinova-gen3-lite-moveit-config](https://index.ros.org/p/kinova_gen3_lite_moveit_config/#rolling), [rolling.kortex-bringup](https://index.ros.org/p/kortex_bringup/#rolling), [rolling.kortex-description](https://index.ros.org/p/kortex_description/#rolling) |
  | ``` callPackageWith: Function called without required argument "_unresolved_position_controllers" ``` | [lyrical.moveit-hybrid-planning](https://index.ros.org/p/moveit_hybrid_planning/#lyrical), [lyrical.moveit-resources](https://index.ros.org/p/moveit_resources/#lyrical), [lyrical.moveit-resources-fanuc-moveit-config](https://index.ros.org/p/moveit_resources_fanuc_moveit_config/#lyrical), [lyrical.moveit-resources-panda-moveit-config](https://index.ros.org/p/moveit_resources_panda_moveit_config/#lyrical), [lyrical.moveit-task-constructor-demo](https://index.ros.org/p/moveit_task_constructor_demo/#lyrical), [lyrical.mujoco-ros2-control-demos](https://index.ros.org/p/mujoco_ros2_control_demos/#lyrical), [rolling.moveit-hybrid-planning](https://index.ros.org/p/moveit_hybrid_planning/#rolling), [rolling.moveit-resources](https://index.ros.org/p/moveit_resources/#rolling), [rolling.moveit-resources-fanuc-moveit-config](https://index.ros.org/p/moveit_resources_fanuc_moveit_config/#rolling), [rolling.moveit-resources-panda-moveit-config](https://index.ros.org/p/moveit_resources_panda_moveit_config/#rolling), [rolling.moveit-task-constructor-demo](https://index.ros.org/p/moveit_task_constructor_demo/#rolling), [rolling.mujoco-ros2-control-demos](https://index.ros.org/p/mujoco_ros2_control_demos/#rolling) |
  | ``` callPackageWith: Function called without required argument "_unresolved_pybind11-json-dev" ``` | [lyrical.rmf-demos-fleet-adapter](https://index.ros.org/p/rmf_demos_fleet_adapter/#lyrical), [lyrical.rmf-fleet-adapter-python](https://index.ros.org/p/rmf_fleet_adapter_python/#lyrical), [rolling.rmf-demos-fleet-adapter](https://index.ros.org/p/rmf_demos_fleet_adapter/#rolling), [rolling.rmf-fleet-adapter-python](https://index.ros.org/p/rmf_fleet_adapter_python/#rolling) |
  | ``` callPackageWith: Function called without required argument "_unresolved_python3-apt" ``` | [jazzy.clearpath-common](https://index.ros.org/p/clearpath_common/#jazzy), [jazzy.clearpath-config-live](https://index.ros.org/p/clearpath_config_live/#jazzy), [jazzy.clearpath-desktop](https://index.ros.org/p/clearpath_desktop/#jazzy), [jazzy.clearpath-generator-common](https://index.ros.org/p/clearpath_generator_common/#jazzy), [jazzy.clearpath-generator-gz](https://index.ros.org/p/clearpath_generator_gz/#jazzy), [jazzy.clearpath-gz](https://index.ros.org/p/clearpath_gz/#jazzy), [jazzy.clearpath-simulator](https://index.ros.org/p/clearpath_simulator/#jazzy), [jazzy.clearpath-tests](https://index.ros.org/p/clearpath_tests/#jazzy) |
  | ``` callPackageWith: Function called without required argument "_unresolved_python3-jsonpickle" ``` | [humble.namosim](https://index.ros.org/p/namosim/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_python3-junitparser" ``` | [humble.replay-testing](https://index.ros.org/p/replay_testing/#humble), [jazzy.replay-testing](https://index.ros.org/p/replay_testing/#jazzy), [kilted.replay-testing](https://index.ros.org/p/replay_testing/#kilted), [lyrical.replay-testing](https://index.ros.org/p/replay_testing/#lyrical), [rolling.replay-testing](https://index.ros.org/p/replay_testing/#rolling) |
  | ``` callPackageWith: Function called without required argument "_unresolved_python3-open3d" ``` | [humble.pointcloud-to-ply](https://index.ros.org/p/pointcloud_to_ply/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_python3-openai-pip" ``` | [humble.ros2ai](https://index.ros.org/p/ros2ai/#humble), [jazzy.ros2ai](https://index.ros.org/p/ros2ai/#jazzy), [kilted.ros2ai](https://index.ros.org/p/ros2ai/#kilted) |
  | ``` callPackageWith: Function called without required argument "_unresolved_python3-pymap3d" ``` | [humble.as2-keyboard-teleoperation](https://index.ros.org/p/as2_keyboard_teleoperation/#humble), [humble.as2-python-api](https://index.ros.org/p/as2_python_api/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_python3-pytorch-pip" ``` | [humble.lidar-situational-graphs](https://index.ros.org/p/lidar_situational_graphs/#humble), [humble.situational-graphs-reasoning](https://index.ros.org/p/situational_graphs_reasoning/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_ros_ign_bridge" ``` | [jazzy.dolly-ignition](https://index.ros.org/p/dolly_ignition/#jazzy) |
  | ``` callPackageWith: Function called without required argument "_unresolved_ros_image_to_qimage" ``` | [rolling.rqt-image-overlay](https://index.ros.org/p/rqt_image_overlay/#rolling) |
  | ``` callPackageWith: Function called without required argument "_unresolved_rviz_visual_tools" ``` | [rolling.moveit-visual-tools](https://index.ros.org/p/moveit_visual_tools/#rolling) |
  | ``` callPackageWith: Function called without required argument "_unresolved_tl_expected" ``` | [lyrical.om-gravity-compensation-controller](https://index.ros.org/p/om_gravity_compensation_controller/#lyrical), [lyrical.open-manipulator](https://index.ros.org/p/open_manipulator/#lyrical), [lyrical.pick-ik](https://index.ros.org/p/pick_ik/#lyrical), [rolling.om-gravity-compensation-controller](https://index.ros.org/p/om_gravity_compensation_controller/#rolling), [rolling.open-manipulator](https://index.ros.org/p/open_manipulator/#rolling), [rolling.pick-ik](https://index.ros.org/p/pick_ik/#rolling) |
  | ``` callPackageWith: Function called without required argument "alsaUtils" ``` | [jazzy.rosbot-utils](https://index.ros.org/p/rosbot_utils/#jazzy) |
  | ``` callPackageWith: Function called without required argument "gazebo_11" ``` | [humble.crane-plus](https://index.ros.org/p/crane_plus/#humble), [humble.crane-plus-control](https://index.ros.org/p/crane_plus_control/#humble), [humble.crane-plus-description](https://index.ros.org/p/crane_plus_description/#humble), [humble.crane-plus-examples](https://index.ros.org/p/crane_plus_examples/#humble), [humble.crane-plus-gazebo](https://index.ros.org/p/crane_plus_gazebo/#humble), [humble.dolly](https://index.ros.org/p/dolly/#humble), [humble.dolly-gazebo](https://index.ros.org/p/dolly_gazebo/#humble), [humble.gazebo-dev](https://index.ros.org/p/gazebo_dev/#humble), [humble.gazebo-model-attachment-plugin](https://index.ros.org/p/gazebo_model_attachment_plugin/#humble), [humble.gazebo-no-physics-plugin](https://index.ros.org/p/gazebo_no_physics_plugin/#humble), [humble.gazebo-planar-move-plugin](https://index.ros.org/p/gazebo_planar_move_plugin/#humble), [humble.gazebo-plugins](https://index.ros.org/p/gazebo_plugins/#humble), [humble.gazebo-ros](https://index.ros.org/p/gazebo_ros/#humble), [humble.gazebo-ros-pkgs](https://index.ros.org/p/gazebo_ros_pkgs/#humble), [humble.gazebo-ros2-control](https://index.ros.org/p/gazebo_ros2_control/#humble), [humble.gazebo-ros2-control-demos](https://index.ros.org/p/gazebo_ros2_control_demos/#humble), [humble.gazebo-set-joint-positions-plugin](https://index.ros.org/p/gazebo_set_joint_positions_plugin/#humble), [humble.gazebo-video-monitor-plugins](https://index.ros.org/p/gazebo_video_monitor_plugins/#humble), [humble.gazebo-video-monitors](https://index.ros.org/p/gazebo_video_monitors/#humble), [humble.irobot-create-gazebo-bringup](https://index.ros.org/p/irobot_create_gazebo_bringup/#humble), [humble.irobot-create-gazebo-plugins](https://index.ros.org/p/irobot_create_gazebo_plugins/#humble), [humble.irobot-create-gazebo-sim](https://index.ros.org/p/irobot_create_gazebo_sim/#humble), [humble.kortex-bringup](https://index.ros.org/p/kortex_bringup/#humble), [humble.nav2-system-tests](https://index.ros.org/p/nav2_system_tests/#humble), [humble.omni-base-bringup](https://index.ros.org/p/omni_base_bringup/#humble), [humble.omni-base-description](https://index.ros.org/p/omni_base_description/#humble), [humble.omni-base-gazebo](https://index.ros.org/p/omni_base_gazebo/#humble), [humble.omni-base-robot](https://index.ros.org/p/omni_base_robot/#humble), [humble.omni-base-simulation](https://index.ros.org/p/omni_base_simulation/#humble), [humble.open-manipulator](https://index.ros.org/p/open_manipulator/#humble), [humble.open-manipulator-x-bringup](https://index.ros.org/p/open_manipulator_x_bringup/#humble), [humble.open-manipulator-x-teleop](https://index.ros.org/p/open_manipulator_x_teleop/#humble), [humble.pal-gazebo-plugins](https://index.ros.org/p/pal_gazebo_plugins/#humble), [humble.pal-sea-arm-gazebo](https://index.ros.org/p/pal_sea_arm_gazebo/#humble), [humble.pal-sea-arm-simulation](https://index.ros.org/p/pal_sea_arm_simulation/#humble), [humble.rmf-building-sim-gz-classic-plugins](https://index.ros.org/p/rmf_building_sim_gz_classic_plugins/#humble), [humble.rmf-robot-sim-gz-classic-plugins](https://index.ros.org/p/rmf_robot_sim_gz_classic_plugins/#humble), [humble.talos-gazebo](https://index.ros.org/p/talos_gazebo/#humble), [humble.tiago-bringup](https://index.ros.org/p/tiago_bringup/#humble), [humble.tiago-description](https://index.ros.org/p/tiago_description/#humble), [humble.tiago-moveit-config](https://index.ros.org/p/tiago_moveit_config/#humble), [humble.tiago-pro-description](https://index.ros.org/p/tiago_pro_description/#humble), [humble.tiago-pro-gazebo](https://index.ros.org/p/tiago_pro_gazebo/#humble), [humble.tiago-pro-head-gazebo](https://index.ros.org/p/tiago_pro_head_gazebo/#humble), [humble.tiago-pro-head-simulation](https://index.ros.org/p/tiago_pro_head_simulation/#humble), [humble.tiago-pro-moveit-config](https://index.ros.org/p/tiago_pro_moveit_config/#humble), [humble.tiago-pro-robot](https://index.ros.org/p/tiago_pro_robot/#humble), [humble.tiago-pro-simulation](https://index.ros.org/p/tiago_pro_simulation/#humble), [humble.tiago-robot](https://index.ros.org/p/tiago_robot/#humble), [humble.turtlebot3-gazebo](https://index.ros.org/p/turtlebot3_gazebo/#humble), [humble.turtlebot3-manipulation-gazebo](https://index.ros.org/p/turtlebot3_manipulation_gazebo/#humble), [humble.turtlebot3-simulations](https://index.ros.org/p/turtlebot3_simulations/#humble), [humble.urdf-sim-tutorial](https://index.ros.org/p/urdf_sim_tutorial/#humble), [humble.velodyne-gazebo-plugins](https://index.ros.org/p/velodyne_gazebo_plugins/#humble), [humble.velodyne-simulator](https://index.ros.org/p/velodyne_simulator/#humble) |
  | ``` error: Package ‘qtwebengine-5.15.19’ is marked as insecure, refusing to evaluate ``` | [humble.py-trees-js](https://index.ros.org/p/py_trees_js/#humble), [humble.py-trees-ros-viewer](https://index.ros.org/p/py_trees_ros_viewer/#humble), [jazzy.py-trees-js](https://index.ros.org/p/py_trees_js/#jazzy), [jazzy.py-trees-ros-viewer](https://index.ros.org/p/py_trees_ros_viewer/#jazzy), [kilted.py-trees-js](https://index.ros.org/p/py_trees_js/#kilted), [kilted.py-trees-ros-viewer](https://index.ros.org/p/py_trees_ros_viewer/#kilted), [lyrical.py-trees-js](https://index.ros.org/p/py_trees_js/#lyrical), [lyrical.py-trees-ros-viewer](https://index.ros.org/p/py_trees_ros_viewer/#lyrical), [rolling.py-trees-js](https://index.ros.org/p/py_trees_js/#rolling), [rolling.py-trees-ros-viewer](https://index.ros.org/p/py_trees_ros_viewer/#rolling) |
  | ``` error: Package ‘ros-humble-mola-test-datasets-0.4.2-r1’ has an unfree license (‘bsd3 bsd3 unknown unknown unknown cc-by-nc-sa-40’), refusing to evaluate ``` | [humble.mola-test-datasets](https://index.ros.org/p/mola_test_datasets/#humble) |
  | ``` error: Package ‘ros-humble-visp-3.7.0-r7’ is marked as broken, refusing to evaluate ``` | [humble.visp](https://index.ros.org/p/visp/#humble) |
  | ``` error: Package ‘ros-jazzy-mola-test-datasets-0.4.2-r1’ has an unfree license (‘bsd3 bsd3 unknown unknown unknown cc-by-nc-sa-40’), refusing to evaluate ``` | [jazzy.mola-test-datasets](https://index.ros.org/p/mola_test_datasets/#jazzy) |
  | ``` error: Package ‘ros-jazzy-visp-3.5.0-r4’ is marked as broken, refusing to evaluate ``` | [jazzy.visp](https://index.ros.org/p/visp/#jazzy) |
  | ``` error: Package ‘ros-kilted-mola-test-datasets-0.4.2-r1’ has an unfree license (‘bsd3 bsd3 unknown unknown unknown cc-by-nc-sa-40’), refusing to evaluate ``` | [kilted.mola-test-datasets](https://index.ros.org/p/mola_test_datasets/#kilted) |
  | ``` error: Package ‘ros-kilted-visp-3.7.0-r6’ is marked as broken, refusing to evaluate ``` | [kilted.visp](https://index.ros.org/p/visp/#kilted) |
  | ``` error: Package ‘ros-lyrical-mola-test-datasets-0.4.2-r3’ has an unfree license (‘bsd3 bsd3 unknown unknown unknown cc-by-nc-sa-40’), refusing to evaluate ``` | [lyrical.mola-test-datasets](https://index.ros.org/p/mola_test_datasets/#lyrical) |
  | ``` error: Package ‘ros-lyrical-visp-3.7.0-r6’ is marked as broken, refusing to evaluate ``` | [lyrical.visp](https://index.ros.org/p/visp/#lyrical) |
  | ``` error: Package ‘ros-rolling-mola-test-datasets-0.4.2-r2’ has an unfree license (‘bsd3 bsd3 unknown unknown unknown cc-by-nc-sa-40’), refusing to evaluate ``` | [rolling.mola-test-datasets](https://index.ros.org/p/mola_test_datasets/#rolling) |
  | ``` error: Package ‘ros-rolling-visp-3.7.0-r5’ is marked as broken, refusing to evaluate ``` | [rolling.visp](https://index.ros.org/p/visp/#rolling) |
  | ``` error: attribute 'Rtree' missing ``` | [jazzy.rmf-building-map-tools](https://index.ros.org/p/rmf_building_map_tools/#jazzy), [jazzy.rmf-demos-bridges](https://index.ros.org/p/rmf_demos_bridges/#jazzy), [jazzy.rmf-dev](https://index.ros.org/p/rmf_dev/#jazzy), [jazzy.rmf-traffic-editor-test-maps](https://index.ros.org/p/rmf_traffic_editor_test_maps/#jazzy), [kilted.rmf-building-map-tools](https://index.ros.org/p/rmf_building_map_tools/#kilted), [kilted.rmf-demos](https://index.ros.org/p/rmf_demos/#kilted), [kilted.rmf-demos-bridges](https://index.ros.org/p/rmf_demos_bridges/#kilted), [kilted.rmf-demos-gz](https://index.ros.org/p/rmf_demos_gz/#kilted), [kilted.rmf-demos-maps](https://index.ros.org/p/rmf_demos_maps/#kilted), [kilted.rmf-dev](https://index.ros.org/p/rmf_dev/#kilted), [kilted.rmf-traffic-editor-test-maps](https://index.ros.org/p/rmf_traffic_editor_test_maps/#kilted), [lyrical.rmf-building-map-tools](https://index.ros.org/p/rmf_building_map_tools/#lyrical), [lyrical.rmf-demos](https://index.ros.org/p/rmf_demos/#lyrical), [lyrical.rmf-demos-bridges](https://index.ros.org/p/rmf_demos_bridges/#lyrical), [lyrical.rmf-demos-gz](https://index.ros.org/p/rmf_demos_gz/#lyrical), [lyrical.rmf-demos-maps](https://index.ros.org/p/rmf_demos_maps/#lyrical), [lyrical.rmf-traffic-editor-test-maps](https://index.ros.org/p/rmf_traffic_editor_test_maps/#lyrical), [rolling.rmf-building-map-tools](https://index.ros.org/p/rmf_building_map_tools/#rolling), [rolling.rmf-demos](https://index.ros.org/p/rmf_demos/#rolling), [rolling.rmf-demos-bridges](https://index.ros.org/p/rmf_demos_bridges/#rolling), [rolling.rmf-demos-gz](https://index.ros.org/p/rmf_demos_gz/#rolling), [rolling.rmf-demos-maps](https://index.ros.org/p/rmf_demos_maps/#rolling), [rolling.rmf-traffic-editor-test-maps](https://index.ros.org/p/rmf_traffic_editor_test_maps/#rolling) |
  | ``` error: attribute 'ardrone-sdk' missing ``` | [kilted.ardrone-sdk](https://index.ros.org/p/ardrone_sdk/#kilted) |
  | ``` error: attribute 'azure-iot-sdk-c' missing ``` | [lyrical.azure-iot-sdk-c](https://index.ros.org/p/azure_iot_sdk_c/#lyrical), [rolling.azure-iot-sdk-c](https://index.ros.org/p/azure_iot_sdk_c/#rolling) |
  | ``` error: attribute 'cloudini-lib' missing ``` | [lyrical.cloudini-lib](https://index.ros.org/p/cloudini_lib/#lyrical), [rolling.cloudini-lib](https://index.ros.org/p/cloudini_lib/#rolling) |
  | ``` error: attribute 'fastrtps' missing ``` | [kilted.fastrtps](https://index.ros.org/p/fastrtps/#kilted), [lyrical.fastrtps](https://index.ros.org/p/fastrtps/#lyrical), [rolling.fastrtps](https://index.ros.org/p/fastrtps/#rolling) |
  | ``` error: attribute 'fmilibrary-vendor' missing ``` | [lyrical.fmilibrary-vendor](https://index.ros.org/p/fmilibrary_vendor/#lyrical), [rolling.fmilibrary-vendor](https://index.ros.org/p/fmilibrary_vendor/#rolling) |
  | ``` error: attribute 'gazebo-ros' missing ``` | [jazzy.gazebo-ros](https://index.ros.org/p/gazebo_ros/#jazzy), [kilted.gazebo-ros](https://index.ros.org/p/gazebo_ros/#kilted), [lyrical.gazebo-ros](https://index.ros.org/p/gazebo_ros/#lyrical), [rolling.gazebo-ros](https://index.ros.org/p/gazebo_ros/#rolling) |
  | ``` error: attribute 'gazebo_11' missing ``` | [humble.aws-robomaker-small-warehouse-world](https://index.ros.org/p/aws_robomaker_small_warehouse_world/#humble), [humble.gazebo](https://index.ros.org/p/gazebo/#humble), [jazzy.gazebo](https://index.ros.org/p/gazebo/#jazzy), [kilted.gazebo](https://index.ros.org/p/gazebo/#kilted), [lyrical.gazebo](https://index.ros.org/p/gazebo/#lyrical), [rolling.gazebo](https://index.ros.org/p/gazebo/#rolling) |
  | ``` error: attribute 'gz-tools-vendor' missing ``` | [humble.gz-tools-vendor](https://index.ros.org/p/gz_tools_vendor/#humble) |
  | ``` error: attribute 'nose' missing ``` | [humble.ament-cmake-nose](https://index.ros.org/p/ament_cmake_nose/#humble) |
  | ``` error: attribute 'popf' missing ``` | [lyrical.popf](https://index.ros.org/p/popf/#lyrical), [rolling.popf](https://index.ros.org/p/popf/#rolling) |
  | ``` error: attribute 'rtabmap-conversions' missing ``` | [lyrical.rtabmap-conversions](https://index.ros.org/p/rtabmap_conversions/#lyrical), [rolling.rtabmap-conversions](https://index.ros.org/p/rtabmap_conversions/#rolling) |
  | ``` error: attribute 'rtabmap-msgs' missing ``` | [lyrical.rtabmap-msgs](https://index.ros.org/p/rtabmap_msgs/#lyrical), [rolling.rtabmap-msgs](https://index.ros.org/p/rtabmap_msgs/#rolling) |
  | ``` error: attribute 'rtabmap-odom' missing ``` | [lyrical.rtabmap-odom](https://index.ros.org/p/rtabmap_odom/#lyrical), [rolling.rtabmap-odom](https://index.ros.org/p/rtabmap_odom/#rolling) |
  | ``` error: attribute 'rtabmap-rviz-plugins' missing ``` | [lyrical.rtabmap-rviz-plugins](https://index.ros.org/p/rtabmap_rviz_plugins/#lyrical), [rolling.rtabmap-rviz-plugins](https://index.ros.org/p/rtabmap_rviz_plugins/#rolling) |
  | ``` error: attribute 'rtabmap-slam' missing ``` | [lyrical.rtabmap-slam](https://index.ros.org/p/rtabmap_slam/#lyrical), [rolling.rtabmap-slam](https://index.ros.org/p/rtabmap_slam/#rolling) |
  | ``` error: attribute 'rtabmap-sync' missing ``` | [lyrical.rtabmap-sync](https://index.ros.org/p/rtabmap_sync/#lyrical), [rolling.rtabmap-sync](https://index.ros.org/p/rtabmap_sync/#rolling) |
  | ``` error: attribute 'rtabmap-viz' missing ``` | [lyrical.rtabmap-viz](https://index.ros.org/p/rtabmap_viz/#lyrical), [rolling.rtabmap-viz](https://index.ros.org/p/rtabmap_viz/#rolling) |
  | ``` error: attribute 'shared-queues-vendor' missing ``` | [kilted.shared-queues-vendor](https://index.ros.org/p/shared_queues_vendor/#kilted), [lyrical.shared-queues-vendor](https://index.ros.org/p/shared_queues_vendor/#lyrical), [rolling.shared-queues-vendor](https://index.ros.org/p/shared_queues_vendor/#rolling) |
  | ``` error: future-1.0.0 not supported for interpreter python3.13 ``` | [humble.as2-platform-mavlink](https://index.ros.org/p/as2_platform_mavlink/#humble), [humble.libmavconn](https://index.ros.org/p/libmavconn/#humble), [humble.mavlink](https://index.ros.org/p/mavlink/#humble), [humble.mavros](https://index.ros.org/p/mavros/#humble), [humble.mavros-examples](https://index.ros.org/p/mavros_examples/#humble), [humble.mavros-extras](https://index.ros.org/p/mavros_extras/#humble), [jazzy.libmavconn](https://index.ros.org/p/libmavconn/#jazzy), [jazzy.mavlink](https://index.ros.org/p/mavlink/#jazzy), [jazzy.mavros](https://index.ros.org/p/mavros/#jazzy), [jazzy.mavros-examples](https://index.ros.org/p/mavros_examples/#jazzy), [jazzy.mavros-extras](https://index.ros.org/p/mavros_extras/#jazzy), [kilted.libmavconn](https://index.ros.org/p/libmavconn/#kilted), [kilted.mavlink](https://index.ros.org/p/mavlink/#kilted), [kilted.mavros](https://index.ros.org/p/mavros/#kilted), [kilted.mavros-examples](https://index.ros.org/p/mavros_examples/#kilted), [kilted.mavros-extras](https://index.ros.org/p/mavros_extras/#kilted), [lyrical.libmavconn](https://index.ros.org/p/libmavconn/#lyrical), [lyrical.mavlink](https://index.ros.org/p/mavlink/#lyrical), [lyrical.mavros](https://index.ros.org/p/mavros/#lyrical), [lyrical.mavros-examples](https://index.ros.org/p/mavros_examples/#lyrical), [lyrical.mavros-extras](https://index.ros.org/p/mavros_extras/#lyrical), [rolling.libmavconn](https://index.ros.org/p/libmavconn/#rolling), [rolling.mavlink](https://index.ros.org/p/mavlink/#rolling), [rolling.mavros](https://index.ros.org/p/mavros/#rolling), [rolling.mavros-examples](https://index.ros.org/p/mavros_examples/#rolling), [rolling.mavros-extras](https://index.ros.org/p/mavros_extras/#rolling) |
</details>

<details>
<summary>⚠️ Still failing builds: 920</summary>


[Hydra comparison](https://hydra.iid.ciirc.cvut.cz/eval/10330?compare=10322)
</details>

