### PR TITLE
rosdistro sync, Fri May 29 18:51:31 2026

### DIFF
--- a/distros/humble/apriltag-msgs/default.nix
+++ b/distros/humble/apriltag-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-apriltag-msgs";
-  version = "2.0.1-r2";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag_msgs-release/archive/release/humble/apriltag_msgs/2.0.1-2.tar.gz";
-    name = "2.0.1-2.tar.gz";
-    sha256 = "151d641264106c2e4fd9d243ffff53489afc9c2c01140222da51142144e01bc0";
+    url = "https://github.com/ros2-gbp/apriltag_msgs-release/archive/release/humble/apriltag_msgs/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "0007ea3aba5c0760817317fe88447cd7d50baadbb7f3bedbe8c1ad641dbbd690";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/apriltag-ros/default.nix
+++ b/distros/humble/apriltag-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-lint-auto, apriltag, apriltag-msgs, camera-ros, clang, cv-bridge, eigen, image-transport, image-transport-plugins, rclcpp, rclcpp-components, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-apriltag-ros";
-  version = "3.3.0-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag_ros-release/archive/release/humble/apriltag_ros/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "57119d38723c94b76f21ac6a85cf67de13b304721486e7452645fe528b142c71";
+    url = "https://github.com/ros2-gbp/apriltag_ros-release/archive/release/humble/apriltag_ros/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "c4bf449a9a99565ec918472073c0101bd0025ebaa742bbb5c9e2709075a03cd8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/camera-calibration-parsers/default.nix
+++ b/distros/humble/camera-calibration-parsers/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, sensor-msgs, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-camera-calibration-parsers";
-  version = "3.1.12-r1";
+  version = "3.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_calibration_parsers/3.1.12-1.tar.gz";
-    name = "3.1.12-1.tar.gz";
-    sha256 = "7b533efae19338ac6642ac39c9ba8617c55c2c50eabc035383e51b8c81d7ed83";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_calibration_parsers/3.1.13-1.tar.gz";
+    name = "3.1.13-1.tar.gz";
+    sha256 = "27bdd1d16ffb65bd3a0a803d9fc7d5c739183261759d927536270d0c84fe822c";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ];
+  buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ rclcpp rcpputils sensor-msgs yaml-cpp-vendor ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
 
   meta = {
     description = "camera_calibration_parsers contains routines for reading and writing camera calibration parameters.";

--- a/distros/humble/camera-info-manager-py/default.nix
+++ b/distros/humble/camera-info-manager-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, python3Packages, rclpy, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-camera-info-manager-py";
-  version = "3.1.12-r1";
+  version = "3.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_info_manager_py/3.1.12-1.tar.gz";
-    name = "3.1.12-1.tar.gz";
-    sha256 = "76f8e35c200f618eaa3552cc7c1e8efe4aa296fe39757bd2ddcb47db5e65767e";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_info_manager_py/3.1.13-1.tar.gz";
+    name = "3.1.13-1.tar.gz";
+    sha256 = "478ae41bb95c1801d46c10db9fa698d53982af6310d1d0d29d9999d9751df085";
   };
 
   buildType = "ament_python";

--- a/distros/humble/camera-info-manager/default.nix
+++ b/distros/humble/camera-info-manager/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rcpputils, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-camera-info-manager";
-  version = "3.1.12-r1";
+  version = "3.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_info_manager/3.1.12-1.tar.gz";
-    name = "3.1.12-1.tar.gz";
-    sha256 = "25e203b90f0b9b23a189efca504d7248b22ec6db6d98265879d6783f30d7aa05";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_info_manager/3.1.13-1.tar.gz";
+    name = "3.1.13-1.tar.gz";
+    sha256 = "b2ce801418f5fdf17d9a81b40157ca44cd360f5c46a6146315a8beaf5be16764";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ];
+  buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ ament-index-cpp camera-calibration-parsers rclcpp rcpputils sensor-msgs ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
 
   meta = {
     description = "This package provides a C++ interface for camera calibration

--- a/distros/humble/color-util/default.nix
+++ b/distros/humble/color-util/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-color-util";
-  version = "1.0.0-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/color_util-release/archive/release/humble/color_util/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "ad88e72db74ed89e5ea85d0c4ecfe934ae1b990321de7927742260d02ad380b2";
+    url = "https://github.com/ros2-gbp/color_util-release/archive/release/humble/color_util/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "52c587fa81c013e5fa684fd585474d677640134720fa99eb3216981749366995";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gtest ];
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ];
   propagatedBuildInputs = [ std-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = "An almost dependency-less library for converting between color spaces";

--- a/distros/humble/diagnostic-aggregator/default.nix
+++ b/distros/humble/diagnostic-aggregator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch-pytest, launch-testing-ament-cmake, launch-testing-ros, pluginlib, rcl-interfaces, rclcpp, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-diagnostic-aggregator";
-  version = "4.0.6-r1";
+  version = "4.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_aggregator/4.0.6-1.tar.gz";
-    name = "4.0.6-1.tar.gz";
-    sha256 = "1c7de4f00a211debd38f49ba37f13900273e02ff61aa837b3ef157dd59e870a9";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_aggregator/4.0.7-1.tar.gz";
+    name = "4.0.7-1.tar.gz";
+    sha256 = "b64d424e725f2d54d2056e563b8661f5523dcded18f56a8ec351bf04c46f8b4b";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
-    description = "diagnostic_aggregator";
+    description = "Aggregates diagnostic information from multiple sources.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/humble/diagnostic-common-diagnostics/default.nix
+++ b/distros/humble/diagnostic-common-diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-python, ament-cmake-xmllint, ament-lint-auto, diagnostic-updater, launch-testing-ament-cmake, lm_sensors, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-diagnostic-common-diagnostics";
-  version = "4.0.6-r1";
+  version = "4.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_common_diagnostics/4.0.6-1.tar.gz";
-    name = "4.0.6-1.tar.gz";
-    sha256 = "ea5b20f98541163e591fea051746cfd2e0f74e30e9d71912e9525add7d1ef2ba";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_common_diagnostics/4.0.7-1.tar.gz";
+    name = "4.0.7-1.tar.gz";
+    sha256 = "25afef55e696a379e134b69b8de9caeafe93eaf154bda23f9bab42bced80e1a7";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
-    description = "diagnostic_common_diagnostics";
+    description = "Common diagnostic functions for e.g. HD or CPU usage.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/humble/diagnostic-remote-logging/default.nix
+++ b/distros/humble/diagnostic-remote-logging/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, curl, diagnostic-msgs, rclcpp-components }:
 buildRosPackage {
   pname = "ros-humble-diagnostic-remote-logging";
-  version = "4.0.6-r1";
+  version = "4.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_remote_logging/4.0.6-1.tar.gz";
-    name = "4.0.6-1.tar.gz";
-    sha256 = "24d5446ad36ff31eddc3235f08a3fc5b87e698951550e0be6e15d035345b9c13";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_remote_logging/4.0.7-1.tar.gz";
+    name = "4.0.7-1.tar.gz";
+    sha256 = "46010ac5bf630746a3e25bb4fdbb4d5a307b6861f93691167d9e179ee84d5290";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "diagnostic_remote_logging";
+    description = "Tools for remotely logging diagnostics data.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/humble/diagnostic-updater/default.nix
+++ b/distros/humble/diagnostic-updater/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch, launch-testing, launch-testing-ros, python3Packages, rclcpp, rclcpp-lifecycle, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-diagnostic-updater";
-  version = "4.0.6-r1";
+  version = "4.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_updater/4.0.6-1.tar.gz";
-    name = "4.0.6-1.tar.gz";
-    sha256 = "20a81466492c221a8ca4e75bd786d049ff5ee3f395f221c517057cedacbf6358";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_updater/4.0.7-1.tar.gz";
+    name = "4.0.7-1.tar.gz";
+    sha256 = "5baa358c5e92364866bb6fe627f7be50a8642377ff3ca93962542e1552b3edeb";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ament-cmake-python ament-cmake-ros ];
 
   meta = {
-    description = "diagnostic_updater contains tools for easily updating diagnostics. it is commonly used in device drivers to keep track of the status of output topics, device status, etc.";
+    description = "Update and publish diagnostic information.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/humble/diagnostics/default.nix
+++ b/distros/humble/diagnostics/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, diagnostic-aggregator, diagnostic-common-diagnostics, diagnostic-updater, self-test }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, diagnostic-aggregator, diagnostic-common-diagnostics, diagnostic-remote-logging, diagnostic-updater, self-test }:
 buildRosPackage {
   pname = "ros-humble-diagnostics";
-  version = "4.0.6-r1";
+  version = "4.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostics/4.0.6-1.tar.gz";
-    name = "4.0.6-1.tar.gz";
-    sha256 = "c9f4fb28722efadd21c6a573e9280a1b40971f25ab3efec252c15407c4363f3b";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostics/4.0.7-1.tar.gz";
+    name = "4.0.7-1.tar.gz";
+    sha256 = "87bd2f366946731d30393da94a7425edb15f9705088f097ad536d292ff40d599";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-common-diagnostics diagnostic-updater self-test ];
+  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-common-diagnostics diagnostic-remote-logging diagnostic-updater self-test ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "diagnostics";
+    description = "Diagnostics tools for monitoring and reporting system status.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/humble/image-common/default.nix
+++ b/distros/humble/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-humble-image-common";
-  version = "3.1.12-r1";
+  version = "3.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/image_common/3.1.12-1.tar.gz";
-    name = "3.1.12-1.tar.gz";
-    sha256 = "70b0c8e616a036fec3665d4e4abb5e47771d7b06b269bcd45b0fe18a9ba99fe1";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/image_common/3.1.13-1.tar.gz";
+    name = "3.1.13-1.tar.gz";
+    sha256 = "d5181fa36d99674f4bce228d49b638306235ffb6f84381638bbacde2077e28de";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/image-transport/default.nix
+++ b/distros/humble/image-transport/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-image-transport";
-  version = "3.1.12-r1";
+  version = "3.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/image_transport/3.1.12-1.tar.gz";
-    name = "3.1.12-1.tar.gz";
-    sha256 = "819799f4115337255c52dc6cb19cf7cad7cefa6fb2f4eec85d2d005791435d64";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/image_transport/3.1.13-1.tar.gz";
+    name = "3.1.13-1.tar.gz";
+    sha256 = "4f07b17990c6f2ad949a84029075e6874654717a2f7ff1f333bbf66d3de8ef6e";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ];
+  buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ message-filters pluginlib rclcpp sensor-msgs ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
 
   meta = {
     description = "image_transport should always be used to subscribe to and publish images. It provides transparent

--- a/distros/humble/librealsense2/default.nix
+++ b/distros/humble/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, git, glfw3, libGL, libGLU, libusb1, libx11, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-humble-librealsense2";
-  version = "2.57.7-r1";
+  version = "2.58.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/librealsense2-release/archive/release/humble/librealsense2/2.57.7-1.tar.gz";
-    name = "2.57.7-1.tar.gz";
-    sha256 = "b05b2bca833558630e557016e54fe1dbceb109a36570cb57cc7e9c16c6fc605b";
+    url = "https://github.com/ros2-gbp/librealsense2-release/archive/release/humble/librealsense2/2.58.1-1.tar.gz";
+    name = "2.58.1-1.tar.gz";
+    sha256 = "407a71fd8de9d04d8372b60674cab208bb8be9397aa6a18e82b86cb9ae508bae";
   };
 
   buildType = "cmake";

--- a/distros/humble/log-view/default.nix
+++ b/distros/humble/log-view/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ncurses, rcl-interfaces, rclcpp, xclip, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ncurses, rcl-interfaces, rclcpp, rosbag2-cpp, rosgraph-msgs, xclip, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-log-view";
-  version = "0.3.3-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/hatchbed/log_view-release/archive/release/humble/log_view/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "1ac96bf8fa982f89aaa80c4c5009dc265e283dea52c5459ed05063d7aefd8c40";
+    url = "https://github.com/hatchbed/log_view-release/archive/release/humble/log_view/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "b14670a61233774c7a870be5f37a993abf9dd507bc015d247ed9808e32a023af";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ncurses rcl-interfaces rclcpp xclip yaml-cpp-vendor ];
+  propagatedBuildInputs = [ ncurses rcl-interfaces rclcpp rosbag2-cpp rosgraph-msgs xclip yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/message-filters/default.nix
+++ b/distros/humble/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, builtin-interfaces, python-cmake-module, rclcpp, rclcpp-lifecycle, rclpy, rcutils, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-message-filters";
-  version = "4.3.16-r1";
+  version = "4.3.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/humble/message_filters/4.3.16-1.tar.gz";
-    name = "4.3.16-1.tar.gz";
-    sha256 = "0d45f77258bf3683b828a45a6067047882ab5f39f52f8e1bb4c89ebdda1023eb";
+    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/humble/message_filters/4.3.18-1.tar.gz";
+    name = "4.3.18-1.tar.gz";
+    sha256 = "8d97de0484e94611390f95a28e440bd80b463521d7558523f4d0257dd7643d27";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mp2p-icp/default.nix
+++ b/distros/humble/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mp2p-icp";
-  version = "2.10.2-r1";
+  version = "2.10.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp/2.10.2-1.tar.gz";
-    name = "2.10.2-1.tar.gz";
-    sha256 = "b0c870c61c79e7510e7587c70d8109ae8f18dda54c55661c9d3440c5c4213260";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp/2.10.3-1.tar.gz";
+    name = "2.10.3-1.tar.gz";
+    sha256 = "6b916ea8f81b6ed55fd058803a62a9ab85d8592e0149f2ad0cdaa52c4f5903b9";
   };
 
   buildType = "cmake";

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -547,6 +547,51 @@ in with lib; {
     hash = "sha256-GpzGMpQ02s/X/XEcGoozzMjigrbqvAu81bcb7QG+36E=";
   };
 
