### PR TITLE
Allow using buildEnv as ROS underlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Using the overlay in your `flake.nix`-based project could look like this:
             pkgs.colcon
             # ... other non-ROS packages
             (with pkgs.rosPackages.humble; buildEnv {
+              underlay = true;
               paths = [
                 ros-core
                 # ... other ROS packages

--- a/distros/build-env/default.nix
+++ b/distros/build-env/default.nix
@@ -10,11 +10,18 @@
 #
 # By default, all binaries in the environment are wrapped, setting the relevant
 # ROS environment variables, allowing use outside of nix-shell.
+# Wrapping prefixes the existing variables with the buildEnv output, which
+# ensures reproducibility and prevents an incompatible user environment from
+# breaking the Nix setup. However, for development environments used within
+# mkShell, it is often desirable for packages in the local ROS workspace to
+# take precedence over Nix-built packages. This can be achieved by setting
+# underlay to true.
 { lib, stdenv, buildPackages, writeText, buildEnv, makeWrapper, python, ros-environment }:
-{ paths ? [], wrapPrograms ? true, postBuild ? "", passthru ? { }, ... }@args:
+{ paths ? [], wrapPrograms ? true, underlay ? false, postBuild ? "", passthru ? { }, ... }@args:
 
 with lib;
-
+assert assertMsg (underlay -> wrapPrograms)
+  "Setting underlay without wrapPrograms has no effect.";
 let
   propagatePackages = packages: let
     validPackages = filter (d: d != null) packages;
@@ -33,7 +40,9 @@ let
 
   propagatedPaths = propagatePackages paths;
 
-  env = (buildEnv ((removeAttrs args [ "wrapPrograms" ]) // {
+  xfix = if underlay then "suffix" else "prefix";
+
+  env = (buildEnv ((removeAttrs args [ "underlay" "wrapPrograms" ]) // {
     name = "ros-env";
     # Only add ROS packages to environment. The rest are propagated like normal.
     # ROS packages propagate a huge number of dependencies, which are added all
@@ -70,13 +79,13 @@ let
           if [[ "$(basename "$link")" == .*-wrapped ]]; then continue; fi
 
           makeWrapper "$file" "$link" \
-            --prefix PATH : "$out/bin" \
-            --prefix LD_LIBRARY_PATH : "$out/lib" \
-            --prefix PYTHONPATH : "$out/${python.sitePackages}" \
-            --prefix CMAKE_PREFIX_PATH : "$out" \
-            --prefix AMENT_PREFIX_PATH : "$out" \
-            --prefix ROS_PACKAGE_PATH : "$out/share" \
-            --prefix GZ_CONFIG_PATH : "$out/share/gz" \
+            --${xfix} PATH : "$out/bin" \
+            --${xfix} LD_LIBRARY_PATH : "$out/lib" \
+            --${xfix} PYTHONPATH : "$out/${python.sitePackages}" \
+            --${xfix} CMAKE_PREFIX_PATH : "$out" \
+            --${xfix} AMENT_PREFIX_PATH : "$out" \
+            --${xfix} ROS_PACKAGE_PATH : "$out/share" \
+            --${xfix} GZ_CONFIG_PATH : "$out/share/gz" \
             --set ROS_DISTRO '${ros-environment.rosDistro}' \
             --set ROS_VERSION '${toString ros-environment.rosVersion}' \
             --set ROS_PYTHON_VERSION '${lib.versions.major python.version}' \

--- a/examples/flake/flake.nix
+++ b/examples/flake/flake.nix
@@ -17,6 +17,7 @@
             pkgs.colcon
             # ... other non-ROS packages
             (with pkgs.rosPackages.humble; buildEnv {
+              underlay = true;
               paths = [
                 ros-core
                 # ... other ROS packages


### PR DESCRIPTION
When one has a package X in a Nix development environment (or nix-shell) and a package of the same name appears in a local ROS workspace, previous buildEnv implementation ignored the local package. With this change, the user can set `underlay = true` to make the local package override the package from Nix. In that case, if the ROS workspace has no package named X, the one from Nix will be visible.

Originally I thought, it should be possible to achieve the same without modifying nix-ros-overlay, by just disabling wrapping of binaries (e.g. ros2) in the buildEnv with `wrapPrograms = false`. But for some reason, it doesn't work. It makes some packages not visible at all, which looks like a bug. Until this bug is fixed, we just do what's in this commit.

Moreover, it's not sufficient to change only AMENT_PREFIX_PATH. It seems that `ros2 launch` searches the packages based on PYTHONPATH rather than based on AMENT_PREFIX_PATH. Therefore, changes performed in Python code in a local workspace launched via `ros2 launch` were not visible. We fix that by setting also PYTHONPATH.

And while we're at it, we also change the remaining variables. It seems to be the right thing for common use cases.

---

P.S. I was replacing `--prefix` with `--suffix` in all of my ROS projects in the past. Since I'm lazy to copy that patch to new projects, I made the change configurable and post it here. I add `underlay = true` to the example template, because this is likely the behavior most people expect.