### PR TITLE
Remove unneeded python aliases

### DIFF
--- a/distros/build-env/default.nix
+++ b/distros/build-env/default.nix
@@ -16,7 +16,7 @@
 # mkShell, it is often desirable for packages in the local ROS workspace to
 # take precedence over Nix-built packages. This can be achieved by setting
 # underlay to true.
-{ lib, stdenv, buildPackages, writeText, buildEnv, makeWrapper, python, ros-environment }:
+{ lib, stdenv, buildPackages, writeText, buildEnv, makeWrapper, python3, ros-environment }:
 { paths ? [], wrapPrograms ? true, underlay ? false, postBuild ? "", passthru ? { }, ... }@args:
 
 with lib;
@@ -85,14 +85,14 @@ let
           makeWrapper "$file" "$link" \
             --${xfix} PATH : "$out/bin" \
             --${xfix} LD_LIBRARY_PATH : "$out/lib" \
-            --${xfix} PYTHONPATH : "$out/${python.sitePackages}" \
+            --${xfix} PYTHONPATH : "$out/${python3.sitePackages}" \
             --${xfix} CMAKE_PREFIX_PATH : "$out" \
             --${xfix} AMENT_PREFIX_PATH : "$out" \
             --${xfix} ROS_PACKAGE_PATH : "$out/share" \
             --${xfix} GZ_CONFIG_PATH : "$out/share/gz" \
             --set ROS_DISTRO '${ros-environment.rosDistro}' \
             --set ROS_VERSION '${toString ros-environment.rosVersion}' \
-            --set ROS_PYTHON_VERSION '${lib.versions.major python.version}' \
+            --set ROS_PYTHON_VERSION '${lib.versions.major python3.version}' \
             ''${rosWrapperArgs[@]}
         done
       fi

--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -29,7 +29,7 @@ let
     python3Packages = rosSelf.python3.pkgs;
 
     boost = self.boost.override {
-      python = rosSelf.python;
+      python = rosSelf.python3;
       enablePython = true;
     };
   };

--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -31,7 +31,7 @@ let
     python3Packages = rosSelf.python3.pkgs;
 
     boost = self.boost.override {
-      python = rosSelf.python;
+      python = rosSelf.python3;
       enablePython = true;
     };
   };
@@ -140,7 +140,7 @@ let
         substituteInPlace CMakeLists.txt --replace-fail /usr/bin/env '${self.buildPackages.coreutils}/bin/env'
         patchShebangs pymavlink/tools/mavgen.py
       '';
-      ROS_PYTHON_VERSION = if rosSelf.python.isPy3k then 3 else 2;
+      ROS_PYTHON_VERSION = 3;
       # Fix eval failure. The future module is broken with Python
       # 3.13+, but mavlink does not need it despite declaring it as
       # dependency.

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -939,13 +939,13 @@ in with lib; {
   rosidl-generator-py = rosSuper.rosidl-generator-py.overrideAttrs ({
     postPatch ? "", ...
   }: let
-    python = rosSelf.python;
+    python3 = rosSelf.python3;
   in {
     # Fix finding NumPy headers
     postPatch = postPatch + ''
       substituteInPlace cmake/rosidl_generator_py_generate_interfaces.cmake \
        --replace-fail '"import numpy"' "" \
-       --replace-fail 'numpy.get_include()' "'${python.pkgs.numpy}/${python.sitePackages}/numpy/_core/include'"
+       --replace-fail 'numpy.get_include()' "'${python3.pkgs.numpy}/${python3.sitePackages}/numpy/_core/include'"
     '';
   });
 

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -400,6 +400,8 @@ in with lib; {
     ];
   });
 