+  librealsense2 = (pipe rosSuper.librealsense2 [
+    (pkg: patchExternalProjectGit pkg {
+      file = "CMake/external_libcurl.cmake";
+      originalUrl = ''"https://github.com/curl/curl.git"'';
+      url = "https://github.com/curl/curl.git";
+      originalRev = ''"curl-8_8_0"'';
+      rev = "curl-8_8_0";
+      fetchgitArgs.hash = "sha256-MjB6k8mDJypyuh6BN2hxy2My7/DfImjw+5iI729snBg=";
+    })
+    (pkg: patchVendorUrl pkg {
+      file = "CMake/external_sqlite3.cmake";
+      url = "https://sqlite.org/2025/sqlite-amalgamation-3490100.zip";
+      hash = "sha256-bOvR2EA/xYww6Tk5skbz5uWNB2WlzVBUbxbAD9gF0sM=";
+    })
+    (pkg: patchExternalProjectGit pkg {
+      file = "CMake/external_yaml_cpp.cmake";
+      url = "https://github.com/jbeder/yaml-cpp.git";
+      rev = "yaml-cpp-0.7.0";
+      fetchgitArgs.hash = "sha256-2tFWccifn0c2lU/U1WNg2FHrBohjx8CXMllPJCevaNk=";
+    })
+  ]).overrideAttrs ({
+    buildInputs ? [], postPatch ? "", ...
+  }: {
+    buildInputs = buildInputs ++ [ self.nlohmann_json ];
+    postPatch = postPatch + ''
+      # Get rid of nlohmann_json vendoring
+      substituteInPlace third-party/CMakeLists.txt \
+        --replace-fail 'include(CMake/external_json.cmake)' ""
+      # Don't try to install to $HOME
+      substituteInPlace tools/realsense-viewer/CMakeLists.txt \
+        --replace-fail '$ENV{HOME}/Documents/librealsense2/presets' ''\'''${CMAKE_INSTALL_PREFIX}/share/librealsense2/presets'
+      substituteInPlace CMake/external_fastcdr.cmake \
+        --replace-fail ''\'''${CMAKE_BINARY_DIR}/third-party/fastcdr' '${fetchTarball {
+          url = "https://github.com/eProsima/Fast-CDR/archive/refs/tags/v1.0.25.tar.gz";
+          sha256 = "sha256:14v85zj5b5fnswhkpps09jk68w6miad8zbhlp625d2kj0yfw4cyp";
+        }}'
+      # If the command below fails, update the above command!
+      substituteInPlace CMake/external_fastcdr.cmake \
+        --replace-fail '--branch v1.0.25' 'see the comment'
+      # https://github.com/realsenseai/librealsense/issues/15120#issuecomment-4586244495
+      substituteInPlace third-party/realsense-file/CMakeLists.txt \
+        --replace-fail '$<$<COMPILE_LANGUAGE:C>:-include stdint.h>' ""
+    '';
+  });
+
   libyaml-vendor = patchExternalProjectGit rosSuper.libyaml-vendor {
     url = "https://github.com/yaml/libyaml.git";
     rev = "2c891fc7a770e8ba2fec34fc6b545c672beb37e6";

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -1162,6 +1162,19 @@ in with lib; {
     nativeBuildInputs = nativeBuildInputs ++ [ self.pkg-config ];
   });
 
+  rosgraph-monitor = rosSuper.rosgraph-monitor.overrideAttrs ({
+    patches ? [], ...
+  }: {
+    # https://github.com/ros-tooling/graph-monitor/pull/51
+    patches = patches ++ [
+      (self.fetchpatch2 {
+        url = "https://github.com/ros-tooling/graph-monitor/commit/c01089650d008fbe140e90ba14bfd3d5c143b24b.patch?full_index=1";
+        hash = "sha256-UJ8k/3Y+FqjQg4rR8Dt0Q8+JsMQN9Hyht1mob5N3m4M=";
+        stripLen = 1;
+      })
+    ];
+  });
+
   rosidl-generator-py = rosSuper.rosidl-generator-py.overrideAttrs ({
     postPatch ? "", ...
   }: let

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -1079,6 +1079,20 @@ in with lib; {
     ];
   });
 
+  pybind11-json-vendor = (patchExternalProjectGit rosSuper.pybind11-json-vendor {
+    url = "https://github.com/pybind/pybind11_json.git";
+    originalRev = "\${pybind11_json_version}";
+    rev = "0fbbe3bbb27bd07a5ec7d71cbb1f17eaf4d37702";
+    fetchgitArgs.hash = "sha256-GQldzT1YU6I1s1RFfzNIJNaIY/LsrsTevoaUoz1SK+Y=";
+  }).overrideAttrs ({
+    postPatch ? "", ...
+  }: {
+    postPatch = postPatch + ''
+      substituteInPlace CMakeLists.txt --replace-fail \
+        'UPDATE_COMMAND ""' 'UPDATE_COMMAND ""'$'\n'"PATCH_COMMAND sed -i -e \"s|cmake_minimum_required(VERSION 3.4.3)|cmake_minimum_required(VERSION 3.10)|\" CMakeLists.txt"
+    '';
+  });
+
   python-qt-binding = rosSuper.python-qt-binding.overrideAttrs ({
     patches ? [], ...
   }: {

--- a/distros/humble/point-cloud-transport-py/default.nix
+++ b/distros/humble/point-cloud-transport-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, pybind11-vendor, python-cmake-module, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-point-cloud-transport-py";
-  version = "1.0.21-r1";
+  version = "1.0.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/humble/point_cloud_transport_py/1.0.21-1.tar.gz";
-    name = "1.0.21-1.tar.gz";
-    sha256 = "5b34253599e6e842f880ab04ebe99fe85781024e1def6c07109a1650e5a444d5";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/humble/point_cloud_transport_py/1.0.22-1.tar.gz";
+    name = "1.0.22-1.tar.gz";
+    sha256 = "f7cf1f65cc20895cb7326971a60caa7ff9f4a46e656c2cd170232a3a70d93910";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/point-cloud-transport/default.nix
+++ b/distros/humble/point-cloud-transport/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rcpputils, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-point-cloud-transport";
-  version = "1.0.21-r1";
+  version = "1.0.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/humble/point_cloud_transport/1.0.21-1.tar.gz";
-    name = "1.0.21-1.tar.gz";
-    sha256 = "1b40d0b09bd5fc83e67935df9cdf77d411577e295f16fb1ad5b316c1a0c1c436";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/humble/point_cloud_transport/1.0.22-1.tar.gz";
+    name = "1.0.22-1.tar.gz";
+    sha256 = "89d8bc1d9da6245d908d85b74c3199b1643fc13a259abdee6786acaed88db440";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ];
+  buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ message-filters pluginlib rclcpp rclcpp-components rcpputils sensor-msgs ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
 
   meta = {
     description = "Support for transporting PointCloud2 messages in compressed format and plugin interface for implementing additional PointCloud2 transports.";

--- a/distros/humble/realsense2-camera-msgs/default.nix
+++ b/distros/humble/realsense2-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-realsense2-camera-msgs";
-  version = "4.57.7-r4";
+  version = "4.58.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realsense-ros-release/archive/release/humble/realsense2_camera_msgs/4.57.7-4.tar.gz";
-    name = "4.57.7-4.tar.gz";
-    sha256 = "e7c04a5554baad3f8c1f9c07fe7efaf08fbc8f4040e26999dc31091049aad86c";
+    url = "https://github.com/ros2-gbp/realsense-ros-release/archive/release/humble/realsense2_camera_msgs/4.58.1-1.tar.gz";
+    name = "4.58.1-1.tar.gz";
+    sha256 = "adaf97d77e48dc0dbf58266085643136bd75ee489bb0439831950ba062ad1d19";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/realsense2-camera/default.nix
+++ b/distros/humble/realsense2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, builtin-interfaces, cv-bridge, diagnostic-updater, eigen, geometry-msgs, image-transport, launch-pytest, launch-ros, launch-testing, librealsense2, lifecycle-msgs, nav-msgs, python3Packages, rclcpp, rclcpp-components, rclcpp-lifecycle, realsense2-camera-msgs, ros-environment, ros2topic, sensor-msgs, sensor-msgs-py, std-msgs, std-srvs, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-realsense2-camera";
-  version = "4.57.7-r4";
+  version = "4.58.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realsense-ros-release/archive/release/humble/realsense2_camera/4.57.7-4.tar.gz";
-    name = "4.57.7-4.tar.gz";
-    sha256 = "3a4fc3694a6419571adfae61b924970d8108b5c740873fa63f698024150391ec";
+    url = "https://github.com/ros2-gbp/realsense-ros-release/archive/release/humble/realsense2_camera/4.58.1-1.tar.gz";
+    name = "4.58.1-1.tar.gz";
+    sha256 = "b7bd3bf94a536ba630208d786584847d64e0fcbeb232e8cb1d13173e9d6f9b8e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/realsense2-description/default.nix
+++ b/distros/humble/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch-ros, rclcpp, rclcpp-components, realsense2-camera-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-realsense2-description";
-  version = "4.57.7-r4";
+  version = "4.58.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realsense-ros-release/archive/release/humble/realsense2_description/4.57.7-4.tar.gz";
-    name = "4.57.7-4.tar.gz";
-    sha256 = "bf3cbd160a1d1913275315bc03e720e0ff5c2ecab587f3e5f278ae087bbcad53";
+    url = "https://github.com/ros2-gbp/realsense-ros-release/archive/release/humble/realsense2_description/4.58.1-1.tar.gz";
+    name = "4.58.1-1.tar.gz";
+    sha256 = "6df8bfe2a63b0e430d492ab68b8c54a49e82af0f8246d5daf84ac3c7fffd4336";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmf-building-map-tools/default.nix
+++ b/distros/humble/rmf-building-map-tools/default.nix
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_python";
   checkInputs = [ python3Packages.pytest ];
-  propagatedBuildInputs = [ _unresolved_ignition-fuel-tools7 ament-index-python python3Packages.Rtree python3Packages.fiona python3Packages.pyproj python3Packages.pyyaml python3Packages.requests python3Packages.shapely rclpy rmf-building-map-msgs rmf-site-map-msgs sqlite std-msgs yaml-cpp ];
+  propagatedBuildInputs = [ _unresolved_ignition-fuel-tools7 ament-index-python python3Packages.fiona python3Packages.pyproj python3Packages.pyyaml python3Packages.requests python3Packages.rtree python3Packages.shapely rclpy rmf-building-map-msgs rmf-site-map-msgs sqlite std-msgs yaml-cpp ];
 
   meta = {
     description = "RMF Building map tools";

--- a/distros/humble/robotraconteur-companion/default.nix
+++ b/distros/humble/robotraconteur-companion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, eigen, gtest, opencv, robotraconteur, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-robotraconteur-companion";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robotraconteur_companion-release/archive/release/humble/robotraconteur_companion/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "6665cd04c544561fb58ca8671c88f8c3e4c7a9e63d46845e59550c1677dfeecc";
+    url = "https://github.com/ros2-gbp/robotraconteur_companion-release/archive/release/humble/robotraconteur_companion/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "df7000e92d054001374a44a738c6f6e6d72408212dd23cc2e7790cdeac00dd2a";
   };
 
   buildType = "cmake";

--- a/distros/humble/robotraconteur/default.nix
+++ b/distros/humble/robotraconteur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bluez, boost, cmake, dbus, gtest, libusb1, openssl, python3, python3Packages, zlib }:
 buildRosPackage {
   pname = "ros-humble-robotraconteur";
-  version = "1.2.7-r1";
+  version = "1.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robotraconteur-release/archive/release/humble/robotraconteur/1.2.7-1.tar.gz";
-    name = "1.2.7-1.tar.gz";
-    sha256 = "b791ed92edfbf65f8096aaf461e59026a65b780094657dd76c4de9cec57c9220";
+    url = "https://github.com/ros2-gbp/robotraconteur-release/archive/release/humble/robotraconteur/1.2.8-1.tar.gz";
+    name = "1.2.8-1.tar.gz";
+    sha256 = "1ea25e7651ba176009048ab90a5063af09a02685893a7f3b75db164ab0043cca";
   };
 
   buildType = "cmake";

--- a/distros/humble/rosapi-msgs/default.nix
+++ b/distros/humble/rosapi-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-rosapi-msgs";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosapi_msgs/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "e1712a97eccca687bee229614a646013a5eb1b06b873f53864f2b8aa451b3143";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosapi_msgs/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "a5fae2d7d8035338e4ed4062027ccfb954d32fcebdb9e802208ff6dcdbe07be9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosapi/default.nix
+++ b/distros/humble/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-mypy, ament-cmake-pytest, ament-cmake-python, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2action, ros2interface, ros2node, ros2param, ros2service, ros2topic, rosapi-msgs, rosbridge-library, rosidl-adapter, rosidl-runtime-py, sensor-msgs, shape-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosapi";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosapi/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "2853ac75cc868d0daf5414f43a59ca3c0b7dd9d9d4e96533c8d68c66c078a14c";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosapi/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "cf514a579919c27ba35a390cff1aa7eb962e0230629c5ab13aad1ce5ec7a5ed2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbridge-library/default.nix
+++ b/distros/humble/rosbridge-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-mypy, ament-cmake-python, ament-cmake-ros, builtin-interfaces, control-msgs, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rcl-interfaces, rclpy, rosbridge-test-msgs, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbridge-library";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_library/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "389b49df58a72441112ea798c95710800d55e7e1016eff73a4628461410ec44b";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_library/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "3eef133d9e247516924f00812a1ead5b1eea30d9524e4f3dcbbe97e99a03ddf8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbridge-msgs/default.nix
+++ b/distros/humble/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-rosbridge-msgs";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_msgs/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "51c0e1d2ca0bc5fc5906354d0407bca0dc037ce9a1d0d85e4f452468cc78f89d";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_msgs/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "8a59f3851276200d8798c3ceab8b4346d7e887a79d55893afb7781a2af0ae0ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbridge-server/default.nix
+++ b/distros/humble/rosbridge-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-mypy, ament-cmake-python, ament-cmake-ros, example-interfaces, launch, launch-ros, launch-testing-ament-cmake, python3Packages, rcl-interfaces, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-rosbridge-server";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_server/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "f794b86fea7eec6cb07e6952883edfded52935114d375b865d9094bd630a568c";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_server/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "305240fb84dcf9c1b10de186f703b2c5582f5cd803ba0c85da5a47d5286cb265";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbridge-suite/default.nix
+++ b/distros/humble/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-humble-rosbridge-suite";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_suite/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "398da843e8e21fcd42a030a089812cd23b0302644a6da90a209a5bbf70bb5be4";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_suite/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "e6b6eb945083ab025e2a2f55cc9e80b32e00723d558f88cc4aa7c4143bcd6714";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbridge-test-msgs/default.nix
+++ b/distros/humble/rosbridge-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbridge-test-msgs";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_test_msgs/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "a434b004f73a960e48cad9de7badb368fa36e50401f14627fc59c7aa665ae615";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_test_msgs/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "1c72012b58c6d98f5a2046d1feaa4e99f4b067b1b61df0c1621b752f31b345b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/self-test/default.nix
+++ b/distros/humble/self-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-self-test";
-  version = "4.0.6-r1";
+  version = "4.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/self_test/4.0.6-1.tar.gz";
-    name = "4.0.6-1.tar.gz";
-    sha256 = "19de059a70dfa7893992d9a2e5f753cd8f2d0caa58ff0a4e458067db9350c1a7";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/self_test/4.0.7-1.tar.gz";
+    name = "4.0.7-1.tar.gz";
+    sha256 = "8490b9eb668866429d72868e5e43bb377da865135330a3819d53e45e819df6f4";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "self_test";
+    description = "Self-test tools for diagnostics.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/jazzy/apriltag-msgs/default.nix
+++ b/distros/jazzy/apriltag-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-apriltag-msgs";
-  version = "2.0.1-r5";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag_msgs-release/archive/release/jazzy/apriltag_msgs/2.0.1-5.tar.gz";
-    name = "2.0.1-5.tar.gz";
-    sha256 = "c8df3ab71238013641eb0544edc691e11c8f86396f94fd165f509403510484ce";
+    url = "https://github.com/ros2-gbp/apriltag_msgs-release/archive/release/jazzy/apriltag_msgs/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "6df6c2b2170e37ff18df428f02ea933a7f9a11c94e57ebbcae509fda749ecc5a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/apriltag-ros/default.nix
+++ b/distros/jazzy/apriltag-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-lint-auto, apriltag, apriltag-msgs, camera-ros, clang, cv-bridge, eigen, image-proc, image-transport, image-transport-plugins, rclcpp, rclcpp-components, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-apriltag-ros";
-  version = "3.3.0-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag_ros-release/archive/release/jazzy/apriltag_ros/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "fbfcb60a822ee3958dae38763baf5f6402d0dc38cd061bb3199a6bf960913e2e";
+    url = "https://github.com/ros2-gbp/apriltag_ros-release/archive/release/jazzy/apriltag_ros/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "f071fdb3871e2170da3179316830b71c3bcb419c938c5971b4c717fe4d67a4ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/camera-calibration-parsers/default.nix
+++ b/distros/jazzy/camera-calibration-parsers/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-camera-calibration-parsers";
-  version = "5.1.7-r1";
+  version = "5.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/camera_calibration_parsers/5.1.7-1.tar.gz";
-    name = "5.1.7-1.tar.gz";
-    sha256 = "f082d7dd4f158af0262512a11effb4bbfbfe966d10b20de9d5ab8e1a33168d35";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/camera_calibration_parsers/5.1.8-1.tar.gz";
+    name = "5.1.8-1.tar.gz";
+    sha256 = "a7192b89dbddcb8fba1c30990f7e9cf626de878a47a966ff84627324b85a149e";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ];
+  buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ rclcpp sensor-msgs yaml-cpp-vendor ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
 
   meta = {
     description = "camera_calibration_parsers contains routines for reading and writing camera calibration parameters.";

--- a/distros/jazzy/camera-info-manager-py/default.nix
+++ b/distros/jazzy/camera-info-manager-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, python3Packages, rclpy, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-camera-info-manager-py";
-  version = "5.1.7-r1";
+  version = "5.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/camera_info_manager_py/5.1.7-1.tar.gz";
-    name = "5.1.7-1.tar.gz";
-    sha256 = "2fff48e1815f99afc1fa8c355ad2ad44dc1969e8832e947cba4d6a56247ad4de";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/camera_info_manager_py/5.1.8-1.tar.gz";
+    name = "5.1.8-1.tar.gz";
+    sha256 = "ec53c50afc87062451cbe76ad806f20cc4caf046b05cccb9f3de43af843b7a3e";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/camera-info-manager/default.nix
+++ b/distros/jazzy/camera-info-manager/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rclcpp-lifecycle, rcpputils, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rclcpp-lifecycle, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-camera-info-manager";
-  version = "5.1.7-r1";
+  version = "5.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/camera_info_manager/5.1.7-1.tar.gz";
-    name = "5.1.7-1.tar.gz";
-    sha256 = "88662483f37460bf0a04df0da460780483b37d3b95acb88b5750aa75ab200347";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/camera_info_manager/5.1.8-1.tar.gz";
+    name = "5.1.8-1.tar.gz";
+    sha256 = "df700533e4df4c1a16092a6878eaf41fb8ec3453dc9dd7e3eeb55e1a162eba4a";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ];
+  buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ ament-index-cpp camera-calibration-parsers rclcpp rclcpp-lifecycle rcpputils sensor-msgs ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
 
   meta = {
     description = "This package provides a C++ interface for camera calibration

--- a/distros/jazzy/canopen-402-driver/default.nix
+++ b/distros/jazzy/canopen-402-driver/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, boost, canopen-base-driver, canopen-core, canopen-interfaces, canopen-proxy-driver, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, boost, canopen-base-driver, canopen-core, canopen-interfaces, canopen-proxy-driver, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-canopen-402-driver";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/canopen_402_driver/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "668ef437d087916a46572a9acf5c500e06d5bb72e64f37d2a03887ca5bfadaea";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/canopen_402_driver/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "4777487cfe2a0abbaff306dd943620f198f1fa69f4c9a9e06f38637022078835";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-lint-auto ];
-  propagatedBuildInputs = [ boost canopen-base-driver canopen-core canopen-interfaces canopen-proxy-driver rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs std-srvs ];
+  propagatedBuildInputs = [ boost canopen-base-driver canopen-core canopen-interfaces canopen-proxy-driver rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {
-    description = "Driiver for devices implementing CIA402 profile";
+    description = "Driver for devices implementing CIA402 profile";
     license = with lib.licenses; [ "LGPL-v3" ];
   };
 }

--- a/distros/jazzy/canopen-base-driver/default.nix
+++ b/distros/jazzy/canopen-base-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, boost, canopen-core, canopen-interfaces, diagnostic-updater, lely-core-libraries, rclcpp, rclcpp-components, rclcpp-lifecycle, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-canopen-base-driver";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/canopen_base_driver/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "045d58b53d994651fea29adac0c8ade0798f35819784aad66e714b46be3c7fa5";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/canopen_base_driver/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "44c5d1a8cd944728438e6b89e3aac72d8ce23e9922120f9b3a7eb6f569dd0107";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/canopen-core/default.nix
+++ b/distros/jazzy/canopen-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, boost, canopen-interfaces, lely-core-libraries, lifecycle-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-canopen-core";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/canopen_core/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "c60decdfb299ff813894d35c83c1287c21306cc3a290b52755396f066f05eaa3";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/canopen_core/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "173a68fe359149f81f7f43ab3472a75144a6c71ba2cb6f38dd062ae1e18d22ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/canopen-fake-slaves/default.nix
+++ b/distros/jazzy/canopen-fake-slaves/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, lely-core-libraries, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-jazzy-canopen-fake-slaves";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/canopen_fake_slaves/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "07de3440787dbc65617be9edfeafe679baa275a9d7b559bcabb0cbda00800a5b";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/canopen_fake_slaves/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "4b853732a6f8d00b9ed41edf99fb67fcbdb225ff5feb98cea630395350d590ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/canopen-interfaces/default.nix
+++ b/distros/jazzy/canopen-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-canopen-interfaces";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/canopen_interfaces/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "6cdfa99e9063ca77b709183c8d0e888196040c55d215f92c465e4ac10a562c64";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/canopen_interfaces/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "0a759e769f5e06e59b882a4ce8731b7b8740c60e06341077289d7c4205ebb613";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/canopen-master-driver/default.nix
+++ b/distros/jazzy/canopen-master-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, canopen-core, canopen-interfaces, lely-core-libraries, rclcpp, rclcpp-components, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-jazzy-canopen-master-driver";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/canopen_master_driver/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "1f0a4302b1621a58c7bcf7ea56aaebbbb8cbc3234704593639311f0108bfe960";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/canopen_master_driver/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "d60c07b8afc29fdd5e26aa16e9aab9cdc0fc5733d31e57716c18edf5e9082318";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/canopen-proxy-driver/default.nix
+++ b/distros/jazzy/canopen-proxy-driver/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, canopen-base-driver, canopen-core, canopen-interfaces, rclcpp, rclcpp-components, rclcpp-lifecycle, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, canopen-base-driver, canopen-core, canopen-interfaces, rclcpp, rclcpp-components, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-jazzy-canopen-proxy-driver";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/canopen_proxy_driver/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "cfbdb1d5c496e9f18a94d7c516bc0ff55a531bf6c92a14964c8e219cb737c782";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/canopen_proxy_driver/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "36154a7c07440780a3ad45bbfc1aa5e19c668c9b9945bf0b7e254885d521ae7f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-lint-auto ];
-  propagatedBuildInputs = [ canopen-base-driver canopen-core canopen-interfaces rclcpp rclcpp-components rclcpp-lifecycle std-msgs std-srvs ];
+  propagatedBuildInputs = [ canopen-base-driver canopen-core canopen-interfaces rclcpp rclcpp-components rclcpp-lifecycle ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/jazzy/canopen-ros2-control/default.nix
+++ b/distros/jazzy/canopen-ros2-control/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, canopen-402-driver, canopen-core, canopen-proxy-driver, hardware-interface, pluginlib, rclcpp, rclcpp-components, rclcpp-lifecycle, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, canopen-402-driver, canopen-core, canopen-proxy-driver, hardware-interface, pluginlib, rclcpp, rclcpp-components, rclcpp-lifecycle, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-canopen-ros2-control";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/canopen_ros2_control/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "ad86bd55a979db71104f60edf7d7668d238272d038d8d19aad0e29a76587c842";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/canopen_ros2_control/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "b374e0a422e36b3f45ec775124ee17b748e43ca2da502083f0b17b4906900b0d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock ros2-control-test-assets ];
+  checkInputs = [ ros2-control-test-assets ];
   propagatedBuildInputs = [ canopen-402-driver canopen-core canopen-proxy-driver hardware-interface pluginlib rclcpp rclcpp-components rclcpp-lifecycle ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/jazzy/canopen-ros2-controllers/default.nix
+++ b/distros/jazzy/canopen-ros2-controllers/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, canopen-402-driver, canopen-interfaces, canopen-proxy-driver, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, canopen-402-driver, canopen-interfaces, canopen-proxy-driver, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-canopen-ros2-controllers";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/canopen_ros2_controllers/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "21bb259332f321d50a007eb0373aa7f1258b7b229543e182b4f3b34f7165ffbd";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/canopen_ros2_controllers/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "77ece72b4d809c778a8f519469308bc12e94e9ffbc44042be194031caad8566e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock ];
   propagatedBuildInputs = [ canopen-402-driver canopen-interfaces canopen-proxy-driver controller-interface controller-manager hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools std-msgs std-srvs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/jazzy/canopen-tests/default.nix
+++ b/distros/jazzy/canopen-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, canopen-402-driver, canopen-core, canopen-fake-slaves, canopen-proxy-driver, canopen-ros2-controllers, controller-manager, forward-command-controller, joint-state-broadcaster, joint-trajectory-controller, lely-core-libraries, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-canopen-tests";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/canopen_tests/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "6929c47239ebdd6460ad7d2a78160919ec169d40d1d9f23132ab84711253c0cf";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/canopen_tests/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "1c6de65afceeeda6257e3401b4e1c358b63a84fb8835483858024b764611b2d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/canopen-utils/default.nix
+++ b/distros/jazzy/canopen-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, canopen-interfaces, lifecycle-msgs, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-canopen-utils";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/canopen_utils/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "b4aa8b1c0d3239b7d819cdb5e76a29a3b80f485ee0be366bee34f7ea350ed746";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/canopen_utils/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "b2668c3fe47a0acebca2a97bd7c216fda2aa47966dbd086c088c81d30166a855";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/canopen/default.nix
+++ b/distros/jazzy/canopen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, canopen-402-driver, canopen-base-driver, canopen-core, canopen-interfaces, canopen-proxy-driver, lely-core-libraries }:
 buildRosPackage {
   pname = "ros-jazzy-canopen";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/canopen/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "db6c0e947de352312389b9cc3acb875eabee9cfd3c3dd7883e22932a6bc2cc9b";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/canopen/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "15468b67c2122e48c41b45032428ae82acd5dc84d412ebc39636ad969a3de8eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-bms-broadcaster/default.nix
+++ b/distros/jazzy/clearpath-bms-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-bms-broadcaster";
-  version = "2.9.7-r1";
+  version = "2.9.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bms_broadcaster/2.9.7-1.tar.gz";
-    name = "2.9.7-1.tar.gz";
-    sha256 = "8f6e4acc588942af7b32c93b4bddb2482993331a70010819a3c9c17422e06fa2";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bms_broadcaster/2.9.8-1.tar.gz";
+    name = "2.9.8-1.tar.gz";
+    sha256 = "99d5d2df0d3791fea2d146102932338862b94f4b0e3cabcc99ea8090095636f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-bt-joy/default.nix
+++ b/distros/jazzy/clearpath-bt-joy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, bluez, joy-linux, python3Packages, twist-mux }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-bt-joy";
-  version = "2.9.7-r1";
+  version = "2.9.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bt_joy/2.9.7-1.tar.gz";
-    name = "2.9.7-1.tar.gz";
-    sha256 = "7f419a6d15544d520c588a13b54301c167c76c943c8cae8d8332bf9bdfa413d5";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bt_joy/2.9.8-1.tar.gz";
+    name = "2.9.8-1.tar.gz";
+    sha256 = "86199e0d3bb77523da1a9fd26d9be5651975f5639b0191b4e952671cd55c344d";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/clearpath-common/default.nix
+++ b/distros/jazzy/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, rmw-zenoh-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-common";
-  version = "2.9.7-r1";
+  version = "2.9.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_common/2.9.7-1.tar.gz";
-    name = "2.9.7-1.tar.gz";
-    sha256 = "91e301c7f9f7b53061a0dee90929d3a62240a50225265aff2cef38d91871d8f6";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_common/2.9.8-1.tar.gz";
+    name = "2.9.8-1.tar.gz";
+    sha256 = "4decf9c1e53dbb0ca6941e7a8c2263930f51e8746ba6b303098358009c8a2566";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-config/default.nix
+++ b/distros/jazzy/clearpath-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-config";
-  version = "2.9.2-r1";
+  version = "2.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/jazzy/clearpath_config/2.9.2-1.tar.gz";
-    name = "2.9.2-1.tar.gz";
-    sha256 = "6bfa4560306b5fc0a2396c527f780281d35f02da7ace8af065d0fc74857e971d";
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/jazzy/clearpath_config/2.9.3-1.tar.gz";
+    name = "2.9.3-1.tar.gz";
+    sha256 = "29062138d46850bed8bb6ec62e72c0ada079d14590f2bb7a61c0e91dc2642823";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/clearpath-control/default.nix
+++ b/distros/jazzy/clearpath-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-bt-joy, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, mecanum-drive-controller, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-control";
-  version = "2.9.7-r1";
+  version = "2.9.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_control/2.9.7-1.tar.gz";
-    name = "2.9.7-1.tar.gz";
-    sha256 = "23bdd616a18f4eb3aaa407fbcc6f5e5bbfc6ec3a01d23a45c19044bf068300d2";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_control/2.9.8-1.tar.gz";
+    name = "2.9.8-1.tar.gz";
+    sha256 = "636c8f859f8c3aa8507599d484b6818689c283ff1cf3a30537fff083ae7f1d4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-customization/default.nix
+++ b/distros/jazzy/clearpath-customization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-customization";
-  version = "2.9.7-r1";
+  version = "2.9.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_customization/2.9.7-1.tar.gz";
-    name = "2.9.7-1.tar.gz";
-    sha256 = "c3872eaeadcdd12e6a181d6f03185901fedc8391b64f102997512215497074da";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_customization/2.9.8-1.tar.gz";
+    name = "2.9.8-1.tar.gz";
+    sha256 = "30351a25b30ae6ece18c128429a2557f3ef687355106ae2e0d71e153d3e90229";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-description/default.nix
+++ b/distros/jazzy/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-description";
-  version = "2.9.7-r1";
+  version = "2.9.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_description/2.9.7-1.tar.gz";
-    name = "2.9.7-1.tar.gz";
-    sha256 = "b00e8360623583debc9c1d361ee425176bc10c0f474a2991748165da69fa465c";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_description/2.9.8-1.tar.gz";
+    name = "2.9.8-1.tar.gz";
+    sha256 = "b86e40e38cab3a7f486d457d9a8d167953a1f4c5f1130f46a4e866cd642609f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-diagnostics/default.nix
+++ b/distros/jazzy/clearpath-diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-platform-msgs, diagnostic-aggregator, diagnostic-updater, foxglove-bridge, rclcpp, ros2launch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-diagnostics";
-  version = "2.9.7-r1";
+  version = "2.9.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_diagnostics/2.9.7-1.tar.gz";
-    name = "2.9.7-1.tar.gz";
-    sha256 = "99a5ee52eb325af4e297202c89507c44692da21a6d92107ce034b7d4d7914b0e";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_diagnostics/2.9.8-1.tar.gz";
+    name = "2.9.8-1.tar.gz";
+    sha256 = "9570d79356ed9ffc6c2ca23dc11ac82805bf111d506c0735bed5ea8bbe5b5268";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-generator-common/default.nix
+++ b/distros/jazzy/clearpath-generator-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, _unresolved_python3-apt, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-diagnostics, clearpath-manipulators, moveit-setup-srdf-plugins }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-generator-common";
-  version = "2.9.7-r1";
+  version = "2.9.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_generator_common/2.9.7-1.tar.gz";
-    name = "2.9.7-1.tar.gz";
-    sha256 = "700a65d174ab3175161ecd7a062b1a69a429ca96c90ab450457c1a3adf45f860";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_generator_common/2.9.8-1.tar.gz";
+    name = "2.9.8-1.tar.gz";
+    sha256 = "7ad3704e39d02a7afee2681ef950a4431502ec35350825719be35463e2461af5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-manipulators-description/default.nix
+++ b/distros/jazzy/clearpath-manipulators-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ewellix-description, robot-state-publisher, robotiq-description, ur-description, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-manipulators-description";
-  version = "2.9.7-r1";
+  version = "2.9.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators_description/2.9.7-1.tar.gz";
-    name = "2.9.7-1.tar.gz";
-    sha256 = "bbf3b7e55fad30b5a8a8e5ee2075b292ed36b22c81435d6310cf21affc22b7ab";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators_description/2.9.8-1.tar.gz";
+    name = "2.9.8-1.tar.gz";
+    sha256 = "da15125b9a6fed30797b70a745d0caf506ddb5dbeaa8c76bd3d8472c999c18b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-manipulators/default.nix
+++ b/distros/jazzy/clearpath-manipulators/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, gripper-controllers, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-warehouse, moveit-setup-srdf-plugins, moveit-simple-controller-manager, position-controllers, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-manipulators";
-  version = "2.9.7-r1";
+  version = "2.9.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators/2.9.7-1.tar.gz";
-    name = "2.9.7-1.tar.gz";
-    sha256 = "7332dbddc8ce631e09038a8a8fff703029d08ef6d11d3ce887ce9b001a8ddca9";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators/2.9.8-1.tar.gz";
+    name = "2.9.8-1.tar.gz";
+    sha256 = "3fe4c5af59beaab071d15ed92b2753cfe28e758258006db6a2aed795451dea95";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-mounts-description/default.nix
+++ b/distros/jazzy/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-mounts-description";
-  version = "2.9.7-r1";
+  version = "2.9.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_mounts_description/2.9.7-1.tar.gz";
-    name = "2.9.7-1.tar.gz";
-    sha256 = "d85ba47d91c967135b624c12d800c1f7dff0c0b76913934e599540aa059fca16";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_mounts_description/2.9.8-1.tar.gz";
+    name = "2.9.8-1.tar.gz";
+    sha256 = "829ac284cfaca0fa46d77dfda83c5b2a45d921e4d3b8f3d0aaf294786a50fe2b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-platform-description/default.nix
+++ b/distros/jazzy/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-platform-description";
-  version = "2.9.7-r1";
+  version = "2.9.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_platform_description/2.9.7-1.tar.gz";
-    name = "2.9.7-1.tar.gz";
-    sha256 = "36f1d8fce0303ac7bdb4d67702fca31192f1372e9105e454d91c539821a32fef";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_platform_description/2.9.8-1.tar.gz";
+    name = "2.9.8-1.tar.gz";
+    sha256 = "9a9338cd7d63c9e5467f73459120b5d4499cbf67501fde32c37c5b6f17bfa688";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-sensors-description/default.nix
+++ b/distros/jazzy/clearpath-sensors-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, axis-description, flir-ptu-description, microstrain-inertial-description, realsense2-description, velodyne-description, zed-description }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-sensors-description";
-  version = "2.9.7-r1";
+  version = "2.9.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_sensors_description/2.9.7-1.tar.gz";
-    name = "2.9.7-1.tar.gz";
-    sha256 = "a6bcfb40352657499cc9650ca66ca9fd8571d14e67ee83a01f2da831c67cd347";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_sensors_description/2.9.8-1.tar.gz";
+    name = "2.9.8-1.tar.gz";
+    sha256 = "315243244652f2b0d04097cc7fbd0ecd52e49b7a0a16aa6876e4677c07c22c10";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/color-util/default.nix
+++ b/distros/jazzy/color-util/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-color-util";
-  version = "1.0.0-r4";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/color_util-release/archive/release/jazzy/color_util/1.0.0-4.tar.gz";
-    name = "1.0.0-4.tar.gz";
-    sha256 = "02d3bcb94a92075e85613542ef8de4c1a0e1169e5b96910ec7ee53416a1e342b";
+    url = "https://github.com/ros2-gbp/color_util-release/archive/release/jazzy/color_util/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "0129f58306035d9a815e4ba9f67110221dba05f90fde7f26acf57c13f3692699";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gtest ];
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ];
   propagatedBuildInputs = [ std-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = "An almost dependency-less library for converting between color spaces";

--- a/distros/jazzy/diagnostic-aggregator/default.nix
+++ b/distros/jazzy/diagnostic-aggregator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch-pytest, launch-testing-ament-cmake, launch-testing-ros, pluginlib, rcl-interfaces, rclcpp, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-diagnostic-aggregator";
-  version = "4.2.6-r1";
+  version = "4.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostic_aggregator/4.2.6-1.tar.gz";
-    name = "4.2.6-1.tar.gz";
-    sha256 = "828ad098b4c3c59c2b5263e0679aba921f5110fa9871f78a9b2c2189c3dd54bc";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostic_aggregator/4.2.7-1.tar.gz";
+    name = "4.2.7-1.tar.gz";
+    sha256 = "cce029769f47ae83d8499398ba0a9fb3f8c29f8467e4b266dc53def766d68a52";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
-    description = "diagnostic_aggregator";
+    description = "Aggregates diagnostic information from multiple sources.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/jazzy/diagnostic-common-diagnostics/default.nix
+++ b/distros/jazzy/diagnostic-common-diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-python, ament-cmake-xmllint, ament-lint-auto, diagnostic-updater, launch-testing-ament-cmake, lm_sensors, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-diagnostic-common-diagnostics";
-  version = "4.2.6-r1";
+  version = "4.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostic_common_diagnostics/4.2.6-1.tar.gz";
-    name = "4.2.6-1.tar.gz";
-    sha256 = "6c3f40cbe34e0d036c4e52b687a39b0209d6e21210d199294a14f70c330caeb3";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostic_common_diagnostics/4.2.7-1.tar.gz";
+    name = "4.2.7-1.tar.gz";
+    sha256 = "16d111ff84cdd95013f7f9b5e5ee6d3ed7e5ecd2e5dbb252e24d3b0e1255a36f";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
-    description = "diagnostic_common_diagnostics";
+    description = "Common diagnostic functions for e.g. HD or CPU usage.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/jazzy/diagnostic-remote-logging/default.nix
+++ b/distros/jazzy/diagnostic-remote-logging/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, curl, diagnostic-msgs, rclcpp-components }:
 buildRosPackage {
   pname = "ros-jazzy-diagnostic-remote-logging";
-  version = "4.2.6-r1";
+  version = "4.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostic_remote_logging/4.2.6-1.tar.gz";
-    name = "4.2.6-1.tar.gz";
-    sha256 = "e76e1297feec1a00eb9240f7f1c86caea9aa3b1745cef8463ee7308c7ca45e75";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostic_remote_logging/4.2.7-1.tar.gz";
+    name = "4.2.7-1.tar.gz";
+    sha256 = "bf3fea0932a2517bfc3a651ec091c8eaab912b81c5ca6fdca9bf61c36a09117f";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "diagnostic_remote_logging";
+    description = "Tools for remotely logging diagnostics data.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/jazzy/diagnostic-updater/default.nix
+++ b/distros/jazzy/diagnostic-updater/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch, launch-testing, launch-testing-ros, python3Packages, rclcpp, rclcpp-lifecycle, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-diagnostic-updater";
-  version = "4.2.6-r1";
+  version = "4.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostic_updater/4.2.6-1.tar.gz";
-    name = "4.2.6-1.tar.gz";
-    sha256 = "6e9aa7835a5b0e0cdda56c7f55bfc38d3716c53748a0fcaa2d913f567336a332";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostic_updater/4.2.7-1.tar.gz";
+    name = "4.2.7-1.tar.gz";
+    sha256 = "1c15396344e6249e4475daf8c7143dfccc50a857ae66ef312e83471d6f0df371";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ament-cmake-python ament-cmake-ros ];
 
   meta = {
-    description = "diagnostic_updater contains tools for easily updating diagnostics. it is commonly used in device drivers to keep track of the status of output topics, device status, etc.";
+    description = "Update and publish diagnostic information.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/jazzy/diagnostics/default.nix
+++ b/distros/jazzy/diagnostics/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, diagnostic-aggregator, diagnostic-common-diagnostics, diagnostic-updater, self-test }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, diagnostic-aggregator, diagnostic-common-diagnostics, diagnostic-remote-logging, diagnostic-updater, self-test }:
 buildRosPackage {
   pname = "ros-jazzy-diagnostics";
-  version = "4.2.6-r1";
+  version = "4.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostics/4.2.6-1.tar.gz";
-    name = "4.2.6-1.tar.gz";
-    sha256 = "d2821bd0da5e3087927e84a25382bb715e87e7cf74562d8cb65e5381a0e5efce";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostics/4.2.7-1.tar.gz";
+    name = "4.2.7-1.tar.gz";
+    sha256 = "6e606659b1a6608644ae226a4ecd466520ae8a65487022ac3400ffda2f340695";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-common-diagnostics diagnostic-updater self-test ];
+  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-common-diagnostics diagnostic-remote-logging diagnostic-updater self-test ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "diagnostics";
+    description = "Diagnostics tools for monitoring and reporting system status.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/jazzy/image-common/default.nix
+++ b/distros/jazzy/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-jazzy-image-common";
-  version = "5.1.7-r1";
+  version = "5.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/image_common/5.1.7-1.tar.gz";
-    name = "5.1.7-1.tar.gz";
-    sha256 = "2c68b8ad8784f831bf68a921e6d1408be9eb8b114b303ad1dc62da9c79b87268";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/image_common/5.1.8-1.tar.gz";
+    name = "5.1.8-1.tar.gz";
+    sha256 = "17de98b0325960e5e4a55b4aae616d788891a7557c8fd07351e99da91ef6f31e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/image-transport/default.nix
+++ b/distros/jazzy/image-transport/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-image-transport";
-  version = "5.1.7-r1";
+  version = "5.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/image_transport/5.1.7-1.tar.gz";
-    name = "5.1.7-1.tar.gz";
-    sha256 = "517cda3897daaa6d10dd9af69a6fbbc6dda0c150b0d4db8545224497060e8b95";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/image_transport/5.1.8-1.tar.gz";
+    name = "5.1.8-1.tar.gz";
+    sha256 = "18ebe24ca317f87079c63a4386e9e90ee656be003fc6b8ba0f030f4304e8320d";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ];
+  buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ message-filters pluginlib rclcpp rclcpp-components sensor-msgs ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
 
   meta = {
     description = "image_transport should always be used to subscribe to and publish images. It provides transparent

--- a/distros/jazzy/lely-core-libraries/default.nix
+++ b/distros/jazzy/lely-core-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, autoconf, automake, git, libtool, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-lely-core-libraries";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/lely_core_libraries/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "ca36f9307f98489856460742e8b34ccd63fbd50930d735e5105f699d9ea200cd";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/jazzy/lely_core_libraries/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "bd11e0c171b770968561697c08de72aaf198146020dace96cf565e127a6dc65e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/librealsense2/default.nix
+++ b/distros/jazzy/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, git, glfw3, libGL, libGLU, libusb1, libx11, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-jazzy-librealsense2";
-  version = "2.57.7-r1";
+  version = "2.58.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/librealsense2-release/archive/release/jazzy/librealsense2/2.57.7-1.tar.gz";
-    name = "2.57.7-1.tar.gz";
-    sha256 = "8d87399324395e4b7517890672998b9bbf693e59bd7b36326571130d2b0a4a1e";
+    url = "https://github.com/ros2-gbp/librealsense2-release/archive/release/jazzy/librealsense2/2.58.1-1.tar.gz";
+    name = "2.58.1-1.tar.gz";
+    sha256 = "e8e6b99a0e9242f0056b16d87b1c59d7814d6484316fab92b8dab132de0a4311";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/log-view/default.nix
+++ b/distros/jazzy/log-view/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ncurses, rcl-interfaces, rclcpp, xclip, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ncurses, rcl-interfaces, rclcpp, rosgraph-msgs, xclip, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-log-view";
-  version = "0.3.3-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/log_view-release/archive/release/jazzy/log_view/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "104f5379404b1572ea8cf97cc320dfabe2000804ecbc7178bb6666d7bccad0a4";
+    url = "https://github.com/ros2-gbp/log_view-release/archive/release/jazzy/log_view/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "ca0ba15c2b952ba500fcfdc2d71f316b26f2abd9db98ca308a1281d6a8d876af";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ncurses rcl-interfaces rclcpp xclip yaml-cpp-vendor ];
+  propagatedBuildInputs = [ ncurses rcl-interfaces rclcpp rosgraph-msgs xclip yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/message-filters/default.nix
+++ b/distros/jazzy/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, builtin-interfaces, python-cmake-module, rclcpp, rclcpp-lifecycle, rclpy, rcutils, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-message-filters";
-  version = "4.11.13-r1";
+  version = "4.11.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/jazzy/message_filters/4.11.13-1.tar.gz";
-    name = "4.11.13-1.tar.gz";
-    sha256 = "c0bf7d10422da499fbab6162b2e943ffba965a4d0fe8202bc31a33610605616c";
+    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/jazzy/message_filters/4.11.15-1.tar.gz";
+    name = "4.11.15-1.tar.gz";
+    sha256 = "ee2c6d1dd9ac0753ab55e70f13a83a93b6b972c8516fbbe1c4d657c66e428103";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mp2p-icp/default.nix
+++ b/distros/jazzy/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mp2p-icp";
-  version = "2.10.2-r1";
+  version = "2.10.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/jazzy/mp2p_icp/2.10.2-1.tar.gz";
-    name = "2.10.2-1.tar.gz";
-    sha256 = "de8f6f4bf228a46b0e8d4f291c654195357e0b9e2ad922c3d8c4e60c71f09264";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/jazzy/mp2p_icp/2.10.3-1.tar.gz";
+    name = "2.10.3-1.tar.gz";
+    sha256 = "1993f53862bd8ec5fc61e7d55103391c0f72069fed038b085aa3075e30465c63";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -600,6 +600,51 @@ in {
     '';
   });
 
+  librealsense2 = (lib.pipe rosSuper.librealsense2 [
+    (pkg: lib.patchExternalProjectGit pkg {
+      file = "CMake/external_libcurl.cmake";
+      originalUrl = ''"https://github.com/curl/curl.git"'';
+      url = "https://github.com/curl/curl.git";
+      originalRev = ''"curl-8_8_0"'';
+      rev = "curl-8_8_0";
+      fetchgitArgs.hash = "sha256-MjB6k8mDJypyuh6BN2hxy2My7/DfImjw+5iI729snBg=";
+    })
+    (pkg: lib.patchVendorUrl pkg {
+      file = "CMake/external_sqlite3.cmake";
+      url = "https://sqlite.org/2025/sqlite-amalgamation-3490100.zip";
+      hash = "sha256-bOvR2EA/xYww6Tk5skbz5uWNB2WlzVBUbxbAD9gF0sM=";
+    })
+    (pkg: lib.patchExternalProjectGit pkg {
+      file = "CMake/external_yaml_cpp.cmake";
+      url = "https://github.com/jbeder/yaml-cpp.git";
+      rev = "yaml-cpp-0.7.0";
+      fetchgitArgs.hash = "sha256-2tFWccifn0c2lU/U1WNg2FHrBohjx8CXMllPJCevaNk=";
+    })
+  ]).overrideAttrs ({
+    buildInputs ? [], postPatch ? "", ...
+  }: {
+    buildInputs = buildInputs ++ [ self.nlohmann_json ];
+    postPatch = postPatch + ''
+      # Get rid of nlohmann_json vendoring
+      substituteInPlace third-party/CMakeLists.txt \
+        --replace-fail 'include(CMake/external_json.cmake)' ""
+      # Don't try to install to $HOME
+      substituteInPlace tools/realsense-viewer/CMakeLists.txt \
+        --replace-fail '$ENV{HOME}/Documents/librealsense2/presets' ''\'''${CMAKE_INSTALL_PREFIX}/share/librealsense2/presets'
+      substituteInPlace CMake/external_fastcdr.cmake \
+        --replace-fail ''\'''${CMAKE_BINARY_DIR}/third-party/fastcdr' '${fetchTarball {
+          url = "https://github.com/eProsima/Fast-CDR/archive/refs/tags/v1.0.25.tar.gz";
+          sha256 = "sha256:14v85zj5b5fnswhkpps09jk68w6miad8zbhlp625d2kj0yfw4cyp";
+        }}'
+      # If the command below fails, update the above command!
+      substituteInPlace CMake/external_fastcdr.cmake \
+        --replace-fail '--branch v1.0.25' 'see the comment'
+      # https://github.com/realsenseai/librealsense/issues/15120#issuecomment-4586244495
+      substituteInPlace third-party/realsense-file/CMakeLists.txt \
+        --replace-fail '$<$<COMPILE_LANGUAGE:C>:-include stdint.h>' ""
+    '';
+  });
+
   mcap-vendor = lib.patchVendorUrl rosSuper.mcap-vendor {
     url = "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v1.3.1.tar.gz";
     hash = "sha256-JCTITBfe8WrEBhWX0rkqLdnHN6qXidUCj1Xz0fmPnac=";

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -583,24 +583,11 @@ in {
 
   lely-core-libraries = (lib.patchExternalProjectGit rosSuper.lely-core-libraries {
     url = "https://gitlab.com/lely_industries/lely-core.git";
-    rev = "fb735b79cab5f0cdda45bc5087414d405ef8f3ab";
+    rev = "9e3267d26018f6f6babd50786f6ae2af89cc57ea";
     fetchgitArgs = {
-      hash = "sha256-TpEWho+lbhXGaZ24+86eVJttrxH2Kc9gZVOGWeR0LBE=";
+      hash = "sha256-A7RsVQwzj59M9+eGTeNt+/yb3rFziJl3fy33K5c36z0=";
       leaveDotGit = true;
     };
-  }).overrideAttrs ({
-    postPatch ? "", ...
-  }: {
-    # ref. https://gitlab.com/lely_industries/lely-core/-/merge_requests/143
-    postPatch = postPatch + ''
-      substituteInPlace CMakeLists.txt --replace-fail \
-        "CONFIGURE_COMMAND autoreconf -i <SOURCE_DIR>" \
-        "PATCH_COMMAND patch -p1 < ${self.fetchpatch2 {
-          url = "https://gitlab.com/lely_industries/lely-core/-/commit/6ed995fa86d828957b636a11470f150830d877ec.patch";
-          hash = "sha256-/kn+BMs9JHigmSXi6BrlHGmt06eF7mzJiKi26a7JQ3c=";
-        }}
-        CONFIGURE_COMMAND autoreconf -i <SOURCE_DIR>"
-    '';
   });
 
   libphidget22 = lib.patchVendorUrl rosSuper.libphidget22 {

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -1037,6 +1037,18 @@ in {
     ];
   });
 
+  pybind11-json-vendor = lib.patchAmentVendorGit rosSuper.pybind11-json-vendor {
+    patchesFor.pybind11_json_vendor = [
+      (self.writeText "cmakelist.patch" ''
+        --- a/CMakeLists.txt
+        +++ b/CMakeLists.txt
+        @@ -1,1 +1,1 @@
+        -cmake_minimum_required(VERSION 3.4.3)
+        +cmake_minimum_required(VERSION 3.10)
+      '')
+    ];
+  };
+
   rcdiscover = rosSuper.rcdiscover.overrideAttrs ({
     postPatch ? "", ...
   }: {

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -191,17 +191,6 @@ in {
     ];
   });
 
-  canopen-core = rosSuper.canopen-core.overrideAttrs ({
-    postPatch ? "", ...
-  }: {
-    # https://github.com/ros-industrial/ros2_canopen/pull/399
-    postPatch = ''
-      substituteInPlace ConfigExtras.cmake --replace-fail \
-        "find_package(Boost REQUIRED system thread)" \
-        "find_package(Boost REQUIRED thread)"
-    '';
-  });
-
   cartographer = rosSuper.cartographer.overrideAttrs ({
     postPatch ? "", ...
   }: {

--- a/distros/jazzy/point-cloud-transport-py/default.nix
+++ b/distros/jazzy/point-cloud-transport-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, pybind11-vendor, python-cmake-module, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-point-cloud-transport-py";
-  version = "4.0.7-r1";
+  version = "4.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/jazzy/point_cloud_transport_py/4.0.7-1.tar.gz";
-    name = "4.0.7-1.tar.gz";
-    sha256 = "19f833a3c606f4c441556e4095ef652cad41817743de607ac8a0460d70a6c3b8";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/jazzy/point_cloud_transport_py/4.0.8-1.tar.gz";
+    name = "4.0.8-1.tar.gz";
+    sha256 = "c9ae3066e045f211e0c218d244c725780f511673efefa9d8ec8a3f07deeab251";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/point-cloud-transport/default.nix
+++ b/distros/jazzy/point-cloud-transport/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rcpputils, rmw, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rcpputils, rmw, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-point-cloud-transport";
-  version = "4.0.7-r1";
+  version = "4.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/jazzy/point_cloud_transport/4.0.7-1.tar.gz";
-    name = "4.0.7-1.tar.gz";
-    sha256 = "ac625ac7d6d2569c0758262d88d7c691c280eedaf9e0a9af6932cb83fa6cd6aa";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/jazzy/point_cloud_transport/4.0.8-1.tar.gz";
+    name = "4.0.8-1.tar.gz";
+    sha256 = "6ad947b660f94c645763b6cdd0a6f922f84e1cf59b5027c715502260d40e529b";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ];
+  buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ message-filters pluginlib rclcpp rclcpp-components rcpputils rmw sensor-msgs ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
 
   meta = {
     description = "Support for transporting PointCloud2 messages in compressed format and plugin interface for implementing additional PointCloud2 transports.";

--- a/distros/jazzy/pybind11-json-vendor/vendored-source.json
+++ b/distros/jazzy/pybind11-json-vendor/vendored-source.json
@@ -1,0 +1,7 @@
+{
+  "pybind11_json_vendor": {
+    "url": "https://github.com/pybind/pybind11_json.git",
+    "rev": "0.2.11",
+    "hash": "sha256-GQldzT1YU6I1s1RFfzNIJNaIY/LsrsTevoaUoz1SK+Y="
+  }
+}

--- a/distros/jazzy/realsense2-camera-msgs/default.nix
+++ b/distros/jazzy/realsense2-camera-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-realsense2-camera-msgs";
-  version = "4.57.7-r1";
+  version = "4.58.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realsense-ros-release/archive/release/jazzy/realsense2_camera_msgs/4.57.7-1.tar.gz";
-    name = "4.57.7-1.tar.gz";
-    sha256 = "32c40bdf4667fea3702fd7d7a7df83967e9b335c8ba9fda42d9ecab0d857df97";
+    url = "https://github.com/ros2-gbp/realsense-ros-release/archive/release/jazzy/realsense2_camera_msgs/4.58.1-1.tar.gz";
+    name = "4.58.1-1.tar.gz";
+    sha256 = "b94a6043d1549ac3fe0da7e3b39e4c566506aba07a74b65bcec09e8c0147f2c0";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-lint-common ];
-  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces rosidl-default-runtime sensor-msgs std-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/jazzy/realsense2-camera/default.nix
+++ b/distros/jazzy/realsense2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, builtin-interfaces, cv-bridge, diagnostic-updater, eigen, geometry-msgs, image-transport, launch-pytest, launch-ros, launch-testing, librealsense2, lifecycle-msgs, nav-msgs, python3Packages, rclcpp, rclcpp-components, rclcpp-lifecycle, realsense2-camera-msgs, ros-environment, ros2topic, sensor-msgs, sensor-msgs-py, std-msgs, std-srvs, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-jazzy-realsense2-camera";
-  version = "4.57.7-r1";
+  version = "4.58.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realsense-ros-release/archive/release/jazzy/realsense2_camera/4.57.7-1.tar.gz";
-    name = "4.57.7-1.tar.gz";
-    sha256 = "3741027e5a9635b99c05dd10b93839db4657bb370074ea9e572910921374b8ad";
+    url = "https://github.com/ros2-gbp/realsense-ros-release/archive/release/jazzy/realsense2_camera/4.58.1-1.tar.gz";
+    name = "4.58.1-1.tar.gz";
+    sha256 = "12a1cbb2387ebe807b5d160ba006b09aaca31fdd21f658b755e1c7f54c003535";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/realsense2-description/default.nix
+++ b/distros/jazzy/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch-ros, rclcpp, rclcpp-components, realsense2-camera-msgs, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-realsense2-description";
-  version = "4.57.7-r1";
+  version = "4.58.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realsense-ros-release/archive/release/jazzy/realsense2_description/4.57.7-1.tar.gz";
-    name = "4.57.7-1.tar.gz";
-    sha256 = "da693b43162c142c5ee34bf663bf0f6d916379bd850c2e4c95bd2730024533b0";
+    url = "https://github.com/ros2-gbp/realsense-ros-release/archive/release/jazzy/realsense2_description/4.58.1-1.tar.gz";
+    name = "4.58.1-1.tar.gz";
+    sha256 = "32f27e94bab7a17fd128e5b7d76a4bbbfd4ec7f9742b656889aae9fc087aeb0f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rmf-building-map-tools/default.nix
+++ b/distros/jazzy/rmf-building-map-tools/default.nix
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_python";
   checkInputs = [ python3Packages.pytest ];
-  propagatedBuildInputs = [ ament-index-python gz-fuel-tools-vendor python3Packages.Rtree python3Packages.fiona python3Packages.pyproj python3Packages.pyyaml python3Packages.requests python3Packages.shapely rclpy rmf-building-map-msgs rmf-site-map-msgs sqlite std-msgs yaml-cpp ];
+  propagatedBuildInputs = [ ament-index-python gz-fuel-tools-vendor python3Packages.fiona python3Packages.pyproj python3Packages.pyyaml python3Packages.requests python3Packages.rtree python3Packages.shapely rclpy rmf-building-map-msgs rmf-site-map-msgs sqlite std-msgs yaml-cpp ];
 
   meta = {
     description = "RMF Building map tools";

--- a/distros/jazzy/robotraconteur-companion/default.nix
+++ b/distros/jazzy/robotraconteur-companion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, eigen, gtest, opencv, robotraconteur, yaml-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-robotraconteur-companion";
-  version = "0.4.2-r1";
+  version = "0.4.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robotraconteur_companion-release/archive/release/jazzy/robotraconteur_companion/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "5661bd057042a25c0f7fa8225b7e7034e871140e6ce29f5f7959544fb5c282fb";
+    url = "https://github.com/ros2-gbp/robotraconteur_companion-release/archive/release/jazzy/robotraconteur_companion/0.4.3-2.tar.gz";
+    name = "0.4.3-2.tar.gz";
+    sha256 = "f8c1fe20a6936766d1828f18f4c8ce925eed9662830cd4929a28510ad9087131";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/robotraconteur/default.nix
+++ b/distros/jazzy/robotraconteur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bluez, boost, cmake, dbus, gtest, libusb1, openssl, python3, python3Packages, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-robotraconteur";
-  version = "1.2.7-r1";
+  version = "1.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robotraconteur-release/archive/release/jazzy/robotraconteur/1.2.7-1.tar.gz";
-    name = "1.2.7-1.tar.gz";
-    sha256 = "51862c690755f867eb04b61696b0394242407222acc8d6a934459dfd826665e0";
+    url = "https://github.com/ros2-gbp/robotraconteur-release/archive/release/jazzy/robotraconteur/1.2.8-1.tar.gz";
+    name = "1.2.8-1.tar.gz";
+    sha256 = "d4fbe02bcd780b85c8ea384f74620f4cbbef5ff8d2e5e5f3ae3e800e1782489c";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/rosapi-msgs/default.nix
+++ b/distros/jazzy/rosapi-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-rosapi-msgs";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosapi_msgs/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "49cffa0ba56a2c236471014e4ad1e8ea2a86328f0827fb9598dd167932b900fd";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosapi_msgs/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "ebc4f3afecb4c5b11fe3f70b4fd60300da33e9a4001ae12b4456a08b2c2a0a59";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosapi/default.nix
+++ b/distros/jazzy/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-mypy, ament-cmake-pytest, ament-cmake-python, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2action, ros2interface, ros2node, ros2service, ros2topic, rosapi-msgs, rosbridge-library, rosidl-adapter, rosidl-runtime-py, sensor-msgs, shape-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rosapi";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosapi/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "59ce248c8df7dafa16b86eaf7a6fae731c095fa3c28660a8966a9299e6dd00ab";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosapi/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "70893842f49f6fb43ee7964a13eed1770d43bf79ffecc20e49f36d27541c12b9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbridge-library/default.nix
+++ b/distros/jazzy/rosbridge-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-mypy, ament-cmake-python, ament-cmake-ros, builtin-interfaces, control-msgs, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rcl-interfaces, rclpy, rosbridge-test-msgs, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rosbridge-library";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_library/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "4128c99c62dc077c36fc893fdaa609af7348edecd8e56ceb4c1c1c6d90280713";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_library/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "c8da55b069fd13579dd2445417eeb25a630cc25bcdd1537b766c2b68c9ecef26";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbridge-msgs/default.nix
+++ b/distros/jazzy/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-rosbridge-msgs";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_msgs/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "9589d4c400ae9a1d4c013c4d3c097e1a777d52bdb21af2cea250f16cb75ada77";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_msgs/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "61a49a64814e8f21f6fd84a3d8dbeb7ba28dcd1190e2b12aec5904855673b2e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbridge-server/default.nix
+++ b/distros/jazzy/rosbridge-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-mypy, ament-cmake-python, ament-cmake-ros, example-interfaces, launch, launch-ros, launch-testing-ament-cmake, python3Packages, rcl-interfaces, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-rosbridge-server";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_server/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "48cb67402715c1fd957ce2c0fae732d977c68e303471ffed39390dfb1fca31b5";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_server/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "194ccb5a156ecb7e51d3cb6df9473abcf79a450f6546a92a6e94f98b4ef48624";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbridge-suite/default.nix
+++ b/distros/jazzy/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-jazzy-rosbridge-suite";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_suite/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "fe6b13bcfdc077a91bb47034d7a9bf21a5869f0e0058e9e03a4de1cd8495aa35";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_suite/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "6caea5ef328fba95626c66e547a1868b2b8c35e5689a8c267d72119b5c81bc49";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbridge-test-msgs/default.nix
+++ b/distros/jazzy/rosbridge-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rosbridge-test-msgs";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_test_msgs/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "ce547517729c76879fe0ee46158feeff0d32fbac5e4f364e22eb1b4779fa7a08";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_test_msgs/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "3060f6a27eacb18e87fbda902044761e91df2dc43965747bef38fe38acd51fbd";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rtsp-image-transport/default.nix
+++ b/distros/jazzy/rtsp-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, ffmpeg, image-transport, live555-vendor, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-rtsp-image-transport";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rtsp_image_transport-release/archive/release/jazzy/rtsp_image_transport/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "3dd26b383fc4295e8b0ba715d36a691f2e556d672a02b4acd076cae746be2ad9";
+    url = "https://github.com/ros2-gbp/rtsp_image_transport-release/archive/release/jazzy/rtsp_image_transport/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "ba4eda917a014fbc54b35c8a172c119610eadda7fe8fc9e2ba0e10d7d635b951";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/self-test/default.nix
+++ b/distros/jazzy/self-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-self-test";
-  version = "4.2.6-r1";
+  version = "4.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/self_test/4.2.6-1.tar.gz";
-    name = "4.2.6-1.tar.gz";
-    sha256 = "95927c4bc3cea49fee91b9bc0eba92c3a1d036a18fe9bfe7a55b535450656838";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/self_test/4.2.7-1.tar.gz";
+    name = "4.2.7-1.tar.gz";
+    sha256 = "4f6a8b2bed130dd8558ae84cd7c5de01ed018c5aec531c2dd051524885bd2796";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "self_test";
+    description = "Self-test tools for diagnostics.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/kilted/camera-calibration-parsers/default.nix
+++ b/distros/kilted/camera-calibration-parsers/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-kilted-camera-calibration-parsers";
-  version = "6.1.3-r1";
+  version = "6.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/kilted/camera_calibration_parsers/6.1.3-1.tar.gz";
-    name = "6.1.3-1.tar.gz";
-    sha256 = "39a3277b283f9c1999a928890e7457e3f77e47c3c1da3dec0f27fe59c52e7b17";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/kilted/camera_calibration_parsers/6.1.4-1.tar.gz";
+    name = "6.1.4-1.tar.gz";
+    sha256 = "76a1335372f9676eebeb84464be5ef4d947d4c5deb54680ff47718119d2b68a8";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ];
+  buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ rclcpp sensor-msgs yaml-cpp-vendor ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
 
   meta = {
     description = "camera_calibration_parsers contains routines for reading and writing camera calibration parameters.";

--- a/distros/kilted/camera-info-manager-py/default.nix
+++ b/distros/kilted/camera-info-manager-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, python3Packages, rclpy, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-camera-info-manager-py";
-  version = "6.1.3-r1";
+  version = "6.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/kilted/camera_info_manager_py/6.1.3-1.tar.gz";
-    name = "6.1.3-1.tar.gz";
-    sha256 = "f772338fc3e0138b47368277fe5124d53bc56bef5ecbbaf47abb4688a6ca24de";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/kilted/camera_info_manager_py/6.1.4-1.tar.gz";
+    name = "6.1.4-1.tar.gz";
+    sha256 = "f4827f3a3959b3879abde7a0e4cd11763c473c100e479c021d06b19381764317";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/camera-info-manager/default.nix
+++ b/distros/kilted/camera-info-manager/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rclcpp-lifecycle, rcpputils, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rclcpp-lifecycle, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-camera-info-manager";
-  version = "6.1.3-r1";
+  version = "6.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/kilted/camera_info_manager/6.1.3-1.tar.gz";
-    name = "6.1.3-1.tar.gz";
-    sha256 = "263343f047f7371d273aa58ee887e604fdf76636814803466e19a0e1bf9db5cd";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/kilted/camera_info_manager/6.1.4-1.tar.gz";
+    name = "6.1.4-1.tar.gz";
+    sha256 = "55de1d33f893a428077ca92779588111cc3f4a9171459a638f0ce0925012fdc5";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ];
+  buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ ament-index-cpp camera-calibration-parsers rclcpp rclcpp-lifecycle rcpputils sensor-msgs ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
 
   meta = {
     description = "This package provides a C++ interface for camera calibration

--- a/distros/kilted/canopen-402-driver/default.nix
+++ b/distros/kilted/canopen-402-driver/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, boost, canopen-base-driver, canopen-core, canopen-interfaces, canopen-proxy-driver, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, boost, canopen-base-driver, canopen-core, canopen-interfaces, canopen-proxy-driver, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-canopen-402-driver";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/canopen_402_driver/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "9fa9f7c27c8d40cc103807f979ce7b01b826dd8303482e3b1eca8016760e4962";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/canopen_402_driver/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "9d23b5ce4116d3aac6461b0811fcb098a965d4f1fffed35253c9830bc84d1b80";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-lint-auto ];
-  propagatedBuildInputs = [ boost canopen-base-driver canopen-core canopen-interfaces canopen-proxy-driver rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs std-srvs ];
+  propagatedBuildInputs = [ boost canopen-base-driver canopen-core canopen-interfaces canopen-proxy-driver rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {
-    description = "Driiver for devices implementing CIA402 profile";
+    description = "Driver for devices implementing CIA402 profile";
     license = with lib.licenses; [ "LGPL-v3" ];
   };
 }

--- a/distros/kilted/canopen-base-driver/default.nix
+++ b/distros/kilted/canopen-base-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, boost, canopen-core, canopen-interfaces, diagnostic-updater, lely-core-libraries, rclcpp, rclcpp-components, rclcpp-lifecycle, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kilted-canopen-base-driver";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/canopen_base_driver/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "758a09bedb5e5e204fa4a76e67c801eb33d04b046adf1ee54502602b79804b79";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/canopen_base_driver/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "9202ccd816511c4604be01b5b1b9b04c32386ba85be143626042a949ff166c95";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/canopen-core/default.nix
+++ b/distros/kilted/canopen-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, boost, canopen-interfaces, lely-core-libraries, lifecycle-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-kilted-canopen-core";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/canopen_core/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "e429b18fc0ddb59ab02556dde01dfc018f0b561a6c715f16e7a53d1439147336";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/canopen_core/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "3b29bcf773018f6810d1314991e673f8710061298d1e92c6d417b74961d13fd7";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/canopen-fake-slaves/default.nix
+++ b/distros/kilted/canopen-fake-slaves/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, lely-core-libraries, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-kilted-canopen-fake-slaves";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/canopen_fake_slaves/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "5e121a738f98e27b04bbb8c3e6a24069079d764a2d9c9f9991f84de41b416896";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/canopen_fake_slaves/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "4871f312afc989164ac25f7d4697949d03ca546b717aac8932620918823ccc56";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/canopen-interfaces/default.nix
+++ b/distros/kilted/canopen-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-kilted-canopen-interfaces";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/canopen_interfaces/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "0f360c2385242c02c2ae5a700d7db278b6748655a53efca9aed98871c84ed700";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/canopen_interfaces/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "693b53cf07d78ff257a152cd12cc56f843b66820561f94e27fffcaff5cb5c9bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/canopen-master-driver/default.nix
+++ b/distros/kilted/canopen-master-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, canopen-core, canopen-interfaces, lely-core-libraries, rclcpp, rclcpp-components, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-kilted-canopen-master-driver";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/canopen_master_driver/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "15c72ea53b7f50392f7ca1c035cfc1b4bc786c37e72e0aed1b93e2602bde2251";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/canopen_master_driver/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "ed6afb912aa1efb46dc50a4f7042696996d5c3113013149caa3a763ead7bdb8a";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/canopen-proxy-driver/default.nix
+++ b/distros/kilted/canopen-proxy-driver/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, canopen-base-driver, canopen-core, canopen-interfaces, rclcpp, rclcpp-components, rclcpp-lifecycle, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, canopen-base-driver, canopen-core, canopen-interfaces, rclcpp, rclcpp-components, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-kilted-canopen-proxy-driver";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/canopen_proxy_driver/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "c00a7a5e03b798992edeab4fef61e7dc062ee74530e4f523dee69f455f97f50d";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/canopen_proxy_driver/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "f6006a5d737597bb6303c3127d5564e0c1ba73b9df8bdb9f1a2d1327e06adb2a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-lint-auto ];
-  propagatedBuildInputs = [ canopen-base-driver canopen-core canopen-interfaces rclcpp rclcpp-components rclcpp-lifecycle std-msgs std-srvs ];
+  propagatedBuildInputs = [ canopen-base-driver canopen-core canopen-interfaces rclcpp rclcpp-components rclcpp-lifecycle ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/kilted/canopen-ros2-control/default.nix
+++ b/distros/kilted/canopen-ros2-control/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, canopen-402-driver, canopen-core, canopen-proxy-driver, hardware-interface, pluginlib, rclcpp, rclcpp-components, rclcpp-lifecycle, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, canopen-402-driver, canopen-core, canopen-proxy-driver, hardware-interface, pluginlib, rclcpp, rclcpp-components, rclcpp-lifecycle, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-kilted-canopen-ros2-control";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/canopen_ros2_control/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "03f5a6912804eefd63bec3979b0aeae6e43f467340f914691569aba5ee37a9d7";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/canopen_ros2_control/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "8237466411e258708b21b5bf891cf40933fd7a91ed4af687dfc01e9da7886b57";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock ros2-control-test-assets ];
+  checkInputs = [ ros2-control-test-assets ];
   propagatedBuildInputs = [ canopen-402-driver canopen-core canopen-proxy-driver hardware-interface pluginlib rclcpp rclcpp-components rclcpp-lifecycle ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/kilted/canopen-ros2-controllers/default.nix
+++ b/distros/kilted/canopen-ros2-controllers/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, canopen-402-driver, canopen-interfaces, canopen-proxy-driver, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, canopen-402-driver, canopen-interfaces, canopen-proxy-driver, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kilted-canopen-ros2-controllers";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/canopen_ros2_controllers/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "569cca0e2df040164beb7c57cf5bf1cb1f79906315876c782717c4301e85d8c0";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/canopen_ros2_controllers/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "e8a2bff49a3aab7f0622532903e5bd7811509b2f66dad261a812da540e09120d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock ];
   propagatedBuildInputs = [ canopen-402-driver canopen-interfaces canopen-proxy-driver controller-interface controller-manager hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools std-msgs std-srvs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/kilted/canopen-tests/default.nix
+++ b/distros/kilted/canopen-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, canopen-402-driver, canopen-core, canopen-fake-slaves, canopen-proxy-driver, canopen-ros2-controllers, controller-manager, forward-command-controller, joint-state-broadcaster, joint-trajectory-controller, lely-core-libraries, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-kilted-canopen-tests";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/canopen_tests/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "d860afe18bb7a07f4c70ace99c6f6e7a4ce6869253ccfde0310b08f432611d8a";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/canopen_tests/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "4ddc7a21658918d4b610194832552e22afb03ec9cf765e04f181050f254fcdab";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/canopen-utils/default.nix
+++ b/distros/kilted/canopen-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, canopen-interfaces, lifecycle-msgs, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-canopen-utils";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/canopen_utils/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "94b0e6808d3823d9a2794dbe2b8e4e42c871a464661afa3b362de57eb5dc961d";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/canopen_utils/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "1c8a1e1c0fdab2ff73922b8674090037d0351a16f282bcffb532b840264ea5a7";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/canopen/default.nix
+++ b/distros/kilted/canopen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, canopen-402-driver, canopen-base-driver, canopen-core, canopen-interfaces, canopen-proxy-driver, lely-core-libraries }:
 buildRosPackage {
   pname = "ros-kilted-canopen";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/canopen/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "5b8a9e091947f159425445c4144936d23d534a7c5024e63da1722543b62f12b8";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/canopen/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "734e7559fb62d7909911d00250444f05695c63da16a8a6f2feee258bf0b2e644";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/color-util/default.nix
+++ b/distros/kilted/color-util/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-color-util";
-  version = "1.0.0-r4";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/color_util-release/archive/release/kilted/color_util/1.0.0-4.tar.gz";
-    name = "1.0.0-4.tar.gz";
-    sha256 = "6cef3aeb18b50bcb7427c6fac410f00260682d20f1b706772c8496d154e1566e";
+    url = "https://github.com/ros2-gbp/color_util-release/archive/release/kilted/color_util/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "d863faa2b7d01da0421fcc71f8b65a06eeb688f6f4d5a5d57b42ce1358c9f228";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gtest ];
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ];
   propagatedBuildInputs = [ std-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = "An almost dependency-less library for converting between color spaces";

--- a/distros/kilted/diagnostic-aggregator/default.nix
+++ b/distros/kilted/diagnostic-aggregator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch-pytest, launch-testing-ament-cmake, launch-testing-ros, pluginlib, rcl-interfaces, rclcpp, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-diagnostic-aggregator";
-  version = "4.3.6-r1";
+  version = "4.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/kilted/diagnostic_aggregator/4.3.6-1.tar.gz";
-    name = "4.3.6-1.tar.gz";
-    sha256 = "9bc1d6e6380e2587c113d645d8ba49e0c995f8a310739885347fdfdb626d8ec6";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/kilted/diagnostic_aggregator/4.3.7-1.tar.gz";
+    name = "4.3.7-1.tar.gz";
+    sha256 = "d00c1a8eec0d822a8b1ca80f400e9ce4b3f32ad5d3dddf7e8097b35e4b1ba44e";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
-    description = "diagnostic_aggregator";
+    description = "Aggregates diagnostic information from multiple sources.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/kilted/diagnostic-common-diagnostics/default.nix
+++ b/distros/kilted/diagnostic-common-diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-python, ament-cmake-xmllint, ament-lint-auto, diagnostic-updater, launch-testing-ament-cmake, lm_sensors, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-kilted-diagnostic-common-diagnostics";
-  version = "4.3.6-r1";
+  version = "4.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/kilted/diagnostic_common_diagnostics/4.3.6-1.tar.gz";
-    name = "4.3.6-1.tar.gz";
-    sha256 = "09ffae242099593ca7cde676a7aeb1c7169187812d6d65471b2930500e829929";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/kilted/diagnostic_common_diagnostics/4.3.7-1.tar.gz";
+    name = "4.3.7-1.tar.gz";
+    sha256 = "fe0e7184bf1aa3759c974596941bd350344b8432c049619ee2d6aef1d44e2be5";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
-    description = "diagnostic_common_diagnostics";
+    description = "Common diagnostic functions for e.g. HD or CPU usage.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/kilted/diagnostic-remote-logging/default.nix
+++ b/distros/kilted/diagnostic-remote-logging/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, curl, diagnostic-msgs, rclcpp-components }:
 buildRosPackage {
   pname = "ros-kilted-diagnostic-remote-logging";
-  version = "4.3.6-r1";
+  version = "4.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/kilted/diagnostic_remote_logging/4.3.6-1.tar.gz";
-    name = "4.3.6-1.tar.gz";
-    sha256 = "7046344094841a82dd4fe5e6bc834594dc319d9c632dfc15597c32cf61404ef3";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/kilted/diagnostic_remote_logging/4.3.7-1.tar.gz";
+    name = "4.3.7-1.tar.gz";
+    sha256 = "6fc2f9806701dde81c6becf5ba0ab09975011de700169ff81c332cc760e72136";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "diagnostic_remote_logging";
+    description = "Tools for remotely logging diagnostics data.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/kilted/diagnostic-updater/default.nix
+++ b/distros/kilted/diagnostic-updater/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch, launch-testing, launch-testing-ros, python3Packages, rclcpp, rclcpp-lifecycle, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-diagnostic-updater";
-  version = "4.3.6-r1";
+  version = "4.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/kilted/diagnostic_updater/4.3.6-1.tar.gz";
-    name = "4.3.6-1.tar.gz";
-    sha256 = "c933ede8ace6d9b8ba21d9c74cd241f8c2ff65a0df9619355049a5e8b20d5d3f";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/kilted/diagnostic_updater/4.3.7-1.tar.gz";
+    name = "4.3.7-1.tar.gz";
+    sha256 = "5e4a9db9c7713480b5a03c80cad7532b46566e2b9016effef5f1ebc8d9d27d62";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ament-cmake-python ament-cmake-ros ];
 
   meta = {
-    description = "diagnostic_updater contains tools for easily updating diagnostics. it is commonly used in device drivers to keep track of the status of output topics, device status, etc.";
+    description = "Update and publish diagnostic information.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/kilted/diagnostics/default.nix
+++ b/distros/kilted/diagnostics/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, diagnostic-aggregator, diagnostic-common-diagnostics, diagnostic-updater, self-test }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, diagnostic-aggregator, diagnostic-common-diagnostics, diagnostic-remote-logging, diagnostic-updater, self-test }:
 buildRosPackage {
   pname = "ros-kilted-diagnostics";
-  version = "4.3.6-r1";
+  version = "4.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/kilted/diagnostics/4.3.6-1.tar.gz";
-    name = "4.3.6-1.tar.gz";
-    sha256 = "c0acaa678ecece264c96e91fbb6d4d2a4e65120d58888d7e347d2db19ec9e652";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/kilted/diagnostics/4.3.7-1.tar.gz";
+    name = "4.3.7-1.tar.gz";
+    sha256 = "895de4c71e2cf569a30460c055a8276f3c43a0e4d92a32efd5cae3182f276c38";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-common-diagnostics diagnostic-updater self-test ];
+  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-common-diagnostics diagnostic-remote-logging diagnostic-updater self-test ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "diagnostics";
+    description = "Diagnostics tools for monitoring and reporting system status.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/kilted/image-common/default.nix
+++ b/distros/kilted/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-kilted-image-common";
-  version = "6.1.3-r1";
+  version = "6.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/kilted/image_common/6.1.3-1.tar.gz";
-    name = "6.1.3-1.tar.gz";
-    sha256 = "cf883e9490174e44144b912d4373720756023ece904282bfe34f41da485eda53";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/kilted/image_common/6.1.4-1.tar.gz";
+    name = "6.1.4-1.tar.gz";
+    sha256 = "0755e5166259e5f9f239468e1a6d1ee8358aef400c270286bbf0c8028c7a38dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/image-transport-py/default.nix
+++ b/distros/kilted/image-transport-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, image-transport, pybind11-vendor, python3, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-image-transport-py";
-  version = "6.1.3-r1";
+  version = "6.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/kilted/image_transport_py/6.1.3-1.tar.gz";
-    name = "6.1.3-1.tar.gz";
-    sha256 = "c908b25878ad7089430971bfe7db57ecbf9cb186c5a6a2bf8046c27e6966964b";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/kilted/image_transport_py/6.1.4-1.tar.gz";
+    name = "6.1.4-1.tar.gz";
+    sha256 = "345707e25f9fae87fe26db5e321ed422efb3778ede8521f132eb63e07933c40f";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/image-transport/default.nix
+++ b/distros/kilted/image-transport/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-image-transport";
-  version = "6.1.3-r1";
+  version = "6.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/kilted/image_transport/6.1.3-1.tar.gz";
-    name = "6.1.3-1.tar.gz";
-    sha256 = "cdb9d7682dbdd924452f3005c5bb0ad1e5df33385b3bb67f7e9a9c084e8b3f11";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/kilted/image_transport/6.1.4-1.tar.gz";
+    name = "6.1.4-1.tar.gz";
+    sha256 = "9b5508ef0809d25bc15cf5eb8065de8ae12e08309280688e117b4f5fb1722697";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ];
+  buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ message-filters pluginlib rclcpp rclcpp-components sensor-msgs ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
 
   meta = {
     description = "image_transport should always be used to subscribe to and publish images. It provides transparent

--- a/distros/kilted/lely-core-libraries/default.nix
+++ b/distros/kilted/lely-core-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, autoconf, automake, git, libtool, python3Packages }:
 buildRosPackage {
   pname = "ros-kilted-lely-core-libraries";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/lely_core_libraries/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "19479ca0f3a7bfaa66135fa6bacd1b6841ea787465f4db32d0c4928ce753a972";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/kilted/lely_core_libraries/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "71b814efe8aea80a8659a83daf04b7275b972bfb0e47ed735ce88b4605dd3996";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/librealsense2/default.nix
+++ b/distros/kilted/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, git, glfw3, libGL, libGLU, libusb1, libx11, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-kilted-librealsense2";
-  version = "2.57.7-r1";
+  version = "2.58.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/librealsense2-release/archive/release/kilted/librealsense2/2.57.7-1.tar.gz";
-    name = "2.57.7-1.tar.gz";
-    sha256 = "3fe889f82549de90e04390dc5e4cacbee53dcccc990ac81fc45731a19b8d22c0";
+    url = "https://github.com/ros2-gbp/librealsense2-release/archive/release/kilted/librealsense2/2.58.1-1.tar.gz";
+    name = "2.58.1-1.tar.gz";
+    sha256 = "6e686ce2475688c38bfb169f905d20414c3a61f753ff7c7ae6cb2138c1de866f";
   };
 
   buildType = "cmake";

--- a/distros/kilted/message-filters/default.nix
+++ b/distros/kilted/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, rclcpp, rclcpp-lifecycle, rclpy, rcutils, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-message-filters";
-  version = "7.1.8-r1";
+  version = "7.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/kilted/message_filters/7.1.8-1.tar.gz";
-    name = "7.1.8-1.tar.gz";
-    sha256 = "2b10c4f244bad8ce14deb7a51e6e59de55217aeb4c0b9ca69f078a2603058a79";
+    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/kilted/message_filters/7.1.10-1.tar.gz";
+    name = "7.1.10-1.tar.gz";
+    sha256 = "47e53319001bb45505b5e303d12c3d76a158efbc788eeccf7215a4f26edd7088";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mp2p-icp/default.nix
+++ b/distros/kilted/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-kilted-mp2p-icp";
-  version = "2.9.1-r1";
+  version = "2.10.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/kilted/mp2p_icp/2.9.1-1.tar.gz";
-    name = "2.9.1-1.tar.gz";
-    sha256 = "f404e68bd00f1b34e5fe70bbfdd7e47eaae9ad59186daac3b5e309425d407e1d";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/kilted/mp2p_icp/2.10.3-1.tar.gz";
+    name = "2.10.3-1.tar.gz";
+    sha256 = "1fdf1f5bff22ff869271052b29b0aa354666979f7cd010ab57efbc2d006b9b95";
   };
 
   buildType = "cmake";

--- a/distros/kilted/novatel-oem7-driver/default.nix
+++ b/distros/kilted/novatel-oem7-driver/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_catkin, _unresolved_gps_common, _unresolved_nodelet, _unresolved_rosbag, _unresolved_roscpp, _unresolved_rostest, boost, nav-msgs, nmea-msgs, novatel-oem7-msgs, sensor-msgs, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, geographiclib, git, gps-msgs, launch-testing, launch-testing-ament-cmake, launch-testing-ros, nav-msgs, nmea-msgs, novatel-oem7-msgs, pluginlib, rclcpp, rclcpp-components, rclpy, rosbag2, rosidl-runtime-py, sensor-msgs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-kilted-novatel-oem7-driver";
-  version = "4.3.0-r2";
+  version = "28.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/kilted/novatel_oem7_driver/4.3.0-2.tar.gz";
-    name = "4.3.0-2.tar.gz";
-    sha256 = "f15ee537f8b36ef976c7c34e24c5b46d00b844893e8b30618f8487e3299f2df3";
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/kilted/novatel_oem7_driver/28.0.0-1.tar.gz";
+    name = "28.0.0-1.tar.gz";
+    sha256 = "4a844b45ad704b1d64b74f8ca57e68bedc6e33b5d5a3c18eedf8a789d3306ff6";
   };
 
-  buildType = "catkin";
-  buildInputs = [ _unresolved_catkin ];
-  checkInputs = [ _unresolved_rosbag _unresolved_rostest ];
-  propagatedBuildInputs = [ _unresolved_gps_common _unresolved_nodelet _unresolved_roscpp boost nav-msgs nmea-msgs novatel-oem7-msgs sensor-msgs tf2-geometry-msgs ];
-  nativeBuildInputs = [ _unresolved_catkin ];
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake git ];
+  checkInputs = [ launch-testing launch-testing-ament-cmake launch-testing-ros rclpy rosbag2 rosidl-runtime-py ];
+  propagatedBuildInputs = [ geographiclib gps-msgs nav-msgs nmea-msgs novatel-oem7-msgs pluginlib rclcpp rclcpp-components sensor-msgs tf2-geometry-msgs ];
+  nativeBuildInputs = [ ament-cmake git ];
 
   meta = {
     description = "NovAtel Oem7 ROS Driver";

--- a/distros/kilted/novatel-oem7-msgs/default.nix
+++ b/distros/kilted/novatel-oem7-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_catkin, _unresolved_message_generation, _unresolved_message_runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-novatel-oem7-msgs";
-  version = "4.3.0-r2";
+  version = "28.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/kilted/novatel_oem7_msgs/4.3.0-2.tar.gz";
-    name = "4.3.0-2.tar.gz";
-    sha256 = "59612f8767e47f5111f7c0c466c99a8d9f64a3b67d28b4a95fd3b7351fed7fd5";
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/kilted/novatel_oem7_msgs/28.0.0-1.tar.gz";
+    name = "28.0.0-1.tar.gz";
+    sha256 = "5f8f7d2844c15c7b591ae8fb2bafb3483e5f26a5aaf211542e33ed0605c5fc98";
   };
 
-  buildType = "catkin";
-  buildInputs = [ _unresolved_catkin _unresolved_message_generation ];
-  propagatedBuildInputs = [ _unresolved_message_runtime std-msgs ];
-  nativeBuildInputs = [ _unresolved_catkin ];
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {
     description = "Messages for NovAtel Oem7 family of receivers.";

--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -682,6 +682,18 @@ in {
     ];
   });
 
+  pybind11-json-vendor = lib.patchAmentVendorGit rosSuper.pybind11-json-vendor {
+    patchesFor.pybind11_json_vendor = [
+      (self.writeText "cmakelist.patch" ''
+        --- a/CMakeLists.txt
+        +++ b/CMakeLists.txt
+        @@ -1,1 +1,1 @@
+        -cmake_minimum_required(VERSION 3.4.3)
+        +cmake_minimum_required(VERSION 3.10)
+      '')
+    ];
+  };
+
   rcdiscover = rosSuper.rcdiscover.overrideAttrs ({
     postPatch ? "", ...
   }: {

--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -47,17 +47,6 @@ in {
     ];
   });
 
-  canopen-core = rosSuper.canopen-core.overrideAttrs ({
-    postPatch ? "", ...
-  }: {
-    # https://github.com/ros-industrial/ros2_canopen/pull/399
-    postPatch = ''
-      substituteInPlace ConfigExtras.cmake --replace-fail \
-        "find_package(Boost REQUIRED system thread)" \
-        "find_package(Boost REQUIRED thread)"
-    '';
-  });
-
   cartographer = rosSuper.cartographer.overrideAttrs ({
     postPatch ? "", ...
   }: {

--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -365,6 +365,51 @@ in {
     hash = "sha256-GpzGMpQ02s/X/XEcGoozzMjigrbqvAu81bcb7QG+36E=";
   };
 
+  librealsense2 = (lib.pipe rosSuper.librealsense2 [
+    (pkg: lib.patchExternalProjectGit pkg {
+      file = "CMake/external_libcurl.cmake";
+      originalUrl = ''"https://github.com/curl/curl.git"'';
+      url = "https://github.com/curl/curl.git";
+      originalRev = ''"curl-8_8_0"'';
+      rev = "curl-8_8_0";
+      fetchgitArgs.hash = "sha256-MjB6k8mDJypyuh6BN2hxy2My7/DfImjw+5iI729snBg=";
+    })
+    (pkg: lib.patchVendorUrl pkg {
+      file = "CMake/external_sqlite3.cmake";
+      url = "https://sqlite.org/2025/sqlite-amalgamation-3490100.zip";
+      hash = "sha256-bOvR2EA/xYww6Tk5skbz5uWNB2WlzVBUbxbAD9gF0sM=";
+    })
+    (pkg: lib.patchExternalProjectGit pkg {
+      file = "CMake/external_yaml_cpp.cmake";
+      url = "https://github.com/jbeder/yaml-cpp.git";
+      rev = "yaml-cpp-0.7.0";
+      fetchgitArgs.hash = "sha256-2tFWccifn0c2lU/U1WNg2FHrBohjx8CXMllPJCevaNk=";
+    })
+  ]).overrideAttrs ({
+    buildInputs ? [], postPatch ? "", ...
+  }: {
+    buildInputs = buildInputs ++ [ self.nlohmann_json ];
+    postPatch = postPatch + ''
+      # Get rid of nlohmann_json vendoring
+      substituteInPlace third-party/CMakeLists.txt \
+        --replace-fail 'include(CMake/external_json.cmake)' ""
+      # Don't try to install to $HOME
+      substituteInPlace tools/realsense-viewer/CMakeLists.txt \
+        --replace-fail '$ENV{HOME}/Documents/librealsense2/presets' ''\'''${CMAKE_INSTALL_PREFIX}/share/librealsense2/presets'
+      substituteInPlace CMake/external_fastcdr.cmake \
+        --replace-fail ''\'''${CMAKE_BINARY_DIR}/third-party/fastcdr' '${fetchTarball {
+          url = "https://github.com/eProsima/Fast-CDR/archive/refs/tags/v1.0.25.tar.gz";
+          sha256 = "sha256:14v85zj5b5fnswhkpps09jk68w6miad8zbhlp625d2kj0yfw4cyp";
+        }}'
+      # If the command below fails, update the above command!
+      substituteInPlace CMake/external_fastcdr.cmake \
+        --replace-fail '--branch v1.0.25' 'see the comment'
+      # https://github.com/realsenseai/librealsense/issues/15120#issuecomment-4586244495
+      substituteInPlace third-party/realsense-file/CMakeLists.txt \
+        --replace-fail '$<$<COMPILE_LANGUAGE:C>:-include stdint.h>' ""
+    '';
+  });
+
   mcap-vendor = (lib.patchVendorUrl rosSuper.mcap-vendor {
     url = "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v1.4.0.tar.gz";
     hash = "sha256-ZP8+URGfN//Pr53uy9mHp8tNTZA110o/03czlaRw/aE=";

--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -364,24 +364,11 @@ in {
 
   lely-core-libraries = (lib.patchExternalProjectGit rosSuper.lely-core-libraries {
     url = "https://gitlab.com/lely_industries/lely-core.git";
-    rev = "fb735b79cab5f0cdda45bc5087414d405ef8f3ab";
+    rev = "9e3267d26018f6f6babd50786f6ae2af89cc57ea";
     fetchgitArgs = {
-      hash = "sha256-TpEWho+lbhXGaZ24+86eVJttrxH2Kc9gZVOGWeR0LBE=";
+      hash = "sha256-A7RsVQwzj59M9+eGTeNt+/yb3rFziJl3fy33K5c36z0=";
       leaveDotGit = true;
     };
-  }).overrideAttrs ({
-    postPatch ? "", ...
-  }: {
-    # ref. https://gitlab.com/lely_industries/lely-core/-/merge_requests/143
-    postPatch = postPatch + ''
-      substituteInPlace CMakeLists.txt --replace-fail \
-        "CONFIGURE_COMMAND autoreconf -i <SOURCE_DIR>" \
-        "PATCH_COMMAND patch -p1 < ${self.fetchpatch2 {
-          url = "https://gitlab.com/lely_industries/lely-core/-/commit/6ed995fa86d828957b636a11470f150830d877ec.patch";
-          hash = "sha256-/kn+BMs9JHigmSXi6BrlHGmt06eF7mzJiKi26a7JQ3c=";
-        }}
-        CONFIGURE_COMMAND autoreconf -i <SOURCE_DIR>"
-    '';
   });
 
   libphidget22 = lib.patchVendorUrl rosSuper.libphidget22 {

--- a/distros/kilted/point-cloud-transport-py/default.nix
+++ b/distros/kilted/point-cloud-transport-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, pybind11-vendor, python3, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-point-cloud-transport-py";
-  version = "5.1.6-r1";
+  version = "5.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/kilted/point_cloud_transport_py/5.1.6-1.tar.gz";
-    name = "5.1.6-1.tar.gz";
-    sha256 = "6b1375409fe77d599aa3dc7d11956c459f755c91b7cc9409dbd3f195f0612bb5";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/kilted/point_cloud_transport_py/5.1.7-1.tar.gz";
+    name = "5.1.7-1.tar.gz";
+    sha256 = "d7379e8f0b6a40c92d03342d95330f2a86b16c2c827f73939890fe2af4c29678";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/point-cloud-transport/default.nix
+++ b/distros/kilted/point-cloud-transport/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rcpputils, rmw, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rcpputils, rmw, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-point-cloud-transport";
-  version = "5.1.6-r1";
+  version = "5.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/kilted/point_cloud_transport/5.1.6-1.tar.gz";
-    name = "5.1.6-1.tar.gz";
-    sha256 = "cebe9dc852f6baf001e59b13c01e1b6ddda76d2b0e321ca15a11695ca004a9b9";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/kilted/point_cloud_transport/5.1.7-1.tar.gz";
+    name = "5.1.7-1.tar.gz";
+    sha256 = "14c290f3f6ee8a19533899d0ca6ebe5e0fd15befba6967ad428916c7b42037e1";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ];
+  buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ message-filters pluginlib rclcpp rclcpp-components rcpputils rmw sensor-msgs ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
 
   meta = {
     description = "Support for transporting PointCloud2 messages in compressed format and plugin interface for implementing additional PointCloud2 transports.";

--- a/distros/kilted/pybind11-json-vendor/vendored-source.json
+++ b/distros/kilted/pybind11-json-vendor/vendored-source.json
@@ -1,0 +1,7 @@
+{
+  "pybind11_json_vendor": {
+    "url": "https://github.com/pybind/pybind11_json.git",
+    "rev": "0.2.11",
+    "hash": "sha256-GQldzT1YU6I1s1RFfzNIJNaIY/LsrsTevoaUoz1SK+Y="
+  }
+}

--- a/distros/kilted/realsense2-camera-msgs/default.nix
+++ b/distros/kilted/realsense2-camera-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-realsense2-camera-msgs";
-  version = "4.57.7-r1";
+  version = "4.58.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realsense-ros-release/archive/release/kilted/realsense2_camera_msgs/4.57.7-1.tar.gz";
-    name = "4.57.7-1.tar.gz";
-    sha256 = "9b99cf50448b5fe96467ccff46a9f1dd51f1b76dd2490ae2f31ad73d7cc50022";
+    url = "https://github.com/ros2-gbp/realsense-ros-release/archive/release/kilted/realsense2_camera_msgs/4.58.1-1.tar.gz";
+    name = "4.58.1-1.tar.gz";
+    sha256 = "03f3e3c217b8f00fb063d8831804640c2298ab013bd6479a261afb7e5281e7fb";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-lint-common ];
-  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces rosidl-default-runtime sensor-msgs std-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/kilted/realsense2-camera/default.nix
+++ b/distros/kilted/realsense2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, builtin-interfaces, cv-bridge, diagnostic-updater, eigen, geometry-msgs, image-transport, launch-pytest, launch-ros, launch-testing, librealsense2, lifecycle-msgs, nav-msgs, python3Packages, rclcpp, rclcpp-components, rclcpp-lifecycle, realsense2-camera-msgs, ros-environment, ros2topic, sensor-msgs, sensor-msgs-py, std-msgs, std-srvs, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-kilted-realsense2-camera";
-  version = "4.57.7-r1";
+  version = "4.58.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realsense-ros-release/archive/release/kilted/realsense2_camera/4.57.7-1.tar.gz";
-    name = "4.57.7-1.tar.gz";
-    sha256 = "fc5c63a0ab609a6db112035617df99bd89f18f625636398167178c14f373d61d";
+    url = "https://github.com/ros2-gbp/realsense-ros-release/archive/release/kilted/realsense2_camera/4.58.1-1.tar.gz";
+    name = "4.58.1-1.tar.gz";
+    sha256 = "0651b41b953d1dd93fbc43fe83002dd4863986d772bfabff2119504c47227755";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/realsense2-description/default.nix
+++ b/distros/kilted/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch-ros, rclcpp, rclcpp-components, realsense2-camera-msgs, xacro }:
 buildRosPackage {
   pname = "ros-kilted-realsense2-description";
-  version = "4.57.7-r1";
+  version = "4.58.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realsense-ros-release/archive/release/kilted/realsense2_description/4.57.7-1.tar.gz";
-    name = "4.57.7-1.tar.gz";
-    sha256 = "eabc5804e16a6e9f7dc56534f684013a17a9c6bf97a6c7d8ab549c556113c09b";
+    url = "https://github.com/ros2-gbp/realsense-ros-release/archive/release/kilted/realsense2_description/4.58.1-1.tar.gz";
+    name = "4.58.1-1.tar.gz";
+    sha256 = "721c6fc5f8ad23ca9ed0c641c60dc23b321ce8f166e8eb607131f941b37da10b";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rmf-building-map-tools/default.nix
+++ b/distros/kilted/rmf-building-map-tools/default.nix
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_python";
   checkInputs = [ python3Packages.pytest ];
-  propagatedBuildInputs = [ ament-index-python gz-fuel-tools-vendor python3Packages.Rtree python3Packages.fiona python3Packages.pyproj python3Packages.pyyaml python3Packages.requests python3Packages.shapely rclpy rmf-building-map-msgs rmf-site-map-msgs sqlite std-msgs yaml-cpp ];
+  propagatedBuildInputs = [ ament-index-python gz-fuel-tools-vendor python3Packages.fiona python3Packages.pyproj python3Packages.pyyaml python3Packages.requests python3Packages.rtree python3Packages.shapely rclpy rmf-building-map-msgs rmf-site-map-msgs sqlite std-msgs yaml-cpp ];
 
   meta = {
     description = "RMF Building map tools";

--- a/distros/kilted/robotraconteur-companion/default.nix
+++ b/distros/kilted/robotraconteur-companion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, eigen, gtest, opencv, robotraconteur, yaml-cpp }:
 buildRosPackage {
   pname = "ros-kilted-robotraconteur-companion";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robotraconteur_companion-release/archive/release/kilted/robotraconteur_companion/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "a7d7b0b7d4df1bbd85b9e1e86a7219b9c492a46dca90038921ac69d3400ee7d6";
+    url = "https://github.com/ros2-gbp/robotraconteur_companion-release/archive/release/kilted/robotraconteur_companion/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "2d0989c22b55aa12d9d3e53765972cf87745e08f225be95baa1c052274b7c54f";
   };
 
   buildType = "cmake";

--- a/distros/kilted/robotraconteur/default.nix
+++ b/distros/kilted/robotraconteur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bluez, boost, cmake, dbus, gtest, libusb1, openssl, python3, python3Packages, zlib }:
 buildRosPackage {
   pname = "ros-kilted-robotraconteur";
-  version = "1.2.7-r1";
+  version = "1.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robotraconteur-release/archive/release/kilted/robotraconteur/1.2.7-1.tar.gz";
-    name = "1.2.7-1.tar.gz";
-    sha256 = "7e01ddd5aecc2ecc6f3455e77740a7b7a46dcf08332ea8642dda167729b1ac3f";
+    url = "https://github.com/ros2-gbp/robotraconteur-release/archive/release/kilted/robotraconteur/1.2.8-1.tar.gz";
+    name = "1.2.8-1.tar.gz";
+    sha256 = "72f14c211f5f9e22ed37d21084ddfd7eca201b579deba01b9d297048c27310a7";
   };
 
   buildType = "cmake";

--- a/distros/kilted/rosapi-msgs/default.nix
+++ b/distros/kilted/rosapi-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-kilted-rosapi-msgs";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/kilted/rosapi_msgs/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "f854c340351ae80fbec1f40436f67b8d51f124e7ffb8e35ac6ec3594b5132875";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/kilted/rosapi_msgs/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "625e2ead423017671940b65707d27bb91028650bd8655cdbb910f9c861b61ba7";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rosapi/default.nix
+++ b/distros/kilted/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-mypy, ament-cmake-pytest, ament-cmake-python, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2action, ros2interface, ros2node, ros2service, ros2topic, rosapi-msgs, rosbridge-library, rosidl-adapter, rosidl-runtime-py, sensor-msgs, shape-msgs }:
 buildRosPackage {
   pname = "ros-kilted-rosapi";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/kilted/rosapi/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "3af074d96289c13897135621b6f2dcbb36c1c86038d6b6c6ee63798d9544e9e0";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/kilted/rosapi/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "5b592ff4675174f49cc3a4fff59c18538764c6f36b007cd27045548bc685a15e";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rosbridge-library/default.nix
+++ b/distros/kilted/rosbridge-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-mypy, ament-cmake-python, ament-cmake-ros, builtin-interfaces, control-msgs, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rcl-interfaces, rclpy, rosbridge-test-msgs, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-rosbridge-library";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/kilted/rosbridge_library/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "fcb73faf547b283257d0974107c35c7ae7160e50f2dfb985139c5e4c7003c1bf";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/kilted/rosbridge_library/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "d7c1eacb0855ce99335d3e80be005499afe8e292d6117ff216e90a2687e6f6d9";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rosbridge-msgs/default.nix
+++ b/distros/kilted/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-kilted-rosbridge-msgs";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/kilted/rosbridge_msgs/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "4febf67797e99bea798e82197dc6cf564b56b57ebd690f3244285046ee82aeee";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/kilted/rosbridge_msgs/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "b1346a810fd0f3192bad22c0eff1aa263b3d1276d99434c39410cc81261327a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rosbridge-server/default.nix
+++ b/distros/kilted/rosbridge-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-mypy, ament-cmake-python, ament-cmake-ros, example-interfaces, launch, launch-ros, launch-testing-ament-cmake, python3Packages, rcl-interfaces, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kilted-rosbridge-server";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/kilted/rosbridge_server/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "24679a4c93e12542951e6aaf0b15e1acd76468dddbc73bd0c641492ba318037f";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/kilted/rosbridge_server/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "1b5eaa935166135fcf067b9a554619fc15da1d427a73b3dc55a32c2e27c751b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rosbridge-suite/default.nix
+++ b/distros/kilted/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-kilted-rosbridge-suite";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/kilted/rosbridge_suite/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "3efe8b85d7eb34b6a58b48305b1390702b852dc0145c3a995b589a7989e6bedb";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/kilted/rosbridge_suite/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "0cfe3eb7c38fd4049a9ae2bca56e2d24167b20c2ad01718d9311c9171e183d75";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rosbridge-test-msgs/default.nix
+++ b/distros/kilted/rosbridge-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-rosbridge-test-msgs";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/kilted/rosbridge_test_msgs/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "b680803dc171983daf11a48e5480b22fe171c69a39d999a92fb23564651698c0";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/kilted/rosbridge_test_msgs/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "e871dc62757b40091d2bfbea16ce1856d9bc1d2b3dfa7a2bf8a1f8270deb2b5d";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/self-test/default.nix
+++ b/distros/kilted/self-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp, ros-environment }:
 buildRosPackage {
   pname = "ros-kilted-self-test";
-  version = "4.3.6-r1";
+  version = "4.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/kilted/self_test/4.3.6-1.tar.gz";
-    name = "4.3.6-1.tar.gz";
-    sha256 = "155a6b81e31cd106543c855412915a42e3b42696ffa041f70657f7d37fdd538f";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/kilted/self_test/4.3.7-1.tar.gz";
+    name = "4.3.7-1.tar.gz";
+    sha256 = "d549dbd89ba7fd219179ce09c8f0b01c3635eda6f246e9302884cabd6a3bc6e5";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "self_test";
+    description = "Self-test tools for diagnostics.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/lyrical/apriltag-msgs/default.nix
+++ b/distros/lyrical/apriltag-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-apriltag-msgs";
-  version = "2.0.1-r6";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag_msgs-release/archive/release/lyrical/apriltag_msgs/2.0.1-6.tar.gz";
-    name = "2.0.1-6.tar.gz";
-    sha256 = "24e9ca5375cd7f4fa0e34cbaf87fc0d1d30d3848128ee1338c2e0b1f5e383fd9";
+    url = "https://github.com/ros2-gbp/apriltag_msgs-release/archive/release/lyrical/apriltag_msgs/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "cb9425b0e04fe7ef8f0558d76e67f95795bfd718a583670760686e990f05778c";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/apriltag-ros/default.nix
+++ b/distros/lyrical/apriltag-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-lint-auto, apriltag, apriltag-msgs, camera-ros, clang, cv-bridge, eigen, image-proc, image-transport, image-transport-plugins, rclcpp, rclcpp-components, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-lyrical-apriltag-ros";
-  version = "3.3.0-r3";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag_ros-release/archive/release/lyrical/apriltag_ros/3.3.0-3.tar.gz";
-    name = "3.3.0-3.tar.gz";
-    sha256 = "e06856cd97f56c9fc801388a0a249e6f639a41eb4df562ed7f92da9191146f19";
+    url = "https://github.com/ros2-gbp/apriltag_ros-release/archive/release/lyrical/apriltag_ros/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "91881df71956a693b0bf16f3248a5485c654046063d133d67e29f3e15be0b7eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/camera-calibration-parsers/default.nix
+++ b/distros/lyrical/camera-calibration-parsers/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-lyrical-camera-calibration-parsers";
-  version = "6.4.8-r1";
+  version = "6.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/lyrical/camera_calibration_parsers/6.4.8-1.tar.gz";
-    name = "6.4.8-1.tar.gz";
-    sha256 = "97ecb69f1ba8ae351cc277df605a39c2b06d00d97e3ee4ce88125fb5c848c03b";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/lyrical/camera_calibration_parsers/6.4.9-1.tar.gz";
+    name = "6.4.9-1.tar.gz";
+    sha256 = "d366c597c3bd56119150ba6487105d61301260d144e4a51af5159d8bd774b355";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ];
+  buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ rclcpp sensor-msgs yaml-cpp-vendor ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
 
   meta = {
     description = "camera_calibration_parsers contains routines for reading and writing camera calibration parameters.";

--- a/distros/lyrical/camera-info-manager-py/default.nix
+++ b/distros/lyrical/camera-info-manager-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, python3Packages, rclpy, sensor-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-camera-info-manager-py";
-  version = "6.4.8-r1";
+  version = "6.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/lyrical/camera_info_manager_py/6.4.8-1.tar.gz";
-    name = "6.4.8-1.tar.gz";
-    sha256 = "261e39c6c679142d58299f3b4e4f588c20ca55ed16a1428f101ab4cd1ef397bc";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/lyrical/camera_info_manager_py/6.4.9-1.tar.gz";
+    name = "6.4.9-1.tar.gz";
+    sha256 = "05e48222653ad85a70586eddc2ffcbce488c3ac685aa9571dc0232c5d720907e";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/camera-info-manager/default.nix
+++ b/distros/lyrical/camera-info-manager/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rclcpp-lifecycle, rcpputils, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rclcpp-lifecycle, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-camera-info-manager";
-  version = "6.4.8-r1";
+  version = "6.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/lyrical/camera_info_manager/6.4.8-1.tar.gz";
-    name = "6.4.8-1.tar.gz";
-    sha256 = "e4336279cba1f1de0c7e03aac8b505a4097eb23e1b1dd8b6fff97eca97cd2d81";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/lyrical/camera_info_manager/6.4.9-1.tar.gz";
+    name = "6.4.9-1.tar.gz";
+    sha256 = "a34664d4e31cb62ebbeec37692e5dff486b41cf12fe51fdc61d088053d1cfb7f";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ];
+  buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ ament-index-cpp camera-calibration-parsers rclcpp rclcpp-lifecycle rcpputils sensor-msgs ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
 
   meta = {
     description = "This package provides a C++ interface for camera calibration

--- a/distros/lyrical/canopen-402-driver/default.nix
+++ b/distros/lyrical/canopen-402-driver/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, boost, canopen-base-driver, canopen-core, canopen-interfaces, canopen-proxy-driver, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, boost, canopen-base-driver, canopen-core, canopen-interfaces, canopen-proxy-driver, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-canopen-402-driver";
-  version = "0.3.2-r3";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/canopen_402_driver/0.3.2-3.tar.gz";
-    name = "0.3.2-3.tar.gz";
-    sha256 = "d14e3070e20f7c22fc1feaacf04e7f24ec92362ed0c7d958c01e2eb6110474e5";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/canopen_402_driver/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "2794940c3bce2f56ed2440b51912c6b1a7f9f4db57c05b1cf036ffcc10196ccf";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-lint-auto ];
-  propagatedBuildInputs = [ boost canopen-base-driver canopen-core canopen-interfaces canopen-proxy-driver rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs std-srvs ];
+  propagatedBuildInputs = [ boost canopen-base-driver canopen-core canopen-interfaces canopen-proxy-driver rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {
-    description = "Driiver for devices implementing CIA402 profile";
+    description = "Driver for devices implementing CIA402 profile";
     license = with lib.licenses; [ "LGPL-v3" ];
   };
 }

--- a/distros/lyrical/canopen-base-driver/default.nix
+++ b/distros/lyrical/canopen-base-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, boost, canopen-core, canopen-interfaces, diagnostic-updater, lely-core-libraries, rclcpp, rclcpp-components, rclcpp-lifecycle, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-lyrical-canopen-base-driver";
-  version = "0.3.2-r3";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/canopen_base_driver/0.3.2-3.tar.gz";
-    name = "0.3.2-3.tar.gz";
-    sha256 = "6ce9ef13576daa1742dcebaa55b5ae731f676df1883c6a08955b741d7fbe9ce9";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/canopen_base_driver/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "73bb7d08fdecf14df13684c05e94580894e5847ec615a621fb508daefc5425ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/canopen-core/default.nix
+++ b/distros/lyrical/canopen-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, boost, canopen-interfaces, lely-core-libraries, lifecycle-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-lyrical-canopen-core";
-  version = "0.3.2-r3";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/canopen_core/0.3.2-3.tar.gz";
-    name = "0.3.2-3.tar.gz";
-    sha256 = "3d74c2c745fa29dff5ed7754f04d1dadcab7a12674586dc72a768d490e0c24b8";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/canopen_core/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "841d784c97cfb68876c557ca0f77d79206170e898a149a9f6e6720f11fdea000";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/canopen-fake-slaves/default.nix
+++ b/distros/lyrical/canopen-fake-slaves/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, lely-core-libraries, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-lyrical-canopen-fake-slaves";
-  version = "0.3.2-r3";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/canopen_fake_slaves/0.3.2-3.tar.gz";
-    name = "0.3.2-3.tar.gz";
-    sha256 = "4282c6397466a82e5f6f8fcfd01581a3040156a962927dfe01f62e9a2aa11e79";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/canopen_fake_slaves/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "6ef5545778612929f596d18ac399cf40110beef8d4eb576a3367230d0c3ed1c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/canopen-interfaces/default.nix
+++ b/distros/lyrical/canopen-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-lyrical-canopen-interfaces";
-  version = "0.3.2-r3";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/canopen_interfaces/0.3.2-3.tar.gz";
-    name = "0.3.2-3.tar.gz";
-    sha256 = "89d1f191db36a71e4451cd5b78bdd916ffbb5cef4d85fe1ecaac6372f1040ffb";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/canopen_interfaces/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "be7c740f78eda6433f99d429792ba62a5b34a77b807e2ab977ff5e163ed15d05";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/canopen-master-driver/default.nix
+++ b/distros/lyrical/canopen-master-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, canopen-core, canopen-interfaces, lely-core-libraries, rclcpp, rclcpp-components, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-lyrical-canopen-master-driver";
-  version = "0.3.2-r3";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/canopen_master_driver/0.3.2-3.tar.gz";
-    name = "0.3.2-3.tar.gz";
-    sha256 = "3734447dbf1c60bfaf869615bc7df4b1ddb4675fea315ecc0b341bff8e6354b3";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/canopen_master_driver/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "32cec36ac22222bb778eafa0d2a8cd11793672ca5a2d54324ece37b8de1703a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/canopen-proxy-driver/default.nix
+++ b/distros/lyrical/canopen-proxy-driver/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, canopen-base-driver, canopen-core, canopen-interfaces, rclcpp, rclcpp-components, rclcpp-lifecycle, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, canopen-base-driver, canopen-core, canopen-interfaces, rclcpp, rclcpp-components, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-lyrical-canopen-proxy-driver";
-  version = "0.3.2-r3";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/canopen_proxy_driver/0.3.2-3.tar.gz";
-    name = "0.3.2-3.tar.gz";
-    sha256 = "11bed82aa4a3fea7bb7db88c14321803ca54d047dddad583373a64ed3dde75e0";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/canopen_proxy_driver/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "ef3048d89c9c33f9e34ffc75d431fdc7bed9e6918d1ebc42d0930ae2b19691df";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-lint-auto ];
-  propagatedBuildInputs = [ canopen-base-driver canopen-core canopen-interfaces rclcpp rclcpp-components rclcpp-lifecycle std-msgs std-srvs ];
+  propagatedBuildInputs = [ canopen-base-driver canopen-core canopen-interfaces rclcpp rclcpp-components rclcpp-lifecycle ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/lyrical/canopen-ros2-control/default.nix
+++ b/distros/lyrical/canopen-ros2-control/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, canopen-402-driver, canopen-core, canopen-proxy-driver, hardware-interface, pluginlib, rclcpp, rclcpp-components, rclcpp-lifecycle, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, canopen-402-driver, canopen-core, canopen-proxy-driver, hardware-interface, pluginlib, rclcpp, rclcpp-components, rclcpp-lifecycle, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-lyrical-canopen-ros2-control";
-  version = "0.3.2-r3";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/canopen_ros2_control/0.3.2-3.tar.gz";
-    name = "0.3.2-3.tar.gz";
-    sha256 = "8f3c84f4d06fc00428223a7c67f076f871c5ca521d25e1315b3914e35b93e7c2";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/canopen_ros2_control/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "8c8f1090091834f40ddf9674d5b60c4c9c0e6da71e5cd7c99bb0186bc36b35f5";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock ros2-control-test-assets ];
+  checkInputs = [ ros2-control-test-assets ];
   propagatedBuildInputs = [ canopen-402-driver canopen-core canopen-proxy-driver hardware-interface pluginlib rclcpp rclcpp-components rclcpp-lifecycle ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/lyrical/canopen-ros2-controllers/default.nix
+++ b/distros/lyrical/canopen-ros2-controllers/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, canopen-402-driver, canopen-interfaces, canopen-proxy-driver, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, canopen-402-driver, canopen-interfaces, canopen-proxy-driver, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-lyrical-canopen-ros2-controllers";
-  version = "0.3.2-r3";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/canopen_ros2_controllers/0.3.2-3.tar.gz";
-    name = "0.3.2-3.tar.gz";
-    sha256 = "7c3fbaa193297fdb8e18f3dc155101a2ab96576f16869e40b94de48f4d1b9e4a";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/canopen_ros2_controllers/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "132590ece02ddb161654ddfa034c5804abd5ebf3cce9026a6db656335fb4afef";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock ];
   propagatedBuildInputs = [ canopen-402-driver canopen-interfaces canopen-proxy-driver controller-interface controller-manager hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools std-msgs std-srvs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/lyrical/canopen-tests/default.nix
+++ b/distros/lyrical/canopen-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, canopen-402-driver, canopen-core, canopen-fake-slaves, canopen-proxy-driver, canopen-ros2-controllers, controller-manager, forward-command-controller, joint-state-broadcaster, joint-trajectory-controller, lely-core-libraries, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-lyrical-canopen-tests";
-  version = "0.3.2-r3";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/canopen_tests/0.3.2-3.tar.gz";
-    name = "0.3.2-3.tar.gz";
-    sha256 = "c664bdb16ea27fe8343691d3c07e36c0e844628926ff8a5db42818bb4229c75e";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/canopen_tests/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "5bd2ed44e29e110c7fd1e83799a3a7ed2d5a933385c2d4a1ee230ffea10ec67e";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/canopen-utils/default.nix
+++ b/distros/lyrical/canopen-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, canopen-interfaces, lifecycle-msgs, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-canopen-utils";
-  version = "0.3.2-r3";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/canopen_utils/0.3.2-3.tar.gz";
-    name = "0.3.2-3.tar.gz";
-    sha256 = "6a33e57f64e16c30f8a74b3fc7bc6b5b698e6fd19c3c9f0245aa836432b0bcdf";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/canopen_utils/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "216ac910fd84005b6cf38a7aaab1f3fa267ee1ded9714a530fdf03bef164cca4";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/canopen/default.nix
+++ b/distros/lyrical/canopen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, canopen-402-driver, canopen-base-driver, canopen-core, canopen-interfaces, canopen-proxy-driver, lely-core-libraries }:
 buildRosPackage {
   pname = "ros-lyrical-canopen";
-  version = "0.3.2-r3";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/canopen/0.3.2-3.tar.gz";
-    name = "0.3.2-3.tar.gz";
-    sha256 = "7eceb763109f5974face207f7c210af826aeaa428229c429d725b2ed0782e7fe";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/canopen/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "4397d73468c100e4477f33b4c62c81a168702b63b54b306391e08580bdf72d7f";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/color-util/default.nix
+++ b/distros/lyrical/color-util/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-color-util";
-  version = "1.1.0-r3";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/color_util-release/archive/release/lyrical/color_util/1.1.0-3.tar.gz";
-    name = "1.1.0-3.tar.gz";
-    sha256 = "c481824e3fb1cb7084dba688bef7d05035320d17a7fec6263f7539ec1ca3afbe";
+    url = "https://github.com/ros2-gbp/color_util-release/archive/release/lyrical/color_util/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "9b3719f9c59cfeb7d51fe9a592b47a1590cae918e5f19f2361df39f5bf897741";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gtest ];
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ];
   propagatedBuildInputs = [ std-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = "An almost dependency-less library for converting between color spaces";

--- a/distros/lyrical/cuda-buffer/default.nix
+++ b/distros/lyrical/cuda-buffer/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_nvidia-cuda, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cuda-buffer-backend-msgs, rcutils, rmw, rosidl-buffer }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cuda-buffer-backend-msgs, cudaPackages, rcutils, rmw, rosidl-buffer }:
 buildRosPackage {
   pname = "ros-lyrical-cuda-buffer";
   version = "0.1.1-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ _unresolved_nvidia-cuda cuda-buffer-backend-msgs rcutils rmw rosidl-buffer ];
+  propagatedBuildInputs = [ cuda-buffer-backend-msgs cudaPackages.cudatoolkit rcutils rmw rosidl-buffer ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/lyrical/diagnostic-aggregator/default.nix
+++ b/distros/lyrical/diagnostic-aggregator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch-pytest, launch-testing-ament-cmake, launch-testing-ros, pluginlib, rcl-interfaces, rclcpp, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-diagnostic-aggregator";
-  version = "4.4.6-r3";
+  version = "4.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/lyrical/diagnostic_aggregator/4.4.6-3.tar.gz";
-    name = "4.4.6-3.tar.gz";
-    sha256 = "a313c09332ea512bf044674619975820d65ffbbc65f9e67dca9816e962173ed8";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/lyrical/diagnostic_aggregator/4.4.7-1.tar.gz";
+    name = "4.4.7-1.tar.gz";
+    sha256 = "576d3bb0cfc71f02b1622e93940d732628dc4a56955be731a85a3e8ebff42ea0";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
-    description = "diagnostic_aggregator";
+    description = "Aggregates diagnostic information from multiple sources.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/lyrical/diagnostic-common-diagnostics/default.nix
+++ b/distros/lyrical/diagnostic-common-diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-python, ament-cmake-xmllint, ament-lint-auto, diagnostic-updater, launch-testing-ament-cmake, lm_sensors, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-lyrical-diagnostic-common-diagnostics";
-  version = "4.4.6-r3";
+  version = "4.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/lyrical/diagnostic_common_diagnostics/4.4.6-3.tar.gz";
-    name = "4.4.6-3.tar.gz";
-    sha256 = "72a85ca4b75f4e4bc4a626c225768be5a9539f9f6f01344473744f5e61e3c988";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/lyrical/diagnostic_common_diagnostics/4.4.7-1.tar.gz";
+    name = "4.4.7-1.tar.gz";
+    sha256 = "a02a728b45d27ad08e8556b95824b0cfa2a68f82e1fcb8ee8059b91f164b25e9";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
-    description = "diagnostic_common_diagnostics";
+    description = "Common diagnostic functions for e.g. HD or CPU usage.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/lyrical/diagnostic-remote-logging/default.nix
+++ b/distros/lyrical/diagnostic-remote-logging/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, curl, diagnostic-msgs, rclcpp-components }:
 buildRosPackage {
   pname = "ros-lyrical-diagnostic-remote-logging";
-  version = "4.4.6-r3";
+  version = "4.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/lyrical/diagnostic_remote_logging/4.4.6-3.tar.gz";
-    name = "4.4.6-3.tar.gz";
-    sha256 = "a58cb5216dc4a425143e5e9a4f02d9417d3267c42cc6227787b1fec3f14507d3";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/lyrical/diagnostic_remote_logging/4.4.7-1.tar.gz";
+    name = "4.4.7-1.tar.gz";
+    sha256 = "d06d0261e37f17940baf94fcdbc901bc9ae6f61da60c42d54d57c6de94c31664";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "diagnostic_remote_logging";
+    description = "Tools for remotely logging diagnostics data.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/lyrical/diagnostic-updater/default.nix
+++ b/distros/lyrical/diagnostic-updater/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch, launch-testing, launch-testing-ros, python3Packages, rclcpp, rclcpp-lifecycle, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-diagnostic-updater";
-  version = "4.4.6-r3";
+  version = "4.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/lyrical/diagnostic_updater/4.4.6-3.tar.gz";
-    name = "4.4.6-3.tar.gz";
-    sha256 = "73178ffa5faa00623f682d04fce4d22cf46aa2824e73f7443af8b8960816513d";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/lyrical/diagnostic_updater/4.4.7-1.tar.gz";
+    name = "4.4.7-1.tar.gz";
+    sha256 = "37210c0ecab5b5012fd2da20afdf5a64485208bc1c89911363499002b1e3a37f";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ament-cmake-python ament-cmake-ros ];
 
   meta = {
-    description = "diagnostic_updater contains tools for easily updating diagnostics. it is commonly used in device drivers to keep track of the status of output topics, device status, etc.";
+    description = "Update and publish diagnostic information.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/lyrical/diagnostics/default.nix
+++ b/distros/lyrical/diagnostics/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, diagnostic-aggregator, diagnostic-common-diagnostics, diagnostic-updater, self-test }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, diagnostic-aggregator, diagnostic-common-diagnostics, diagnostic-remote-logging, diagnostic-updater, self-test }:
 buildRosPackage {
   pname = "ros-lyrical-diagnostics";
-  version = "4.4.6-r3";
+  version = "4.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/lyrical/diagnostics/4.4.6-3.tar.gz";
-    name = "4.4.6-3.tar.gz";
-    sha256 = "a5c5f96473e38a8de10dad3a09496c48bf78a9e9c98df3860d5cfa06a35b0d1b";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/lyrical/diagnostics/4.4.7-1.tar.gz";
+    name = "4.4.7-1.tar.gz";
+    sha256 = "00fad7cc6e566b6f306f5051df4ea811d7b78f39bb1e7f70ec91fb22258a993a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-common-diagnostics diagnostic-updater self-test ];
+  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-common-diagnostics diagnostic-remote-logging diagnostic-updater self-test ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "diagnostics";
+    description = "Diagnostics tools for monitoring and reporting system status.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/lyrical/generated.nix
+++ b/distros/lyrical/generated.nix
@@ -1290,6 +1290,8 @@ self: super: {
 
  mola-input-mulran-dataset = self.callPackage ./mola-input-mulran-dataset {};
 
+ mola-input-ouster = self.callPackage ./mola-input-ouster {};
+
  mola-input-paris-luco-dataset = self.callPackage ./mola-input-paris-luco-dataset {};
 
  mola-input-rawlog = self.callPackage ./mola-input-rawlog {};
@@ -1570,6 +1572,8 @@ self: super: {
 
  novatel-gps-msgs = self.callPackage ./novatel-gps-msgs {};
 
+ novatel-oem6-msgs = self.callPackage ./novatel-oem6-msgs {};
+
  ntpd-driver = self.callPackage ./ntpd-driver {};
 
  ntrip-client = self.callPackage ./ntrip-client {};
@@ -1811,6 +1815,8 @@ self: super: {
  py-trees-ros-tutorials = self.callPackage ./py-trees-ros-tutorials {};
 
  py-trees-ros-viewer = self.callPackage ./py-trees-ros-viewer {};
+
+ pybind11-json-vendor = self.callPackage ./pybind11-json-vendor {};
 
  pybind11-vendor = self.callPackage ./pybind11-vendor {};
 

--- a/distros/lyrical/image-common/default.nix
+++ b/distros/lyrical/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-lyrical-image-common";
-  version = "6.4.8-r1";
+  version = "6.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/lyrical/image_common/6.4.8-1.tar.gz";
-    name = "6.4.8-1.tar.gz";
-    sha256 = "9cfbf22ebbd6637fda1802fa267d4fcabe9161fda7a10d05bb8005687c7c16bf";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/lyrical/image_common/6.4.9-1.tar.gz";
+    name = "6.4.9-1.tar.gz";
+    sha256 = "830b4fa2b5f76cbe3ae1e3e8ab6ae97d91c5a72ddd9617aee6371d47a57a2455";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/image-transport-py/default.nix
+++ b/distros/lyrical/image-transport-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, image-transport, python3, python3Packages, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-image-transport-py";
-  version = "6.4.8-r1";
+  version = "6.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/lyrical/image_transport_py/6.4.8-1.tar.gz";
-    name = "6.4.8-1.tar.gz";
-    sha256 = "0a9f4aded356a77ccf442b555f90da7282db256e6df937fd798115c0e3ea31ca";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/lyrical/image_transport_py/6.4.9-1.tar.gz";
+    name = "6.4.9-1.tar.gz";
+    sha256 = "43694bf25896fa418ac55121928e04d88468764899007b50737730f4f7252dcf";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/image-transport/default.nix
+++ b/distros/lyrical/image-transport/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, tinyxml-2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-lyrical-image-transport";
-  version = "6.4.8-r1";
+  version = "6.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/lyrical/image_transport/6.4.8-1.tar.gz";
-    name = "6.4.8-1.tar.gz";
-    sha256 = "78cdb4c9d031e461d7b8e3635e1e462b74e27d8468951bc06233fef306f5e9df";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/lyrical/image_transport/6.4.9-1.tar.gz";
+    name = "6.4.9-1.tar.gz";
+    sha256 = "edd54ce8b25afbd9e9a8761edc19a0dc8357d4cf00061325ddca372e15b7fd90";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ];
+  buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common rclcpp-lifecycle ];
   propagatedBuildInputs = [ message-filters pluginlib rclcpp rclcpp-components sensor-msgs tinyxml-2 ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
 
   meta = {
     description = "image_transport should always be used to subscribe to and publish images. It provides transparent

--- a/distros/lyrical/lely-core-libraries/default.nix
+++ b/distros/lyrical/lely-core-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, autoconf, automake, git, libtool, python3Packages }:
 buildRosPackage {
   pname = "ros-lyrical-lely-core-libraries";
-  version = "0.3.2-r3";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/lely_core_libraries/0.3.2-3.tar.gz";
-    name = "0.3.2-3.tar.gz";
-    sha256 = "83e4ccc9c452129a0a857f993d07748a47a5e53eb21b5097e4abe7526204182b";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/lyrical/lely_core_libraries/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "0a99e8e1c6f8e0d01bf9537d4d0db2e5adec15c3685e03cc254be7bce59075d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/leo-bringup/default.nix
+++ b/distros/lyrical/leo-bringup/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-index-python, ament-lint-auto, geometry-msgs, image-proc, launch, launch-ros, leo-description, leo-filters, leo-fw, leo-msgs, python3Packages, robot-state-publisher, rosapi, rosbridge-server, sensor-msgs, web-video-server, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-index-python, ament-lint-auto, geometry-msgs, image-proc, launch, launch-ros, leo-description, leo-filters, leo-fw, leo-msgs, python3Packages, rclpy, robot-state-publisher, rosapi, rosbridge-server, sensor-msgs, tf-transformations, web-video-server, xacro }:
 buildRosPackage {
   pname = "ros-lyrical-leo-bringup";
-  version = "2.5.0-r3";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/lyrical/leo_bringup/2.5.0-3.tar.gz";
-    name = "2.5.0-3.tar.gz";
-    sha256 = "f69c64d54b90a3dae38b2539ae844e694b42b947f08d4bdd22bb0a5e92a46ab0";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/lyrical/leo_bringup/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "65d38614765d765c684d8d34b340745203ca463a6e55b7f7d9272791ce2fc89c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-black ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ ament-index-python geometry-msgs image-proc launch launch-ros leo-description leo-filters leo-fw leo-msgs python3Packages.smbus2 robot-state-publisher rosapi rosbridge-server sensor-msgs web-video-server xacro ];
+  propagatedBuildInputs = [ ament-index-python geometry-msgs image-proc launch launch-ros leo-description leo-filters leo-fw leo-msgs python3Packages.smbus2 rclpy robot-state-publisher rosapi rosbridge-server sensor-msgs tf-transformations web-video-server xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/lyrical/leo-filters/default.nix
+++ b/distros/lyrical/leo-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, generate-parameter-library, geometry-msgs, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, std-srvs, tf2, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-lyrical-leo-filters";
-  version = "2.5.0-r3";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/lyrical/leo_filters/2.5.0-3.tar.gz";
-    name = "2.5.0-3.tar.gz";
-    sha256 = "ceeb38eca96db65611b4716662ed819c910c2b55f0752a9689db065c1bbc228f";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/lyrical/leo_filters/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "2d025435c7afbc2d23c088b562a363d7ba872bfeaefd707d301cdfb02649ae74";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/leo-fw/default.nix
+++ b/distros/lyrical/leo-fw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-pep257, ament-cmake-python, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-python, ament-lint-auto, geometry-msgs, leo-msgs, nav-msgs, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, ros2cli, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-lyrical-leo-fw";
-  version = "2.5.0-r3";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/lyrical/leo_fw/2.5.0-3.tar.gz";
-    name = "2.5.0-3.tar.gz";
-    sha256 = "9369b274d38b84452ba8de3c3fd68284d83851462ada60c545425c88e042aa14";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/lyrical/leo_fw/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "e0bdae2e6be25edcb4f3481cdad0c6a61a2169205773fd3f980ebfaa8fb0c88d";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/leo-robot/default.nix
+++ b/distros/lyrical/leo-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, leo, leo-bringup, leo-filters, leo-fw }:
 buildRosPackage {
   pname = "ros-lyrical-leo-robot";
-  version = "2.5.0-r3";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/lyrical/leo_robot/2.5.0-3.tar.gz";
-    name = "2.5.0-3.tar.gz";
-    sha256 = "024c38cd333e42735d6c4dbd44e072e862af684e8b33e99d1bdf598d3a353da7";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/lyrical/leo_robot/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "d44357b9634e10c37b910b838beaabdba23dc34e4eb911194af58b0a86536918";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/mola-input-ouster/default.nix
+++ b/distros/lyrical/mola-input-ouster/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, curl, eigen, flatbuffers, libpng, libtins, libzip, mola-kernel, mola-yaml, mrpt-libmaps, mrpt-libobs, openssl, zstd }:
+buildRosPackage {
+  pname = "ros-lyrical-mola-input-ouster";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_input_ouster-release/archive/release/lyrical/mola_input_ouster/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "c7f9722dcdb7292076b3fd9e53e5637cc6570918f2f1e6913b60e8a976aac98c";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen flatbuffers libpng libtins libzip openssl zstd ];
+  propagatedBuildInputs = [ curl mola-kernel mola-yaml mrpt-libmaps mrpt-libobs ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "MOLA input module for Ouster LiDAR sensors using the native Ouster C++ SDK.
+    Provides direct sensor connection and PCAP replay without ROS middleware.";
+    license = with lib.licenses; [ "GPL-3.0" ];
+  };
+}

--- a/distros/lyrical/mp2p-icp/default.nix
+++ b/distros/lyrical/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-lyrical-mp2p-icp";
-  version = "2.10.2-r1";
+  version = "2.10.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/lyrical/mp2p_icp/2.10.2-1.tar.gz";
-    name = "2.10.2-1.tar.gz";
-    sha256 = "fb5fa73c1fbc4e05b4a2ac18a95179352b28cee26f78d80870a5c012017adf1b";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/lyrical/mp2p_icp/2.10.3-1.tar.gz";
+    name = "2.10.3-1.tar.gz";
+    sha256 = "edc7ce08cf3c064bc8fd832e504bbcefc582fde99ece84a251a1c033d361e165";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mrpt-generic-sensor/default.nix
+++ b/distros/lyrical/mrpt-generic-sensor/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt-sensorlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-msgs, mrpt-sensorlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-lyrical-mrpt-generic-sensor";
-  version = "0.2.4-r3";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/lyrical/mrpt_generic_sensor/0.2.4-3.tar.gz";
-    name = "0.2.4-3.tar.gz";
-    sha256 = "4690a687618840dff3a9640ca483e942d29a154239c7544d9cc4a68928aa18d7";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/lyrical/mrpt_generic_sensor/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "cee88e190fbb466cca78ee8dce6caf5f99cd8ea201eab4111e29886dc1be34c4";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-msgs mrpt-sensorlib rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-msgs mrpt-sensorlib rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/lyrical/mrpt-sensor-bumblebee-stereo/default.nix
+++ b/distros/lyrical/mrpt-sensor-bumblebee-stereo/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, rclcpp-components, ros-environment, tf2-ros }:
 buildRosPackage {
   pname = "ros-lyrical-mrpt-sensor-bumblebee-stereo";
-  version = "0.2.4-r3";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/lyrical/mrpt_sensor_bumblebee_stereo/0.2.4-3.tar.gz";
-    name = "0.2.4-3.tar.gz";
-    sha256 = "14e023c6b14ee5c56830f9ad06a877673eee6ec55aea4228e79f651ed97df09d";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/lyrical/mrpt_sensor_bumblebee_stereo/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "5794e8792003d0c1be11e6e72385b78953bcc4d2fb635c55f7225ab4496fd8ad";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib rclcpp-components tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/lyrical/mrpt-sensor-gnss-nmea/default.nix
+++ b/distros/lyrical/mrpt-sensor-gnss-nmea/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nmea-msgs, rclcpp-components, ros-environment, tf2-ros }:
 buildRosPackage {
   pname = "ros-lyrical-mrpt-sensor-gnss-nmea";
-  version = "0.2.4-r3";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/lyrical/mrpt_sensor_gnss_nmea/0.2.4-3.tar.gz";
-    name = "0.2.4-3.tar.gz";
-    sha256 = "fc9d5796a5edf6595cd7c8f390b3a5b5bbe85e382aba5416468192b0f78e722d";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/lyrical/mrpt_sensor_gnss_nmea/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "affe2104a187929c4242db4e54859f78592df0995fe7d86198c802b5bb25e390";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs nmea-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nmea-msgs rclcpp-components tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/lyrical/mrpt-sensor-gnss-novatel/default.nix
+++ b/distros/lyrical/mrpt-sensor-gnss-novatel/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, novatel-oem6-msgs, rclcpp-components, ros-environment, tf2-ros }:
 buildRosPackage {
   pname = "ros-lyrical-mrpt-sensor-gnss-novatel";
-  version = "0.2.4-r3";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/lyrical/mrpt_sensor_gnss_novatel/0.2.4-3.tar.gz";
-    name = "0.2.4-3.tar.gz";
-    sha256 = "316913391ccf3455efa13662a4438a833bdff0b417312e01cca6bb2792694fe5";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/lyrical/mrpt_sensor_gnss_novatel/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "72273b25d084fa64fa14a3ed56a2a6c32f5a1b926a116dff78b32ccb2f3860dc";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib novatel-oem6-msgs rclcpp-components tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/lyrical/mrpt-sensor-imu-taobotics/default.nix
+++ b/distros/lyrical/mrpt-sensor-imu-taobotics/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, rclcpp-components, ros-environment, tf2-ros }:
 buildRosPackage {
   pname = "ros-lyrical-mrpt-sensor-imu-taobotics";
-  version = "0.2.4-r3";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/lyrical/mrpt_sensor_imu_taobotics/0.2.4-3.tar.gz";
-    name = "0.2.4-3.tar.gz";
-    sha256 = "96aa66b66b103c90ac3eb93f3c8682331d1282283c925259e81269577e254a56";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/lyrical/mrpt_sensor_imu_taobotics/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "8cff70cd10abf5f254e0eb87770702725579b28e7241f3d3442ca50e6663d69c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib rclcpp-components tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/lyrical/mrpt-sensorlib/default.nix
+++ b/distros/lyrical/mrpt-sensorlib/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, diagnostic-updater, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, rclcpp-components, ros-environment, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-lyrical-mrpt-sensorlib";
-  version = "0.2.4-r3";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/lyrical/mrpt_sensorlib/0.2.4-3.tar.gz";
-    name = "0.2.4-3.tar.gz";
-    sha256 = "c0241411a4e4558268859f4a6e6d760dd300685eb7f7a3f4db4fb027fd14c410";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/lyrical/mrpt_sensorlib/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "1573be31d261e34797ea3949e018c0d46e792e4f23ae46ea3bb45e2222332d08";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ diagnostic-updater mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs rclcpp-components tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/lyrical/mrpt-sensors/default.nix
+++ b/distros/lyrical/mrpt-sensors/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-generic-sensor, mrpt-sensor-bumblebee-stereo, mrpt-sensor-gnss-nmea, mrpt-sensor-gnss-novatel, mrpt-sensor-imu-taobotics, mrpt-sensorlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, mrpt-generic-sensor, mrpt-sensor-bumblebee-stereo, mrpt-sensor-gnss-nmea, mrpt-sensor-gnss-novatel, mrpt-sensor-imu-taobotics, mrpt-sensorlib }:
 buildRosPackage {
   pname = "ros-lyrical-mrpt-sensors";
-  version = "0.2.4-r3";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/lyrical/mrpt_sensors/0.2.4-3.tar.gz";
-    name = "0.2.4-3.tar.gz";
-    sha256 = "9f4119e4d56e742f996270f1e4487215552c134a7c6ad61c85902a9af7e87dc0";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/lyrical/mrpt_sensors/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "2724e2e2626f7659372e85fb83a8d1a135ec1546f016c5566620c1a63f3cbc19";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-generic-sensor mrpt-sensor-bumblebee-stereo mrpt-sensor-gnss-nmea mrpt-sensor-gnss-novatel mrpt-sensor-imu-taobotics mrpt-sensorlib ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ mrpt-generic-sensor mrpt-sensor-bumblebee-stereo mrpt-sensor-gnss-nmea mrpt-sensor-gnss-novatel mrpt-sensor-imu-taobotics mrpt-sensorlib ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/lyrical/novatel-oem6-msgs/default.nix
+++ b/distros/lyrical/novatel-oem6-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-novatel-oem6-msgs";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/lyrical/novatel_oem6_msgs/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "dbc448b2d994dccab0a5f6d4c2c86e9193e1eb20bfe126dee6828ea4097d8c8d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-cmake-xmllint ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "ROS messages and services for Novatel OEM6";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -335,24 +335,11 @@ in {
 
   lely-core-libraries = (lib.patchExternalProjectGit rosSuper.lely-core-libraries {
     url = "https://gitlab.com/lely_industries/lely-core.git";
-    rev = "fb735b79cab5f0cdda45bc5087414d405ef8f3ab";
+    rev = "9e3267d26018f6f6babd50786f6ae2af89cc57ea";
     fetchgitArgs = {
-      hash = "sha256-TpEWho+lbhXGaZ24+86eVJttrxH2Kc9gZVOGWeR0LBE=";
+      hash = "sha256-A7RsVQwzj59M9+eGTeNt+/yb3rFziJl3fy33K5c36z0=";
       leaveDotGit = true;
     };
-  }).overrideAttrs ({
-    postPatch ? "", ...
-  }: {
-    # ref. https://gitlab.com/lely_industries/lely-core/-/merge_requests/143
-    postPatch = postPatch + ''
-      substituteInPlace CMakeLists.txt --replace-fail \
-        "CONFIGURE_COMMAND autoreconf -i <SOURCE_DIR>" \
-        "PATCH_COMMAND patch -p1 < ${self.fetchpatch2 {
-          url = "https://gitlab.com/lely_industries/lely-core/-/commit/6ed995fa86d828957b636a11470f150830d877ec.patch";
-          hash = "sha256-/kn+BMs9JHigmSXi6BrlHGmt06eF7mzJiKi26a7JQ3c=";
-        }}
-        CONFIGURE_COMMAND autoreconf -i <SOURCE_DIR>"
-    '';
   });
 
   libphidget22 = lib.patchVendorUrl rosSuper.libphidget22 {

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -469,6 +469,8 @@ in {
     ];
   });
 
+  pybind11-json-vendor = lib.patchAmentVendorGit rosSuper.pybind11-json-vendor { };
+
   # This meta-package is referenced by the rosdep key python3-qt-bindings,
   # which is used by packages such as rqt. These packages depend on Qt5 in
   # older ROS distributions and Qt6 in Lyrical and newer releases.

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -336,6 +336,27 @@ in {
     hash = "sha256-GpzGMpQ02s/X/XEcGoozzMjigrbqvAu81bcb7QG+36E=";
   };
 
+  librealsense2 = (lib.patchExternalProjectGit rosSuper.librealsense2 {
+    file = "CMake/external_libcurl.cmake";
+    originalUrl = ''"https://github.com/curl/curl.git"'';
+    url = "https://github.com/curl/curl.git";
+    originalRev = ''"curl-8_8_0"'';
+    rev = "curl-8_8_0";
+    fetchgitArgs.hash = "sha256-MjB6k8mDJypyuh6BN2hxy2My7/DfImjw+5iI729snBg=";
+  }).overrideAttrs ({
+    buildInputs ? [], postPatch ? "", ...
+  }: {
+    buildInputs = buildInputs ++ [ self.nlohmann_json ];
+    postPatch = postPatch + ''
+      # Get rid of nlohmann_json vendoring
+      substituteInPlace third-party/CMakeLists.txt \
+        --replace-fail 'include(CMake/external_json.cmake)' ""
+      # Don't try to install to $HOME
+      substituteInPlace tools/realsense-viewer/CMakeLists.txt \
+        --replace-fail '$ENV{HOME}/Documents/librealsense2/presets' ''\'''${CMAKE_INSTALL_PREFIX}/share/librealsense2/presets'
+    '';
+  });
+
   mcap-vendor = lib.patchVendorUrl rosSuper.mcap-vendor {
     url = "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v2.1.3.tar.gz";
     hash = "sha256-GBp8UsyYJETN71Mwh7MhU4sCX8xe7CWOBInWi5zlPe0=";

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -34,17 +34,6 @@ in {
     ];
   });
 
-  canopen-core = rosSuper.canopen-core.overrideAttrs ({
-    postPatch ? "", ...
-  }: {
-    # https://github.com/ros-industrial/ros2_canopen/pull/399
-    postPatch = ''
-      substituteInPlace ConfigExtras.cmake --replace-fail \
-        "find_package(Boost REQUIRED system thread)" \
-        "find_package(Boost REQUIRED thread)"
-    '';
-  });
-
   cartographer = rosSuper.cartographer.overrideAttrs ({
     postPatch ? "", ...
   }: {

--- a/distros/lyrical/point-cloud-transport-py/default.nix
+++ b/distros/lyrical/point-cloud-transport-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, python3, python3Packages, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-point-cloud-transport-py";
-  version = "5.4.1-r1";
+  version = "5.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/lyrical/point_cloud_transport_py/5.4.1-1.tar.gz";
-    name = "5.4.1-1.tar.gz";
-    sha256 = "e8e74e782d2132a35713f422117368df755b900690f1f884181ad505a6fba758";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/lyrical/point_cloud_transport_py/5.4.2-1.tar.gz";
+    name = "5.4.2-1.tar.gz";
+    sha256 = "571f39bc27bed244a025edcc55a4bdbd67cdebfb98195cd3f1c0cc62f6cb54d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/point-cloud-transport/default.nix
+++ b/distros/lyrical/point-cloud-transport/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rcpputils, rmw, sensor-msgs, tinyxml-2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rcpputils, rmw, sensor-msgs, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-lyrical-point-cloud-transport";
-  version = "5.4.1-r1";
+  version = "5.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/lyrical/point_cloud_transport/5.4.1-1.tar.gz";
-    name = "5.4.1-1.tar.gz";
-    sha256 = "6f11915a117f8ac88d39d8960d1cd66fd7eb6bfa2f141e5e59733724aca6c923";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/lyrical/point_cloud_transport/5.4.2-1.tar.gz";
+    name = "5.4.2-1.tar.gz";
+    sha256 = "94b8fbd3f3f972bd65b9e9f9a3f948e40ea8ecb258a91196ea9095649c972769";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ];
+  buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ message-filters pluginlib rclcpp rclcpp-components rcpputils rmw sensor-msgs tinyxml-2 ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
 
   meta = {
     description = "Support for transporting PointCloud2 messages in compressed format and plugin interface for implementing additional PointCloud2 transports.";

--- a/distros/lyrical/pybind11-json-vendor/default.nix
+++ b/distros/lyrical/pybind11-json-vendor/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, nlohmann_json, pybind11-vendor }:
+buildRosPackage {
+  pname = "ros-lyrical-pybind11-json-vendor";
+  version = "0.7.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/pybind11_json_vendor-release/archive/release/lyrical/pybind11_json_vendor/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "55563fb46c40fb4e7677f11a6c6ab044e97744b17e4c0bdcb7cb2d81e6caf28e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-vendor-package ];
+  propagatedBuildInputs = [ nlohmann_json pybind11-vendor ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package ];
+
+  meta = {
+    description = "A vendor package for pybind11_json for Modern C++";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/pybind11-json-vendor/vendored-source.json
+++ b/distros/lyrical/pybind11-json-vendor/vendored-source.json
@@ -1,0 +1,7 @@
+{
+  "pybind11_json_vendor": {
+    "url": "https://github.com/pybind/pybind11_json.git",
+    "rev": "0.2.15",
+    "hash": "sha256-e9mBvSg8mIuYO1x2yJhejY3iP0TPIiQXwzxy5asf9tk="
+  }
+}

--- a/distros/lyrical/rmf-building-map-tools/default.nix
+++ b/distros/lyrical/rmf-building-map-tools/default.nix
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_python";
   checkInputs = [ python3Packages.pytest ];
-  propagatedBuildInputs = [ ament-index-python gz-fuel-tools-vendor python3Packages.Rtree python3Packages.fiona python3Packages.pyproj python3Packages.pyyaml python3Packages.requests python3Packages.shapely rclpy rmf-building-map-msgs rmf-site-map-msgs sqlite std-msgs yaml-cpp ];
+  propagatedBuildInputs = [ ament-index-python gz-fuel-tools-vendor python3Packages.fiona python3Packages.pyproj python3Packages.pyyaml python3Packages.requests python3Packages.rtree python3Packages.shapely rclpy rmf-building-map-msgs rmf-site-map-msgs sqlite std-msgs yaml-cpp ];
 
   meta = {
     description = "RMF Building map tools";

--- a/distros/lyrical/robotraconteur-companion/default.nix
+++ b/distros/lyrical/robotraconteur-companion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, eigen, gtest, opencv, robotraconteur, yaml-cpp }:
 buildRosPackage {
   pname = "ros-lyrical-robotraconteur-companion";
-  version = "0.4.2-r4";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robotraconteur_companion-release/archive/release/lyrical/robotraconteur_companion/0.4.2-4.tar.gz";
-    name = "0.4.2-4.tar.gz";
-    sha256 = "b6bc2913f356c47bf6598e9fa268a4ab7d0b402575ac5abccb447710475d62b9";
+    url = "https://github.com/ros2-gbp/robotraconteur_companion-release/archive/release/lyrical/robotraconteur_companion/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "2c3e46154cb624071b441e732fa7a5c82180273d9eec9e3c3101352e145f01e8";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/robotraconteur/default.nix
+++ b/distros/lyrical/robotraconteur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bluez, boost, cmake, dbus, gtest, libusb1, openssl, python3, python3Packages, zlib }:
 buildRosPackage {
   pname = "ros-lyrical-robotraconteur";
-  version = "1.2.7-r4";
+  version = "1.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robotraconteur-release/archive/release/lyrical/robotraconteur/1.2.7-4.tar.gz";
-    name = "1.2.7-4.tar.gz";
-    sha256 = "edd27c687798c6e4cfbb5730e2c1d19349552f4dc873db090f65774ab0357f84";
+    url = "https://github.com/ros2-gbp/robotraconteur-release/archive/release/lyrical/robotraconteur/1.2.8-1.tar.gz";
+    name = "1.2.8-1.tar.gz";
+    sha256 = "5d626036d35837ed44ae8fa434eeb36f9617f2475b41460b397658c22d747bd4";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/rosapi-msgs/default.nix
+++ b/distros/lyrical/rosapi-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-lyrical-rosapi-msgs";
-  version = "4.1.0-r3";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/lyrical/rosapi_msgs/4.1.0-3.tar.gz";
-    name = "4.1.0-3.tar.gz";
-    sha256 = "4d9a0f6a66e108fe6928d13cdf6b8ca65a793ff86ad28acf4f8d0201bd34dfd6";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/lyrical/rosapi_msgs/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "174ce2a53c17d27d54a9cc47317b967d1df0c0fafafa79087dc971cf5b500ab6";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosapi/default.nix
+++ b/distros/lyrical/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-mypy, ament-cmake-pytest, ament-cmake-python, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2action, ros2interface, ros2node, ros2service, ros2topic, rosapi-msgs, rosbridge-library, rosidl-adapter, rosidl-runtime-py, sensor-msgs, shape-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-rosapi";
-  version = "4.1.0-r3";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/lyrical/rosapi/4.1.0-3.tar.gz";
-    name = "4.1.0-3.tar.gz";
-    sha256 = "0e15ad891d4144cb02f37a371fee1706bc6cc2a27caab936c86041688d65474d";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/lyrical/rosapi/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "181bd1dcce63a8f59fc09c93886308546d9af05b795ba1b58d23307240a5b6ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosbridge-library/default.nix
+++ b/distros/lyrical/rosbridge-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-mypy, ament-cmake-python, ament-cmake-ros, builtin-interfaces, control-msgs, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rcl-interfaces, rclpy, rosbridge-test-msgs, rosidl-pycommon, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-rosbridge-library";
-  version = "4.1.0-r3";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/lyrical/rosbridge_library/4.1.0-3.tar.gz";
-    name = "4.1.0-3.tar.gz";
-    sha256 = "ee8524919c02637c743501a9cdd9823db76d55e2e83aaec9a0dd600d3bc709f8";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/lyrical/rosbridge_library/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "8a0ca50a3d0b14d74e998775975b0485309d5eac317a7b23f23a4995f3151457";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosbridge-msgs/default.nix
+++ b/distros/lyrical/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-lyrical-rosbridge-msgs";
-  version = "4.1.0-r3";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/lyrical/rosbridge_msgs/4.1.0-3.tar.gz";
-    name = "4.1.0-3.tar.gz";
-    sha256 = "e89c261ed7cbe3e09044e9eac8a3397065c3669f9b5ec9cac5af26d9e9f34abf";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/lyrical/rosbridge_msgs/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "43d4f200bea8ad7137b1c054184c3c2502ede64026f6659dfd99aa700b084fe4";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosbridge-server/default.nix
+++ b/distros/lyrical/rosbridge-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-mypy, ament-cmake-python, ament-cmake-ros, example-interfaces, launch, launch-ros, launch-testing-ament-cmake, python3Packages, rcl-interfaces, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-lyrical-rosbridge-server";
-  version = "4.1.0-r3";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/lyrical/rosbridge_server/4.1.0-3.tar.gz";
-    name = "4.1.0-3.tar.gz";
-    sha256 = "a4500af87423c09c3ba25e59da61f58ecfa3d3f4659ab400ab4e4e02c2669447";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/lyrical/rosbridge_server/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "27484916587760e2ef436c9727325602cd59176c1cc0f2d33b7d8bce3fa2007a";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosbridge-suite/default.nix
+++ b/distros/lyrical/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-lyrical-rosbridge-suite";
-  version = "4.1.0-r3";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/lyrical/rosbridge_suite/4.1.0-3.tar.gz";
-    name = "4.1.0-3.tar.gz";
-    sha256 = "419192ff2fb4928b1f5650e0d38a247f3bb745fedff2628ec8670ba9ca1a1d05";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/lyrical/rosbridge_suite/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "dac87a78ee958062741668f8a946678476e2578990c1280ae99dc04480079800";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosbridge-test-msgs/default.nix
+++ b/distros/lyrical/rosbridge-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-rosbridge-test-msgs";
-  version = "4.1.0-r3";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/lyrical/rosbridge_test_msgs/4.1.0-3.tar.gz";
-    name = "4.1.0-3.tar.gz";
-    sha256 = "b97bc10d4d6bbbfff139e9d2a12ab552cda8707e15c12a7245d7bbc183214aa2";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/lyrical/rosbridge_test_msgs/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "1df0a3d04ff07ba484715cb2f6270264669458ed44f1897df8cb782396800217";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosidlcpp-generator-c/default.nix
+++ b/distros/lyrical/rosidlcpp-generator-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-ros-core, fmt, nlohmann_json, rcutils, ros-environment, rosidl-cmake, rosidl-generator-type-description, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-lyrical-rosidlcpp-generator-c";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp_generator_c/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "4b2373facea267e647466c70aed0126da3d876ea6be51534768438f9383c11b3";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp_generator_c/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "a1d86dc5b9e3ac05600e2bcbfa8d22ff60af6bf715a7bf3d80fb364ca3e0c536";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosidlcpp-generator-core/default.nix
+++ b/distros/lyrical/rosidlcpp-generator-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, fmt, nlohmann_json, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-lyrical-rosidlcpp-generator-core";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp_generator_core/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "769948d254b88512642e78578a654c4cba7ff6b7941b027cd7759844abe48616";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp_generator_core/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "5a8d43a8ba87d0c789097fac977458dc8b7f4f55d6a9223221ce09e77f8cf55c";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosidlcpp-generator-cpp/default.nix
+++ b/distros/lyrical/rosidlcpp-generator-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, fmt, nlohmann_json, rcutils, rosidl-cmake, rosidl-generator-type-description, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-lyrical-rosidlcpp-generator-cpp";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp_generator_cpp/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "f03d7f70d65981cbeb7c0d43df79747faea09a2ad71974ccd0daadc2d2a610ad";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp_generator_cpp/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "834ec3b80ee35709e6136fbe144195ca03a7527861145e87434b193f688a3396";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosidlcpp-generator-py/default.nix
+++ b/distros/lyrical/rosidlcpp-generator-py/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, fmt, nlohmann_json, python-cmake-module, rmw, rosidl-generator-c, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-c, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, fmt, nlohmann_json, rmw, rosidl-generator-c, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-c, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-lyrical-rosidlcpp-generator-py";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp_generator_py/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "67e9458bcbf275eff44269af05ad0e102995b18ad3275514c4e0784d25ef649e";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp_generator_py/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "52747ef8545609b50bfdaf3232f7debc0a0c9187df43a2bc4e12fa423b07551b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ rosidl-runtime-c ];
-  propagatedBuildInputs = [ ament-cmake ament-index-python fmt nlohmann_json python-cmake-module rmw rosidl-generator-c rosidl-pycommon rosidl-typesupport-c rosidl-typesupport-interface rosidlcpp-generator-core rosidlcpp-parser ];
-  nativeBuildInputs = [ ament-cmake ament-index-python python-cmake-module rosidl-generator-c rosidl-pycommon rosidl-typesupport-c rosidl-typesupport-interface ];
+  propagatedBuildInputs = [ ament-cmake ament-index-python fmt nlohmann_json rmw rosidl-generator-c rosidl-pycommon rosidl-typesupport-c rosidl-typesupport-interface rosidlcpp-generator-core rosidlcpp-parser ];
+  nativeBuildInputs = [ ament-cmake ament-index-python rosidl-generator-c rosidl-pycommon rosidl-typesupport-c rosidl-typesupport-interface ];
 
   meta = {
     description = "Generate the ROS interfaces in Python.";

--- a/distros/lyrical/rosidlcpp-generator-type-description/default.nix
+++ b/distros/lyrical/rosidlcpp-generator-type-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, fmt, nlohmann_json, rcutils, rosidl-runtime-c, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-lyrical-rosidlcpp-generator-type-description";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp_generator_type_description/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "6ac5fdf05a22ed9c88be523aba2c11af898dd86225cd186289823ff826aa1f0e";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp_generator_type_description/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "3003ed0a23a940f377fe26f8f74255a2b73d2b47ca95d6ecc5b3c1ff7d641553";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosidlcpp-parser/default.nix
+++ b/distros/lyrical/rosidlcpp-parser/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, fmt, nlohmann_json }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, fmt, nlohmann_json, rosidl-pycommon }:
 buildRosPackage {
   pname = "ros-lyrical-rosidlcpp-parser";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp_parser/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "0d2df6657c4b704457136e698664681608c60aa4228f5d20b5e5259ca74ee44a";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp_parser/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "cf92054d6bfddf923c0bbf625b77e2cadf5a36a2f8983bff97304820342a1544";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake fmt nlohmann_json ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-pycommon ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/lyrical/rosidlcpp-typesupport-c/default.nix
+++ b/distros/lyrical/rosidlcpp-typesupport-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-ros-core, ament-index-python, fmt, nlohmann_json, rcpputils, rcutils, ros-environment, rosidl-cli, rosidl-generator-c, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-c, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-lyrical-rosidlcpp-typesupport-c";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp_typesupport_c/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "ef817ed9b5f0a369ee1b5686d3022d2194f76971d0920f849a33191f05ebe4e8";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp_typesupport_c/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "e2552437407f91619cd3c27c937cafe46e1061aaf48dde0ac7f6d11fb0558c86";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosidlcpp-typesupport-cpp/default.nix
+++ b/distros/lyrical/rosidlcpp-typesupport-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-ros-core, ament-index-python, fmt, nlohmann_json, rcpputils, rcutils, ros-environment, rosidl-cli, rosidl-generator-c, rosidl-generator-type-description, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-cpp, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-lyrical-rosidlcpp-typesupport-cpp";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp_typesupport_cpp/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "bc120d40eedfb2c0a17be48b4df0cfbf15299fc7ac854a5ec3dc29daadbfe55f";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp_typesupport_cpp/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "cbbb141e5c9d729129ae5a3bdde5db94a91728d5ccc2836e89946749b91a9d4c";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosidlcpp-typesupport-fastrtps-c/default.nix
+++ b/distros/lyrical/rosidlcpp-typesupport-fastrtps-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-cmake-ros, fastcdr, fmt, nlohmann_json, rmw, rosidl-generator-c, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-lyrical-rosidlcpp-typesupport-fastrtps-c";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp_typesupport_fastrtps_c/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "5646fc7f82c0273a417273fb8046fffa0898a26f7b43df79d14a5539121140fd";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp_typesupport_fastrtps_c/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "c11ff81ee976bfd253076c2be372f5dde5d79c87bd3f7d2545db9d13e2939f94";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosidlcpp-typesupport-fastrtps-cpp/default.nix
+++ b/distros/lyrical/rosidlcpp-typesupport-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-cmake-ros, fastcdr, fmt, nlohmann_json, rmw, rosidl-generator-c, rosidl-generator-cpp, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-lyrical-rosidlcpp-typesupport-fastrtps-cpp";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp_typesupport_fastrtps_cpp/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "b3fabee6dcec326392e1e019fd9f25cded252ecb924f16a088e81854ce44abc8";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp_typesupport_fastrtps_cpp/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "202050fdf2b7758fff427db2da66e630db5b63c9fa878a862fc3290937bdfd34";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosidlcpp-typesupport-introspection-c/default.nix
+++ b/distros/lyrical/rosidlcpp-typesupport-introspection-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros-core, ament-index-python, fmt, nlohmann_json, ros-environment, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-interface, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-lyrical-rosidlcpp-typesupport-introspection-c";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp_typesupport_introspection_c/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "e72ab2eaa415dbf795fdbcf4850d51fb88c2e82fa0f90bbdf3cf36a73b220aac";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp_typesupport_introspection_c/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "0d34d56c3c9822a5fb277b525527baf29e28ea172903ee15597f403371b1e808";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosidlcpp-typesupport-introspection-cpp/default.nix
+++ b/distros/lyrical/rosidlcpp-typesupport-introspection-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros-core, ament-index-python, fmt, nlohmann_json, ros-environment, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidl-typesupport-introspection-c, rosidlcpp-generator-core, rosidlcpp-parser }:
 buildRosPackage {
   pname = "ros-lyrical-rosidlcpp-typesupport-introspection-cpp";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp_typesupport_introspection_cpp/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "69a7332529a933d24981a7a4830c1b6f7d529d566f84522ce34ae2afeffaec81";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp_typesupport_introspection_cpp/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "64dc5686516b5a30cda9931f7d921564cd292fa0fc4f809776aac502a6213b0e";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosidlcpp/default.nix
+++ b/distros/lyrical/rosidlcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, rosidlcpp-generator-c, rosidlcpp-generator-cpp, rosidlcpp-generator-py, rosidlcpp-generator-type-description, rosidlcpp-typesupport-c, rosidlcpp-typesupport-cpp, rosidlcpp-typesupport-fastrtps-c, rosidlcpp-typesupport-fastrtps-cpp, rosidlcpp-typesupport-introspection-c, rosidlcpp-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-lyrical-rosidlcpp";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "72154c71d267f1aec4c1dbe52ca4c56e6e6a8210709e661bc511504f0f24e87d";
+    url = "https://github.com/ros2-gbp/rosidlcpp-release/archive/release/lyrical/rosidlcpp/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "1ffefcd2056823f8c34a3c37875765054cb562781a4f746bb3178cbb4ddf0d11";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rtest/default.nix
+++ b/distros/lyrical/rtest/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-clang-tidy, ament-cmake, ament-cmake-copyright, ament-cmake-ros, ament-lint-auto, ament-lint-common, boost, gmock-vendor, gtest, rcl, rcl-action, rclcpp, rclcpp-action, ros-environment }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-clang-tidy, ament-cmake, ament-cmake-copyright, ament-cmake-ros, ament-lint-auto, ament-lint-common, boost, gtest, rcl, rcl-action, rclcpp, rclcpp-action, ros-environment }:
 buildRosPackage {
   pname = "ros-lyrical-rtest";
-  version = "0.2.2-r3";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rtest-release/archive/release/lyrical/rtest/0.2.2-3.tar.gz";
-    name = "0.2.2-3.tar.gz";
-    sha256 = "7840fb14393919249704b54210c091c3f7a437e456f3986fbf100f661130c7bf";
+    url = "https://github.com/ros2-gbp/rtest-release/archive/release/lyrical/rtest/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "2873fd720120244054baa15ec1bb2296ec8a2a6e9326995f02e7711726233c3b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-ros boost gtest ros-environment ];
   checkInputs = [ ament-clang-tidy ament-cmake-copyright ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ action-msgs gmock-vendor rcl rcl-action rclcpp rclcpp-action ];
+  propagatedBuildInputs = [ action-msgs rcl rcl-action rclcpp rclcpp-action ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 
   meta = {

--- a/distros/lyrical/rtsp-image-transport/default.nix
+++ b/distros/lyrical/rtsp-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, ffmpeg, image-transport, live555-vendor, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-lyrical-rtsp-image-transport";
-  version = "2.0.1-r3";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rtsp_image_transport-release/archive/release/lyrical/rtsp_image_transport/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "ad39495f46b4ffa8e9f184699a7b42c6b248ae2ab5d9f6dfe207c314527da877";
+    url = "https://github.com/ros2-gbp/rtsp_image_transport-release/archive/release/lyrical/rtsp_image_transport/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "1a7808897857fbf8d960f9531cab86a71e7d4f953337341dbb63efb993479112";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/self-test/default.nix
+++ b/distros/lyrical/self-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp, ros-environment }:
 buildRosPackage {
   pname = "ros-lyrical-self-test";
-  version = "4.4.6-r3";
+  version = "4.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/lyrical/self_test/4.4.6-3.tar.gz";
-    name = "4.4.6-3.tar.gz";
-    sha256 = "a89f0aae2a7b3d7c8bb52c22441777a4adf705f69424cd994937347e74d1670e";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/lyrical/self_test/4.4.7-1.tar.gz";
+    name = "4.4.7-1.tar.gz";
+    sha256 = "760f3fa7ce28c43b5e0991fc3e14b7c7ca3a7630e6c8ad7b39703985cb4d8f1c";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "self_test";
+    description = "Self-test tools for diagnostics.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/lyrical/slider-publisher/default.nix
+++ b/distros/lyrical/slider-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-lyrical-slider-publisher";
-  version = "2.4.3-r3";
+  version = "2.5.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/slider_publisher-release/archive/release/lyrical/slider_publisher/2.4.3-3.tar.gz";
-    name = "2.4.3-3.tar.gz";
-    sha256 = "27c114ff6714cff1bf2dba03c6cd62482767999bc7fd6315db243c48649e392c";
+    url = "https://github.com/ros2-gbp/slider_publisher-release/archive/release/lyrical/slider_publisher/2.5.0-2.tar.gz";
+    name = "2.5.0-2.tar.gz";
+    sha256 = "f9b93dfc9eff2ac1c3e83d7952edf1801f670d29bd9f28873ae1a0e6b1b28c35";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ur-client-library/default.nix
+++ b/distros/lyrical/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-lyrical-ur-client-library";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/lyrical/ur_client_library/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "30f6c8d1081353f9a196af96ea95b433b599d7e8010f8190e759ab227b7bab14";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/lyrical/ur_client_library/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "66d012c11ecd4d394923b4390457babb74e6572405b721a5f7d1f224737770cd";
   };
 
   buildType = "cmake";

--- a/distros/rolling/apriltag-msgs/default.nix
+++ b/distros/rolling/apriltag-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-apriltag-msgs";
-  version = "2.0.1-r5";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag_msgs-release/archive/release/rolling/apriltag_msgs/2.0.1-5.tar.gz";
-    name = "2.0.1-5.tar.gz";
-    sha256 = "b3091f895f991ad7abc18f859686f81d0817bcdb62d43670048ddd095da1d0c3";
+    url = "https://github.com/ros2-gbp/apriltag_msgs-release/archive/release/rolling/apriltag_msgs/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "be239f674140602e8a529e0ff4beef45f0065e195cc3fdc86b2aaa33377e3fb6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/apriltag-ros/default.nix
+++ b/distros/rolling/apriltag-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-lint-auto, apriltag, apriltag-msgs, camera-ros, clang, cv-bridge, eigen, image-proc, image-transport, image-transport-plugins, rclcpp, rclcpp-components, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-apriltag-ros";
-  version = "3.3.0-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag_ros-release/archive/release/rolling/apriltag_ros/3.3.0-2.tar.gz";
-    name = "3.3.0-2.tar.gz";
-    sha256 = "1eb58ce32fdcc9285486bd7589aa84046313242948ef76a5afd51e897ca8f206";
+    url = "https://github.com/ros2-gbp/apriltag_ros-release/archive/release/rolling/apriltag_ros/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "67330d28f6297d67d54cd8959c230302ae7107b38860f3075a5594c075934b65";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/camera-calibration-parsers/default.nix
+++ b/distros/rolling/camera-calibration-parsers/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-camera-calibration-parsers";
-  version = "7.0.0-r1";
+  version = "7.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_calibration_parsers/7.0.0-1.tar.gz";
-    name = "7.0.0-1.tar.gz";
-    sha256 = "bbe94f12fbe1325850e15acf60729f85934ebfa964e16f495a91462951f2c22e";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_calibration_parsers/7.0.1-1.tar.gz";
+    name = "7.0.1-1.tar.gz";
+    sha256 = "59d206091bc2d19e19589098bb6efcbc6e64151d24a2b4e59a61c6c68e572e58";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ];
+  buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ rclcpp sensor-msgs yaml-cpp-vendor ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
 
   meta = {
     description = "camera_calibration_parsers contains routines for reading and writing camera calibration parameters.";

--- a/distros/rolling/camera-info-manager-py/default.nix
+++ b/distros/rolling/camera-info-manager-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, python3Packages, rclpy, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-camera-info-manager-py";
-  version = "7.0.0-r1";
+  version = "7.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_info_manager_py/7.0.0-1.tar.gz";
-    name = "7.0.0-1.tar.gz";
-    sha256 = "c8399fe74be98447a673b4a64a41b0f9db1feca6c3241dcb00896391b466a8f9";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_info_manager_py/7.0.1-1.tar.gz";
+    name = "7.0.1-1.tar.gz";
+    sha256 = "767f37a9ca3d642d97ad26b4d3c75dd949522c7a6b2356e507f20b249486c6e5";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/camera-info-manager/default.nix
+++ b/distros/rolling/camera-info-manager/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rclcpp-lifecycle, rcpputils, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rclcpp-lifecycle, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-camera-info-manager";
-  version = "7.0.0-r1";
+  version = "7.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_info_manager/7.0.0-1.tar.gz";
-    name = "7.0.0-1.tar.gz";
-    sha256 = "16c8cc3c12cfee16489396c5a82f767eaf44ef16a251f72bb163ab76c9a3bbbe";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_info_manager/7.0.1-1.tar.gz";
+    name = "7.0.1-1.tar.gz";
+    sha256 = "dddcced439d29f1285763c5e00a20f4ef06841f97ef8061e71710bb567cad8d7";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ];
+  buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ ament-index-cpp camera-calibration-parsers rclcpp rclcpp-lifecycle rcpputils sensor-msgs ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
 
   meta = {
     description = "This package provides a C++ interface for camera calibration

--- a/distros/rolling/canopen-402-driver/default.nix
+++ b/distros/rolling/canopen-402-driver/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, boost, canopen-base-driver, canopen-core, canopen-interfaces, canopen-proxy-driver, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, boost, canopen-base-driver, canopen-core, canopen-interfaces, canopen-proxy-driver, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-canopen-402-driver";
-  version = "0.3.2-r2";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_402_driver/0.3.2-2.tar.gz";
-    name = "0.3.2-2.tar.gz";
-    sha256 = "43c23e9bc5440738367b8fa7587e7f76483a925429c6740e9365af1d28a3d863";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_402_driver/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "d88ac82c23522e5761ab50f3b77f0f0fa85f5f3e62d2f9ac11240c2a3cdbad95";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-lint-auto ];
-  propagatedBuildInputs = [ boost canopen-base-driver canopen-core canopen-interfaces canopen-proxy-driver rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs std-srvs ];
+  propagatedBuildInputs = [ boost canopen-base-driver canopen-core canopen-interfaces canopen-proxy-driver rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {
-    description = "Driiver for devices implementing CIA402 profile";
+    description = "Driver for devices implementing CIA402 profile";
     license = with lib.licenses; [ "LGPL-v3" ];
   };
 }

--- a/distros/rolling/canopen-base-driver/default.nix
+++ b/distros/rolling/canopen-base-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, boost, canopen-core, canopen-interfaces, diagnostic-updater, lely-core-libraries, rclcpp, rclcpp-components, rclcpp-lifecycle, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-canopen-base-driver";
-  version = "0.3.2-r2";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_base_driver/0.3.2-2.tar.gz";
-    name = "0.3.2-2.tar.gz";
-    sha256 = "71369cb4091268040540d96a59ff1fc544ed5d4d5bd2def2d23c4722946ed855";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_base_driver/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "ed2a33d2508c72ea618aa55e6acf810a42bc26991bf07a47f67669ed16989b24";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/canopen-core/default.nix
+++ b/distros/rolling/canopen-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, boost, canopen-interfaces, lely-core-libraries, lifecycle-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-canopen-core";
-  version = "0.3.2-r2";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_core/0.3.2-2.tar.gz";
-    name = "0.3.2-2.tar.gz";
-    sha256 = "024c1777cf65781aa764e3607bee2f3c2b0f8a8b08dfb4f77ba4e90153c2866b";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_core/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "ffe4f01f8f6573adb7b366ffa102435873db8e059d6975e397d26b794b60f15d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/canopen-fake-slaves/default.nix
+++ b/distros/rolling/canopen-fake-slaves/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, lely-core-libraries, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-rolling-canopen-fake-slaves";
-  version = "0.3.2-r2";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_fake_slaves/0.3.2-2.tar.gz";
-    name = "0.3.2-2.tar.gz";
-    sha256 = "d73dd6ef818611033ee4273abdf2e525e990229d8e0a5247b5f0d1620e696f2d";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_fake_slaves/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "0806ae6b3efe35925d58129a15b9766eb40b77da1453603b514dcd79957222e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/canopen-interfaces/default.nix
+++ b/distros/rolling/canopen-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-canopen-interfaces";
-  version = "0.3.2-r2";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_interfaces/0.3.2-2.tar.gz";
-    name = "0.3.2-2.tar.gz";
-    sha256 = "2b251880005d647670161727c7bd5005c087ef6631eafd73118e9e259d4c4454";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_interfaces/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "653ac80f8bb1b407c5a409a2e13d16423682aefb2ececf876204640bb45eae75";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/canopen-master-driver/default.nix
+++ b/distros/rolling/canopen-master-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, canopen-core, canopen-interfaces, lely-core-libraries, rclcpp, rclcpp-components, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-rolling-canopen-master-driver";
-  version = "0.3.2-r2";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_master_driver/0.3.2-2.tar.gz";
-    name = "0.3.2-2.tar.gz";
-    sha256 = "921ded2ee3adcf879e2b3b784b193221ddc8c3c828900785fb6275f7ad289fe0";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_master_driver/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "34fbce766adc7b3f020967be0b7b67fecf010702d4c19175993107810d55c1d7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/canopen-proxy-driver/default.nix
+++ b/distros/rolling/canopen-proxy-driver/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, canopen-base-driver, canopen-core, canopen-interfaces, rclcpp, rclcpp-components, rclcpp-lifecycle, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, canopen-base-driver, canopen-core, canopen-interfaces, rclcpp, rclcpp-components, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-rolling-canopen-proxy-driver";
-  version = "0.3.2-r2";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_proxy_driver/0.3.2-2.tar.gz";
-    name = "0.3.2-2.tar.gz";
-    sha256 = "eff6f67506a5de8cde16eec4512701d471c737c14d672a441f558498dc969616";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_proxy_driver/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "9ec553f21ba2807f953c810a99e38226250a66002331e9bb165b8d665c16f1d2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-lint-auto ];
-  propagatedBuildInputs = [ canopen-base-driver canopen-core canopen-interfaces rclcpp rclcpp-components rclcpp-lifecycle std-msgs std-srvs ];
+  propagatedBuildInputs = [ canopen-base-driver canopen-core canopen-interfaces rclcpp rclcpp-components rclcpp-lifecycle ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/rolling/canopen-ros2-control/default.nix
+++ b/distros/rolling/canopen-ros2-control/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, canopen-402-driver, canopen-core, canopen-proxy-driver, hardware-interface, pluginlib, rclcpp, rclcpp-components, rclcpp-lifecycle, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, canopen-402-driver, canopen-core, canopen-proxy-driver, hardware-interface, pluginlib, rclcpp, rclcpp-components, rclcpp-lifecycle, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-canopen-ros2-control";
-  version = "0.3.2-r2";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_ros2_control/0.3.2-2.tar.gz";
-    name = "0.3.2-2.tar.gz";
-    sha256 = "d626a6e8a91c0b52a41535bd655ee6ccef5f35061827571f58e56f7daac470c4";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_ros2_control/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "2ea2b304e5251a1aef0fcfb893e965f6cb13d9b619cf8beec8886999b5997f3c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock ros2-control-test-assets ];
+  checkInputs = [ ros2-control-test-assets ];
   propagatedBuildInputs = [ canopen-402-driver canopen-core canopen-proxy-driver hardware-interface pluginlib rclcpp rclcpp-components rclcpp-lifecycle ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/canopen-ros2-controllers/default.nix
+++ b/distros/rolling/canopen-ros2-controllers/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, canopen-402-driver, canopen-interfaces, canopen-proxy-driver, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, canopen-402-driver, canopen-interfaces, canopen-proxy-driver, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-canopen-ros2-controllers";
-  version = "0.3.2-r2";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_ros2_controllers/0.3.2-2.tar.gz";
-    name = "0.3.2-2.tar.gz";
-    sha256 = "e9188037cc4b5ebd76e71b3362c5e7d53b7ff16e4de9776fff500ddc4cbea8b6";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_ros2_controllers/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "a835983df13d45284001e9c02f5f1931189ac40b4fbc1e3cb3bbd571eb74efbd";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock ];
   propagatedBuildInputs = [ canopen-402-driver canopen-interfaces canopen-proxy-driver controller-interface controller-manager hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools std-msgs std-srvs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/canopen-tests/default.nix
+++ b/distros/rolling/canopen-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, canopen-402-driver, canopen-core, canopen-fake-slaves, canopen-proxy-driver, canopen-ros2-controllers, controller-manager, forward-command-controller, joint-state-broadcaster, joint-trajectory-controller, lely-core-libraries, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-rolling-canopen-tests";
-  version = "0.3.2-r2";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_tests/0.3.2-2.tar.gz";
-    name = "0.3.2-2.tar.gz";
-    sha256 = "6946b48e69ded8ab262736db128ea90ea252bcc42291d743f15c187125936322";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_tests/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "bc7ea193eb51a5383e0cc76d630731acbb17134c3c4b9cab81dc85b55efd1a78";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/canopen-utils/default.nix
+++ b/distros/rolling/canopen-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, canopen-interfaces, lifecycle-msgs, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-canopen-utils";
-  version = "0.3.2-r2";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_utils/0.3.2-2.tar.gz";
-    name = "0.3.2-2.tar.gz";
-    sha256 = "6bee80108729388bf9693876b52e07d7caecc2cb1225d2145164ee0fa507e659";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_utils/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "27bafa709facc461398c270044d77dbbbca5d5555d689c26258d9d518f772739";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/canopen/default.nix
+++ b/distros/rolling/canopen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, canopen-402-driver, canopen-base-driver, canopen-core, canopen-interfaces, canopen-proxy-driver, lely-core-libraries }:
 buildRosPackage {
   pname = "ros-rolling-canopen";
-  version = "0.3.2-r2";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen/0.3.2-2.tar.gz";
-    name = "0.3.2-2.tar.gz";
-    sha256 = "0bd28fdc40ef2709bb69739a988d0544c6124f11e794cfc14de89ab4e9736ab4";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "9ffd757334f841304c993f10ff887e756b31e94189dcc86cf0aa88b968d55f11";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/cuda-buffer/default.nix
+++ b/distros/rolling/cuda-buffer/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_nvidia-cuda, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cuda-buffer-backend-msgs, rcutils, rmw, rosidl-buffer }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cuda-buffer-backend-msgs, cudaPackages, rcutils, rmw, rosidl-buffer }:
 buildRosPackage {
   pname = "ros-rolling-cuda-buffer";
   version = "0.1.1-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ _unresolved_nvidia-cuda cuda-buffer-backend-msgs rcutils rmw rosidl-buffer ];
+  propagatedBuildInputs = [ cuda-buffer-backend-msgs cudaPackages.cudatoolkit rcutils rmw rosidl-buffer ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/diagnostic-aggregator/default.nix
+++ b/distros/rolling/diagnostic-aggregator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch-pytest, launch-testing-ament-cmake, launch-testing-ros, pluginlib, rcl-interfaces, rclcpp, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diagnostic-aggregator";
-  version = "4.4.6-r2";
+  version = "4.5.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/diagnostic_aggregator/4.4.6-2.tar.gz";
-    name = "4.4.6-2.tar.gz";
-    sha256 = "17f687b1120847eec5e4a40f8c3ef4770e4a356511acb2e87bfc63c7b7b85a44";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/diagnostic_aggregator/4.5.7-1.tar.gz";
+    name = "4.5.7-1.tar.gz";
+    sha256 = "f62c95eed67ef3c3a3d5fcb5de3f11929875847fd60b43e562d1c53ef1bfedfa";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
-    description = "diagnostic_aggregator";
+    description = "Aggregates diagnostic information from multiple sources.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/rolling/diagnostic-common-diagnostics/default.nix
+++ b/distros/rolling/diagnostic-common-diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-python, ament-cmake-xmllint, ament-lint-auto, diagnostic-updater, launch-testing-ament-cmake, lm_sensors, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-diagnostic-common-diagnostics";
-  version = "4.4.6-r2";
+  version = "4.5.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/diagnostic_common_diagnostics/4.4.6-2.tar.gz";
-    name = "4.4.6-2.tar.gz";
-    sha256 = "f10185e158be7759c6034939d0fdee3182742e2ca3070bbbfd68b0227ad4d9e6";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/diagnostic_common_diagnostics/4.5.7-1.tar.gz";
+    name = "4.5.7-1.tar.gz";
+    sha256 = "5f0b1e36b44ebb63ed3f86ef67222b00912391245a78a0cb45e3d3cbde265471";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
-    description = "diagnostic_common_diagnostics";
+    description = "Common diagnostic functions for e.g. HD or CPU usage.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/rolling/diagnostic-remote-logging/default.nix
+++ b/distros/rolling/diagnostic-remote-logging/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, curl, diagnostic-msgs, rclcpp-components }:
 buildRosPackage {
   pname = "ros-rolling-diagnostic-remote-logging";
-  version = "4.4.6-r2";
+  version = "4.5.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/diagnostic_remote_logging/4.4.6-2.tar.gz";
-    name = "4.4.6-2.tar.gz";
-    sha256 = "34065cc339eb436f72fa0539efeb43b12b86f250d2bc0698a20cb241290a7bfb";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/diagnostic_remote_logging/4.5.7-1.tar.gz";
+    name = "4.5.7-1.tar.gz";
+    sha256 = "55341e7a93930692d5ad5d0e45dbbaffff169693e115bc504be690d30235d3ca";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "diagnostic_remote_logging";
+    description = "Tools for remotely logging diagnostics data.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/rolling/diagnostic-updater/default.nix
+++ b/distros/rolling/diagnostic-updater/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch, launch-testing, launch-testing-ros, python3Packages, rclcpp, rclcpp-lifecycle, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diagnostic-updater";
-  version = "4.4.6-r2";
+  version = "4.5.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/diagnostic_updater/4.4.6-2.tar.gz";
-    name = "4.4.6-2.tar.gz";
-    sha256 = "17f73543080040f59c539bd3a85b8cc5a0019589e5e118c1c1ae20dd0540057e";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/diagnostic_updater/4.5.7-1.tar.gz";
+    name = "4.5.7-1.tar.gz";
+    sha256 = "8eb717c4c81e3dec93385f578909ef0faf10bf60f62af54269b6cd1d8e840cf7";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ament-cmake-python ament-cmake-ros ];
 
   meta = {
-    description = "diagnostic_updater contains tools for easily updating diagnostics. it is commonly used in device drivers to keep track of the status of output topics, device status, etc.";
+    description = "Update and publish diagnostic information.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/rolling/diagnostics/default.nix
+++ b/distros/rolling/diagnostics/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, diagnostic-aggregator, diagnostic-common-diagnostics, diagnostic-updater, self-test }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, diagnostic-aggregator, diagnostic-common-diagnostics, diagnostic-remote-logging, diagnostic-updater, self-test }:
 buildRosPackage {
   pname = "ros-rolling-diagnostics";
-  version = "4.4.6-r2";
+  version = "4.5.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/diagnostics/4.4.6-2.tar.gz";
-    name = "4.4.6-2.tar.gz";
-    sha256 = "83555e24ceef7201c740f4b617e896a2bde4aad024e60d9d1be147c92a7e7580";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/diagnostics/4.5.7-1.tar.gz";
+    name = "4.5.7-1.tar.gz";
+    sha256 = "09205ce2eeaea9cc51683359b852e2e1cf4c43d6a8de317b80944a7552208b55";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-common-diagnostics diagnostic-updater self-test ];
+  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-common-diagnostics diagnostic-remote-logging diagnostic-updater self-test ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "diagnostics";
+    description = "Diagnostics tools for monitoring and reporting system status.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/rolling/image-common/default.nix
+++ b/distros/rolling/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-rolling-image-common";
-  version = "7.0.0-r1";
+  version = "7.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_common/7.0.0-1.tar.gz";
-    name = "7.0.0-1.tar.gz";
-    sha256 = "2dcf52793865c0a050d7d42783dba95f3d9a7b96e0a88875f5e75b4dd9423eb0";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_common/7.0.1-1.tar.gz";
+    name = "7.0.1-1.tar.gz";
+    sha256 = "f3c914df899ec04d1a7ba2c1c49219ebbc1c1271c86c863e0beeedbaa4fa9f42";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-transport-py/default.nix
+++ b/distros/rolling/image-transport-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, image-transport, python3, python3Packages, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-image-transport-py";
-  version = "7.0.0-r1";
+  version = "7.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_transport_py/7.0.0-1.tar.gz";
-    name = "7.0.0-1.tar.gz";
-    sha256 = "a08b20620a5370f7b235cffb7b6f4865c2e30e80e25283384e6f394c4d0070e5";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_transport_py/7.0.1-1.tar.gz";
+    name = "7.0.1-1.tar.gz";
+    sha256 = "abe36b357eb67473ddebba05b98740ac65b819406f25986fcf64eb7df60c6af7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-transport/default.nix
+++ b/distros/rolling/image-transport/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, tinyxml-2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-rolling-image-transport";
-  version = "7.0.0-r1";
+  version = "7.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_transport/7.0.0-1.tar.gz";
-    name = "7.0.0-1.tar.gz";
-    sha256 = "125d81c8bd9a27e63a72f2b187005866749261cd7724005a0ab53add5323a6a5";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_transport/7.0.1-1.tar.gz";
+    name = "7.0.1-1.tar.gz";
+    sha256 = "4c027f49db68bd2c0e3879f08388769230edf68a71adb05edc7e496acfd71f1c";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ];
+  buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common rclcpp-lifecycle ];
   propagatedBuildInputs = [ message-filters pluginlib rclcpp rclcpp-components sensor-msgs tinyxml-2 ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
 
   meta = {
     description = "image_transport should always be used to subscribe to and publish images. It provides transparent

--- a/distros/rolling/laser-geometry/default.nix
+++ b/distros/rolling/laser-geometry/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, python3Packages, rclcpp, rclpy, sensor-msgs, sensor-msgs-py, tf2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, python3Packages, rclcpp, rclpy, sensor-msgs, sensor-msgs-py, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-laser-geometry";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/laser_geometry-release/archive/release/rolling/laser_geometry/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "4321e653a781099aa6cd7878e8937627f44a2f4f567832982ff8ab86e741adcc";
+    url = "https://github.com/ros2-gbp/laser_geometry-release/archive/release/rolling/laser_geometry/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "ac40ea4d32a34979f08704c19924d6d4dab66d99098424bdf640a8da18098314";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-python ];
+  buildInputs = [ ament-cmake ament-cmake-python tf2-geometry-msgs ];
   checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ eigen eigen3-cmake-module python3Packages.numpy rclcpp rclpy sensor-msgs sensor-msgs-py tf2 ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python eigen3-cmake-module ];

--- a/distros/rolling/lely-core-libraries/default.nix
+++ b/distros/rolling/lely-core-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, autoconf, automake, git, libtool, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-lely-core-libraries";
-  version = "0.3.2-r2";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/lely_core_libraries/0.3.2-2.tar.gz";
-    name = "0.3.2-2.tar.gz";
-    sha256 = "7b28ddf6c1ff877d0dd2a8adbe52d8d0e4d7db99fac84ea47e5ba9167ccbea17";
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/lely_core_libraries/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "47d14205e94ddac00134759d8ee8a0f102b3dfa40719ebee203b2cf9a18641ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/log-view/default.nix
+++ b/distros/rolling/log-view/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ncurses, rcl-interfaces, rclcpp, xclip, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ncurses, rcl-interfaces, rclcpp, rosbag2-cpp, rosgraph-msgs, xclip, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-log-view";
-  version = "0.3.3-r2";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/log_view-release/archive/release/rolling/log_view/0.3.3-2.tar.gz";
-    name = "0.3.3-2.tar.gz";
-    sha256 = "58ade36ba2364d9b1b185bc2306fb3d89790ff7d8f704e068edd932c7e67d35c";
+    url = "https://github.com/ros2-gbp/log_view-release/archive/release/rolling/log_view/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "ea40479565cedf21da98f391fd7043726b1645715511eb951e7be2986eb0d3f0";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ncurses rcl-interfaces rclcpp xclip yaml-cpp-vendor ];
+  propagatedBuildInputs = [ ncurses rcl-interfaces rclcpp rosbag2-cpp rosgraph-msgs xclip yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/motion-capture-tracking-interfaces/default.nix
+++ b/distros/rolling/motion-capture-tracking-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-motion-capture-tracking-interfaces";
-  version = "1.0.6-r2";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/rolling/motion_capture_tracking_interfaces/1.0.6-2.tar.gz";
-    name = "1.0.6-2.tar.gz";
-    sha256 = "2c0f05cc46822706c1c3daef3b0e89de4adcfc43d8f47fd4f100eab9ca3d4b99";
+    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/rolling/motion_capture_tracking_interfaces/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "a9aaebcd9753586654e414d8ee848aef6318d873fe1b68ab578f8699c062bf0d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/motion-capture-tracking/default.nix
+++ b/distros/rolling/motion-capture-tracking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, motion-capture-tracking-interfaces, pcl, rclcpp, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-motion-capture-tracking";
-  version = "1.0.6-r2";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/rolling/motion_capture_tracking/1.0.6-2.tar.gz";
-    name = "1.0.6-2.tar.gz";
-    sha256 = "943794dea7dac8720998de9df7fe6b28d6b9ce070df2b959ac9c8b52e78ad7b3";
+    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/rolling/motion_capture_tracking/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "4e7cc506a83a77ffce366f4713c429636aacfe53dc24b0f798275ef678a203c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mp2p-icp/default.nix
+++ b/distros/rolling/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mp2p-icp";
-  version = "2.10.2-r1";
+  version = "2.10.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp/2.10.2-1.tar.gz";
-    name = "2.10.2-1.tar.gz";
-    sha256 = "eab85160c5fc4724cbe294a62806f91ddb3c7f577673e95a7b184862245f893f";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp/2.10.3-1.tar.gz";
+    name = "2.10.3-1.tar.gz";
+    sha256 = "add044439456e334b556b5749e591b2bade6936521e98b843ab68e711cb4698c";
   };
 
   buildType = "cmake";

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -315,24 +315,11 @@ in {
 
   lely-core-libraries = (lib.patchExternalProjectGit rosSuper.lely-core-libraries {
     url = "https://gitlab.com/lely_industries/lely-core.git";
-    rev = "fb735b79cab5f0cdda45bc5087414d405ef8f3ab";
+    rev = "9e3267d26018f6f6babd50786f6ae2af89cc57ea";
     fetchgitArgs = {
-      hash = "sha256-TpEWho+lbhXGaZ24+86eVJttrxH2Kc9gZVOGWeR0LBE=";
+      hash = "sha256-A7RsVQwzj59M9+eGTeNt+/yb3rFziJl3fy33K5c36z0=";
       leaveDotGit = true;
     };
-  }).overrideAttrs ({
-    postPatch ? "", ...
-  }: {
-    # ref. https://gitlab.com/lely_industries/lely-core/-/merge_requests/143
-    postPatch = postPatch + ''
-      substituteInPlace CMakeLists.txt --replace-fail \
-        "CONFIGURE_COMMAND autoreconf -i <SOURCE_DIR>" \
-        "PATCH_COMMAND patch -p1 < ${self.fetchpatch2 {
-          url = "https://gitlab.com/lely_industries/lely-core/-/commit/6ed995fa86d828957b636a11470f150830d877ec.patch";
-          hash = "sha256-/kn+BMs9JHigmSXi6BrlHGmt06eF7mzJiKi26a7JQ3c=";
-        }}
-        CONFIGURE_COMMAND autoreconf -i <SOURCE_DIR>"
-    '';
   });
 
   libphidget22 = lib.patchVendorUrl rosSuper.libphidget22 {

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -311,6 +311,27 @@ in {
     };
   });
 
+  librealsense2 = (lib.patchExternalProjectGit rosSuper.librealsense2 {
+    file = "CMake/external_libcurl.cmake";
+    originalUrl = ''"https://github.com/curl/curl.git"'';
+    url = "https://github.com/curl/curl.git";
+    originalRev = ''"curl-8_8_0"'';
+    rev = "curl-8_8_0";
+    fetchgitArgs.hash = "sha256-MjB6k8mDJypyuh6BN2hxy2My7/DfImjw+5iI729snBg=";
+  }).overrideAttrs ({
+    buildInputs ? [], postPatch ? "", ...
+  }: {
+    buildInputs = buildInputs ++ [ self.nlohmann_json ];
+    postPatch = postPatch + ''
+      # Get rid of nlohmann_json vendoring
+      substituteInPlace third-party/CMakeLists.txt \
+        --replace-fail 'include(CMake/external_json.cmake)' ""
+      # Don't try to install to $HOME
+      substituteInPlace tools/realsense-viewer/CMakeLists.txt \
+        --replace-fail '$ENV{HOME}/Documents/librealsense2/presets' ''\'''${CMAKE_INSTALL_PREFIX}/share/librealsense2/presets'
+    '';
+  });
+
   libphidget22 = lib.patchVendorUrl rosSuper.libphidget22 {
     url = "https://www.phidgets.com/downloads/phidget22/libraries/linux/libphidget22/libphidget22-1.19.20240304.tar.gz";
     hash = "sha256-GpzGMpQ02s/X/XEcGoozzMjigrbqvAu81bcb7QG+36E=";

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -34,17 +34,6 @@ in {
     ];
   });
 
-  canopen-core = rosSuper.canopen-core.overrideAttrs ({
-    postPatch ? "", ...
-  }: {
-    # https://github.com/ros-industrial/ros2_canopen/pull/399
-    postPatch = ''
-      substituteInPlace ConfigExtras.cmake --replace-fail \
-        "find_package(Boost REQUIRED system thread)" \
-        "find_package(Boost REQUIRED thread)"
-    '';
-  });
-
   cartographer = rosSuper.cartographer.overrideAttrs ({
     postPatch ? "", ...
   }: {

--- a/distros/rolling/performance-test/default.nix
+++ b/distros/rolling/performance-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, git, rclcpp, rmw-implementation, ros-environment, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-performance-test";
-  version = "2.3.0-r2";
+  version = "2.3.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/performance_test-release/archive/release/rolling/performance_test/2.3.0-2.tar.gz";
-    name = "2.3.0-2.tar.gz";
-    sha256 = "71d1b3c8732847a146f8ec5b700fa3e66242a08bf0485941a71d1ce9fde1e7c4";
+    url = "https://github.com/ros2-gbp/performance_test-release/archive/release/rolling/performance_test/2.3.0-3.tar.gz";
+    name = "2.3.0-3.tar.gz";
+    sha256 = "6e7ce1ccbe51e8dbfcbef24039cc2ce98fe159a24a4fd5b3341b73833449d738";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/point-cloud-transport-py/default.nix
+++ b/distros/rolling/point-cloud-transport-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, python3, python3Packages, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-transport-py";
-  version = "6.0.0-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport_py/6.0.0-1.tar.gz";
-    name = "6.0.0-1.tar.gz";
-    sha256 = "32d0786c73ce178c60e0421eb73df127dcffc5ba712a96cf188a08555a2a7f13";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport_py/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "e626c4dbcc80648c71878547a3a0593e68e495c9e27b42a01eb5af7d0c80cfde";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/point-cloud-transport/default.nix
+++ b/distros/rolling/point-cloud-transport/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rcpputils, rmw, sensor-msgs, tinyxml-2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rcpputils, rmw, sensor-msgs, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-transport";
-  version = "6.0.0-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport/6.0.0-1.tar.gz";
-    name = "6.0.0-1.tar.gz";
-    sha256 = "9aa8ab40be8ec5fb6df65682c4ed8e3ee8ae2dc4f535d0af6e037c87af9cbc71";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "567cc8f715f79aba1728228dd94f6cf81a52a4ba165725c35fac88dc84d6f9c7";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ];
+  buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ message-filters pluginlib rclcpp rclcpp-components rcpputils rmw sensor-msgs tinyxml-2 ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
 
   meta = {
     description = "Support for transporting PointCloud2 messages in compressed format and plugin interface for implementing additional PointCloud2 transports.";

--- a/distros/rolling/rcl-action/default.nix
+++ b/distros/rolling/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rcl-action";
-  version = "10.5.0-r1";
+  version = "10.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/10.5.0-1.tar.gz";
-    name = "10.5.0-1.tar.gz";
-    sha256 = "bffa6f753117e9c99eda8d7048a6f2373210e5551a21a102f6e8a3e6fc0b423d";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/10.5.1-1.tar.gz";
+    name = "10.5.1-1.tar.gz";
+    sha256 = "af92163d2379464fd8a75ee322ba641ed87da85f20c389dbca8897e7cc9b4152";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-lifecycle/default.nix
+++ b/distros/rolling/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rcl-lifecycle";
-  version = "10.5.0-r1";
+  version = "10.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/10.5.0-1.tar.gz";
-    name = "10.5.0-1.tar.gz";
-    sha256 = "edaa53bd6dfb0eb946cc66d14f9798a9294421a4f8a5208bec56162dd60d311b";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/10.5.1-1.tar.gz";
+    name = "10.5.1-1.tar.gz";
+    sha256 = "1e88c469bf8f076a82d8c6d5dc2fa8df573d76830d7db7687ea5c4f1cb96306f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-yaml-param-parser/default.nix
+++ b/distros/rolling/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-rolling-rcl-yaml-param-parser";
-  version = "10.5.0-r1";
+  version = "10.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/10.5.0-1.tar.gz";
-    name = "10.5.0-1.tar.gz";
-    sha256 = "ea2b4a830018c9a0ece91695ffb69e77866d0a2b51304fb9f807ae565d2d3219";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/10.5.1-1.tar.gz";
+    name = "10.5.1-1.tar.gz";
+    sha256 = "5726fbb538cff493481b2ad5b4c53763eae592b4e653cd53f2a929a9b1a80c69";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl/default.nix
+++ b/distros/rolling/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-implementation, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, rosidl-runtime-cpp, service-msgs, test-msgs, tracetools, type-description-interfaces }:
 buildRosPackage {
   pname = "ros-rolling-rcl";
-  version = "10.5.0-r1";
+  version = "10.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/10.5.0-1.tar.gz";
-    name = "10.5.0-1.tar.gz";
-    sha256 = "5f364e91c4f9c8705ae507b994d94dbb80f0178d1b33d47c1128c1db815260f7";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/10.5.1-1.tar.gz";
+    name = "10.5.1-1.tar.gz";
+    sha256 = "ecb4e623e82ff913f0a5662e8b1988333557fed76b70f3303ea2d6ca60fe0d08";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-action/default.nix
+++ b/distros/rolling/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-action";
-  version = "33.0.0-r1";
+  version = "33.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/33.0.0-1.tar.gz";
-    name = "33.0.0-1.tar.gz";
-    sha256 = "a918c94cbc2e52cf63fd663256a27dad2532650ccedd92f20dac582b672a88ab";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/33.0.1-1.tar.gz";
+    name = "33.0.1-1.tar.gz";
+    sha256 = "5b3774de4cc9ce333c55b5c1b4b6430267c8d5f82d38cba9d656e9e082bbdf40";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-components/default.nix
+++ b/distros/rolling/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, rcl-interfaces, rclcpp, rcpputils, rmw }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-components";
-  version = "33.0.0-r1";
+  version = "33.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/33.0.0-1.tar.gz";
-    name = "33.0.0-1.tar.gz";
-    sha256 = "d626854ac0e09e339fa8e828b93148ce646824c5070c1f4594406f02001591fb";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/33.0.1-1.tar.gz";
+    name = "33.0.1-1.tar.gz";
+    sha256 = "0b9db3fc252bd0ff455f57e31377cceda6446446a15bb88e95e9a34554945476";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-lifecycle/default.nix
+++ b/distros/rolling/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-lifecycle";
-  version = "33.0.0-r1";
+  version = "33.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/33.0.0-1.tar.gz";
-    name = "33.0.0-1.tar.gz";
-    sha256 = "5e2746eac65d7e42e732c2660c9e8ef7a3f0843dae2e81cef0f966c4e8845c40";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/33.0.1-1.tar.gz";
+    name = "33.0.1-1.tar.gz";
+    sha256 = "a934039a739f7a37cfdd7cd173a8ffd07b7743dd5b822f482812ac4803794e1b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp/default.nix
+++ b/distros/rolling/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-cmake-ros-core, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, python3Packages, rcl, rcl-interfaces, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp";
-  version = "33.0.0-r1";
+  version = "33.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/33.0.0-1.tar.gz";
-    name = "33.0.0-1.tar.gz";
-    sha256 = "98a02efe1ea075b38ac4a5048d70e9ce67af613aecb1f7fc4bd679e4895cf54c";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/33.0.1-1.tar.gz";
+    name = "33.0.1-1.tar.gz";
+    sha256 = "065256706181774f6db46755349ed3759a858d903bc0374979f612c5bd1d591f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclpy/default.nix
+++ b/distros/rolling/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, lifecycle-msgs, python3, python3Packages, rcl, rcl-action, rcl-interfaces, rcl-lifecycle, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rosidl-pycommon, rosidl-runtime-c, rpyutils, service-msgs, test-msgs, type-description-interfaces, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclpy";
-  version = "11.0.0-r1";
+  version = "11.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/rolling/rclpy/11.0.0-1.tar.gz";
-    name = "11.0.0-1.tar.gz";
-    sha256 = "7e49eafa22e8350b407b6ac79968e9223b2785cd1047e3413201714b4ccc650a";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/rolling/rclpy/11.0.1-1.tar.gz";
+    name = "11.0.1-1.tar.gz";
+    sha256 = "e78300c2839642d8472d39245d93fa3942b9871a7e744b38365905885958e212";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-building-map-tools/default.nix
+++ b/distros/rolling/rmf-building-map-tools/default.nix
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_python";
   checkInputs = [ python3Packages.pytest ];
-  propagatedBuildInputs = [ ament-index-python gz-fuel-tools-vendor python3Packages.Rtree python3Packages.fiona python3Packages.pyproj python3Packages.pyyaml python3Packages.requests python3Packages.shapely rclpy rmf-building-map-msgs rmf-site-map-msgs sqlite std-msgs yaml-cpp ];
+  propagatedBuildInputs = [ ament-index-python gz-fuel-tools-vendor python3Packages.fiona python3Packages.pyproj python3Packages.pyyaml python3Packages.requests python3Packages.rtree python3Packages.shapely rclpy rmf-building-map-msgs rmf-site-map-msgs sqlite std-msgs yaml-cpp ];
 
   meta = {
     description = "RMF Building map tools";

--- a/distros/rolling/robotraconteur-companion/default.nix
+++ b/distros/rolling/robotraconteur-companion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, eigen, gtest, opencv, robotraconteur, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-robotraconteur-companion";
-  version = "0.4.2-r3";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robotraconteur_companion-release/archive/release/rolling/robotraconteur_companion/0.4.2-3.tar.gz";
-    name = "0.4.2-3.tar.gz";
-    sha256 = "ce611624e2da4f472c8158b97377a1cb94842f01083a74416b09baecfaa82c41";
+    url = "https://github.com/ros2-gbp/robotraconteur_companion-release/archive/release/rolling/robotraconteur_companion/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "81ac0efc089da75f6c8fdcd23c506385ce09d16ef54940b660bfe7f3c4e357b4";
   };
 
   buildType = "cmake";

--- a/distros/rolling/robotraconteur/default.nix
+++ b/distros/rolling/robotraconteur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bluez, boost, cmake, dbus, gtest, libusb1, openssl, python3, python3Packages, zlib }:
 buildRosPackage {
   pname = "ros-rolling-robotraconteur";
-  version = "1.2.7-r3";
+  version = "1.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robotraconteur-release/archive/release/rolling/robotraconteur/1.2.7-3.tar.gz";
-    name = "1.2.7-3.tar.gz";
-    sha256 = "71c6a90810a41deaba858dbf903c4edca2118e76efd9e41796ac128cbca919a1";
+    url = "https://github.com/ros2-gbp/robotraconteur-release/archive/release/rolling/robotraconteur/1.2.8-1.tar.gz";
+    name = "1.2.8-1.tar.gz";
+    sha256 = "1b97ae814c3dfad7530d0942954f1592d57f800d14c889432bdf882ea35dbabb";
   };
 
   buildType = "cmake";

--- a/distros/rolling/rosapi-msgs/default.nix
+++ b/distros/rolling/rosapi-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rosapi-msgs";
-  version = "4.1.0-r2";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosapi_msgs/4.1.0-2.tar.gz";
-    name = "4.1.0-2.tar.gz";
-    sha256 = "b231ca274d7654b026d160eb59ff421cb4ec1a3f691b6382de52e872ec45b84e";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosapi_msgs/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "5da569766af4329e66339f63b15a1b05034044b028638059dc732ae370e7ca86";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosapi/default.nix
+++ b/distros/rolling/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-mypy, ament-cmake-pytest, ament-cmake-python, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2action, ros2interface, ros2node, ros2service, ros2topic, rosapi-msgs, rosbridge-library, rosidl-adapter, rosidl-runtime-py, sensor-msgs, shape-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosapi";
-  version = "4.1.0-r2";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosapi/4.1.0-2.tar.gz";
-    name = "4.1.0-2.tar.gz";
-    sha256 = "c8b5355bf518ebbba9e03b6290179537fa406b5f7d09bd2b8b6033aa85a30051";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosapi/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "9504526efdb4c5334baf9e4b1225626c9b0b032737d9b2744907b5f58fe59f32";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbridge-library/default.nix
+++ b/distros/rolling/rosbridge-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-mypy, ament-cmake-python, ament-cmake-ros, builtin-interfaces, control-msgs, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rcl-interfaces, rclpy, rosbridge-test-msgs, rosidl-pycommon, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbridge-library";
-  version = "4.1.0-r2";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_library/4.1.0-2.tar.gz";
-    name = "4.1.0-2.tar.gz";
-    sha256 = "1beafd13a689a2e81dfc8cb241647101b4139c2ae04649298af23f633c427ec1";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_library/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "c85626e0eac9eb25c9b4adf6ebb3ad6e81eff2a468abe7347caec740f17a8c77";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbridge-msgs/default.nix
+++ b/distros/rolling/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rosbridge-msgs";
-  version = "4.1.0-r2";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_msgs/4.1.0-2.tar.gz";
-    name = "4.1.0-2.tar.gz";
-    sha256 = "7af88d27ba0ae8ea7ed1c79a06d05e42c74a0f19101214dd1dc9a7c79742976f";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_msgs/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "7cf7c3fef97dcf4e126fa858e7b83e6af607f2b79e68a288c06c95e8e6266550";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbridge-server/default.nix
+++ b/distros/rolling/rosbridge-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-mypy, ament-cmake-python, ament-cmake-ros, example-interfaces, launch, launch-ros, launch-testing-ament-cmake, python3Packages, rcl-interfaces, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-rosbridge-server";
-  version = "4.1.0-r2";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_server/4.1.0-2.tar.gz";
-    name = "4.1.0-2.tar.gz";
-    sha256 = "f679b55e8ba8c8ecc01f34afe83cdc6a53329ceb91d9acef4652d15fee6f5699";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_server/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "bc38fcf06d0cd547f78586e69ef6713626a33d9c8b745420a6379fbc417a927e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbridge-suite/default.nix
+++ b/distros/rolling/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-rolling-rosbridge-suite";
-  version = "4.1.0-r2";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_suite/4.1.0-2.tar.gz";
-    name = "4.1.0-2.tar.gz";
-    sha256 = "2ed35c6c7c3966e3095da2d1a740bd915f8654b5b6244a33b42c52d7af3b2801";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_suite/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "61a7b837f44323c47a1a46b55be0b37aff7185e2da6774736f05ecbb4882b9ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbridge-test-msgs/default.nix
+++ b/distros/rolling/rosbridge-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbridge-test-msgs";
-  version = "4.1.0-r2";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_test_msgs/4.1.0-2.tar.gz";
-    name = "4.1.0-2.tar.gz";
-    sha256 = "0aab4669053098997e81ff6a4cf694fc56d465eee91259a609c5407618777e88";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_test_msgs/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "747e90b056f3a41ddad84be53548a0ba3387a4af313d4e365528cd912aa442ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rtsp-image-transport/default.nix
+++ b/distros/rolling/rtsp-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, ffmpeg, image-transport, live555-vendor, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-rtsp-image-transport";
-  version = "2.0.1-r2";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rtsp_image_transport-release/archive/release/rolling/rtsp_image_transport/2.0.1-2.tar.gz";
-    name = "2.0.1-2.tar.gz";
-    sha256 = "6ccb95d9409e0370a8cf6df0220b0e7f4873dc25197a66dac37a3be908c17743";
+    url = "https://github.com/ros2-gbp/rtsp_image_transport-release/archive/release/rolling/rtsp_image_transport/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "f04910c36b11e40ee057bf2aa3e0d4a45a2426b0efe32f5a95666c7089a7a9ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/self-test/default.nix
+++ b/distros/rolling/self-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-self-test";
-  version = "4.4.6-r2";
+  version = "4.5.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/self_test/4.4.6-2.tar.gz";
-    name = "4.4.6-2.tar.gz";
-    sha256 = "e9a45c69d232be715a2fb4959cf710c2a6d512e96bb23506bc829da015591a88";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/self_test/4.5.7-1.tar.gz";
+    name = "4.5.7-1.tar.gz";
+    sha256 = "47c799796e23edca775bc8553f11f473713e9da9e72465df6e0d97501c8feda2";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "self_test";
+    description = "Self-test tools for diagnostics.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/rolling/sync-tooling-msgs/default.nix
+++ b/distros/rolling/sync-tooling-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, protobuf }:
 buildRosPackage {
   pname = "ros-rolling-sync-tooling-msgs";
-  version = "0.2.7-r2";
+  version = "0.2.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sync_tooling_msgs-release/archive/release/rolling/sync_tooling_msgs/0.2.7-2.tar.gz";
-    name = "0.2.7-2.tar.gz";
-    sha256 = "b9655607487d5be89bb3bb879036d74f4fc3a0c8214892c0ccb8f5ba95e8d908";
+    url = "https://github.com/ros2-gbp/sync_tooling_msgs-release/archive/release/rolling/sync_tooling_msgs/0.2.9-1.tar.gz";
+    name = "0.2.9-1.tar.gz";
+    sha256 = "23c14e0da7d679ddeb42440217627c7668896fdc023db7c46bba9dc950fce842";
   };
 
   buildType = "ament_cmake";

--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -243,52 +243,6 @@ with rosSelf.lib; {
     nativeBuildInputs = nativeBuildInputs ++ [ self.ninja ];
   });
 
-  librealsense2 = (pipe rosSuper.librealsense2 [
-    (pkg: patchExternalProjectGit pkg {
-      file = "CMake/external_libcurl.cmake";
-      originalUrl = ''"https://github.com/curl/curl.git"'';
-      url = "https://github.com/curl/curl.git";
-      originalRev = ''"curl-8_8_0"'';
-      rev = "curl-8_8_0";
-      fetchgitArgs.hash = "sha256-MjB6k8mDJypyuh6BN2hxy2My7/DfImjw+5iI729snBg=";
-    })
-    (pkg: patchVendorUrl pkg {
-      file = "CMake/external_sqlite3.cmake";
-      url = "https://sqlite.org/2025/sqlite-amalgamation-3490100.zip";
-      hash = "sha256-bOvR2EA/xYww6Tk5skbz5uWNB2WlzVBUbxbAD9gF0sM=";
-    })
-    (pkg: patchExternalProjectGit pkg {
-      file = "CMake/external_yaml_cpp.cmake";
-      url = "https://github.com/jbeder/yaml-cpp.git";
-      rev = "yaml-cpp-0.7.0";
-      fetchgitArgs.hash = "sha256-2tFWccifn0c2lU/U1WNg2FHrBohjx8CXMllPJCevaNk=";
-    })
-  ]).overrideAttrs ({
-    buildInputs ? [], postPatch ? "", ...
-  }: {
-    buildInputs = buildInputs ++ [ self.nlohmann_json ];
-    postPatch = postPatch + ''
-      # Get rid of nlohmann_json vendoring
-      substituteInPlace third-party/CMakeLists.txt \
-        --replace-fail 'include(CMake/external_json.cmake)' ""
-      # Don't try to install to $HOME
-      substituteInPlace tools/realsense-viewer/CMakeLists.txt \
-        --replace-fail '$ENV{HOME}/Documents/librealsense2/presets' ''\'''${CMAKE_INSTALL_PREFIX}/share/librealsense2/presets'
-      substituteInPlace CMake/external_fastcdr.cmake \
-        --replace-fail ''\'''${CMAKE_BINARY_DIR}/third-party/fastcdr' '${fetchTarball {
-          url = "https://github.com/eProsima/Fast-CDR/archive/refs/tags/v1.0.25.tar.gz";
-          sha256 = "sha256:14v85zj5b5fnswhkpps09jk68w6miad8zbhlp625d2kj0yfw4cyp";
-        }}'
-      # If the command below fails, update the above command!
-      substituteInPlace CMake/external_fastcdr.cmake \
-        --replace-fail '--branch v1.0.25' 'see the comment'
-      # https://github.com/realsenseai/librealsense/issues/15120#issuecomment-4586244495
-      substituteInPlace third-party/realsense-file/CMakeLists.txt \
-        --replace-fail '$<$<COMPILE_LANGUAGE:C>:-include stdint.h>' ""
-    '';
-  });
-
-
   # Fix for loading the default plugins for the `move-group` executable.
   #
   # Essentially the executable tries to dynamically load the capabilites .so to

--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -282,6 +282,9 @@ with rosSelf.lib; {
       # If the command below fails, update the above command!
       substituteInPlace CMake/external_fastcdr.cmake \
         --replace-fail '--branch v1.0.25' 'see the comment'
+      # https://github.com/realsenseai/librealsense/issues/15120#issuecomment-4586244495
+      substituteInPlace third-party/realsense-file/CMakeLists.txt \
+        --replace-fail '$<$<COMPILE_LANGUAGE:C>:-include stdint.h>' ""
     '';
   });
 

--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -243,14 +243,27 @@ with rosSelf.lib; {
     nativeBuildInputs = nativeBuildInputs ++ [ self.ninja ];
   });
 
-  librealsense2 = (patchExternalProjectGit rosSuper.librealsense2 {
-    file = "CMake/external_libcurl.cmake";
-    originalUrl = ''"https://github.com/curl/curl.git"'';
-    url = "https://github.com/curl/curl.git";
-    originalRev = ''"curl-8_8_0"'';
-    rev = "curl-8_8_0";
-    fetchgitArgs.hash = "sha256-MjB6k8mDJypyuh6BN2hxy2My7/DfImjw+5iI729snBg=";
-  }).overrideAttrs ({
+  librealsense2 = (pipe rosSuper.librealsense2 [
+    (pkg: patchExternalProjectGit pkg {
+      file = "CMake/external_libcurl.cmake";
+      originalUrl = ''"https://github.com/curl/curl.git"'';
+      url = "https://github.com/curl/curl.git";
+      originalRev = ''"curl-8_8_0"'';
+      rev = "curl-8_8_0";
+      fetchgitArgs.hash = "sha256-MjB6k8mDJypyuh6BN2hxy2My7/DfImjw+5iI729snBg=";
+    })
+    (pkg: patchVendorUrl pkg {
+      file = "CMake/external_sqlite3.cmake";
+      url = "https://sqlite.org/2025/sqlite-amalgamation-3490100.zip";
+      hash = "sha256-bOvR2EA/xYww6Tk5skbz5uWNB2WlzVBUbxbAD9gF0sM=";
+    })
+    (pkg: patchExternalProjectGit pkg {
+      file = "CMake/external_yaml_cpp.cmake";
+      url = "https://github.com/jbeder/yaml-cpp.git";
+      rev = "yaml-cpp-0.7.0";
+      fetchgitArgs.hash = "sha256-2tFWccifn0c2lU/U1WNg2FHrBohjx8CXMllPJCevaNk=";
+    })
+  ]).overrideAttrs ({
     buildInputs ? [], postPatch ? "", ...
   }: {
     buildInputs = buildInputs ++ [ self.nlohmann_json ];

--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -261,6 +261,14 @@ with rosSelf.lib; {
       # Don't try to install to $HOME
       substituteInPlace tools/realsense-viewer/CMakeLists.txt \
         --replace-fail '$ENV{HOME}/Documents/librealsense2/presets' ''\'''${CMAKE_INSTALL_PREFIX}/share/librealsense2/presets'
+      substituteInPlace CMake/external_fastcdr.cmake \
+        --replace-fail ''\'''${CMAKE_BINARY_DIR}/third-party/fastcdr' '${fetchTarball {
+          url = "https://github.com/eProsima/Fast-CDR/archive/refs/tags/v1.0.25.tar.gz";
+          sha256 = "sha256:14v85zj5b5fnswhkpps09jk68w6miad8zbhlp625d2kj0yfw4cyp";
+        }}'
+      # If the command below fails, update the above command!
+      substituteInPlace CMake/external_fastcdr.cmake \
+        --replace-fail '--branch v1.0.25' 'see the comment'
     '';
   });
 

--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
     "rosdistro": {
       "flake": false,
       "locked": {
-        "lastModified": 1779440547,
-        "narHash": "sha256-zwkFhi7/rGJ1DPykUsulXnAJXFxbR5YQO10GuFUEBfo=",
+        "lastModified": 1780067887,
+        "narHash": "sha256-zb6ubdTFku4W8Mjb651VWJL1tWBP6BJg0iXcKypT29M=",
         "owner": "ros",
         "repo": "rosdistro",
-        "rev": "7111412b11e86fbb1751db4c4955d798f95e5cf3",
+        "rev": "1c698d63a1a2d31dd24502a41bb1139eeb00e876",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'kilted', 'lyrical', 'rolling'] from nix-ros-overlay commit 8968c5736feebcc0a3038ab07e6af697845d4ba4.
This pull request was generated by running the following command:

```
superflore-gen-nix --dry-run --output-repository-path . --all --tar-archive-dir /home/runner/.ros/tar --upstream-branch develop
```

Changes:
========
Humble Changes:
---------------
* *apriltag-msgs 2.0.1-r2 --> 2.0.2-r1*
* *apriltag-ros 3.3.0-r1 --> 3.4.0-r1*
* *camera-calibration-parsers 3.1.12-r1 --> 3.1.13-r1*
* *camera-info-manager 3.1.12-r1 --> 3.1.13-r1*
* *camera-info-manager-py 3.1.12-r1 --> 3.1.13-r1*
* *color-util 1.0.0-r1 --> 1.0.2-r1*
* *diagnostic-aggregator 4.0.6-r1 --> 4.0.7-r1*
* *diagnostic-common-diagnostics 4.0.6-r1 --> 4.0.7-r1*
* *diagnostic-remote-logging 4.0.6-r1 --> 4.0.7-r1*
* *diagnostic-updater 4.0.6-r1 --> 4.0.7-r1*
* *diagnostics 4.0.6-r1 --> 4.0.7-r1*
* *image-common 3.1.12-r1 --> 3.1.13-r1*
* *image-transport 3.1.12-r1 --> 3.1.13-r1*
* *librealsense2 2.57.7-r1 --> 2.58.1-r1*
* *log-view 0.3.3-r1 --> 0.5.0-r1*
* *message-filters 4.3.16-r1 --> 4.3.18-r1*
* *mp2p-icp 2.10.2-r1 --> 2.10.3-r1*
* *point-cloud-transport 1.0.21-r1 --> 1.0.22-r1*
* *point-cloud-transport-py 1.0.21-r1 --> 1.0.22-r1*
* *realsense2-camera 4.57.7-r4 --> 4.58.1-r1*
* *realsense2-camera-msgs 4.57.7-r4 --> 4.58.1-r1*
* *realsense2-description 4.57.7-r4 --> 4.58.1-r1*
* *robotraconteur 1.2.7-r1 --> 1.2.8-r1*
* *robotraconteur-companion 0.4.2-r1 --> 0.4.3-r1*
* *rosapi 2.0.6-r1 --> 2.0.7-r1*
* *rosapi-msgs 2.0.6-r1 --> 2.0.7-r1*
* *rosbridge-library 2.0.6-r1 --> 2.0.7-r1*
* *rosbridge-msgs 2.0.6-r1 --> 2.0.7-r1*
* *rosbridge-server 2.0.6-r1 --> 2.0.7-r1*
* *rosbridge-suite 2.0.6-r1 --> 2.0.7-r1*
* *rosbridge-test-msgs 2.0.6-r1 --> 2.0.7-r1*
* *self-test 4.0.6-r1 --> 4.0.7-r1*

Jazzy Changes:
--------------
* *apriltag-msgs 2.0.1-r5 --> 2.0.2-r1*
* *apriltag-ros 3.3.0-r1 --> 3.4.0-r1*
* *camera-calibration-parsers 5.1.7-r1 --> 5.1.8-r1*
* *camera-info-manager 5.1.7-r1 --> 5.1.8-r1*
* *camera-info-manager-py 5.1.7-r1 --> 5.1.8-r1*
* *canopen 0.3.2-r1 --> 0.3.4-r1*
* *canopen-402-driver 0.3.2-r1 --> 0.3.4-r1*
* *canopen-base-driver 0.3.2-r1 --> 0.3.4-r1*
* *canopen-core 0.3.2-r1 --> 0.3.4-r1*
* *canopen-fake-slaves 0.3.2-r1 --> 0.3.4-r1*
* *canopen-interfaces 0.3.2-r1 --> 0.3.4-r1*
* *canopen-master-driver 0.3.2-r1 --> 0.3.4-r1*
* *canopen-proxy-driver 0.3.2-r1 --> 0.3.4-r1*
* *canopen-ros2-control 0.3.2-r1 --> 0.3.4-r1*
* *canopen-ros2-controllers 0.3.2-r1 --> 0.3.4-r1*
* *canopen-tests 0.3.2-r1 --> 0.3.4-r1*
* *canopen-utils 0.3.2-r1 --> 0.3.4-r1*
* *clearpath-bms-broadcaster 2.9.7-r1 --> 2.9.8-r1*
* *clearpath-bt-joy 2.9.7-r1 --> 2.9.8-r1*
* *clearpath-common 2.9.7-r1 --> 2.9.8-r1*
* *clearpath-config 2.9.2-r1 --> 2.9.3-r1*
* *clearpath-control 2.9.7-r1 --> 2.9.8-r1*
* *clearpath-customization 2.9.7-r1 --> 2.9.8-r1*
* *clearpath-description 2.9.7-r1 --> 2.9.8-r1*
* *clearpath-diagnostics 2.9.7-r1 --> 2.9.8-r1*
* *clearpath-generator-common 2.9.7-r1 --> 2.9.8-r1*
* *clearpath-manipulators 2.9.7-r1 --> 2.9.8-r1*
* *clearpath-manipulators-description 2.9.7-r1 --> 2.9.8-r1*
* *clearpath-mounts-description 2.9.7-r1 --> 2.9.8-r1*
* *clearpath-platform-description 2.9.7-r1 --> 2.9.8-r1*
* *clearpath-sensors-description 2.9.7-r1 --> 2.9.8-r1*
* *color-util 1.0.0-r4 --> 1.0.2-r1*
* *diagnostic-aggregator 4.2.6-r1 --> 4.2.7-r1*
* *diagnostic-common-diagnostics 4.2.6-r1 --> 4.2.7-r1*
* *diagnostic-remote-logging 4.2.6-r1 --> 4.2.7-r1*
* *diagnostic-updater 4.2.6-r1 --> 4.2.7-r1*
* *diagnostics 4.2.6-r1 --> 4.2.7-r1*
* *image-common 5.1.7-r1 --> 5.1.8-r1*
* *image-transport 5.1.7-r1 --> 5.1.8-r1*
* *lely-core-libraries 0.3.2-r1 --> 0.3.4-r1*
* *librealsense2 2.57.7-r1 --> 2.58.1-r1*
* *log-view 0.3.3-r1 --> 0.4.0-r1*
* *message-filters 4.11.13-r1 --> 4.11.15-r1*
* *mp2p-icp 2.10.2-r1 --> 2.10.3-r1*
* *point-cloud-transport 4.0.7-r1 --> 4.0.8-r1*
* *point-cloud-transport-py 4.0.7-r1 --> 4.0.8-r1*
* *realsense2-camera 4.57.7-r1 --> 4.58.1-r1*
* *realsense2-camera-msgs 4.57.7-r1 --> 4.58.1-r1*
* *realsense2-description 4.57.7-r1 --> 4.58.1-r1*
* *robotraconteur 1.2.7-r1 --> 1.2.8-r1*
* *robotraconteur-companion 0.4.2-r1 --> 0.4.3-r2*
* *rosapi 2.6.0-r1 --> 2.7.0-r1*
* *rosapi-msgs 2.6.0-r1 --> 2.7.0-r1*
* *rosbridge-library 2.6.0-r1 --> 2.7.0-r1*
* *rosbridge-msgs 2.6.0-r1 --> 2.7.0-r1*
* *rosbridge-server 2.6.0-r1 --> 2.7.0-r1*
* *rosbridge-suite 2.6.0-r1 --> 2.7.0-r1*
* *rosbridge-test-msgs 2.6.0-r1 --> 2.7.0-r1*
* *rtsp-image-transport 2.0.1-r1 --> 2.0.2-r1*
* *self-test 4.2.6-r1 --> 4.2.7-r1*

Kilted Changes:
---------------
* *camera-calibration-parsers 6.1.3-r1 --> 6.1.4-r1*
* *camera-info-manager 6.1.3-r1 --> 6.1.4-r1*
* *camera-info-manager-py 6.1.3-r1 --> 6.1.4-r1*
* *canopen 0.3.2-r1 --> 0.3.4-r1*
* *canopen-402-driver 0.3.2-r1 --> 0.3.4-r1*
* *canopen-base-driver 0.3.2-r1 --> 0.3.4-r1*
* *canopen-core 0.3.2-r1 --> 0.3.4-r1*
* *canopen-fake-slaves 0.3.2-r1 --> 0.3.4-r1*
* *canopen-interfaces 0.3.2-r1 --> 0.3.4-r1*
* *canopen-master-driver 0.3.2-r1 --> 0.3.4-r1*
* *canopen-proxy-driver 0.3.2-r1 --> 0.3.4-r1*
* *canopen-ros2-control 0.3.2-r1 --> 0.3.4-r1*
* *canopen-ros2-controllers 0.3.2-r1 --> 0.3.4-r1*
* *canopen-tests 0.3.2-r1 --> 0.3.4-r1*
* *canopen-utils 0.3.2-r1 --> 0.3.4-r1*
* *color-util 1.0.0-r4 --> 1.2.0-r1*
* *diagnostic-aggregator 4.3.6-r1 --> 4.3.7-r1*
* *diagnostic-common-diagnostics 4.3.6-r1 --> 4.3.7-r1*
* *diagnostic-remote-logging 4.3.6-r1 --> 4.3.7-r1*
* *diagnostic-updater 4.3.6-r1 --> 4.3.7-r1*
* *diagnostics 4.3.6-r1 --> 4.3.7-r1*
* *image-common 6.1.3-r1 --> 6.1.4-r1*
* *image-transport 6.1.3-r1 --> 6.1.4-r1*
* *image-transport-py 6.1.3-r1 --> 6.1.4-r1*
* *lely-core-libraries 0.3.2-r1 --> 0.3.4-r1*
* *librealsense2 2.57.7-r1 --> 2.58.1-r1*
* *message-filters 7.1.8-r1 --> 7.1.10-r1*
* *mp2p-icp 2.9.1-r1 --> 2.10.3-r1*
* *novatel-oem7-driver 4.3.0-r2 --> 28.0.0-r1*
* *novatel-oem7-msgs 4.3.0-r2 --> 28.0.0-r1*
* *point-cloud-transport 5.1.6-r1 --> 5.1.7-r1*
* *point-cloud-transport-py 5.1.6-r1 --> 5.1.7-r1*
* *realsense2-camera 4.57.7-r1 --> 4.58.1-r1*
* *realsense2-camera-msgs 4.57.7-r1 --> 4.58.1-r1*
* *realsense2-description 4.57.7-r1 --> 4.58.1-r1*
* *robotraconteur 1.2.7-r1 --> 1.2.8-r1*
* *robotraconteur-companion 0.4.2-r1 --> 0.4.3-r1*
* *rosapi 3.2.0-r1 --> 3.3.0-r1*
* *rosapi-msgs 3.2.0-r1 --> 3.3.0-r1*
* *rosbridge-library 3.2.0-r1 --> 3.3.0-r1*
* *rosbridge-msgs 3.2.0-r1 --> 3.3.0-r1*
* *rosbridge-server 3.2.0-r1 --> 3.3.0-r1*
* *rosbridge-suite 3.2.0-r1 --> 3.3.0-r1*
* *rosbridge-test-msgs 3.2.0-r1 --> 3.3.0-r1*
* *self-test 4.3.6-r1 --> 4.3.7-r1*

Lyrical Changes:
----------------
* *apriltag-msgs 2.0.1-r6 --> 2.0.2-r1*
* *apriltag-ros 3.3.0-r3 --> 3.4.0-r1*
* *camera-calibration-parsers 6.4.8-r1 --> 6.4.9-r1*
* *camera-info-manager 6.4.8-r1 --> 6.4.9-r1*
* *camera-info-manager-py 6.4.8-r1 --> 6.4.9-r1*
* *canopen 0.3.2-r3 --> 0.3.4-r1*
* *canopen-402-driver 0.3.2-r3 --> 0.3.4-r1*
* *canopen-base-driver 0.3.2-r3 --> 0.3.4-r1*
* *canopen-core 0.3.2-r3 --> 0.3.4-r1*
* *canopen-fake-slaves 0.3.2-r3 --> 0.3.4-r1*
* *canopen-interfaces 0.3.2-r3 --> 0.3.4-r1*
* *canopen-master-driver 0.3.2-r3 --> 0.3.4-r1*
* *canopen-proxy-driver 0.3.2-r3 --> 0.3.4-r1*
* *canopen-ros2-control 0.3.2-r3 --> 0.3.4-r1*
* *canopen-ros2-controllers 0.3.2-r3 --> 0.3.4-r1*
* *canopen-tests 0.3.2-r3 --> 0.3.4-r1*
* *canopen-utils 0.3.2-r3 --> 0.3.4-r1*
* *color-util 1.1.0-r3 --> 1.2.0-r2*
* *diagnostic-aggregator 4.4.6-r3 --> 4.4.7-r1*
* *diagnostic-common-diagnostics 4.4.6-r3 --> 4.4.7-r1*
* *diagnostic-remote-logging 4.4.6-r3 --> 4.4.7-r1*
* *diagnostic-updater 4.4.6-r3 --> 4.4.7-r1*
* *diagnostics 4.4.6-r3 --> 4.4.7-r1*
* *image-common 6.4.8-r1 --> 6.4.9-r1*
* *image-transport 6.4.8-r1 --> 6.4.9-r1*
* *image-transport-py 6.4.8-r1 --> 6.4.9-r1*
* *lely-core-libraries 0.3.2-r3 --> 0.3.4-r1*
* *leo-bringup 2.5.0-r3 --> 2.6.1-r1*
* *leo-filters 2.5.0-r3 --> 2.6.1-r1*
* *leo-fw 2.5.0-r3 --> 2.6.1-r1*
* *leo-robot 2.5.0-r3 --> 2.6.1-r1*
* *mola-input-ouster 0.1.0-r1*
* *mp2p-icp 2.10.2-r1 --> 2.10.3-r1*
* *mrpt-generic-sensor 0.2.4-r3 --> 0.3.0-r1*
* *mrpt-sensor-bumblebee-stereo 0.2.4-r3 --> 0.3.0-r1*
* *mrpt-sensor-gnss-nmea 0.2.4-r3 --> 0.3.0-r1*
* *mrpt-sensor-gnss-novatel 0.2.4-r3 --> 0.3.0-r1*
* *mrpt-sensor-imu-taobotics 0.2.4-r3 --> 0.3.0-r1*
* *mrpt-sensorlib 0.2.4-r3 --> 0.3.0-r1*
* *mrpt-sensors 0.2.4-r3 --> 0.3.0-r1*
* *novatel-oem6-msgs 0.3.0-r1*
* *point-cloud-transport 5.4.1-r1 --> 5.4.2-r1*
* *point-cloud-transport-py 5.4.1-r1 --> 5.4.2-r1*
* *pybind11-json-vendor 0.7.0-r1*
* *robotraconteur 1.2.7-r4 --> 1.2.8-r1*
* *robotraconteur-companion 0.4.2-r4 --> 0.4.3-r1*
* *rosapi 4.1.0-r3 --> 4.2.0-r1*
* *rosapi-msgs 4.1.0-r3 --> 4.2.0-r1*
* *rosbridge-library 4.1.0-r3 --> 4.2.0-r1*
* *rosbridge-msgs 4.1.0-r3 --> 4.2.0-r1*
* *rosbridge-server 4.1.0-r3 --> 4.2.0-r1*
* *rosbridge-suite 4.1.0-r3 --> 4.2.0-r1*
* *rosbridge-test-msgs 4.1.0-r3 --> 4.2.0-r1*
* *rosidlcpp 0.5.0-r3 --> 0.6.0-r1*
* *rosidlcpp-generator-c 0.5.0-r3 --> 0.6.0-r1*
* *rosidlcpp-generator-core 0.5.0-r3 --> 0.6.0-r1*
* *rosidlcpp-generator-cpp 0.5.0-r3 --> 0.6.0-r1*
* *rosidlcpp-generator-py 0.5.0-r3 --> 0.6.0-r1*
* *rosidlcpp-generator-type-description 0.5.0-r3 --> 0.6.0-r1*
* *rosidlcpp-parser 0.5.0-r3 --> 0.6.0-r1*
* *rosidlcpp-typesupport-c 0.5.0-r3 --> 0.6.0-r1*
* *rosidlcpp-typesupport-cpp 0.5.0-r3 --> 0.6.0-r1*
* *rosidlcpp-typesupport-fastrtps-c 0.5.0-r3 --> 0.6.0-r1*
* *rosidlcpp-typesupport-fastrtps-cpp 0.5.0-r3 --> 0.6.0-r1*
* *rosidlcpp-typesupport-introspection-c 0.5.0-r3 --> 0.6.0-r1*
* *rosidlcpp-typesupport-introspection-cpp 0.5.0-r3 --> 0.6.0-r1*
* *rtest 0.2.2-r3 --> 0.2.3-r1*
* *rtsp-image-transport 2.0.1-r3 --> 2.0.2-r1*
* *self-test 4.4.6-r3 --> 4.4.7-r1*
* *slider-publisher 2.4.3-r3 --> 2.5.0-r2*
* *ur-client-library 2.11.0-r1 --> 2.12.0-r1*

Rolling Changes:
----------------
* *apriltag-msgs 2.0.1-r5 --> 2.0.2-r1*
* *apriltag-ros 3.3.0-r2 --> 3.4.0-r1*
* *camera-calibration-parsers 7.0.0-r1 --> 7.0.1-r1*
* *camera-info-manager 7.0.0-r1 --> 7.0.1-r1*
* *camera-info-manager-py 7.0.0-r1 --> 7.0.1-r1*
* *canopen 0.3.2-r2 --> 0.3.4-r1*
* *canopen-402-driver 0.3.2-r2 --> 0.3.4-r1*
* *canopen-base-driver 0.3.2-r2 --> 0.3.4-r1*
* *canopen-core 0.3.2-r2 --> 0.3.4-r1*
* *canopen-fake-slaves 0.3.2-r2 --> 0.3.4-r1*
* *canopen-interfaces 0.3.2-r2 --> 0.3.4-r1*
* *canopen-master-driver 0.3.2-r2 --> 0.3.4-r1*
* *canopen-proxy-driver 0.3.2-r2 --> 0.3.4-r1*
* *canopen-ros2-control 0.3.2-r2 --> 0.3.4-r1*
* *canopen-ros2-controllers 0.3.2-r2 --> 0.3.4-r1*
* *canopen-tests 0.3.2-r2 --> 0.3.4-r1*
* *canopen-utils 0.3.2-r2 --> 0.3.4-r1*
* *diagnostic-aggregator 4.4.6-r2 --> 4.5.7-r1*
* *diagnostic-common-diagnostics 4.4.6-r2 --> 4.5.7-r1*
* *diagnostic-remote-logging 4.4.6-r2 --> 4.5.7-r1*
* *diagnostic-updater 4.4.6-r2 --> 4.5.7-r1*
* *diagnostics 4.4.6-r2 --> 4.5.7-r1*
* *image-common 7.0.0-r1 --> 7.0.1-r1*
* *image-transport 7.0.0-r1 --> 7.0.1-r1*
* *image-transport-py 7.0.0-r1 --> 7.0.1-r1*
* *laser-geometry 3.0.0-r1 --> 3.0.1-r1*
* *lely-core-libraries 0.3.2-r2 --> 0.3.4-r1*
* *log-view 0.3.3-r2 --> 0.5.0-r1*
* *motion-capture-tracking 1.0.6-r2 --> 1.0.7-r1*
* *motion-capture-tracking-interfaces 1.0.6-r2 --> 1.0.7-r1*
* *mp2p-icp 2.10.2-r1 --> 2.10.3-r1*
* *performance-test 2.3.0-r2 --> 2.3.0-r3*
* *point-cloud-transport 6.0.0-r1 --> 6.0.1-r1*
* *point-cloud-transport-py 6.0.0-r1 --> 6.0.1-r1*
* *rcl 10.5.0-r1 --> 10.5.1-r1*
* *rcl-action 10.5.0-r1 --> 10.5.1-r1*
* *rcl-lifecycle 10.5.0-r1 --> 10.5.1-r1*
* *rcl-yaml-param-parser 10.5.0-r1 --> 10.5.1-r1*
* *rclcpp 33.0.0-r1 --> 33.0.1-r1*
* *rclcpp-action 33.0.0-r1 --> 33.0.1-r1*
* *rclcpp-components 33.0.0-r1 --> 33.0.1-r1*
* *rclcpp-lifecycle 33.0.0-r1 --> 33.0.1-r1*
* *rclpy 11.0.0-r1 --> 11.0.1-r1*
* *robotraconteur 1.2.7-r3 --> 1.2.8-r1*
* *robotraconteur-companion 0.4.2-r3 --> 0.4.3-r1*
* *rosapi 4.1.0-r2 --> 4.2.0-r1*
* *rosapi-msgs 4.1.0-r2 --> 4.2.0-r1*
* *rosbridge-library 4.1.0-r2 --> 4.2.0-r1*
* *rosbridge-msgs 4.1.0-r2 --> 4.2.0-r1*
* *rosbridge-server 4.1.0-r2 --> 4.2.0-r1*
* *rosbridge-suite 4.1.0-r2 --> 4.2.0-r1*
* *rosbridge-test-msgs 4.1.0-r2 --> 4.2.0-r1*
* *rtsp-image-transport 2.0.1-r2 --> 2.0.2-r1*
* *self-test 4.4.6-r2 --> 4.5.7-r1*
* *sync-tooling-msgs 0.2.7-r2 --> 0.2.9-r1*


No missing dependencies.