### PR TITLE
buildEnv: Enable allowSubstitutes

### DIFF
--- a/distros/build-env/default.nix
+++ b/distros/build-env/default.nix
@@ -56,6 +56,10 @@ let
       dontGzipMan = true;
       dontPatchShebangs = true;
       dontMoveLib64 = true;
+
+      # nixpkgs's buildEnv disables substitutes, which can lead to
+      # unnecessarily long build times for development environments.
+      allowSubstitutes = true;
     };
 
     postBuild = postBuild + ''


### PR DESCRIPTION
`buildEnv` in nixpkgs sets `allowSubstitutes` to false, which causes the `buildEnv` derivations to be rebuilt by every user of a ROS-based project. In some cases this can take relatively long time. For example, when the hicolor-icon-theme setup hook[¹] is included, it can execute for several seconds, because its code is O(n²). Such a delay is especially annoying when using direnv or similar tools and project CI ensures that the environment is prebuilt in the binary cache.

This is discussed in more detail in https://github.com/NixOS/nix/issues/4442.

Setting `allowSubstitutes` should ensure that the environment is fetched from the binary cache if it's available there. If somebody wants the previous behavior, they can override attributes of the resulting derivation.

[¹]: https://github.com/NixOS/nixpkgs/blob/1b1a11ef315321357075af9ccdd7394691f89486/pkgs/by-name/hi/hicolor-icon-theme/setup-hook.sh