+  inverse-dynamics-solver = rosSuper.inverse-dynamics-solver.override { python = self.python3; };
+
   io-context = rosSuper.io-context.overrideAttrs ({
     patches ? [], ...
   }: {

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -1182,13 +1182,13 @@ in with lib; {
   rosidl-generator-py = rosSuper.rosidl-generator-py.overrideAttrs ({
     postPatch ? "", ...
   }: let
-    python = rosSelf.python;
+    python3 = rosSelf.python3;
   in {
     # Fix finding NumPy headers
     postPatch = postPatch + ''
       substituteInPlace cmake/rosidl_generator_py_generate_interfaces.cmake \
        --replace-fail '"import numpy"' "" \
-       --replace-fail 'numpy.get_include()' "'${python.pkgs.numpy}/${python.sitePackages}/numpy/_core/include'"
+       --replace-fail 'numpy.get_include()' "'${python3.pkgs.numpy}/${python3.sitePackages}/numpy/_core/include'"
     '';
   });
 

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -489,6 +489,8 @@ in {
     ];
   });
 
+  inverse-dynamics-solver = rosSuper.inverse-dynamics-solver.override { python = self.python3; };
+
   io-context = rosSuper.io-context.overrideAttrs ({
     patches ? [], ...
   }: {

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -552,7 +552,7 @@ in {
     dontUnpack = true;
     dontBuild = true;
     dontInstall = true;
-    propagatedBuildInputs = with rosSelf.pythonPackages; [
+    propagatedBuildInputs = with rosSelf.python3Packages; [
       pyqt-builder
       pyqt6
       pyqt6-sip

--- a/distros/qt5-overlay.nix
+++ b/distros/qt5-overlay.nix
@@ -22,7 +22,7 @@ rosSelf: rosSuper: with rosSelf.lib; {
   python-qt-binding = rosSuper.python-qt-binding.overrideAttrs ({
     propagatedBuildInputs ? [], ...
   }: {
-    propagatedBuildInputs = propagatedBuildInputs ++ (with rosSelf.pythonPackages; [
+    propagatedBuildInputs = propagatedBuildInputs ++ (with rosSelf.python3Packages; [
       sip4
     ]);
    dontWrapQtApps = true;

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -203,6 +203,8 @@ in {
     ];
   });
 
+  inverse-dynamics-solver = rosSuper.inverse-dynamics-solver.override { python = self.python3; };
+
   io-context = rosSuper.io-context.overrideAttrs ({
     patches ? [], ...
   }: {

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -504,7 +504,7 @@ in {
     dontUnpack = true;
     dontBuild = true;
     dontInstall = true;
-    propagatedBuildInputs = with rosSelf.pythonPackages; [
+    propagatedBuildInputs = with rosSelf.python3Packages; [
       pyqt-builder
       pyqt6
       pyqt6-sip

--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -14,10 +14,6 @@ let
 in
 with rosSelf.lib; {
 
-  # TODO: remove once https://github.com/ros/rosdistro/pull/43895 is merged
-  python = rosSelf.python3;
-  pythonPackages = rosSelf.python.pkgs;
-
   ardrone-sdk = rosSuper.ardrone-sdk.overrideAttrs ({
     nativeBuildInputs ? [], ...
   }: {
@@ -302,12 +298,12 @@ with rosSelf.lib; {
   });
 
   python-cmake-module = rosSuper.python-cmake-module.overrideAttrs ({ ... }: let
-    python = rosSelf.python;
+    python3 = rosSelf.python3;
     libExt = self.stdenv.hostPlatform.extensions.sharedLibrary;
   in {
-    pythonExecutable = python.pythonOnBuildForHost.interpreter;
-    pythonLibrary = "${python}/lib/lib${python.libPrefix}${libExt}";
-    pythonIncludeDir = "${python}/include/${python.libPrefix}";
+    pythonExecutable = python3.pythonOnBuildForHost.interpreter;
+    pythonLibrary = "${python3}/lib/lib${python3.libPrefix}${libExt}";
+    pythonIncludeDir = "${python3}/include/${python3.libPrefix}";
     setupHook = ./python-cmake-module-setup-hook.sh;
     outputs = [ "out" "dev" ];
   });

--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -14,10 +14,6 @@ let
 in
 with rosSelf.lib; {
 
-  # TODO: remove once https://github.com/ros/rosdistro/pull/43895 is merged
-  python = rosSelf.python3;
-  pythonPackages = rosSelf.python.pkgs;
-
   ardrone-sdk = rosSuper.ardrone-sdk.overrideAttrs ({
     nativeBuildInputs ? [], ...
   }: {
@@ -273,12 +269,12 @@ with rosSelf.lib; {
   });
 
   python-cmake-module = rosSuper.python-cmake-module.overrideAttrs ({ ... }: let
-    python = rosSelf.python;
+    python3 = rosSelf.python3;
     libExt = self.stdenv.hostPlatform.extensions.sharedLibrary;
   in {
-    pythonExecutable = python.pythonOnBuildForHost.interpreter;
-    pythonLibrary = "${python}/lib/lib${python.libPrefix}${libExt}";
-    pythonIncludeDir = "${python}/include/${python.libPrefix}";
+    pythonExecutable = python3.pythonOnBuildForHost.interpreter;
+    pythonLibrary = "${python3}/lib/lib${python3.libPrefix}${libExt}";
+    pythonIncludeDir = "${python3}/include/${python3.libPrefix}";
     setupHook = ./python-cmake-module-setup-hook.sh;
     outputs = [ "out" "dev" ];
   });


### PR DESCRIPTION
The aliases were relevant in Python 2 times. 

This will need to wait for https://github.com/ros/rosdistro/pull/51650.