### PR TITLE
Fix buildEnv

### DIFF
--- a/distros/build-env/default.nix
+++ b/distros/build-env/default.nix
@@ -112,5 +112,19 @@ let
         '';
       };
     };
-  }));
+  })).overrideAttrs ({ buildCommand, ...}: {
+    # Hack to execute buildPhase and fixupPhase instead of just
+    # buildCommand provided by nixpkgs buildEnv. We need fixupPhase
+    # for shell hooks to set ROS env. variables and for input
+    # propagation.
+    buildCommand = null;
+    oldBuildCommand = buildCommand;
+    buildPhase = ''
+      . $NIX_ATTRS_SH_FILE
+      runHook preBuild
+      eval "$oldBuildCommand"
+      runHook postBuild
+    '';
+    phases = [ "buildPhase" "fixupPhase" ];
+  });
 in env


### PR DESCRIPTION
Recent commit 228044c0e9 ("buildEnv: update for https://github.com/NixOS/nixpkgs/pull/434815", 2026-05-27) forgot to
run `fixupPhase`, which was run by the previous implementation. This, among other things, sets `AMENT_PREFIX_PATH` variable, which is needed by many ROS tools.

This mimics the structure of the implementation before 228044c0e9 and as such should be more backward compatible. This way, if users override the `fixupPhase` or set {pre,post}{Build,Fixup} hooks, the result should behave as before 228044c0e9.
