### PR TITLE
colcon-clean: init at 0.2.1

### DIFF
--- a/pkgs/colcon/clean.nix
+++ b/pkgs/colcon/clean.nix
@@ -1,0 +1,35 @@
+{ lib, buildPythonPackage, fetchPypi, colcon-core, scantree, setuptools }:
+
+buildPythonPackage rec {
+  pname = "colcon-clean";
+  version = "0.2.1";
+
+  pyproject = true;
+  build-system = [ setuptools ];
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-8rvyck24SxIhhP9AKiR7h1jY9pLJ8yulOAH2nabc61Q=";
+  };
+
+  # Fix for https://github.com/colcon/colcon-clean/pull/46 is
+  # available in scantree 0.4.0 in nixpkgs, so we don't need to
+  # restrict the version anymore.
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace-fail "scantree<0.0.2a0" "scantree"
+  '';
+
+  dependencies = [ colcon-core scantree ];
+
+  pythonImportsCheck = [
+    "colcon_clean"
+  ];
+
+  meta = with lib; {
+    description = "An extension for colcon-core to clean package workspaces.";
+    homepage = "https://colcon.readthedocs.io";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ wentasah ];
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -99,6 +99,8 @@ self: super: with self.lib; {
 
       colcon-cargo = pyFinal.callPackage ./colcon/cargo.nix { };
 
+      colcon-clean = pyFinal.callPackage ./colcon/clean.nix { };
+
       colcon-cmake = pyFinal.callPackage ./colcon/cmake.nix { };
 
       colcon-core = pyFinal.callPackage ./colcon/core.nix { setuptools = pyFinal.setuptools_79; };


### PR DESCRIPTION
You can use this extension as follows:

    pkgs.colcon.withExtensions [ pkgs.python3Packages.colcon-clean ]

where pkgs is the packages set from this overlay.

This is updated version of #345. scantree was finally merged into nixpkgs so we do not need to vendor it. Also the version was updated to 2.1.

Closes #719
Closes #345