### PR TITLE
lyrical.fuse-core: Remove patch applied upstream (again)

### DIFF
--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -119,18 +119,8 @@ in {
   });
 
   fuse-core = rosSuper.fuse-core.overrideAttrs ({
-    patches ? [], postPatch ? "", ...
+    postPatch ? "", ...
   }: {
-    patches = patches ++ [
-      # Don't fail with boost >= 1.86
-      # https://github.com/locusrobotics/fuse/pull/423
-      (self.fetchpatch2 {
-        url = "https://github.com/wentasah/fuse/commit/037b417d9db394b3d5154a800283c30d0ae30cee.patch?full_index=1";
-        hash = "sha256-ShWKk5H/6eaViWfAOL0T+ynCps2FgsPWtAZDoUjvR50=";
-        stripLen = 1;
-      })
-    ];
-
     # https://github.com/locusrobotics/fuse/pull/424
     postPatch = postPatch + ''
       substituteInPlace \


### PR DESCRIPTION
This does the same as commit c341f57a1d ("lyrical.fuse-core: Remove patch applied upstream", 2026-05-23), which was accidentally removed by my incorrect conflict resolution.