### PR TITLE
modules/ros2: Add applyOverlay option, default to false

### DIFF
--- a/modules/ros2/ros.nix
+++ b/modules/ros2/ros.nix
@@ -21,6 +21,26 @@ in {
   options.services.ros2 = {
     enable = mkEnableOption "Robot Operating System, version 2";
 
+    applyOverlay = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether this module should inject `nix-ros-overlay` into
+        <option>nixpkgs.overlays</option>.
+
+        Defaults to `false`: the consumer is expected to add
+        `nix-ros-overlay.overlays.default` to their nixpkgs instantiation
+        explicitly (for example via flake-parts, blueprint, or a manual
+        `import nixpkgs { overlays = [ ... ]; }`). This avoids ambiguity
+        about where the overlay is applied and prevents accidental
+        double application, which duplicates package patches and breaks
+        builds (e.g. `libfyaml` reversed-patch errors).
+
+        Set to `true` only when the module is the single owner of the
+        overlay and no other code path has already applied it.
+      '';
+    };
+
     distro = mkOption {
       type = types.str;
       default = "humble";
@@ -69,10 +89,30 @@ in {
   # Implementation
 
   config = mkIf cfg.enable {
-    # mkAfter is used to make sure the Python overlay (which uses overrideScope)
-    # is applied after any user overlays that use packageOverrides, so that
-    # composition works.
-    nixpkgs.overlays = mkAfter (singleton (import ../../overlay.nix));
+    assertions = [{
+      assertion = cfg.applyOverlay || (pkgs ? rosPackages);
+      message = ''
+        services.ros2 is enabled but nix-ros-overlay is not applied to
+        pkgs (pkgs.rosPackages is missing). Add
+        nix-ros-overlay.overlays.default to your nixpkgs.overlays, or
+        set services.ros2.applyOverlay = true to let this module inject
+        the overlay for you.
+      '';
+    }];
+
+    warnings = lib.optional (cfg.applyOverlay && (pkgs ? rosPackages)) ''
+      services.ros2.applyOverlay = true but nix-ros-overlay is already
+      present in pkgs (pkgs.rosPackages exists). The overlay will be
+      applied a second time, which duplicates package patches and
+      breaks builds. Set services.ros2.applyOverlay = false (the
+      default) and rely on the overlay already present in pkgs.
+    '';
+
+    # When the module owns the overlay injection, apply it with mkAfter
+    # so the Python overlay (which uses overrideScope) lands after any
+    # user overlays that use packageOverrides, preserving composition.
+    nixpkgs.overlays = mkIf cfg.applyOverlay
+      (mkAfter (singleton (import ../../overlay.nix)));
 
     services.ros2.pkgs = mkDefault (pkgs.rosPackages."${cfg.distro}".overrideScope cfg.overlays);
 


### PR DESCRIPTION
The module unconditionally injects `nix-ros-overlay` into `nixpkgs.overlays`,
which double-applies the overlay when the consumer already added
`nix-ros-overlay.overlays.default` to their `pkgs` instantiation (e.g. via
`flake-parts`, `blueprint`, or a manual `import nixpkgs`). Double application
duplicates package patches and breaks builds (e.g. `libfyaml`
reversed-patch errors, that was my case).

Add a `services.ros2.applyOverlay` option (default `false`) that controls
whether the module injects the overlay itself. Consumers are now
expected to add `nix-ros-overlay.overlays.default` to `nixpkgs.overlays`
explicitly, which removes the ambiguity about where the overlay is
applied. Setting `applyOverlay = true` restores the previous behavior for
users who prefer the module to manage the overlay.

An assertion catches the misconfiguration where `applyOverlay` is `false`
but `pkgs.rosPackages` is missing, and a warning is emitted when
`applyOverlay` is `true` but the overlay is already present in `pkgs`.

This is a breaking change: existing configurations that rely on the
module injecting the overlay must either set `applyOverlay = true` or
add the overlay to `nixpkgs.overlays` themselves.
