### PR TITLE
rosdistro sync, Fri Jun  5 20:42:53 2026

### DIFF
--- a/distros/humble/clearpath-common/default.nix
+++ b/distros/humble/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common }:
 buildRosPackage {
   pname = "ros-humble-clearpath-common";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "12edb46409104ea82960270d684eb9037b3c17c11c9a0d14c64c5893166a9fac";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "d7e7723b920b10448f921e592db088dd1a7961405bf45d142b3c8734b1fea2ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-control/default.nix
+++ b/distros/humble/clearpath-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-mecanum-drive-controller, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-humble-clearpath-control";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "4bdc2c206c1191e3e7ad8bcc98c1f21a629a04c5782dfa54a9b0eb301a224331";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "da6ba27162fb68d1be0381c780bdf37ef308176037670d0fbb276c69987474ed";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-customization/default.nix
+++ b/distros/humble/clearpath-customization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-clearpath-customization";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_customization/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "37489487efd3eec7acc15eb23026abf1d3402fd4d657f9ccc44224c514e25c11";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_customization/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "b423533e9f4fd5057127fcad425fa8eafdb4ab12f3d5a5befd79c65be56391e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-description/default.nix
+++ b/distros/humble/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-description";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "aa41a4fffd4b9d5a5ee19b864c6ab455fe4497839142f428415fe846704db478";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "657461b573671525b92b2f93c04cdfd8f6667a2d3c28dd27830ddc41a98c4791";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-generator-common/default.nix
+++ b/distros/humble/clearpath-generator-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-manipulators, moveit-setup-srdf-plugins }:
 buildRosPackage {
   pname = "ros-humble-clearpath-generator-common";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "81a20c0a910ed61179b9a2b2351e0ab806cb837322f85ba1949c13c296c8a3e5";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "86e64feb58498c1b18ec55239df3dd02a860e4c87bc2608ac6c99ed291b8e374";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-manipulators-description/default.nix
+++ b/distros/humble/clearpath-manipulators-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ewellix-description, franka-description, kortex-description, robot-state-publisher, robotiq-description, ur-description, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-manipulators-description";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators_description/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "73d5bcb0eca16b8ecb5a700d2d2a102bb9a7305a2979c82650ca3e3bce2ac3c8";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators_description/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "af78aad96a7e03142aa31615c606869d79a1fb36d22e9921a1445abd47b793b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-manipulators/default.nix
+++ b/distros/humble/clearpath-manipulators/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, gripper-controllers, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-warehouse, moveit-simple-controller-manager, position-controllers, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-manipulators";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "339409c48cf1caec31bee3e2146f56c14837d0256cd57fe3cd8cef3c1abc6191";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "78c5b569593f364561d77df47915b7ef7e5f44be18a5e4d87e9885076b2895dd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-mounts-description/default.nix
+++ b/distros/humble/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-clearpath-mounts-description";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "c35b77af3f4bafc348dc14f618d7b4f3eaa1941242277d2fe94e0001c8095c95";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "1a2f52d84ac0b792c32d29015e87c13ad0ffc4abda05beae716bd54dc0bca67a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform-description/default.nix
+++ b/distros/humble/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform-description";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "f8abe3eaca1970636dc2556c3e633804486c5c0fbbde3f183e145c62d6b722af";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "0f42c773b465cbf86544dc2ab434ab40e67a9289ef92e9cddc60b6e56cd85f8c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-sensors-description/default.nix
+++ b/distros/humble/clearpath-sensors-description/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-description, realsense2-description, velodyne-description }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-description, realsense2-description, velodyne-description, zed-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-sensors-description";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "24432bda8452476733528aba341f0736ab2506375cdd0701bf7af137d9033ba6";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "c819ac4e54213318ac17d27f6bcd0f3b63684f2691af02509911da3b5b46656a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ microstrain-inertial-description realsense2-description velodyne-description ];
+  propagatedBuildInputs = [ microstrain-inertial-description realsense2-description velodyne-description zed-description ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/compass-msgs/default.nix
+++ b/distros/humble/compass-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-compass-msgs";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/compass_msgs/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "b666a202fb196579c33b91a7f3ffe8462120d179494de90d0fdc7030d74ff465";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/compass_msgs/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "a2d79916e6480a2ea54ecd34a87517e67ad9c571c6b42057dce1b24d3097a88d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/continental-msgs/default.nix
+++ b/distros/humble/continental-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, autoware-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-continental-msgs";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/continental_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "856d5093e63e59afd72b59641e1f6112344f92278acbb01fc3373fb47d294727";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/continental_msgs/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "ad7eb85f772f7ee56934f48ca462b14e6acc08f8b8dd94bc3d9c299427fcb579";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/continental-srvs/default.nix
+++ b/distros/humble/continental-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, autoware-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-continental-srvs";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/continental_srvs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "d904e19642833cf4ee77193b468baf1420e6e4e853a1f2ed1248c9f9600302d5";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/continental_srvs/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "6b535503e60eef2f25deeff3aad3cfac0daa5b828f83f1faf591d942ebbe767e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/foxglove-bridge/default.nix
+++ b/distros/humble/foxglove-bridge/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, geometry-msgs, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, rosx-introspection, sensor-msgs, std-msgs, std-srvs, websocketpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, geometry-msgs, nlohmann_json, rcl-interfaces, rclcpp, rclcpp-components, rcpputils, rcutils, resource-retriever, ros-environment, rosgraph-msgs, rosidl-typesupport-introspection-cpp, rosx-introspection, sensor-msgs, std-msgs, std-srvs, websocketpp }:
 buildRosPackage {
   pname = "ros-humble-foxglove-bridge";
-  version = "3.3.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_bridge/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "10b5304dd941f3afb96235a4cc7e6e22260277999e2b13709c1cde1ceb6ebfbf";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_bridge/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "ac202de6f865054105be4a96e5833c80b8a95dbb311b90d2330e52467d43f6ab";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake asio geometry-msgs nlohmann_json ros-environment sensor-msgs ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto openssl std-msgs std-srvs websocketpp ];
-  propagatedBuildInputs = [ ament-index-cpp rclcpp rclcpp-components resource-retriever rosgraph-msgs rosx-introspection std-msgs ];
+  buildInputs = [ ament-cmake geometry-msgs ros-environment sensor-msgs ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto asio nlohmann_json std-msgs std-srvs websocketpp ];
+  propagatedBuildInputs = [ ament-index-cpp rcl-interfaces rclcpp rclcpp-components rcpputils rcutils resource-retriever rosgraph-msgs rosidl-typesupport-introspection-cpp rosx-introspection std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/foxglove-msgs/default.nix
+++ b/distros/humble/foxglove-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-foxglove-msgs";
-  version = "3.3.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_msgs/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "3540dc2d56da3b1dc9b7c31cb6d6b18101ea8372cac48a297fe3a2275d8ffd2c";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_msgs/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "7e6a7cae3b1f8102089b544dea32247a249e839afb732a469fed52177264eb4b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/fusioncore-core/default.nix
+++ b/distros/humble/fusioncore-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module }:
 buildRosPackage {
   pname = "ros-humble-fusioncore-core";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/fusioncore_core/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "f31c29b080a345a13f585840112256d65b40e96e9f85b50a6851634779127e6b";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/fusioncore_core/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "3ff23045f13c00dc56c5d51b64f088c368299f26a60343604180469cddf4fa7a";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "Pure C++ UKF sensor fusion library underlying FusionCore. Fuses IMU, wheel encoders, GPS, and visual SLAM pose in a 22-state unscented Kalman filter. Includes ECEF GPS conversion, IMU bias estimation, adaptive noise covariance, chi-squared outlier gating, ZUPT, and GPS-denied operation. No ROS dependency, usable standalone.";
+    description = "Pure C++ UKF sensor fusion library underlying FusionCore. Fuses IMU, wheel encoders, GPS, and visual SLAM pose in a 23-state unscented Kalman filter. Includes ECEF GPS conversion, online gyro/accel/encoder bias estimation, adaptive noise covariance, chi-squared outlier gating, ZUPT, and GPS-denied operation. No ROS dependency, usable standalone.";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/humble/fusioncore-datasets/default.nix
+++ b/distros/humble/fusioncore-datasets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fusioncore-ros, geometry-msgs, nav-msgs, rclpy, robot-localization, rosgraph-msgs, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-fusioncore-datasets";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/fusioncore_datasets/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "7cfe7f7547644c05ac40e8ece6de3f66a96deb79912d733eaa011ae4116a11d0";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/fusioncore_datasets/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "8a30b22d51d5c47bcaafd6759b14bb6c44a8158fce76d2a6c744b02e4c4b9571";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/fusioncore-gazebo/default.nix
+++ b/distros/humble/fusioncore-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fusioncore-ros, nav-msgs, rclpy, robot-state-publisher, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-fusioncore-gazebo";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/fusioncore_gazebo/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "a814642a4821dfb1a7c7746f46d71cf47f48912a6b2a9f1c3f994e319c054b5c";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/fusioncore_gazebo/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "ee06dc3beff5387f6ff936dc8f84c5623d953164cfd77c86b1c8c7e7f850c341";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/fusioncore-ros/default.nix
+++ b/distros/humble/fusioncore-ros/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, compass-msgs, diagnostic-msgs, eigen3-cmake-module, fusioncore-core, geographic-msgs, geometry-msgs, nav-msgs, proj, rclcpp, rclcpp-lifecycle, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, compass-msgs, diagnostic-msgs, eigen3-cmake-module, fusioncore-core, geographic-msgs, geometry-msgs, gps-msgs, nav-msgs, proj, rclcpp, rclcpp-lifecycle, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-fusioncore-ros";
-  version = "0.2.4-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/fusioncore_ros/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "0500dd2afe36c5c311e38f39d298dbb9490401e18ccb746a9afbbf7311a53d71";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/fusioncore_ros/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "b2e76fffe72edf971ac339ebb090fd164da1950a05e509304968daeb2ec4e192";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
-  propagatedBuildInputs = [ compass-msgs diagnostic-msgs eigen3-cmake-module fusioncore-core geographic-msgs geometry-msgs nav-msgs proj rclcpp rclcpp-lifecycle rosidl-default-runtime sensor-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ compass-msgs diagnostic-msgs eigen3-cmake-module fusioncore-core geographic-msgs geometry-msgs gps-msgs nav-msgs proj rclcpp rclcpp-lifecycle rosidl-default-runtime sensor-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {
-    description = "ROS 2 UKF sensor fusion for IMU, wheel encoders, GPS, and visual SLAM pose. 22-state filter with ECEF-native GPS handling, automatic IMU bias estimation, adaptive noise covariance, chi-squared outlier rejection on every sensor, and map reinitialization recovery for GPS-denied operation. Drop-in robot_localization alternative. Native ROS 2 Jazzy, benchmarked on 6 NCLT public dataset sequences.";
+    description = "ROS 2 UKF sensor fusion for IMU, wheel encoders, GPS, and visual SLAM pose. 23-state filter with ECEF-native GPS handling, online gyro/accel/encoder bias estimation, adaptive noise covariance, chi-squared outlier rejection on every sensor, and map reinitialization recovery for GPS-denied operation. Drop-in robot_localization alternative. Benchmarked on 12 full-length NCLT sequences: wins 10 of 12 vs robot_localization EKF.";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/humble/mapviz-interfaces/default.nix
+++ b/distros/humble/mapviz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-mapviz-interfaces";
-  version = "2.6.4-r1";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz_interfaces/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "85ae5f8e2a209bd926d60f83ffc711478da84c4c8a09fc45b2c3b32411e918b8";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz_interfaces/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "7fa775e8375ebcd13e85e988c24dad5695399a706a982c41cd94bc2778effa5b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mapviz-plugins/default.nix
+++ b/distros/humble/mapviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, cv-bridge, geometry-msgs, gps-msgs, image-transport, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-sensor-msgs, marti-visualization-msgs, nav-msgs, opencv, pluginlib, qt5, rclcpp, rclcpp-action, ros-environment, sensor-msgs, std-msgs, std-srvs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, tf2, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-mapviz-plugins";
-  version = "2.6.4-r1";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz_plugins/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "eaaed3573622acfdf8cbdaaa377520a8631e66ed3d8fe4e9505f49f3bf641e10";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz_plugins/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "c0f3e55cee5b26dceb04242a2ca5fc0d57d49b047e30b00e3afabb1ffe50284d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mapviz/default.nix
+++ b/distros/humble/mapviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, freeglut, geometry-msgs, glew, image-transport, libxi, libxmu, mapviz-interfaces, opencv, pkg-config, pluginlib, qt5, rclcpp, ros-environment, rqt-gui, rqt-gui-cpp, std-srvs, swri-math-util, swri-transform-util, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-mapviz";
-  version = "2.6.4-r1";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "7ee4c12b9d657176ccc14158a6f1689b22e82d6d976a3a1a9e6d449174717f4a";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "4ecd6047cffaa75e90b1fbad550c008fcb9a206eb009285c9840115d7affcec2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-georeferencing/default.nix
+++ b/distros/humble/mola-georeferencing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, gtsam, mola-common, mola-gtsam-factors, mola-yaml, mp2p-icp, mrpt-libmaps, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-humble-mola-georeferencing";
-  version = "2.4.0-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_georeferencing/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "c3cd5d492d377406597328617fe274b6e172892a6fb98898245111655c46efa5";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_georeferencing/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "0b68ee2ef9a527d186e75328a76679f1e1a12f8c9cf34649b78f8f580dd3dac9";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-gtsam-factors/default.nix
+++ b/distros/humble/mola-gtsam-factors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, gtsam, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-humble-mola-gtsam-factors";
-  version = "2.4.0-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_gtsam_factors/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "dbef323c86434ebf7a26666aaf2ccc11de1423def5b08f73e7948e76d75ef2a0";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_gtsam_factors/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "8bed680182acf0a636a3c3f53a008b4237ab2ece01163445f44a116125d57cda";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-lidar-odometry/default.nix
+++ b/distros/humble/mola-lidar-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-imu-preintegration, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-humble-mola-lidar-odometry";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/humble/mola_lidar_odometry/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "e2d1eee044759a23be7698422f37aabec6788691e2869b945aa8a592980e019b";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/humble/mola_lidar_odometry/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "85b6f507c3b020a4a11f691519945fc495b7b3114161e0066f5e5aab77878738";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-state-estimation-simple/default.nix
+++ b/distros/humble/mola-state-estimation-simple/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-state-estimation-simple";
-  version = "2.4.0-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation_simple/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "41086068d67fe3906acf00fc38d399c917ccbd3fdef52aaca767b645827489e2";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation_simple/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "bf311e9226cc63ecf68b3ddd4f675b2b3d7ff0469b0fef95bd06b4ce49ad6f2e";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-state-estimation-smoother/default.nix
+++ b/distros/humble/mola-state-estimation-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-xmllint, boost, cmake, geometry-msgs, gtsam, launch-testing, launch-testing-ament-cmake, launch-testing-ros, mola-bridge-ros2, mola-common, mola-gtsam-factors, mola-imu-preintegration, mola-kernel, mola-launcher, mrpt-libobs, nav-msgs, rclpy, ros-environment, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-mola-state-estimation-smoother";
-  version = "2.4.0-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation_smoother/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "836f561bbf10dca03374bf091f8330f4bc16316b894851df5a578f4137bc7e95";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation_smoother/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "8d3d7ca4bfbf1ce18e82af1cc6394366a2baa6c9fa09ecbf8bdc949e42b0c7a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-state-estimation/default.nix
+++ b/distros/humble/mola-state-estimation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, mola-state-estimation-simple, mola-state-estimation-smoother }:
 buildRosPackage {
   pname = "ros-humble-mola-state-estimation";
-  version = "2.4.0-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "10543616feab25aa4c3eace3954793cb5c22208c633156772c848037d5cd0b10";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "af88639278893fbc4e99400420d01cbb531fb8acb4215941bc872fd3c932fc79";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/multires-image/default.nix
+++ b/distros/humble/multires-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, mapviz, pluginlib, qt5, rclcpp, rclpy, swri-math-util, swri-transform-util, tf2 }:
 buildRosPackage {
   pname = "ros-humble-multires-image";
-  version = "2.6.4-r1";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/multires_image/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "4ea303e84d61b0d1617ef7e6f12b9b5928d17c136aac98a0f82a449289f12cfc";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/multires_image/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "23f5818d467aa4e6eb162231aa27942b3609fdc3759646491dcbf621f61c2697";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula-continental-common/default.nix
+++ b/distros/humble/nebula-continental-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, autoware-cmake, boost, nebula-core-common, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-nebula-continental-common";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_continental_common/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "8d07ee13a1c64dad6616796e95af8ea544cad54dd49b29d5a873cdddb1fe4f9a";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_continental_common/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "1ec3d78225250e7bf14b37d92bed18585820ef0cadf690a583551ffa157e4a6d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula-continental-decoders/default.nix
+++ b/distros/humble/nebula-continental-decoders/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, autoware-cmake, boost, continental-msgs, diagnostic-msgs, nebula-continental-common, nebula-core-common, nebula-msgs, rclcpp, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-nebula-continental-decoders";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_continental_decoders/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "ee599bfdf05431f914c41a42fd53a2de0ff13171730ec78c37cad57e77bd7936";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_continental_decoders/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "03afc978691202d9783f038b8bc6379de89ce428490c63bd393c1f7e17e55ff1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula-continental-hw-interfaces/default.nix
+++ b/distros/humble/nebula-continental-hw-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, autoware-cmake, nebula-continental-common, nebula-core-common, nebula-core-hw-interfaces, nebula-msgs }:
 buildRosPackage {
   pname = "ros-humble-nebula-continental-hw-interfaces";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_continental_hw_interfaces/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "ac623eefbb15e7c603934e04065a02e6b439596f51a27d5b59808c85ccd99c8e";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_continental_hw_interfaces/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "0f89b30fc5f3c940985296e3cec5c028aa600999b492ad465537719d64d069d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula-continental/default.nix
+++ b/distros/humble/nebula-continental/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-lint-auto, autoware-cmake, autoware-sensing-msgs, continental-msgs, continental-srvs, diagnostic-msgs, diagnostic-updater, geometry-msgs, message-filters, nebula-continental-common, nebula-continental-decoders, nebula-continental-hw-interfaces, nebula-core-common, nebula-core-ros, nebula-msgs, radar-msgs, rclcpp, rclcpp-components, ros-environment, ros-testing, rosbag2-cpp, sensor-msgs, sync-tooling-msgs, tf2-ros, visualization-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-nebula-continental";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_continental/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "35e6ee18e2db3518c581d54da50ada6db950c4aa606a020f46ffcfd32662bf1e";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_continental/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "48d36ead80a248020928fc4b7597434946ce598a2c6e491aaac47b8037d75526";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula-core-common/default.nix
+++ b/distros/humble/nebula-core-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-lint-auto, autoware-cmake, boost, nlohmann_json, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-nebula-core-common";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_core_common/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "b84a1b3c94884a82e0c48750999991bf1e5e81879e9fd89c43b4eade8fec0278";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_core_common/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "c7009be305cd7633e9ccb9060e8b117a5c3a5675ef63a5ccfb8ed1f4ad19bc5e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula-core-decoders/default.nix
+++ b/distros/humble/nebula-core-decoders/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-lint-auto, autoware-cmake, boost, eigen, libpng, nebula-core-common, pngpp, ros-environment, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-nebula-core-decoders";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_core_decoders/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "c3eeb37786ac950e01bdf064747df672323626e1f47ecd845e07afd2b86273a5";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_core_decoders/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "db7dcce7f78330505a9b00bac6b2336dc2b8182f185258444058fa7650b16e03";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula-core-hw-interfaces/default.nix
+++ b/distros/humble/nebula-core-hw-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-lint-auto, autoware-cmake, nebula-core-common }:
 buildRosPackage {
   pname = "ros-humble-nebula-core-hw-interfaces";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_core_hw_interfaces/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "f38caa924ddb9f7307e7a826ef94b77c0cd6e0b00d368c7a536d111238c94f8b";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_core_hw_interfaces/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "f2d419a59001ece609144e42252bc695af995a8b9a1dd22f568eb455a22c9c97";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula-core-ros/default.nix
+++ b/distros/humble/nebula-core-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-lint-auto, autoware-cmake, boost, diagnostic-msgs, diagnostic-updater, nebula-core-common, rclcpp, ros-environment, ros-testing, rosbag2-storage }:
 buildRosPackage {
   pname = "ros-humble-nebula-core-ros";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_core_ros/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "2832d959f2a9f90aa959c21d5273c79464b4257958c594f17ac4f0961416d35f";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_core_ros/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "bd4c065f2cfe23ef9a48bddb6b20fa706d8c1be2b09807ddc3b982ef542acc80";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula-hesai-common/default.nix
+++ b/distros/humble/nebula-hesai-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, autoware-cmake, nebula-core-common, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-nebula-hesai-common";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_hesai_common/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "704efecf7a0330709ba116e3ba2200db36c2fc6e413961552ee9d75eb68bdb89";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_hesai_common/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "b84579fbf0144164b14c05b1a66c9752439197814c5ed47e6de350ed0d24abc5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula-hesai-decoders/default.nix
+++ b/distros/humble/nebula-hesai-decoders/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, autoware-cmake, boost, nebula-core-common, nebula-core-decoders, nebula-hesai-common, rclcpp, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-nebula-hesai-decoders";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_hesai_decoders/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "72dc2299558112405c92f9dcb24a3b2443588636dd568489b433b027bfca1d76";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_hesai_decoders/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "3cf7d2e7c52b318b167aeb86c572d9fd7bbbc1f1676c6f210c5b3c230051e3b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula-hesai-hw-interfaces/default.nix
+++ b/distros/humble/nebula-hesai-hw-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, autoware-cmake, boost, nebula-core-common, nebula-core-hw-interfaces, nebula-hesai-common }:
 buildRosPackage {
   pname = "ros-humble-nebula-hesai-hw-interfaces";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_hesai_hw_interfaces/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "5553855d18f4c50594add4c86be72261d67a3b671e4ba386c1e713cf1b8ecbc1";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_hesai_hw_interfaces/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "2c1a8140a778ae4cfe732bbf6003b3476fa2220d7af343ca90f2a71e7ff7e524";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula-hesai/default.nix
+++ b/distros/humble/nebula-hesai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-lint-auto, autoware-cmake, autoware-internal-debug-msgs, autoware-utils-debug, boost, diagnostic-msgs, diagnostic-updater, nebula-core-common, nebula-core-decoders, nebula-core-hw-interfaces, nebula-core-ros, nebula-hesai-common, nebula-hesai-decoders, nebula-hesai-hw-interfaces, nebula-msgs, pandar-msgs, rclcpp, rclcpp-components, ros-environment, ros-testing, rosbag2-cpp, sensor-msgs, sync-tooling-msgs }:
 buildRosPackage {
   pname = "ros-humble-nebula-hesai";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_hesai/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "de4135e425c785b6826054cd68e10d98f73b82f952de289446cd3899ba404288";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_hesai/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "d20e196026516243e7e56bde58bbc44179c3e2f09ac2cf2990e1351ed380c6d9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula-msgs/default.nix
+++ b/distros/humble/nebula-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, autoware-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nebula-msgs";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "7f872ef4077b7a03b3a86332bf1767bea6f5fc36ce832bb6a47c363685084e80";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_msgs/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "c8b6d5cb2ac4128437624b1b3a2a0985895df4d63cef484433606c9b72720d46";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula-robosense-common/default.nix
+++ b/distros/humble/nebula-robosense-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, autoware-cmake, nebula-core-common, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-nebula-robosense-common";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_robosense_common/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "638a1b39bc54d6f11fb6af72f3484a894d7b61d736fcd1af97cc863e5802d2bb";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_robosense_common/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "c4e1f49c1f6121291765b9de36f723a35ab4f91b5d42ff17dee6eef5e931bd4a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula-robosense-decoders/default.nix
+++ b/distros/humble/nebula-robosense-decoders/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, autoware-cmake, boost, nebula-core-common, nebula-core-decoders, nebula-robosense-common, rclcpp, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-nebula-robosense-decoders";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_robosense_decoders/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "88d56144faec55d4632232ac6791dcaff5292bb073e6b955694d705c8d422441";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_robosense_decoders/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "1809e702277f0e94f220a5ef322d042601fb0c2c275756b66debbc987693b792";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula-robosense-hw-interfaces/default.nix
+++ b/distros/humble/nebula-robosense-hw-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, autoware-cmake, nebula-core-common, nebula-core-hw-interfaces, nebula-msgs, nebula-robosense-common, robosense-msgs }:
 buildRosPackage {
   pname = "ros-humble-nebula-robosense-hw-interfaces";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_robosense_hw_interfaces/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "b3baa431c36f343230bb23e576d891e90b13e2fe7fdeb4c37a616342560c5558";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_robosense_hw_interfaces/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "114eaf74aa287258cefb5cd107fd41e7f9c3c0c34ddb1fb686abbc1e1c4a1806";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula-robosense/default.nix
+++ b/distros/humble/nebula-robosense/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-lint-auto, autoware-cmake, boost, diagnostic-msgs, diagnostic-updater, nebula-core-common, nebula-core-decoders, nebula-core-hw-interfaces, nebula-core-ros, nebula-msgs, nebula-robosense-common, nebula-robosense-decoders, nebula-robosense-hw-interfaces, rclcpp, rclcpp-components, robosense-msgs, ros-environment, ros-testing, sensor-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-nebula-robosense";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_robosense/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "c02f91fc95dc6beb5accb62ba313d3714d4eb0f6d96f029add2eed121b2cd80d";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_robosense/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "519d465e098878d3cc7aed3185674e01d481ca66b9d8043208e11dee066187ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula-sample-common/default.nix
+++ b/distros/humble/nebula-sample-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, autoware-cmake, nebula-core-common, nebula-core-decoders, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-nebula-sample-common";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_sample_common/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "c57edd011aa2f1cdf53eb19df6a66384803ee71432124afeb78ef404cf92da56";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_sample_common/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "448cbf2268ea81bed0ee4f883d1fb5a80ce711e4224aac6341e9f7eca56158ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula-sample-decoders/default.nix
+++ b/distros/humble/nebula-sample-decoders/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, autoware-cmake, nebula-core-common, nebula-core-decoders, nebula-sample-common, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-nebula-sample-decoders";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_sample_decoders/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "5d4d0498e45de13e93d045a2fb2432f9d3911ff009d7c7eca32081221e82c09a";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_sample_decoders/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "2db44dd8eb5af1987dcff088f65b5faea19c94ff3113a7d176992b2324d54ce7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula-sample-hw-interfaces/default.nix
+++ b/distros/humble/nebula-sample-hw-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, autoware-cmake, nebula-core-common, nebula-core-hw-interfaces, nebula-sample-common }:
 buildRosPackage {
   pname = "ros-humble-nebula-sample-hw-interfaces";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_sample_hw_interfaces/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "0b15cb40a6a43e73bf9ebe3534e4621bc7a36fd7a0fcc9fea1fdfff385ed125e";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_sample_hw_interfaces/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "79aaba1218223635e3bed2c4db24e1cf96c4e093690e9f8b3efaf2cf23d18e31";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula-sample/default.nix
+++ b/distros/humble/nebula-sample/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, autoware-cmake, diagnostic-msgs, diagnostic-updater, nebula-core-common, nebula-core-ros, nebula-msgs, nebula-sample-common, nebula-sample-decoders, nebula-sample-hw-interfaces, rclcpp, rclcpp-components, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nebula-sample";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_sample/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "60e9f8fcff8c05630f5793a5274feedb80c2106ddfe8cb0dce9cec9c2e9ddb36";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_sample/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "56e321a8281157561f4dbf473c7a8affb078aef614da596d27bcfc359e17e0cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula-velodyne-common/default.nix
+++ b/distros/humble/nebula-velodyne-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, autoware-cmake, nebula-core-common, ros-environment, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-nebula-velodyne-common";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_velodyne_common/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "4bcf583bcd51c62e53ce5faf801bc075d121ad49c82f5bc888d670680917dde1";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_velodyne_common/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "2083e2b839456b411fa635d7b64da62a2cfcb8ee26b22bf604820aca44968e91";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula-velodyne-decoders/default.nix
+++ b/distros/humble/nebula-velodyne-decoders/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, autoware-cmake, boost, nebula-core-common, nebula-core-decoders, nebula-velodyne-common, rclcpp, ros-environment, velodyne-msgs }:
 buildRosPackage {
   pname = "ros-humble-nebula-velodyne-decoders";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_velodyne_decoders/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "1643d9c06b6c00836b1abc2017fb06028902a5b9279f1f1d84918bbcf1df5db3";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_velodyne_decoders/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "553bba0359639735b66a7c3463a202a1b3aa374748ed0b99da5d56733ac88dfd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula-velodyne-hw-interfaces/default.nix
+++ b/distros/humble/nebula-velodyne-hw-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, autoware-cmake, boost, nebula-core-common, nebula-core-hw-interfaces, nebula-velodyne-common }:
 buildRosPackage {
   pname = "ros-humble-nebula-velodyne-hw-interfaces";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_velodyne_hw_interfaces/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "b6c289a98084af9259ded2da8836790b66e0c394625bb3df5885ef5137191139";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_velodyne_hw_interfaces/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "681451db390549174d49e7fc8e70ec0f63665cb16f19950acb14ec1ace070d43";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula-velodyne/default.nix
+++ b/distros/humble/nebula-velodyne/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-lint-auto, autoware-cmake, boost, diagnostic-msgs, diagnostic-updater, nebula-core-common, nebula-core-decoders, nebula-core-hw-interfaces, nebula-core-ros, nebula-msgs, nebula-velodyne-common, nebula-velodyne-decoders, nebula-velodyne-hw-interfaces, rclcpp, rclcpp-components, ros-environment, ros-testing, rosbag2-cpp, velodyne-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-nebula-velodyne";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_velodyne/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "8d84f05f236faff1adc01f4a9f80644b676fa72c0c012416cef4c696cca70581";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula_velodyne/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "ddeb407579578e2308bad2900318b4af1d3e8783d53d640e265fe68e09d60bec";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nebula/default.nix
+++ b/distros/humble/nebula/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nebula-continental, nebula-hesai, nebula-robosense, nebula-velodyne }:
 buildRosPackage {
   pname = "ros-humble-nebula";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "1fe02393714cbf0a98464576a74842afca5613d86b3a73ea75f6b7e438f774b2";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/nebula/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "1f2d3d2d9148ca2074ce20c78d54895106d5c347c8d42f0ee30b6f2f7a93c892";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/novatel-gps-driver/default.nix
+++ b/distros/humble/novatel-gps-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, boost, diagnostic-msgs, diagnostic-updater, gps-msgs, libpcap, nav-msgs, novatel-gps-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, swri-math-util, swri-roscpp, swri-serial-util, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-novatel-gps-driver";
-  version = "4.2.1-r1";
+  version = "4.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/humble/novatel_gps_driver/4.2.1-1.tar.gz";
-    name = "4.2.1-1.tar.gz";
-    sha256 = "90025c94343f41535b32cf4e942a26eb47efed8c4a28aca4b6453754498efb97";
+    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/humble/novatel_gps_driver/4.3.0-1.tar.gz";
+    name = "4.3.0-1.tar.gz";
+    sha256 = "836b40ed0fe4041f42464ccb91b1071693bcec895db943f30b29d9f0f0575266";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/novatel-gps-msgs/default.nix
+++ b/distros/humble/novatel-gps-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-novatel-gps-msgs";
-  version = "4.2.1-r1";
+  version = "4.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/humble/novatel_gps_msgs/4.2.1-1.tar.gz";
-    name = "4.2.1-1.tar.gz";
-    sha256 = "d981fa355fce17bc8aae1d33bbeda097da8649ad11c605d6876c062e33bd3e04";
+    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/humble/novatel_gps_msgs/4.3.0-1.tar.gz";
+    name = "4.3.0-1.tar.gz";
+    sha256 = "a402a7d7a19c0e7f267794234c11b7f09552ca005743ed3d4e05d343b2059e17";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -303,14 +303,14 @@ in with lib; {
       # https://github.com/foxglove/foxglove-sdk/blob/main/ros/src/foxglove_bridge/CMakeLists.txt.
       # If the version doesn't match, cmake fails with "Hash mismatch"
       # and we can fix it here.
-      FOXGLOVE_SDK_VERSION = "0.23.1";
+      FOXGLOVE_SDK_VERSION = "0.25.1";
       systemToPlatform = {
         "x86_64-linux" = "x86_64-unknown-linux-gnu";
         "aarch64-linux" = "aarch64-unknown-linux-gnu";
       };
       systemToHash = {
-        "x86_64-linux" = "sha256-uUkpXoDrGpuzVuZXucJXnIhnF/rCkMTkil6YRgY78ug=";
-        "aarch64-linux" = "sha256-7CC88ap2n8m3bYT/PhXA3z8KKz7lbrfuRePx5DBmILw=";
+        "x86_64-linux" = "sha256-C500jfOo6Y0sLO4jYMyfUug7s0RQRN69dx0bRtw1i+Q=";
+        "aarch64-linux" = "sha256-xw41x48ON/O6jQJRzTHzU7sQsf0QYgDcbF9AntTfGRg=";
       };
       FOXGLOVE_SDK_PLATFORM = systemToPlatform.${self.system};
       sdk = self.fetchurl {

--- a/distros/humble/pandar-msgs/default.nix
+++ b/distros/humble/pandar-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, autoware-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-pandar-msgs";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/pandar_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "1f200959b9abe2246a7e80373c9ca1f41904d9b18b6f1802c2472ffdb05a3d1d";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/pandar_msgs/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "2e1b862c6d7e2870b7e740c2d402dc408f253b4b2bb7f048456fdaf5c57daa41";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/robosense-msgs/default.nix
+++ b/distros/humble/robosense-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, autoware-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-robosense-msgs";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/robosense_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "17cb96547f802fa54f94509f655c16f36bf318eb4f591cf8aa156fe9d9cdedc6";
+    url = "https://github.com/ros2-gbp/nebula-release/archive/release/humble/robosense_msgs/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "eeed20b9f8a8bc33c57d50df71bfbc95a4d9419218d3fc1b84c2ebc24636746c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-adapter/default.nix
+++ b/distros/humble/rosidl-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3, python3Packages, rosidl-cli }:
 buildRosPackage {
   pname = "ros-humble-rosidl-adapter";
-  version = "3.1.8-r1";
+  version = "3.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_adapter/3.1.8-1.tar.gz";
-    name = "3.1.8-1.tar.gz";
-    sha256 = "4c6b523cccd050a16fd51d8980c65d4b765fe412098c62f8f1963630fdd6af85";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_adapter/3.1.9-1.tar.gz";
+    name = "3.1.9-1.tar.gz";
+    sha256 = "d4d12de6b489520e7bbff3a21e5a2e0699f43f5b387f5eb7e2e78494937e9a1e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-cli/default.nix
+++ b/distros/humble/rosidl-cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-rosidl-cli";
-  version = "3.1.8-r1";
+  version = "3.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_cli/3.1.8-1.tar.gz";
-    name = "3.1.8-1.tar.gz";
-    sha256 = "30428290027ef855b076b3b4b22601ebdc63e586c040cdfc1e840d0d8ffaa1ee";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_cli/3.1.9-1.tar.gz";
+    name = "3.1.9-1.tar.gz";
+    sha256 = "c5ae7836304c7e36ffec7898975c6201e5c1e6d24b8562c26106334cfc70014d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rosidl-cmake/default.nix
+++ b/distros/humble/rosidl-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python3Packages, rosidl-adapter, rosidl-parser }:
 buildRosPackage {
   pname = "ros-humble-rosidl-cmake";
-  version = "3.1.8-r1";
+  version = "3.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_cmake/3.1.8-1.tar.gz";
-    name = "3.1.8-1.tar.gz";
-    sha256 = "b6b1408059bf52bd183762d7b0797d30e28a146975081eed239a5e7ca506bd0b";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_cmake/3.1.9-1.tar.gz";
+    name = "3.1.9-1.tar.gz";
+    sha256 = "4298c11d1b68e924d668eaf30a26a4232fcb7f1a3f8500b9d1eefa84e982ed88";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-generator-c/default.nix
+++ b/distros/humble/rosidl-generator-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rcutils, rosidl-cli, rosidl-cmake, rosidl-parser, rosidl-runtime-c, rosidl-typesupport-interface, test-interface-files }:
 buildRosPackage {
   pname = "ros-humble-rosidl-generator-c";
-  version = "3.1.8-r1";
+  version = "3.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_generator_c/3.1.8-1.tar.gz";
-    name = "3.1.8-1.tar.gz";
-    sha256 = "2fa0a9db600c3e2d50f082fd22a4ecddd7916e03c591db634baa3c97138235cf";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_generator_c/3.1.9-1.tar.gz";
+    name = "3.1.9-1.tar.gz";
+    sha256 = "6cca4eba3d8bb204f7886dd177281d6bc2c3c12e830c1a2c8e2abf871a87a57a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-generator-cpp/default.nix
+++ b/distros/humble/rosidl-generator-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-parser, rosidl-runtime-c, rosidl-runtime-cpp, test-interface-files }:
 buildRosPackage {
   pname = "ros-humble-rosidl-generator-cpp";
-  version = "3.1.8-r1";
+  version = "3.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_generator_cpp/3.1.8-1.tar.gz";
-    name = "3.1.8-1.tar.gz";
-    sha256 = "2128a7c99eae786ef48e46f58c85785c16f3d822ce67b4fe3a201fc897c78dc6";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_generator_cpp/3.1.9-1.tar.gz";
+    name = "3.1.9-1.tar.gz";
+    sha256 = "c80fcb31e65fff8cae908e4f4e8236dd31db6d1069b7bd503afd5291df396fbe";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-parser/default.nix
+++ b/distros/humble/rosidl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, rosidl-adapter }:
 buildRosPackage {
   pname = "ros-humble-rosidl-parser";
-  version = "3.1.8-r1";
+  version = "3.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_parser/3.1.8-1.tar.gz";
-    name = "3.1.8-1.tar.gz";
-    sha256 = "4f69402bbd55e56fcabf89fb7e65440cd9eded6ea65e91d10368569b34106e5e";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_parser/3.1.9-1.tar.gz";
+    name = "3.1.9-1.tar.gz";
+    sha256 = "c93c46331367eceb89354758829cd70e2a80e6a360e7e2c6eaa21b11c06946f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-runtime-c/default.nix
+++ b/distros/humble/rosidl-runtime-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, performance-test-fixture, rcutils, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-humble-rosidl-runtime-c";
-  version = "3.1.8-r1";
+  version = "3.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_runtime_c/3.1.8-1.tar.gz";
-    name = "3.1.8-1.tar.gz";
-    sha256 = "f53fdf7e187cd394440535089bb7074a662edfa6a31937c170d691467304072a";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_runtime_c/3.1.9-1.tar.gz";
+    name = "3.1.9-1.tar.gz";
+    sha256 = "b1b99f97678818c92bc556f3ea4c0458ddec69eb0226894cff4fbf6f22e274be";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-runtime-cpp/default.nix
+++ b/distros/humble/rosidl-runtime-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, performance-test-fixture, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-humble-rosidl-runtime-cpp";
-  version = "3.1.8-r1";
+  version = "3.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_runtime_cpp/3.1.8-1.tar.gz";
-    name = "3.1.8-1.tar.gz";
-    sha256 = "a22d8e03134e70f9087f109d90f5fc8c04c1944a3fefe8f5ce6dcdbe1ba25f5d";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_runtime_cpp/3.1.9-1.tar.gz";
+    name = "3.1.9-1.tar.gz";
+    sha256 = "03c4b8b2456be9f9f432f230b07a3276e733a398a6162758c437261463f5543a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-typesupport-interface/default.nix
+++ b/distros/humble/rosidl-typesupport-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-rosidl-typesupport-interface";
-  version = "3.1.8-r1";
+  version = "3.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_typesupport_interface/3.1.8-1.tar.gz";
-    name = "3.1.8-1.tar.gz";
-    sha256 = "d8da49c9ae1531e4ee6114db4cfc17bee5a724b03e3010675421b73a47f6d425";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_typesupport_interface/3.1.9-1.tar.gz";
+    name = "3.1.9-1.tar.gz";
+    sha256 = "9d589de2e53cb704fa4cbd274fbe68e13cf8ee8f1fc5a2b05460030b3a086f11";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-typesupport-introspection-c/default.nix
+++ b/distros/humble/rosidl-typesupport-introspection-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-parser, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-humble-rosidl-typesupport-introspection-c";
-  version = "3.1.8-r1";
+  version = "3.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_typesupport_introspection_c/3.1.8-1.tar.gz";
-    name = "3.1.8-1.tar.gz";
-    sha256 = "c418de6ce44f996b66fc18b49c16cd5a2f3ec700b1a2896f1a0fb4a4df3cecb5";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_typesupport_introspection_c/3.1.9-1.tar.gz";
+    name = "3.1.9-1.tar.gz";
+    sha256 = "4b3809680d6c80258e04204225dd230de3ec08c76d13bf4fec0c81ddc11e6032";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-typesupport-introspection-cpp/default.nix
+++ b/distros/humble/rosidl-typesupport-introspection-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-parser, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidl-typesupport-introspection-c }:
 buildRosPackage {
   pname = "ros-humble-rosidl-typesupport-introspection-cpp";
-  version = "3.1.8-r1";
+  version = "3.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_typesupport_introspection_cpp/3.1.8-1.tar.gz";
-    name = "3.1.8-1.tar.gz";
-    sha256 = "331464b37269369367f95b69e572da01176ff5e5e88d551b1d6fc06f73c1d111";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_typesupport_introspection_cpp/3.1.9-1.tar.gz";
+    name = "3.1.9-1.tar.gz";
+    sha256 = "1d5490bd1fefba4e4c0f9b4a319f78da0f5a852fda0b3e86daa4d5879b6bbf2e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-cli-tools/default.nix
+++ b/distros/humble/swri-cli-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, marti-introspection-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, ros2topic }:
 buildRosPackage {
   pname = "ros-humble-swri-cli-tools";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_cli_tools/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "e9ac4e3a838bbe5f7a365522cad24a713ff9c93f4276a03f1e7ea0a7b202de37";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_cli_tools/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "8f5c4389b9aba929878945c7f21d5ec41479c2d34eb34f5bb6e0a62130173605";
   };
 
   buildType = "ament_python";

--- a/distros/humble/swri-console-util/default.nix
+++ b/distros/humble/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-swri-console-util";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_console_util/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "adc90207dfecc00117c13b0058665d0bad3544ac74017ef0ed63717eaf6c63f6";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_console_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "4a27f513abc851beb0b92bdf571f77c745394995a7e0c97a305f7cdf57c3a011";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-dbw-interface/default.nix
+++ b/distros/humble/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-swri-dbw-interface";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_dbw_interface/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "310699805d60f97d0dfc428f27eb31fa526d7d05fb81bc7e04a6462852555d84";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_dbw_interface/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "4f2d54f25b56198511b6af6454997114cb4037c1155bc3ad7bb2876bb502e474";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-geometry-util/default.nix
+++ b/distros/humble/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, geos, opencv, pkg-config, tf2 }:
 buildRosPackage {
   pname = "ros-humble-swri-geometry-util";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_geometry_util/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "f8bed57998f4da2edb60ccce80089e8cc7077d014ca06cc026b4bcc5f3ab855e";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_geometry_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "af7850f4da6c60249091bd1b0c5408e46799ce699b1621c734f0811b34dfeab5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-image-util/default.nix
+++ b/distros/humble/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, camera-calibration-parsers, cv-bridge, eigen, image-geometry, image-transport, message-filters, opencv, pkg-config, rcl-interfaces, rclcpp, rclcpp-components, rclpy, swri-geometry-util, swri-math-util, swri-opencv-util, tf2 }:
 buildRosPackage {
   pname = "ros-humble-swri-image-util";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_image_util/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "3eaed4f2d40be70a64d43626af747d1b4b74c883b6256bcc943e4ae860805137";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_image_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "02b4ad351e9ce44a1390f4e47bd3dd91ff2b02842869eb15baf29fccc1dafb90";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-math-util/default.nix
+++ b/distros/humble/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-swri-math-util";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_math_util/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "8ae0e3804d09d2e0b1bb91872d7e8bf3196ada73f58044d0f92319248acae55b";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_math_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "ce5a677ba22c40ef2de9898b5292e13c09916811d8357af1b823d64e27eb9baf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-opencv-util/default.nix
+++ b/distros/humble/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, opencv, swri-math-util }:
 buildRosPackage {
   pname = "ros-humble-swri-opencv-util";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_opencv_util/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "67812c233c1382905945ce1efca065b45a892ec746589b8ff94c0907001f6d71";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_opencv_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "0afa2c2e973bd0ac5d2bf155b677cdd53d921485fb365364d7e1f585628b6801";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-roscpp/default.nix
+++ b/distros/humble/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, diagnostic-msgs, diagnostic-updater, gtest, marti-common-msgs, nav-msgs, rclcpp, ros-environment, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-swri-roscpp";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_roscpp/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "ae1f7e457f69d86c10a20ecf7c88eaa8d15039d31da3ce7b66547183d1ebeb54";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_roscpp/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "071131604cb318efb11b9b06b621c6d45d73964a7ef3ea906840ae46317189f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-route-util/default.nix
+++ b/distros/humble/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-transform-util, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-swri-route-util";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_route_util/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "76a695dc0733abe5fcaf7fe88d696835b05f511fbf2f7943236391f38ae70ebb";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_route_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "4ccd78a13ea235e950c970884cd2fe17553d455df2cbd9feb664337e3d282008";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-serial-util/default.nix
+++ b/distros/humble/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-swri-serial-util";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_serial_util/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "794eddb114d8bf5a77cf25788b1efe09bdb1f4331d5f3373cab68f764f0fb2ce";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_serial_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "964aab53d0822de424c4849f524ab2b49559a87a6833f20da0cb3aa085c1e4f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-transform-util/default.nix
+++ b/distros/humble/swri-transform-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-index-cpp, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geographiclib, geometry-msgs, geos, gps-msgs, launch-ros, launch-testing, launch-testing-ament-cmake, marti-nav-msgs, opencv, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-swri-transform-util";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_transform_util/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "8aaa355a25311f1fd4389f0170dc8a537a2345563985a54e583e0c5c41739474";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_transform_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "7378b636a567bdae1df09cc4c6bd81270743a44a994e4eaeeedd4b7b5a28f28e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/sync-tooling-msgs/default.nix
+++ b/distros/humble/sync-tooling-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, protobuf }:
 buildRosPackage {
   pname = "ros-humble-sync-tooling-msgs";
-  version = "0.2.9-r1";
+  version = "0.2.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sync_tooling_msgs-release/archive/release/humble/sync_tooling_msgs/0.2.9-1.tar.gz";
-    name = "0.2.9-1.tar.gz";
-    sha256 = "dbd265944c01f628d30ab9d0fc4678b47aea8372ae7b5f18bc63136a20376977";
+    url = "https://github.com/ros2-gbp/sync_tooling_msgs-release/archive/release/humble/sync_tooling_msgs/0.2.10-1.tar.gz";
+    name = "0.2.10-1.tar.gz";
+    sha256 = "d10a9fe27f6456cf2d44a0c1b9409ebff0a7db9a17bfb962df3220142e3d0148";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tile-map/default.nix
+++ b/distros/humble/tile-map/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, glew, jsoncpp, mapviz, pluginlib, qt5, rclcpp, swri-math-util, swri-transform-util, tf2, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-tile-map";
-  version = "2.6.4-r1";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/tile_map/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "33983610fa6717ec906380b796e1655b9a06c4250ca8d021c2dfa9c6c5ed0f42";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/tile_map/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "00a964deb18877a67abb19025e6a522473e5a68a93020fe20b063f5c8d786462";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/visp/default.nix
+++ b/distros/humble/visp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bzip2, cmake, doxygen, eigen, gsl, libjpeg, liblapack, libpng, libv4l, libx11, libxml2, llvmPackages, nlohmann_json, openblas, opencv, zbar }:
 buildRosPackage {
   pname = "ros-humble-visp";
-  version = "3.7.0-r7";
+  version = "3.7.0-r8";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/visp-release/archive/release/humble/visp/3.7.0-7.tar.gz";
-    name = "3.7.0-7.tar.gz";
-    sha256 = "6dc5817fa4051501ddfbe0a6cb622fae06af73105f16a4a15aeac2c11f123b76";
+    url = "https://github.com/ros2-gbp/visp-release/archive/release/humble/visp/3.7.0-8.tar.gz";
+    name = "3.7.0-8.tar.gz";
+    sha256 = "310a214606f97accba97b4aeb92b1b4870fe1134cd60414f8084f132ca765045";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/action-tutorials-cpp/default.nix
+++ b/distros/jazzy/action-tutorials-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-action, rclcpp-components }:
 buildRosPackage {
   pname = "ros-jazzy-action-tutorials-cpp";
-  version = "0.33.10-r1";
+  version = "0.33.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/action_tutorials_cpp/0.33.10-1.tar.gz";
-    name = "0.33.10-1.tar.gz";
-    sha256 = "57b7fb3cd5a80be3b6608ba395537ea9f80b70fdfb62b36d7134f68547ef4c53";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/action_tutorials_cpp/0.33.11-1.tar.gz";
+    name = "0.33.11-1.tar.gz";
+    sha256 = "5b1e0427a18664fc7a8bc5f011bbbfc35130e9096121b26a0b82521086a8d988";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/action-tutorials-interfaces/default.nix
+++ b/distros/jazzy/action-tutorials-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-action-tutorials-interfaces";
-  version = "0.33.10-r1";
+  version = "0.33.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/action_tutorials_interfaces/0.33.10-1.tar.gz";
-    name = "0.33.10-1.tar.gz";
-    sha256 = "638d0d3a193d9615181a638c212aaacf4e8ea029357ba9ac0d384e99cb7bec7c";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/action_tutorials_interfaces/0.33.11-1.tar.gz";
+    name = "0.33.11-1.tar.gz";
+    sha256 = "e3f426f93508a18b1d2fbec816407d816356606a5e564185b51126444ce0a9f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/action-tutorials-py/default.nix
+++ b/distros/jazzy/action-tutorials-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-copyright, ament-flake8, ament-pep257, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-action-tutorials-py";
-  version = "0.33.10-r1";
+  version = "0.33.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/action_tutorials_py/0.33.10-1.tar.gz";
-    name = "0.33.10-1.tar.gz";
-    sha256 = "ffe5eac980b05be0590955cb4e05812f0dbbf76e451bac1746c4528752d9e4bc";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/action_tutorials_py/0.33.11-1.tar.gz";
+    name = "0.33.11-1.tar.gz";
+    sha256 = "5999e4ae25b689ed085eca5212814365a3b96caeed79c98ae8f60853855fbf87";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ament-cmake-ros/default.nix
+++ b/distros/jazzy/ament-cmake-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, domain-coordinator }:
 buildRosPackage {
   pname = "ros-jazzy-ament-cmake-ros";
-  version = "0.12.0-r3";
+  version = "0.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/jazzy/ament_cmake_ros/0.12.0-3.tar.gz";
-    name = "0.12.0-3.tar.gz";
-    sha256 = "94deffbc6124619c8761bea8203d01b58f787b0c7a214210080f630025fde8fe";
+    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/jazzy/ament_cmake_ros/0.12.1-1.tar.gz";
+    name = "0.12.1-1.tar.gz";
+    sha256 = "e864e3f2045c851d8704e6caf624f482a921a5ef83ed094ab037d6e0b52d5141";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/backward-global-planner/default.nix
+++ b/distros/jazzy/backward-global-planner/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, angles, forward-global-planner, geometry-msgs, nav-2d-utils, nav-msgs, nav2-core, nav2-costmap-2d, tf2, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-backward-global-planner";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/backward_global_planner/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "3c0e3541124b4cd5a0efc8421cc93b923dec161378e1180f4cf1dfb274553811";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ angles forward-global-planner geometry-msgs nav-2d-utils nav-msgs nav2-core nav2-costmap-2d tf2 visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The backward_global_planner package.";
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/jazzy/backward-local-planner/default.nix
+++ b/distros/jazzy/backward-local-planner/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-2d-utils, nav-msgs, nav2-core, nav2-costmap-2d, nav2z-planners-common, std-msgs, tf2 }:
+buildRosPackage {
+  pname = "ros-jazzy-backward-local-planner";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/backward_local_planner/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "b8bdeb2e3f58c965fe4e4518f5602b737a16a7f34839c05a065ddbfbd005dfe5";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ geometry-msgs nav-2d-utils nav-msgs nav2-core nav2-costmap-2d nav2z-planners-common std-msgs tf2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The backward_local_planner package.";
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/jazzy/cl-foundation-pose/default.nix
+++ b/distros/jazzy/cl-foundation-pose/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, smacc2, tf2-geometry-msgs, tf2-ros, vision-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-cl-foundation-pose";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/cl_foundation_pose/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "98f1cc88ba3b019c480bc89ce80e0e351569ffd8c75fa4ca6d96f31fcd72705e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ geometry-msgs smacc2 tf2-geometry-msgs tf2-ros vision-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "SMACC2 client for NVIDIA Foundation Pose object tracking";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/cl-gcalcli/default.nix
+++ b/distros/jazzy/cl-gcalcli/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, smacc2 }:
+buildRosPackage {
+  pname = "ros-jazzy-cl-gcalcli";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/cl_gcalcli/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "98688bdcf9d0945706976bbb41349de7904fe34f0150cef262ecb22c04078976";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ smacc2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "SMACC2 client library for Google Calendar integration via gcalcli";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/cl-generic-sensor/default.nix
+++ b/distros/jazzy/cl-generic-sensor/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, smacc2, smacc2-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-cl-generic-sensor";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/cl_generic_sensor/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "3a777248151dd74ececf9dd98e7e78ecc8e63ac9e8cc984b086c183885f70e61";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ smacc2 smacc2-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The cl_generic_sensor package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/cl-http/default.nix
+++ b/distros/jazzy/cl-http/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, smacc2 }:
+buildRosPackage {
+  pname = "ros-jazzy-cl-http";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/cl_http/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "5b5256762ca53245175c694208c354df0c55be1a9c2b602f37e605db9260ff1f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ smacc2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The cl_http package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/cl-keyboard/default.nix
+++ b/distros/jazzy/cl-keyboard/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, smacc2, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-cl-keyboard";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/cl_keyboard/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "2837ab673010f0cbcf663ea3b5eac5cededf12b4995269b4eb2042fbdcffd16f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ smacc2 std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The cl_keyboard package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/cl-lifecycle-node/default.nix
+++ b/distros/jazzy/cl-lifecycle-node/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rclcpp, rclcpp-lifecycle, smacc2 }:
+buildRosPackage {
+  pname = "ros-jazzy-cl-lifecycle-node";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/cl_lifecycle_node/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "6a7231b05b922fe8fc715b7aebd62a834fb2e367ac06b25fa46f8bad01dfb834";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ rclcpp rclcpp-lifecycle smacc2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The cl_lifecycle_node package implements SMACC Action Client Plugin for the ROS Navigation State - move_base node.  Developed by Reel Robotics.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/cl-mission-tracker/default.nix
+++ b/distros/jazzy/cl-mission-tracker/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, smacc2 }:
+buildRosPackage {
+  pname = "ros-jazzy-cl-mission-tracker";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/cl_mission_tracker/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "69dcc3b6c848e5164dc19bab654f49fd6c2264041468bd52b826c4e584cbef67";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ smacc2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "SMACC2 client for mission state and decision tracking";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/cl-modbus-tcp-relay/default.nix
+++ b/distros/jazzy/cl-modbus-tcp-relay/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, libmodbus, pkg-config, rclcpp, smacc2 }:
+buildRosPackage {
+  pname = "ros-jazzy-cl-modbus-tcp-relay";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/cl_modbus_tcp_relay/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "b41dee8abe62af9bf2dc2897217809f674ef951e90889c4195814998d65c1db4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake pkg-config ];
+  propagatedBuildInputs = [ libmodbus rclcpp smacc2 ];
+  nativeBuildInputs = [ ament-cmake pkg-config ];
+
+  meta = {
+    description = "SMACC2 client for Modbus TCP relay control (8-channel Waveshare POE ETH Relay)";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/cl-moveit2z/default.nix
+++ b/distros/jazzy/cl-moveit2z/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, moveit-ros-planning-interface, smacc2, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp, yaml-cpp-vendor }:
+buildRosPackage {
+  pname = "ros-jazzy-cl-moveit2z";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/cl_moveit2z/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "5a932e90a5df8009b73a9755620d86a5e65878d1b34015cb1313320f6dd43e2b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ament-index-cpp moveit-ros-planning-interface smacc2 tf2 tf2-geometry-msgs tf2-ros yaml-cpp yaml-cpp-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The cl_moveit2z package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/cl-nav2z/default.nix
+++ b/distros/jazzy/cl-nav2z/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, angles, bond, nav-2d-utils, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp-action, slam-toolbox, smacc2, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, yaml-cpp-vendor }:
+buildRosPackage {
+  pname = "ros-jazzy-cl-nav2z";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/cl_nav2z/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "6dd68b415bd1dd021135392990a705fc452f992a1dc6496f4119e71933f4631b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ament-index-cpp angles bond nav-2d-utils nav2-core nav2-costmap-2d nav2-msgs nav2-util pluginlib rclcpp-action slam-toolbox smacc2 std-msgs std-srvs tf2-geometry-msgs tf2-ros yaml-cpp-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The cl_nav2z package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/cl-px4-mr/default.nix
+++ b/distros/jazzy/cl-px4-mr/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, _unresolved_px4_msgs, ament-cmake, rclcpp, smacc2 }:
+buildRosPackage {
+  pname = "ros-jazzy-cl-px4-mr";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/cl_px4_mr/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "991142bc4406304081894c3e9f9b69fe1bcf737aab0e533220b88b6b08d1c4ce";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ _unresolved_px4_msgs rclcpp smacc2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "SMACC2 client library for PX4 multirotor control via ROS 2 XRCE-DDS";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/cl-ros2-timer/default.nix
+++ b/distros/jazzy/cl-ros2-timer/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, smacc2 }:
+buildRosPackage {
+  pname = "ros-jazzy-cl-ros2-timer";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/cl_ros2_timer/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "67fcc94d5cc18af1cb0f212ef53c09eafdecb8ab68cb8bb47e7d98bdf97e21a3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ smacc2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The cl_ros2_timer package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/class-loader/default.nix
+++ b/distros/jazzy/class-loader/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, console-bridge, console-bridge-vendor, rcpputils }:
 buildRosPackage {
   pname = "ros-jazzy-class-loader";
-  version = "2.7.0-r3";
+  version = "2.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/class_loader-release/archive/release/jazzy/class_loader/2.7.0-3.tar.gz";
-    name = "2.7.0-3.tar.gz";
-    sha256 = "87166eb87b5c9b1dd52b53108a70153ac0b3301141fc7b01ebf1641ce8dc6d43";
+    url = "https://github.com/ros2-gbp/class_loader-release/archive/release/jazzy/class_loader/2.7.1-1.tar.gz";
+    name = "2.7.1-1.tar.gz";
+    sha256 = "1f4f508fc7497ff7f0676983508e7b15658bc9906149be54540353b58b8cb249";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-config/default.nix
+++ b/distros/jazzy/clearpath-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-config";
-  version = "2.9.3-r1";
+  version = "2.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/jazzy/clearpath_config/2.9.3-1.tar.gz";
-    name = "2.9.3-1.tar.gz";
-    sha256 = "29062138d46850bed8bb6ec62e72c0ada079d14590f2bb7a61c0e91dc2642823";
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/jazzy/clearpath_config/2.9.4-1.tar.gz";
+    name = "2.9.4-1.tar.gz";
+    sha256 = "66676635f03f1bc9808963f8e307cf8407377ff7ca12d0ea2e281e2678755b11";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/composition/default.nix
+++ b/distros/jazzy/composition/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-composition";
-  version = "0.33.10-r1";
+  version = "0.33.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/composition/0.33.10-1.tar.gz";
-    name = "0.33.10-1.tar.gz";
-    sha256 = "462e13e3e0583ceece4f75fd9fb7162de24a1b4fce627dc3f43d1fd558d98aa9";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/composition/0.33.11-1.tar.gz";
+    name = "0.33.11-1.tar.gz";
+    sha256 = "c7ee336982f0fb09e8bf571256158e1fa7acf5785aa6e2112fcf10d7d0bf27ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/console-bridge-vendor/default.nix
+++ b/distros/jazzy/console-bridge-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-lint-auto, ament-lint-common, console-bridge, performance-test-fixture }:
 buildRosPackage {
   pname = "ros-jazzy-console-bridge-vendor";
-  version = "1.7.1-r3";
+  version = "1.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/console_bridge_vendor-release/archive/release/jazzy/console_bridge_vendor/1.7.1-3.tar.gz";
-    name = "1.7.1-3.tar.gz";
-    sha256 = "3331c618cf351f15480d2090374647b5b842a4e42b6e565d080c5caa35b3987b";
+    url = "https://github.com/ros2-gbp/console_bridge_vendor-release/archive/release/jazzy/console_bridge_vendor/1.7.2-1.tar.gz";
+    name = "1.7.2-1.tar.gz";
+    sha256 = "45819ea2807982fc81b22fa0cb85ba05860c2c814e9477bf4ee95a8f7e7b405b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/demo-nodes-cpp-native/default.nix
+++ b/distros/jazzy/demo-nodes-cpp-native/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rmw-fastrtps-cpp, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-demo-nodes-cpp-native";
-  version = "0.33.10-r1";
+  version = "0.33.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/demo_nodes_cpp_native/0.33.10-1.tar.gz";
-    name = "0.33.10-1.tar.gz";
-    sha256 = "3aecbff747a8c483f3692e33d631ab54c8db15ed4a5965552d04616668348860";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/demo_nodes_cpp_native/0.33.11-1.tar.gz";
+    name = "0.33.11-1.tar.gz";
+    sha256 = "a26430e881bdb83562b94544d6bf76318fa1d528299da01404e250677228a28d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/demo-nodes-cpp/default.nix
+++ b/distros/jazzy/demo-nodes-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, launch-xml, rcl, rcl-interfaces, rclcpp, rclcpp-components, rcpputils, rcutils, rmw, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-demo-nodes-cpp";
-  version = "0.33.10-r1";
+  version = "0.33.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/demo_nodes_cpp/0.33.10-1.tar.gz";
-    name = "0.33.10-1.tar.gz";
-    sha256 = "45f28295e50de2ef9ec3289b07e6e69b7f53e41041c676a8af856f34c817a10f";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/demo_nodes_cpp/0.33.11-1.tar.gz";
+    name = "0.33.11-1.tar.gz";
+    sha256 = "761b46ab7047ffc5554f4993d5f4a162a6ec92bc55afc9754bfb81175613e362";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/demo-nodes-py/default.nix
+++ b/distros/jazzy/demo-nodes-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, example-interfaces, python3Packages, rcl-interfaces, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-demo-nodes-py";
-  version = "0.33.10-r1";
+  version = "0.33.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/demo_nodes_py/0.33.10-1.tar.gz";
-    name = "0.33.10-1.tar.gz";
-    sha256 = "ec3845dd7476a246ec1dedb89939d7d83aede15313c84ee2b41d811b6873ad1a";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/demo_nodes_py/0.33.11-1.tar.gz";
+    name = "0.33.11-1.tar.gz";
+    sha256 = "7fa3b67c7610592f0c83542363aac2927335a6bb87bae0bb7c1782abeb383413";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/domain-coordinator/default.nix
+++ b/distros/jazzy/domain-coordinator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-domain-coordinator";
-  version = "0.12.0-r3";
+  version = "0.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/jazzy/domain_coordinator/0.12.0-3.tar.gz";
-    name = "0.12.0-3.tar.gz";
-    sha256 = "ccd3792be892fef6dc986bff63adac6100139c63e3d2072b216337d8a28268b6";
+    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/jazzy/domain_coordinator/0.12.1-1.tar.gz";
+    name = "0.12.1-1.tar.gz";
+    sha256 = "99ca403670c0de588f46743a90b3a1dff4875b1e2eb5df4bef2a7cd3a77260ff";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/dummy-map-server/default.nix
+++ b/distros/jazzy/dummy-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-dummy-map-server";
-  version = "0.33.10-r1";
+  version = "0.33.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/dummy_map_server/0.33.10-1.tar.gz";
-    name = "0.33.10-1.tar.gz";
-    sha256 = "d6914e9319c806c23ad4e2d718f3aedcdd80cea07c8a9be874fca2481e9e838c";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/dummy_map_server/0.33.11-1.tar.gz";
+    name = "0.33.11-1.tar.gz";
+    sha256 = "95b906656fe3ee45441ef2dbc2635161744da1d795664a04e9d1b921cf95fff5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dummy-robot-bringup/default.nix
+++ b/distros/jazzy/dummy-robot-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, dummy-map-server, dummy-sensors, launch, launch-ros, robot-state-publisher }:
 buildRosPackage {
   pname = "ros-jazzy-dummy-robot-bringup";
-  version = "0.33.10-r1";
+  version = "0.33.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/dummy_robot_bringup/0.33.10-1.tar.gz";
-    name = "0.33.10-1.tar.gz";
-    sha256 = "7f4c19c727541b1cb4327c17505b92f9380d8af69f6bbb00d39adf6ce97bbcd3";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/dummy_robot_bringup/0.33.11-1.tar.gz";
+    name = "0.33.11-1.tar.gz";
+    sha256 = "7908e64e3acf1381553eb196ff105dd0606fbc8443ed553a59425f60627246c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dummy-sensors/default.nix
+++ b/distros/jazzy/dummy-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-dummy-sensors";
-  version = "0.33.10-r1";
+  version = "0.33.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/dummy_sensors/0.33.10-1.tar.gz";
-    name = "0.33.10-1.tar.gz";
-    sha256 = "f45cd11921d5db5f6dd1e5e6a07a7a2de75007f6eb8bf48970521c8b27d768a1";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/dummy_sensors/0.33.11-1.tar.gz";
+    name = "0.33.11-1.tar.gz";
+    sha256 = "f355c531177b5b087d522d9d7ba9b49884568b9ba79daea6bce654bb5e10d843";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/eg-conditional-generator/default.nix
+++ b/distros/jazzy/eg-conditional-generator/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, smacc2 }:
+buildRosPackage {
+  pname = "ros-jazzy-eg-conditional-generator";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/eg_conditional_generator/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "d08fa238ec64067c273230387f875eec13385506156fd0eda289489999038874";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ smacc2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The eg_random_generator package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/eg-random-generator/default.nix
+++ b/distros/jazzy/eg-random-generator/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, smacc2 }:
+buildRosPackage {
+  pname = "ros-jazzy-eg-random-generator";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/eg_random_generator/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "3a59f0cd4df4d30aa995a5e6a8c6c85861b2b88ac5df32ae4e52ffdea712bc52";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ smacc2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The eg_random_generator package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/eigen3-cmake-module/default.nix
+++ b/distros/jazzy/eigen3-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-lint-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-eigen3-cmake-module";
-  version = "0.3.0-r3";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/eigen3_cmake_module-release/archive/release/jazzy/eigen3_cmake_module/0.3.0-3.tar.gz";
-    name = "0.3.0-3.tar.gz";
-    sha256 = "244f4369b354e3acd1f31bd1ad3a99d0f1f3bfe3e3f338bc01fd89b31701920b";
+    url = "https://github.com/ros2-gbp/eigen3_cmake_module-release/archive/release/jazzy/eigen3_cmake_module/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "b8cb77a5024edf07e5a6c2831873372f49de3ef3bf806696765709fd6f469cf2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/example-interfaces/default.nix
+++ b/distros/jazzy/example-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-example-interfaces";
-  version = "0.12.0-r3";
+  version = "0.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/example_interfaces-release/archive/release/jazzy/example_interfaces/0.12.0-3.tar.gz";
-    name = "0.12.0-3.tar.gz";
-    sha256 = "d33c03d8f05370ac1666124d4c406c5e998cfdc3d7a2491c2f689eaaa118b237";
+    url = "https://github.com/ros2-gbp/example_interfaces-release/archive/release/jazzy/example_interfaces/0.12.1-1.tar.gz";
+    name = "0.12.1-1.tar.gz";
+    sha256 = "2eafd72e89aeffaddf585a3dde1702c9af2e16395105efd5f0355ce1e8c0a40d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/examples-tf2-py/default.nix
+++ b/distros/jazzy/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch-ros, python3Packages, rclpy, sensor-msgs, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-jazzy-examples-tf2-py";
-  version = "0.36.20-r1";
+  version = "0.36.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/examples_tf2_py/0.36.20-1.tar.gz";
-    name = "0.36.20-1.tar.gz";
-    sha256 = "56bf3e2a2bed7d11f4cbd36cedf70ae8be57abb85554fea322a7d90318866bfe";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/examples_tf2_py/0.36.21-1.tar.gz";
+    name = "0.36.21-1.tar.gz";
+    sha256 = "7b58954a8db0c975c9e31cb9adb4cc40d01cbe93f3df73893af613afa87219af";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/fastrtps-cmake-module/default.nix
+++ b/distros/jazzy/fastrtps-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-jazzy-fastrtps-cmake-module";
-  version = "3.6.3-r1";
+  version = "3.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/jazzy/fastrtps_cmake_module/3.6.3-1.tar.gz";
-    name = "3.6.3-1.tar.gz";
-    sha256 = "569b579f4dc368d59d3fad77726483136b6b73d0d06d9809d827bffd0aa3e6ad";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/jazzy/fastrtps_cmake_module/3.6.4-1.tar.gz";
+    name = "3.6.4-1.tar.gz";
+    sha256 = "fbb577cca927cb2a871efcde5ad67b8c4ba976c04f5ed47190790e798a9b5e3b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/forward-global-planner/default.nix
+++ b/distros/jazzy/forward-global-planner/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-2d-utils, nav-msgs, nav2-core, nav2-costmap-2d, nav2z-planners-common, pluginlib, tf2 }:
+buildRosPackage {
+  pname = "ros-jazzy-forward-global-planner";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/forward_global_planner/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "d8bf53ffaab5d3514d26d48f10d4c90e0430eabfda2ea7a9f78f155a8c7cc8ce";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake pluginlib ];
+  propagatedBuildInputs = [ geometry-msgs nav-2d-utils nav-msgs nav2-core nav2-costmap-2d nav2z-planners-common tf2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The forward_global_planner package.";
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/jazzy/forward-local-planner/default.nix
+++ b/distros/jazzy/forward-local-planner/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-2d-utils, nav-msgs, nav2-core, nav2-costmap-2d, nav2z-planners-common, std-msgs, tf2 }:
+buildRosPackage {
+  pname = "ros-jazzy-forward-local-planner";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/forward_local_planner/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "bec2ace3c7815e4f4630d02524e41c4e8c5939fd58ff18ad28f2f5428439ba31";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ geometry-msgs nav-2d-utils nav-msgs nav2-core nav2-costmap-2d nav2z-planners-common std-msgs tf2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "forward_local_planner package.";
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/jazzy/foxglove-bridge/default.nix
+++ b/distros/jazzy/foxglove-bridge/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, geometry-msgs, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, rosx-introspection, sensor-msgs, std-msgs, std-srvs, websocketpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, geometry-msgs, nlohmann_json, rcl-interfaces, rclcpp, rclcpp-components, rcpputils, rcutils, resource-retriever, ros-environment, rosgraph-msgs, rosidl-typesupport-introspection-cpp, rosx-introspection, sensor-msgs, std-msgs, std-srvs, websocketpp }:
 buildRosPackage {
   pname = "ros-jazzy-foxglove-bridge";
-  version = "3.3.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/jazzy/foxglove_bridge/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "11a28165f27979d2df7cfea1b18b85ba8fbc050166f5e442b408160dbbb74348";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/jazzy/foxglove_bridge/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "c4fb781baba9a44f71ab17f163e2c224910928e07ed2a30d391069d986151f0e";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake asio geometry-msgs nlohmann_json ros-environment sensor-msgs ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto openssl std-msgs std-srvs websocketpp ];
-  propagatedBuildInputs = [ ament-index-cpp rclcpp rclcpp-components resource-retriever rosgraph-msgs rosx-introspection std-msgs ];
+  buildInputs = [ ament-cmake geometry-msgs ros-environment sensor-msgs ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto asio nlohmann_json std-msgs std-srvs websocketpp ];
+  propagatedBuildInputs = [ ament-index-cpp rcl-interfaces rclcpp rclcpp-components rcpputils rcutils resource-retriever rosgraph-msgs rosidl-typesupport-introspection-cpp rosx-introspection std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/foxglove-msgs/default.nix
+++ b/distros/jazzy/foxglove-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-foxglove-msgs";
-  version = "3.3.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/jazzy/foxglove_msgs/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "075e2ad6c07bcac72f0b004b0036c2421a84b97a46a27cc2b2310fddc6c148ad";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/jazzy/foxglove_msgs/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "2e74856669e8f51ebefd6e383caa9327af014b0c38688288c2f66a488da27948";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -474,6 +474,10 @@ self: super: {
 
  azure-iot-sdk-c = self.callPackage ./azure-iot-sdk-c {};
 
+ backward-global-planner = self.callPackage ./backward-global-planner {};
+
+ backward-local-planner = self.callPackage ./backward-local-planner {};
+
  backward-ros = self.callPackage ./backward-ros {};
 
  bag2-to-image = self.callPackage ./bag2-to-image {};
@@ -589,6 +593,30 @@ self: super: {
  chained-filter-controller = self.callPackage ./chained-filter-controller {};
 
  chomp-motion-planner = self.callPackage ./chomp-motion-planner {};
+
+ cl-foundation-pose = self.callPackage ./cl-foundation-pose {};
+
+ cl-gcalcli = self.callPackage ./cl-gcalcli {};
+
+ cl-generic-sensor = self.callPackage ./cl-generic-sensor {};
+
+ cl-http = self.callPackage ./cl-http {};
+
+ cl-keyboard = self.callPackage ./cl-keyboard {};
+
+ cl-lifecycle-node = self.callPackage ./cl-lifecycle-node {};
+
+ cl-mission-tracker = self.callPackage ./cl-mission-tracker {};
+
+ cl-modbus-tcp-relay = self.callPackage ./cl-modbus-tcp-relay {};
+
+ cl-moveit2z = self.callPackage ./cl-moveit2z {};
+
+ cl-nav2z = self.callPackage ./cl-nav2z {};
+
+ cl-px4-mr = self.callPackage ./cl-px4-mr {};
+
+ cl-ros2-timer = self.callPackage ./cl-ros2-timer {};
 
  class-loader = self.callPackage ./class-loader {};
 
@@ -1084,6 +1112,10 @@ self: super: {
 
  effort-controllers = self.callPackage ./effort-controllers {};
 
+ eg-conditional-generator = self.callPackage ./eg-conditional-generator {};
+
+ eg-random-generator = self.callPackage ./eg-random-generator {};
+
  eigen3-cmake-module = self.callPackage ./eigen3-cmake-module {};
 
  eigen-stl-containers = self.callPackage ./eigen-stl-containers {};
@@ -1338,6 +1370,10 @@ self: super: {
 
  forward-command-controller = self.callPackage ./forward-command-controller {};
 
+ forward-global-planner = self.callPackage ./forward-global-planner {};
+
+ forward-local-planner = self.callPackage ./forward-local-planner {};
+
  four-wheel-steering-msgs = self.callPackage ./four-wheel-steering-msgs {};
 
  foxglove-bridge = self.callPackage ./foxglove-bridge {};
@@ -1557,6 +1593,8 @@ self: super: {
  human-description = self.callPackage ./human-description {};
 
  husarion-components-description = self.callPackage ./husarion-components-description {};
+
+ husarion-mecanum-drive-controller = self.callPackage ./husarion-mecanum-drive-controller {};
 
  husarion-ugv-description = self.callPackage ./husarion-ugv-description {};
 
@@ -1853,6 +1891,8 @@ self: super: {
  log-view = self.callPackage ./log-view {};
 
  logging-demo = self.callPackage ./logging-demo {};
+
+ low-pass-filter = self.callPackage ./low-pass-filter {};
 
  lttngpy = self.callPackage ./lttngpy {};
 
@@ -2326,6 +2366,8 @@ self: super: {
 
  nav2-waypoint-follower = self.callPackage ./nav2-waypoint-follower {};
 
+ nav2z-planners-common = self.callPackage ./nav2z-planners-common {};
+
  nav-2d-msgs = self.callPackage ./nav-2d-msgs {};
 
  nav-2d-utils = self.callPackage ./nav-2d-utils {};
@@ -2723,6 +2765,8 @@ self: super: {
  proxsuite = self.callPackage ./proxsuite {};
 
  ptz-action-server-msgs = self.callPackage ./ptz-action-server-msgs {};
+
+ pure-spinning-local-planner = self.callPackage ./pure-spinning-local-planner {};
 
  py-binding-tools = self.callPackage ./py-binding-tools {};
 
@@ -3616,6 +3660,56 @@ self: super: {
 
  slider-publisher = self.callPackage ./slider-publisher {};
 
+ sm-advanced-recovery-1 = self.callPackage ./sm-advanced-recovery-1 {};
+
+ sm-atomic = self.callPackage ./sm-atomic {};
+
+ sm-atomic-http = self.callPackage ./sm-atomic-http {};
+
+ sm-atomic-lifecycle = self.callPackage ./sm-atomic-lifecycle {};
+
+ sm-atomic-mode-states = self.callPackage ./sm-atomic-mode-states {};
+
+ sm-atomic-performance-trace-1 = self.callPackage ./sm-atomic-performance-trace-1 {};
+
+ sm-atomic-subscribers-performance-test = self.callPackage ./sm-atomic-subscribers-performance-test {};
+
+ sm-branching = self.callPackage ./sm-branching {};
+
+ sm-cl-gcalcli-test-1 = self.callPackage ./sm-cl-gcalcli-test-1 {};
+
+ sm-cl-keyboard-unit-test-1 = self.callPackage ./sm-cl-keyboard-unit-test-1 {};
+
+ sm-cl-px4-mr-test-1 = self.callPackage ./sm-cl-px4-mr-test-1 {};
+
+ sm-cl-px4-mr-test-2 = self.callPackage ./sm-cl-px4-mr-test-2 {};
+
+ sm-cl-ros2-timer-unit-test-1 = self.callPackage ./sm-cl-ros2-timer-unit-test-1 {};
+
+ sm-coretest-transition-speed-1 = self.callPackage ./sm-coretest-transition-speed-1 {};
+
+ sm-data-sharing-1 = self.callPackage ./sm-data-sharing-1 {};
+
+ sm-data-sharing-2 = self.callPackage ./sm-data-sharing-2 {};
+
+ sm-modbus-tcp-relay-test-1 = self.callPackage ./sm-modbus-tcp-relay-test-1 {};
+
+ sm-multi-stage-1 = self.callPackage ./sm-multi-stage-1 {};
+
+ sm-multithread-test-1 = self.callPackage ./sm-multithread-test-1 {};
+
+ sm-nav2-gazebo-test-1 = self.callPackage ./sm-nav2-gazebo-test-1 {};
+
+ sm-pack-ml = self.callPackage ./sm-pack-ml {};
+
+ sm-panda-cl-moveit2z-cb-inventory = self.callPackage ./sm-panda-cl-moveit2z-cb-inventory {};
+
+ sm-panda-cl-moveit2z-cb-inventory-isaacsim = self.callPackage ./sm-panda-cl-moveit2z-cb-inventory-isaacsim {};
+
+ sm-simple-action-client = self.callPackage ./sm-simple-action-client {};
+
+ sm-three-some = self.callPackage ./sm-three-some {};
+
  smacc2 = self.callPackage ./smacc2 {};
 
  smacc2-msgs = self.callPackage ./smacc2-msgs {};
@@ -3667,6 +3761,12 @@ self: super: {
  splsm-7-conversion = self.callPackage ./splsm-7-conversion {};
 
  sqlite3-vendor = self.callPackage ./sqlite3-vendor {};
+
+ sr-all-events-go = self.callPackage ./sr-all-events-go {};
+
+ sr-conditional = self.callPackage ./sr-conditional {};
+
+ sr-event-countdown = self.callPackage ./sr-event-countdown {};
 
  srdfdom = self.callPackage ./srdfdom {};
 
@@ -3998,6 +4098,8 @@ self: super: {
 
  twist-mux = self.callPackage ./twist-mux {};
 
+ twist-mux-controller = self.callPackage ./twist-mux-controller {};
+
  twist-mux-msgs = self.callPackage ./twist-mux-msgs {};
 
  twist-stamper = self.callPackage ./twist-stamper {};
@@ -4027,6 +4129,8 @@ self: super: {
  udp-msgs = self.callPackage ./udp-msgs {};
 
  uncrustify-vendor = self.callPackage ./uncrustify-vendor {};
+
+ undo-path-global-planner = self.callPackage ./undo-path-global-planner {};
 
  unique-identifier-msgs = self.callPackage ./unique-identifier-msgs {};
 

--- a/distros/jazzy/geometry2/default.nix
+++ b/distros/jazzy/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-jazzy-geometry2";
-  version = "0.36.20-r1";
+  version = "0.36.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/geometry2/0.36.20-1.tar.gz";
-    name = "0.36.20-1.tar.gz";
-    sha256 = "23d15ea2168329a391ea15a2bb91d2c70f2d5f24e13c942f4788c1f10b1812db";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/geometry2/0.36.21-1.tar.gz";
+    name = "0.36.21-1.tar.gz";
+    sha256 = "e78d0ea61eeea7e240dd9394df25bf58d50ee5c1dc3bd5922fc0809510a6bc55";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/husarion-mecanum-drive-controller/default.nix
+++ b/distros/jazzy/husarion-mecanum-drive-controller/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, control-toolbox, controller-interface, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, tf2, tf2-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-husarion-mecanum-drive-controller";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/husarion/husarion_controllers-release/archive/release/jazzy/husarion_mecanum_drive_controller/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "9223b73e4f4de1df6c68c2040aa8bb0fc78be21ca5111873f988d30fefe599e3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake generate-parameter-library ];
+  propagatedBuildInputs = [ control-toolbox controller-interface geometry-msgs hardware-interface nav-msgs pluginlib rclcpp rclcpp-lifecycle rcpputils realtime-tools tf2 tf2-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Controller for a mecanum drive mobile base.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/image-tools/default.nix
+++ b/distros/jazzy/image-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, opencv, rclcpp, rclcpp-components, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-image-tools";
-  version = "0.33.10-r1";
+  version = "0.33.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/image_tools/0.33.10-1.tar.gz";
-    name = "0.33.10-1.tar.gz";
-    sha256 = "be9acc4415a1fc44bd53a2f16b0079893092a834122a8bb6f0433c11722dbe94";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/image_tools/0.33.11-1.tar.gz";
+    name = "0.33.11-1.tar.gz";
+    sha256 = "143aad1d09b15094e6ec4cd3f388855898a1e82c4a8a2240daea6a0fcc36f543";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/intra-process-demo/default.nix
+++ b/distros/jazzy/intra-process-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, opencv, rclcpp, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-intra-process-demo";
-  version = "0.33.10-r1";
+  version = "0.33.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/intra_process_demo/0.33.10-1.tar.gz";
-    name = "0.33.10-1.tar.gz";
-    sha256 = "efa98ab7c955c4f2fbc7ad80d9b383a2ef12ef833010dfca1883f958747b6cad";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/intra_process_demo/0.33.11-1.tar.gz";
+    name = "0.33.11-1.tar.gz";
+    sha256 = "e5aaff3255f8f23da05231c73f348e88ee397699eb9e09469ebc8cc42c348dc3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/launch-pytest/default.nix
+++ b/distros/jazzy/launch-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-testing, osrf-pycommon, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-launch-pytest";
-  version = "3.4.10-r1";
+  version = "3.4.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/jazzy/launch_pytest/3.4.10-1.tar.gz";
-    name = "3.4.10-1.tar.gz";
-    sha256 = "6a97bc66ea8fafab8036626543109bccec8a573978ef856fe0126b724cd97ee5";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/jazzy/launch_pytest/3.4.11-1.tar.gz";
+    name = "3.4.11-1.tar.gz";
+    sha256 = "d37aa7b8f8958e21ce4da2e60f898789aabb77b2367a0b002946207baa868d9f";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/launch-ros/default.nix
+++ b/distros/jazzy/launch-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, composition-interfaces, launch, lifecycle-msgs, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-launch-ros";
-  version = "0.26.11-r1";
+  version = "0.26.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/jazzy/launch_ros/0.26.11-1.tar.gz";
-    name = "0.26.11-1.tar.gz";
-    sha256 = "6218c11a937053bdbf1b57e27cd373a0ac5dc9f6a8669cf9e184f15feabe3743";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/jazzy/launch_ros/0.26.12-1.tar.gz";
+    name = "0.26.12-1.tar.gz";
+    sha256 = "b9beb612415a5ba97a214f447be6de154543b73ec951b1b66ea817dc5d871b50";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/launch-testing-ament-cmake/default.nix
+++ b/distros/jazzy/launch-testing-ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-test, launch-testing, python-cmake-module }:
 buildRosPackage {
   pname = "ros-jazzy-launch-testing-ament-cmake";
-  version = "3.4.10-r1";
+  version = "3.4.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/jazzy/launch_testing_ament_cmake/3.4.10-1.tar.gz";
-    name = "3.4.10-1.tar.gz";
-    sha256 = "0f1733bb8be3203fae9029c2fe015e176a4dfae34d70e836a139c8d369b77f64";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/jazzy/launch_testing_ament_cmake/3.4.11-1.tar.gz";
+    name = "3.4.11-1.tar.gz";
+    sha256 = "e108745bca628ffd4adeffb66204c26648a45096122d317debae07a3688d27ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/launch-testing-ros/default.nix
+++ b/distros/jazzy/launch-testing-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch-ros, launch-testing, python3Packages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-launch-testing-ros";
-  version = "0.26.11-r1";
+  version = "0.26.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/jazzy/launch_testing_ros/0.26.11-1.tar.gz";
-    name = "0.26.11-1.tar.gz";
-    sha256 = "52188795cfbbde77330e4b6bb439ac352ae7308b66e7fc6e4cec08a9310dd11d";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/jazzy/launch_testing_ros/0.26.12-1.tar.gz";
+    name = "0.26.12-1.tar.gz";
+    sha256 = "5eb2004f85dd9f5096c7c05982e846b33522cc1b71822a300a13315e652360b2";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/launch-testing/default.nix
+++ b/distros/jazzy/launch-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-xml, launch-yaml, osrf-pycommon, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-launch-testing";
-  version = "3.4.10-r1";
+  version = "3.4.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/jazzy/launch_testing/3.4.10-1.tar.gz";
-    name = "3.4.10-1.tar.gz";
-    sha256 = "7d180df6fa3cf3ce4a6618e41f076169f8ad6ad13a231e1124ca30c295877f04";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/jazzy/launch_testing/3.4.11-1.tar.gz";
+    name = "3.4.11-1.tar.gz";
+    sha256 = "918fc688b937df763f820eff2ac1d94f9057db3971f87db537d6e0ce93df8aed";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/launch-xml/default.nix
+++ b/distros/jazzy/launch-xml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-launch-xml";
-  version = "3.4.10-r1";
+  version = "3.4.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/jazzy/launch_xml/3.4.10-1.tar.gz";
-    name = "3.4.10-1.tar.gz";
-    sha256 = "3e580e90fde6cdf237b2c1210bed0a6c0d13b6abac25351a6c6169081e02e739";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/jazzy/launch_xml/3.4.11-1.tar.gz";
+    name = "3.4.11-1.tar.gz";
+    sha256 = "b162c6f8d494a0937604d8bb92916d509fa3e82cba3607b5fd037878f3540e93";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/launch-yaml/default.nix
+++ b/distros/jazzy/launch-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-launch-yaml";
-  version = "3.4.10-r1";
+  version = "3.4.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/jazzy/launch_yaml/3.4.10-1.tar.gz";
-    name = "3.4.10-1.tar.gz";
-    sha256 = "7f1b5053e270cfe08fe306ef72571199725addf84c5de6502d95f488004edd96";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/jazzy/launch_yaml/3.4.11-1.tar.gz";
+    name = "3.4.11-1.tar.gz";
+    sha256 = "f98d3434c3987fff5f62f6a84822e7161398be677e416ba710b1e3653b141f5b";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/launch/default.nix
+++ b/distros/jazzy/launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-mypy, ament-pep257, osrf-pycommon, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-launch";
-  version = "3.4.10-r1";
+  version = "3.4.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/jazzy/launch/3.4.10-1.tar.gz";
-    name = "3.4.10-1.tar.gz";
-    sha256 = "00d4957bcf6c0cc2e89755edb6bea8c5673632f73c4d7b4fe2d43553c35dfe50";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/jazzy/launch/3.4.11-1.tar.gz";
+    name = "3.4.11-1.tar.gz";
+    sha256 = "3431b57e3afab97683b73e8fb5d9116d717011113305013437374ef9dbc1508d";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/liblz4-vendor/default.nix
+++ b/distros/jazzy/liblz4-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, lz4 }:
 buildRosPackage {
   pname = "ros-jazzy-liblz4-vendor";
-  version = "0.26.10-r2";
+  version = "0.26.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/liblz4_vendor/0.26.10-2.tar.gz";
-    name = "0.26.10-2.tar.gz";
-    sha256 = "2a5097ed462869dd366eaadf5c00c2948b19bcf3fc372b69c77936428d71e6b2";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/liblz4_vendor/0.26.11-1.tar.gz";
+    name = "0.26.11-1.tar.gz";
+    sha256 = "2ce5432eb7ae131e56b0d60480fd9b6a567dd8ef71540c9539a397e80f4a8a8b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/libyaml-vendor/default.nix
+++ b/distros/jazzy/libyaml-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-vendor-package, ament-lint-auto, ament-lint-common, libyaml, performance-test-fixture, pkg-config }:
 buildRosPackage {
   pname = "ros-jazzy-libyaml-vendor";
-  version = "1.6.3-r2";
+  version = "1.6.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libyaml_vendor-release/archive/release/jazzy/libyaml_vendor/1.6.3-2.tar.gz";
-    name = "1.6.3-2.tar.gz";
-    sha256 = "39f0b4e188f64d98e5911530792200c10e6f6fb03dc0707d4b77a67c3984800a";
+    url = "https://github.com/ros2-gbp/libyaml_vendor-release/archive/release/jazzy/libyaml_vendor/1.6.4-2.tar.gz";
+    name = "1.6.4-2.tar.gz";
+    sha256 = "2f99d6b24d015e2501bd15a952a6e32f6b4bdae72b3befbd861f671733eb4e65";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/lifecycle-py/default.nix
+++ b/distros/jazzy/lifecycle-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, lifecycle, lifecycle-msgs, rclpy, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-lifecycle-py";
-  version = "0.33.10-r1";
+  version = "0.33.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/lifecycle_py/0.33.10-1.tar.gz";
-    name = "0.33.10-1.tar.gz";
-    sha256 = "658c68f12f928904985c612781f5e89b22b6d007c6238f66fa7c0b0e300726ce";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/lifecycle_py/0.33.11-1.tar.gz";
+    name = "0.33.11-1.tar.gz";
+    sha256 = "799fc2f5719e4ce514a9f933d38456be61434f96cb0709b4e2ca602df6842507";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/lifecycle/default.nix
+++ b/distros/jazzy/lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-lifecycle";
-  version = "0.33.10-r1";
+  version = "0.33.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/lifecycle/0.33.10-1.tar.gz";
-    name = "0.33.10-1.tar.gz";
-    sha256 = "1e2f9a7da5c81f9f58c77470b6eddf15059a277e78f5111490bbc0ecec696af7";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/lifecycle/0.33.11-1.tar.gz";
+    name = "0.33.11-1.tar.gz";
+    sha256 = "1ab40c0b99570284b8e0ef67142ef33bfaa9ee275a94c6bf7907a6c580c6432d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/logging-demo/default.nix
+++ b/distros/jazzy/logging-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-logging-demo";
-  version = "0.33.10-r1";
+  version = "0.33.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/logging_demo/0.33.10-1.tar.gz";
-    name = "0.33.10-1.tar.gz";
-    sha256 = "277f7031cff37b085f9742b1aa95ed1b05c702d2dc3d2d25df56e747ea511885";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/logging_demo/0.33.11-1.tar.gz";
+    name = "0.33.11-1.tar.gz";
+    sha256 = "0d7f26a3dc8d9b94b2d19a9e7ac708c8b6ab3442bac5fe4fd3e8b0b03925b50f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/low-pass-filter/default.nix
+++ b/distros/jazzy/low-pass-filter/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, control-msgs, control-toolbox, controller-interface, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools }:
+buildRosPackage {
+  pname = "ros-jazzy-low-pass-filter";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/husarion/husarion_controllers-release/archive/release/jazzy/low_pass_filter/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "360c895dcb7088c6f31ab81793e68be5a3adfe882e887687d94c5eadd65927b1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ control-msgs control-toolbox controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Wrapper for low pass filter";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/lttngpy/default.nix
+++ b/distros/jazzy/lttngpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, lttng-tools, pkg-config, pybind11-vendor, python-cmake-module, rpyutils }:
 buildRosPackage {
   pname = "ros-jazzy-lttngpy";
-  version = "8.2.5-r1";
+  version = "8.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/jazzy/lttngpy/8.2.5-1.tar.gz";
-    name = "8.2.5-1.tar.gz";
-    sha256 = "feaf1a63bca4335fbc1832608a30178b6f6a09f8a37a3114c8d9dadecfd58919";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/jazzy/lttngpy/8.2.6-1.tar.gz";
+    name = "8.2.6-1.tar.gz";
+    sha256 = "d7146c4b0b5c1b3bce245e49323260feb69d9fc66542e872225474a6b4258d9d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mapviz-interfaces/default.nix
+++ b/distros/jazzy/mapviz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-mapviz-interfaces";
-  version = "2.6.4-r1";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/mapviz_interfaces/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "a2955b126d0717da8c9b712b25da311b9fbd5b752ae6f3e708ec0845d2715e8a";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/mapviz_interfaces/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "9de7ce3c573ec7d1713323896995a6a750b6c03368466a304fbd604bfa3e28aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mapviz-plugins/default.nix
+++ b/distros/jazzy/mapviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, cv-bridge, geometry-msgs, gps-msgs, image-transport, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-sensor-msgs, marti-visualization-msgs, nav-msgs, opencv, pluginlib, qt5, rclcpp, rclcpp-action, ros-environment, sensor-msgs, std-msgs, std-srvs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, tf2, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mapviz-plugins";
-  version = "2.6.4-r1";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/mapviz_plugins/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "917d0ba30d3f11170333130acc862915daf1e1647b26fa91d2c5a7bc7c2601f6";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/mapviz_plugins/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "b35875ff78b5923d030824289c8d5e4a201c23f6ff837724cb393b98b73fec7e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mapviz/default.nix
+++ b/distros/jazzy/mapviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, freeglut, geometry-msgs, glew, image-transport, libxi, libxmu, mapviz-interfaces, opencv, pkg-config, pluginlib, qt5, rclcpp, ros-environment, rqt-gui, rqt-gui-cpp, std-srvs, swri-math-util, swri-transform-util, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-mapviz";
-  version = "2.6.4-r1";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/mapviz/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "99f88b73c9a859e00649027eceb66fd9e05e268a340ea0baffb6feec9ce34638";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/mapviz/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "d832aff05b42afa64e578b5eade9d57e6ec44f7d8fdf75e1aceec071a3869ad6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mcap-vendor/default.nix
+++ b/distros/jazzy/mcap-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, liblz4-vendor, zstd-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-mcap-vendor";
-  version = "0.26.10-r2";
+  version = "0.26.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/mcap_vendor/0.26.10-2.tar.gz";
-    name = "0.26.10-2.tar.gz";
-    sha256 = "ecae03049409cfd22776e95b311d83a0cb47ad5ab7f6009e77f6d1af064470dd";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/mcap_vendor/0.26.11-1.tar.gz";
+    name = "0.26.11-1.tar.gz";
+    sha256 = "705f15607451b986743fb83bca8703fd745ba47e18d0fd8ca3141dd67d1e79ae";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mimick-vendor/default.nix
+++ b/distros/jazzy/mimick-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-jazzy-mimick-vendor";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mimick_vendor-release/archive/release/jazzy/mimick_vendor/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "5f6b3fe333ee7113c9c103cbfa7d5a87961a57197de635fe25c235b73cc8853f";
+    url = "https://github.com/ros2-gbp/mimick_vendor-release/archive/release/jazzy/mimick_vendor/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "e1d94b919577986fcf982aebfa3eac303e8cc98f4edb7228d3c2659e577a94d7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/multires-image/default.nix
+++ b/distros/jazzy/multires-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, mapviz, pluginlib, qt5, rclcpp, rclpy, swri-math-util, swri-transform-util, tf2 }:
 buildRosPackage {
   pname = "ros-jazzy-multires-image";
-  version = "2.6.4-r1";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/multires_image/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "d380be0ead98e354080e1a8101f429f614cd13fc78c9fd1d81505e610cb2f2b9";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/multires_image/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "243f0de5d2a16d4895d1707558f11b15b25b0faa1b7bfb2d620c154e9293ce5f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2z-planners-common/default.nix
+++ b/distros/jazzy/nav2z-planners-common/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, angles, geometry-msgs, nav-msgs, rclcpp, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-nav2z-planners-common";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/nav2z_planners_common/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "32d1b17942fff527d7677e6de4612b208ca0a820a11418d4da68c2908eecf454";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ angles geometry-msgs nav-msgs rclcpp rclcpp-lifecycle tf2 tf2-geometry-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The nav2z_planners_common package.";
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/jazzy/orocos-kdl-vendor/default.nix
+++ b/distros/jazzy/orocos-kdl-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, orocos-kdl }:
 buildRosPackage {
   pname = "ros-jazzy-orocos-kdl-vendor";
-  version = "0.5.1-r2";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/orocos_kdl_vendor-release/archive/release/jazzy/orocos_kdl_vendor/0.5.1-2.tar.gz";
-    name = "0.5.1-2.tar.gz";
-    sha256 = "aa687a98ccbabde2c206442fbdfc7794fb06e41a9c383fcfa9ea65f5c4b72ab8";
+    url = "https://github.com/ros2-gbp/orocos_kdl_vendor-release/archive/release/jazzy/orocos_kdl_vendor/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "f9b15eaf69350a91f92af15e2fdef47fbdfad63e425cb77d6d6d0fed21b246e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -1049,16 +1049,6 @@ in {
     ];
   };
 
-  rcdiscover = rosSuper.rcdiscover.overrideAttrs ({
-    postPatch ? "", ...
-  }: {
-    postPatch = postPatch + ''
-      substituteInPlace CMakeLists.txt --replace-fail \
-        "cmake_minimum_required (VERSION 3.1)" \
-        "cmake_minimum_required (VERSION 3.10)"\
-    '';
-  });
-
   rc-genicam-api = rosSuper.rc-genicam-api.overrideAttrs ({
     postPatch ? "", ...
   }: {

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -304,14 +304,14 @@ in {
       # https://github.com/foxglove/foxglove-sdk/blob/main/ros/src/foxglove_bridge/CMakeLists.txt.
       # If the version doesn't match, cmake fails with "Hash mismatch"
       # and we can fix it here.
-      FOXGLOVE_SDK_VERSION = "0.23.1";
+      FOXGLOVE_SDK_VERSION = "0.25.1";
       systemToPlatform = {
         "x86_64-linux" = "x86_64-unknown-linux-gnu";
         "aarch64-linux" = "aarch64-unknown-linux-gnu";
       };
       systemToHash = {
-        "x86_64-linux" = "sha256-uUkpXoDrGpuzVuZXucJXnIhnF/rCkMTkil6YRgY78ug=";
-        "aarch64-linux" = "sha256-7CC88ap2n8m3bYT/PhXA3z8KKz7lbrfuRePx5DBmILw=";
+        "x86_64-linux" = "sha256-C500jfOo6Y0sLO4jYMyfUug7s0RQRN69dx0bRtw1i+Q=";
+        "aarch64-linux" = "sha256-xw41x48ON/O6jQJRzTHzU7sQsf0QYgDcbF9AntTfGRg=";
       };
       FOXGLOVE_SDK_PLATFORM = systemToPlatform.${self.system};
       sdk = self.fetchurl {

--- a/distros/jazzy/pendulum-control/default.nix
+++ b/distros/jazzy/pendulum-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pendulum-msgs, rclcpp, rmw-implementation-cmake, ros2run, rttest, tlsf-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-pendulum-control";
-  version = "0.33.10-r1";
+  version = "0.33.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/pendulum_control/0.33.10-1.tar.gz";
-    name = "0.33.10-1.tar.gz";
-    sha256 = "d15ad90b292c56620b90c004e2ce95ab631c8a4179fcf49d9ab3a79e5d107bfc";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/pendulum_control/0.33.11-1.tar.gz";
+    name = "0.33.11-1.tar.gz";
+    sha256 = "c73f884143bce09e9a9a743c1cd7127e4be275d3b9d575cdd5db8a3b492e9ae4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pendulum-msgs/default.nix
+++ b/distros/jazzy/pendulum-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-pendulum-msgs";
-  version = "0.33.10-r1";
+  version = "0.33.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/pendulum_msgs/0.33.10-1.tar.gz";
-    name = "0.33.10-1.tar.gz";
-    sha256 = "9244cb87f7aeece770c23bd1be3ab14e9442e4d4e52b09a4ffb83beb98697628";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/pendulum_msgs/0.33.11-1.tar.gz";
+    name = "0.33.11-1.tar.gz";
+    sha256 = "9b4f05d9cab585ca8fade1e1b3d108730b9b38871dede93a40fbd63fbee6138b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/performance-test-fixture/default.nix
+++ b/distros/jazzy/performance-test-fixture/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-export-targets, ament-cmake-google-benchmark, ament-cmake-test, ament-lint-auto, ament-lint-common, google-benchmark-vendor, osrf-testing-tools-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-performance-test-fixture";
-  version = "0.2.1-r2";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/performance_test_fixture-release/archive/release/jazzy/performance_test_fixture/0.2.1-2.tar.gz";
-    name = "0.2.1-2.tar.gz";
-    sha256 = "11712323a634d344a1d4010b4508126b4dc5f2936dc393932a0436b0becf23bb";
+    url = "https://github.com/ros2-gbp/performance_test_fixture-release/archive/release/jazzy/performance_test_fixture/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "5c016692c293522a5374b8578302f194f4b099e43f49aef68831a23fae3b6840";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pure-spinning-local-planner/default.nix
+++ b/distros/jazzy/pure-spinning-local-planner/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-2d-utils, nav-msgs, nav2-core, nav2-costmap-2d, nav2z-planners-common, pluginlib, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-jazzy-pure-spinning-local-planner";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/pure_spinning_local_planner/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "95b654fb88ba968c01dea8f642c2f5feacd166588cb5b3c3600628694a3b0b09";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake pluginlib ];
+  propagatedBuildInputs = [ geometry-msgs nav-2d-utils nav-msgs nav2-core nav2-costmap-2d nav2z-planners-common tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The pure_spinning_local_planner package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/python-orocos-kdl-vendor/default.nix
+++ b/distros/jazzy/python-orocos-kdl-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, orocos-kdl-vendor, pybind11-vendor, python-cmake-module, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-python-orocos-kdl-vendor";
-  version = "0.5.1-r2";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/orocos_kdl_vendor-release/archive/release/jazzy/python_orocos_kdl_vendor/0.5.1-2.tar.gz";
-    name = "0.5.1-2.tar.gz";
-    sha256 = "c7cf99495b8bf080d5dc3c34ef1cbbf5d2513a255336d7b4e1e0b9696c3e30df";
+    url = "https://github.com/ros2-gbp/orocos_kdl_vendor-release/archive/release/jazzy/python_orocos_kdl_vendor/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "4f6933d9ebfb284d4e32478a933ad191fef2e41deb9e3827e06fd7262039264a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/quality-of-service-demo-cpp/default.nix
+++ b/distros/jazzy/quality-of-service-demo-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, rclcpp, rclcpp-components, rcutils, rmw, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-quality-of-service-demo-cpp";
-  version = "0.33.10-r1";
+  version = "0.33.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/quality_of_service_demo_cpp/0.33.10-1.tar.gz";
-    name = "0.33.10-1.tar.gz";
-    sha256 = "617c27f854c38094f67a0069413e913c3ef65c8fe03a8574f81c8eec22e6fc50";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/quality_of_service_demo_cpp/0.33.11-1.tar.gz";
+    name = "0.33.11-1.tar.gz";
+    sha256 = "bc9e88e367f2e6ad477e1c4040a77cac1487171c47d315ddbbf520212c0dab38";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/quality-of-service-demo-py/default.nix
+++ b/distros/jazzy/quality-of-service-demo-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-quality-of-service-demo-py";
-  version = "0.33.10-r1";
+  version = "0.33.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/quality_of_service_demo_py/0.33.10-1.tar.gz";
-    name = "0.33.10-1.tar.gz";
-    sha256 = "9334eba143b54acdb8cdbb824075af3e0dfabf10890961bf504c68c62a83726c";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/quality_of_service_demo_py/0.33.11-1.tar.gz";
+    name = "0.33.11-1.tar.gz";
+    sha256 = "484c93d5af2dbb44cf95c018c807c6b6e9be4f5d774e7ebb5059809d866655ac";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rcdiscover/default.nix
+++ b/distros/jazzy/rcdiscover/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-jazzy-rcdiscover";
-  version = "1.1.7-r2";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcdiscover-release/archive/release/jazzy/rcdiscover/1.1.7-2.tar.gz";
-    name = "1.1.7-2.tar.gz";
-    sha256 = "9100a08246bb764f3ae0464274976cdf828da1460bda58948040200ee83724e9";
+    url = "https://github.com/ros2-gbp/rcdiscover-release/archive/release/jazzy/rcdiscover/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "63b677a39da9fb2f95bfe0df2a1c5366e0f98e99970d3f8181a2df4b750da858";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/rcl-action/default.nix
+++ b/distros/jazzy/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rcl-action";
-  version = "9.2.9-r1";
+  version = "9.2.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/jazzy/rcl_action/9.2.9-1.tar.gz";
-    name = "9.2.9-1.tar.gz";
-    sha256 = "5e0a983a7c5e4e35ea5f7931e972d58e7d448f55b49c2a3e12df23806d6a9bd1";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/jazzy/rcl_action/9.2.10-1.tar.gz";
+    name = "9.2.10-1.tar.gz";
+    sha256 = "d6b6b5bba68cc5266dd77599fd5835409945e87a001db7a0920456ad144592ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rcl-lifecycle/default.nix
+++ b/distros/jazzy/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-jazzy-rcl-lifecycle";
-  version = "9.2.9-r1";
+  version = "9.2.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/jazzy/rcl_lifecycle/9.2.9-1.tar.gz";
-    name = "9.2.9-1.tar.gz";
-    sha256 = "14046e39b41a571abf8336aef5a956c0144c372157763f1794f623f82c65f909";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/jazzy/rcl_lifecycle/9.2.10-1.tar.gz";
+    name = "9.2.10-1.tar.gz";
+    sha256 = "1e56079c9be2ca0674623fc573e8e8253ddc0d03093d547ea7a182a5476c0045";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rcl-yaml-param-parser/default.nix
+++ b/distros/jazzy/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-jazzy-rcl-yaml-param-parser";
-  version = "9.2.9-r1";
+  version = "9.2.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/jazzy/rcl_yaml_param_parser/9.2.9-1.tar.gz";
-    name = "9.2.9-1.tar.gz";
-    sha256 = "a82e43694f8b7cf101353ce382a8464b8ffaf6ceda8909a4df869e434348e8bc";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/jazzy/rcl_yaml_param_parser/9.2.10-1.tar.gz";
+    name = "9.2.10-1.tar.gz";
+    sha256 = "949922938dc9653f138448d1a249a2e1457bcc3ce81831947c4e2d27bb5c1b39";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rcl/default.nix
+++ b/distros/jazzy/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, rosidl-runtime-cpp, service-msgs, test-msgs, tracetools, type-description-interfaces }:
 buildRosPackage {
   pname = "ros-jazzy-rcl";
-  version = "9.2.9-r1";
+  version = "9.2.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/jazzy/rcl/9.2.9-1.tar.gz";
-    name = "9.2.9-1.tar.gz";
-    sha256 = "5ab434952edb4845a73ca1a7ec0c60b874f99d1461d1f159ff39a8f67e5ed1b3";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/jazzy/rcl/9.2.10-1.tar.gz";
+    name = "9.2.10-1.tar.gz";
+    sha256 = "0d3c8317ec8320bc76a58203db8f1b91853e7fc02fbec153ed69707eaa308287";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rclcpp-action/default.nix
+++ b/distros/jazzy/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rclcpp-action";
-  version = "28.1.18-r1";
+  version = "28.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp_action/28.1.18-1.tar.gz";
-    name = "28.1.18-1.tar.gz";
-    sha256 = "4eb8ea6643365d9d43385623e93f27978d8895c8f1c894ba84a10094f1843369";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp_action/28.1.19-1.tar.gz";
+    name = "28.1.19-1.tar.gz";
+    sha256 = "50525c801475e946283e11233c0dd0c2bfe24508ab69130e76c803087c21f4e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rclcpp-components/default.nix
+++ b/distros/jazzy/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rclcpp-components";
-  version = "28.1.18-r1";
+  version = "28.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp_components/28.1.18-1.tar.gz";
-    name = "28.1.18-1.tar.gz";
-    sha256 = "8bf2a849669795467d01c2acfe76584cf97d6d7614944a6199578f9544ba5f3a";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp_components/28.1.19-1.tar.gz";
+    name = "28.1.19-1.tar.gz";
+    sha256 = "4bf1ee2193b98eaa33af0ec7940fd5bbc64fce26e0f866bd95e807ffa0b4fbc6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rclcpp-lifecycle/default.nix
+++ b/distros/jazzy/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rclcpp-lifecycle";
-  version = "28.1.18-r1";
+  version = "28.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp_lifecycle/28.1.18-1.tar.gz";
-    name = "28.1.18-1.tar.gz";
-    sha256 = "9c05be62fc5528cfe7c00bcbea760119b8cdb4d6d17e8de193fbfc1afe5fc5da";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp_lifecycle/28.1.19-1.tar.gz";
+    name = "28.1.19-1.tar.gz";
+    sha256 = "90e277ae20becd285969de1eeef0ccd70ca9de843d85f496f8c97c2e75e596f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rclcpp/default.nix
+++ b/distros/jazzy/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-jazzy-rclcpp";
-  version = "28.1.18-r1";
+  version = "28.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp/28.1.18-1.tar.gz";
-    name = "28.1.18-1.tar.gz";
-    sha256 = "e49665ee8de963a43c66489dcb8b67b3e94274ed64e52e8fe4c707f4ff33d319";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp/28.1.19-1.tar.gz";
+    name = "28.1.19-1.tar.gz";
+    sha256 = "55e4e62f0231a6e33289a9c32dc40929c03da5911bed073c4843154ff0458ecb";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rcpputils/default.nix
+++ b/distros/jazzy/rcpputils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, rcutils }:
 buildRosPackage {
   pname = "ros-jazzy-rcpputils";
-  version = "2.11.3-r1";
+  version = "2.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/jazzy/rcpputils/2.11.3-1.tar.gz";
-    name = "2.11.3-1.tar.gz";
-    sha256 = "bd3715cc2513375584ffe5d4c36db0c85203bfdcb6e09fc2f931635cf513d271";
+    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/jazzy/rcpputils/2.11.4-1.tar.gz";
+    name = "2.11.4-1.tar.gz";
+    sha256 = "ff1ddae9941245fb44e59190f39fe66e615617e567fed7acaf1327b9f189af67";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rcutils/default.nix
+++ b/distros/jazzy/rcutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-rcutils";
-  version = "6.7.5-r1";
+  version = "6.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/jazzy/rcutils/6.7.5-1.tar.gz";
-    name = "6.7.5-1.tar.gz";
-    sha256 = "338d1fffe324f682f755250653af11bb2ac1bc936e5b4fc7a3c204f1020d5c1d";
+    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/jazzy/rcutils/6.7.6-1.tar.gz";
+    name = "6.7.6-1.tar.gz";
+    sha256 = "ac599f6e8efb75f48221fc34287dcf3045f86e828c9b735687e05c79a41ebba3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rmw-fastrtps-cpp/default.nix
+++ b/distros/jazzy/rmw-fastrtps-cpp/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-dynamic-typesupport, rosidl-dynamic-typesupport-fastrtps, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs, tracetools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-dynamic-typesupport, rosidl-dynamic-typesupport-fastrtps, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-jazzy-rmw-fastrtps-cpp";
-  version = "8.4.3-r1";
+  version = "8.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/jazzy/rmw_fastrtps_cpp/8.4.3-1.tar.gz";
-    name = "8.4.3-1.tar.gz";
-    sha256 = "59901075c2ef8854fb093e8067b9c1a11e2e2b0f643e4ba8a59803d85b1fbac5";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/jazzy/rmw_fastrtps_cpp/8.4.4-1.tar.gz";
+    name = "8.4.4-1.tar.gz";
+    sha256 = "b19beff50d6ee341d54805c2b777a14e63094fdfa6fd71084221ee86114f1437";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common osrf-testing-tools-cpp test-msgs ];
-  propagatedBuildInputs = [ ament-cmake fastcdr fastrtps fastrtps-cmake-module rcpputils rcutils rmw rmw-dds-common rmw-fastrtps-shared-cpp rosidl-dynamic-typesupport rosidl-dynamic-typesupport-fastrtps rosidl-runtime-c rosidl-runtime-cpp rosidl-typesupport-fastrtps-c rosidl-typesupport-fastrtps-cpp tracetools ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-ros fastrtps-cmake-module ];
+  propagatedBuildInputs = [ fastcdr fastrtps fastrtps-cmake-module rcpputils rcutils rmw rmw-dds-common rmw-fastrtps-shared-cpp rosidl-dynamic-typesupport rosidl-dynamic-typesupport-fastrtps rosidl-runtime-c rosidl-runtime-cpp rosidl-typesupport-fastrtps-c rosidl-typesupport-fastrtps-cpp tracetools ];
+  nativeBuildInputs = [ ament-cmake-ros fastrtps-cmake-module ];
 
   meta = {
     description = "Implement the ROS middleware interface using eProsima FastRTPS static code generation in C++.";

--- a/distros/jazzy/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/jazzy/rmw-fastrtps-dynamic-cpp/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rmw-fastrtps-dynamic-cpp";
-  version = "8.4.3-r1";
+  version = "8.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/jazzy/rmw_fastrtps_dynamic_cpp/8.4.3-1.tar.gz";
-    name = "8.4.3-1.tar.gz";
-    sha256 = "58739a58ad119c5bc0ab635dc9efb5b8d279f2bc524ec9c0b74aeecbf4c0f66a";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/jazzy/rmw_fastrtps_dynamic_cpp/8.4.4-1.tar.gz";
+    name = "8.4.4-1.tar.gz";
+    sha256 = "a5689549ea75f427c71f093dd5e9e49cc3c4c8cdb4e0f18d91456a1d486c77c2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common osrf-testing-tools-cpp test-msgs ];
-  propagatedBuildInputs = [ ament-cmake fastcdr fastrtps fastrtps-cmake-module rcpputils rcutils rmw rmw-dds-common rmw-fastrtps-shared-cpp rosidl-runtime-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-ros fastrtps-cmake-module ];
+  propagatedBuildInputs = [ fastcdr fastrtps fastrtps-cmake-module rcpputils rcutils rmw rmw-dds-common rmw-fastrtps-shared-cpp rosidl-runtime-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp ];
+  nativeBuildInputs = [ ament-cmake-ros fastrtps-cmake-module ];
 
   meta = {
     description = "Implement the ROS middleware interface using introspection type support.";

--- a/distros/jazzy/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/jazzy/rmw-fastrtps-shared-cpp/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-jazzy-rmw-fastrtps-shared-cpp";
-  version = "8.4.3-r1";
+  version = "8.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/jazzy/rmw_fastrtps_shared_cpp/8.4.3-1.tar.gz";
-    name = "8.4.3-1.tar.gz";
-    sha256 = "a4cb5a2c8fb0997234904973ab2c5df5293a82496899c219166ce50013a8a4e4";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/jazzy/rmw_fastrtps_shared_cpp/8.4.4-1.tar.gz";
+    name = "8.4.4-1.tar.gz";
+    sha256 = "fc1ef2eea16a1d1ad31bf24cbb9d3ddddad6b3f283abc4fb918746cd2cd22558";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros rosidl-runtime-c ];
   checkInputs = [ ament-lint-auto ament-lint-common osrf-testing-tools-cpp ];
-  propagatedBuildInputs = [ ament-cmake fastcdr fastrtps fastrtps-cmake-module rcpputils rcutils rmw rmw-dds-common rosidl-dynamic-typesupport rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp tracetools ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-ros fastrtps-cmake-module ];
+  propagatedBuildInputs = [ fastcdr fastrtps fastrtps-cmake-module rcpputils rcutils rmw rmw-dds-common rosidl-dynamic-typesupport rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp tracetools ];
+  nativeBuildInputs = [ ament-cmake-ros fastrtps-cmake-module ];
 
   meta = {
     description = "Code shared on static and dynamic type support of rmw_fastrtps_cpp.";

--- a/distros/jazzy/robot-state-publisher/default.nix
+++ b/distros/jazzy/robot-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, kdl-parser, launch-ros, launch-testing-ament-cmake, orocos-kdl-vendor, rcl-interfaces, rclcpp, rclcpp-components, sensor-msgs, std-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-robot-state-publisher";
-  version = "3.3.3-r3";
+  version = "3.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_state_publisher-release/archive/release/jazzy/robot_state_publisher/3.3.3-3.tar.gz";
-    name = "3.3.3-3.tar.gz";
-    sha256 = "7d511eafdc1731691676e1740212a70f6050d1c3993ac16748741e3691fd180b";
+    url = "https://github.com/ros2-gbp/robot_state_publisher-release/archive/release/jazzy/robot_state_publisher/3.3.4-1.tar.gz";
+    name = "3.3.4-1.tar.gz";
+    sha256 = "e1092215ce536705f201e4a0b70f0de4f4684ed2270d5e2ee1afa1e3222d86dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros-testing/default.nix
+++ b/distros/jazzy/ros-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-export-dependencies, launch-testing, launch-testing-ament-cmake, launch-testing-ros, ros2test }:
 buildRosPackage {
   pname = "ros-jazzy-ros-testing";
-  version = "0.6.0-r3";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_testing-release/archive/release/jazzy/ros_testing/0.6.0-3.tar.gz";
-    name = "0.6.0-3.tar.gz";
-    sha256 = "29963ef7caf1beca81103f3081e0f7cd086d05ae3723073d67f293990042f5da";
+    url = "https://github.com/ros2-gbp/ros_testing-release/archive/release/jazzy/ros_testing/0.6.1-1.tar.gz";
+    name = "0.6.1-1.tar.gz";
+    sha256 = "f7a9b06a4985de80c5547c0d8fc20a111ca931466c43eb55d4ef2b9a2dad0f64";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2action/default.nix
+++ b/distros/jazzy/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2action";
-  version = "0.32.9-r1";
+  version = "0.32.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2action/0.32.9-1.tar.gz";
-    name = "0.32.9-1.tar.gz";
-    sha256 = "fc291394b6da25afb838769c95ea6cdfaa67c1ff283f66613c1019d19d306cf6";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2action/0.32.10-1.tar.gz";
+    name = "0.32.10-1.tar.gz";
+    sha256 = "af07907d7511d517b53e9777c1d38d963c251fdc01bc63eeeef38026b81cd810";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2bag/default.nix
+++ b/distros/jazzy/ros2bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosbag2-py, rosbag2-storage-default-plugins, rosbag2-test-common }:
 buildRosPackage {
   pname = "ros-jazzy-ros2bag";
-  version = "0.26.10-r2";
+  version = "0.26.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/ros2bag/0.26.10-2.tar.gz";
-    name = "0.26.10-2.tar.gz";
-    sha256 = "eed5860f0c148821d908bc6844c6f0ca0a26d7a01bd5a129c37de76ea1e8f798";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/ros2bag/0.26.11-1.tar.gz";
+    name = "0.26.11-1.tar.gz";
+    sha256 = "d89edf02f1b0d31acc403f0201fb9926e64db4765a2592abe566e3df556570b9";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2cli-test-interfaces/default.nix
+++ b/distros/jazzy/ros2cli-test-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-ros2cli-test-interfaces";
-  version = "0.32.9-r1";
+  version = "0.32.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2cli_test_interfaces/0.32.9-1.tar.gz";
-    name = "0.32.9-1.tar.gz";
-    sha256 = "5ce97ddbc032ba26ecb7723d1241df94abfaba6dda4e09162f014d6d545b3cac";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2cli_test_interfaces/0.32.10-1.tar.gz";
+    name = "0.32.10-1.tar.gz";
+    sha256 = "1e8f3c4122c7cca6edef50bda1cfa5367b33bb28d04a5bf3bef87f82d03cda08";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2cli/default.nix
+++ b/distros/jazzy/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, rclpy, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2cli";
-  version = "0.32.9-r1";
+  version = "0.32.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2cli/0.32.9-1.tar.gz";
-    name = "0.32.9-1.tar.gz";
-    sha256 = "10f566660b1ba49e77809ace12c3d2c75f2090012d8f4d9dc642315c70b01187";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2cli/0.32.10-1.tar.gz";
+    name = "0.32.10-1.tar.gz";
+    sha256 = "1c907b35273c287294e35cafcef8ff13ac64e925db50e930551f815e39521542";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2component/default.nix
+++ b/distros/jazzy/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, python3Packages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-jazzy-ros2component";
-  version = "0.32.9-r1";
+  version = "0.32.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2component/0.32.9-1.tar.gz";
-    name = "0.32.9-1.tar.gz";
-    sha256 = "02ad2352529e120383956342facade07705bb512bc92bd90f3e1e8970368b297";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2component/0.32.10-1.tar.gz";
+    name = "0.32.10-1.tar.gz";
+    sha256 = "33cb7e644f6dcd276a2bd6c8ea84b50baf73b5cce22691bb1eaa713f43162438";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2doctor/default.nix
+++ b/distros/jazzy/ros2doctor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros-environment, ros2cli, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2doctor";
-  version = "0.32.9-r1";
+  version = "0.32.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2doctor/0.32.9-1.tar.gz";
-    name = "0.32.9-1.tar.gz";
-    sha256 = "2497f4a8554f692881658be9c285c806a75eb5f1e69d25c030955de33ae5298b";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2doctor/0.32.10-1.tar.gz";
+    name = "0.32.10-1.tar.gz";
+    sha256 = "a47ed1d7f357ae3fc1a66d911025adc46796172eaed13fa1b208c5eab00bbc54";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2interface/default.nix
+++ b/distros/jazzy/ros2interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, ros2cli, ros2cli-test-interfaces, rosidl-adapter, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2interface";
-  version = "0.32.9-r1";
+  version = "0.32.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2interface/0.32.9-1.tar.gz";
-    name = "0.32.9-1.tar.gz";
-    sha256 = "6eeffb15481b4472f4aff97407df794f88e63462d53a2fffa8963ff73e371abb";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2interface/0.32.10-1.tar.gz";
+    name = "0.32.10-1.tar.gz";
+    sha256 = "b5e74353bbbae532d4b1966ebfb94bfc26cc87ca319d017e288fb3f88bc64cad";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2launch/default.nix
+++ b/distros/jazzy/ros2launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, launch-xml, launch-yaml, python3Packages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-jazzy-ros2launch";
-  version = "0.26.11-r1";
+  version = "0.26.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/jazzy/ros2launch/0.26.11-1.tar.gz";
-    name = "0.26.11-1.tar.gz";
-    sha256 = "f9668921cbc98cda6e4140d9050d1180e26805438c8fb5a31b1328a8fa4d5d4c";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/jazzy/ros2launch/0.26.12-1.tar.gz";
+    name = "0.26.12-1.tar.gz";
+    sha256 = "125c6a3554148b60eff980941258f6c41c15cb5b08e90f05ecf32ab9ff3b580a";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2lifecycle-test-fixtures/default.nix
+++ b/distros/jazzy/ros2lifecycle-test-fixtures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-jazzy-ros2lifecycle-test-fixtures";
-  version = "0.32.9-r1";
+  version = "0.32.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2lifecycle_test_fixtures/0.32.9-1.tar.gz";
-    name = "0.32.9-1.tar.gz";
-    sha256 = "a5438f8e83e31fe4643ae1399032e71f4bdd695c1ad1d2e28fb78c99bd938f2f";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2lifecycle_test_fixtures/0.32.10-1.tar.gz";
+    name = "0.32.10-1.tar.gz";
+    sha256 = "8a26daacc21e3658aa630204e783195dc8681fa9505f718483e492baf7ded69d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2lifecycle/default.nix
+++ b/distros/jazzy/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, lifecycle-msgs, python3Packages, rclpy, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-jazzy-ros2lifecycle";
-  version = "0.32.9-r1";
+  version = "0.32.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2lifecycle/0.32.9-1.tar.gz";
-    name = "0.32.9-1.tar.gz";
-    sha256 = "96b42d569675d611b1832889dcbe1db444d0000a6d9ce2a0c764b283c735fe9e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2lifecycle/0.32.10-1.tar.gz";
+    name = "0.32.10-1.tar.gz";
+    sha256 = "5b531e20e34605ef3a6cac1c6bb3eaa922a732eb52b529fd3c8e1a3e3be44875";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2multicast/default.nix
+++ b/distros/jazzy/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, ros2cli }:
 buildRosPackage {
   pname = "ros-jazzy-ros2multicast";
-  version = "0.32.9-r1";
+  version = "0.32.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2multicast/0.32.9-1.tar.gz";
-    name = "0.32.9-1.tar.gz";
-    sha256 = "e69d14ba63b4e05301abb4d429a2e126143e38ec704223916d3286641e1a0ed4";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2multicast/0.32.10-1.tar.gz";
+    name = "0.32.10-1.tar.gz";
+    sha256 = "4160b53455d6b05d8a97ef19f9f1fd9649efc66416ebf297ae3ee966c8f48eab";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2node/default.nix
+++ b/distros/jazzy/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2node";
-  version = "0.32.9-r1";
+  version = "0.32.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2node/0.32.9-1.tar.gz";
-    name = "0.32.9-1.tar.gz";
-    sha256 = "67621984168086790384f576275f0ce5a8a0a60abff3cd5f2848e4f2e91a577c";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2node/0.32.10-1.tar.gz";
+    name = "0.32.10-1.tar.gz";
+    sha256 = "88e99f2088e00cc8e814e80850132d341bf9070e5271f12a6aebc1439fd0a937";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2param/default.nix
+++ b/distros/jazzy/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-jazzy-ros2param";
-  version = "0.32.9-r1";
+  version = "0.32.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2param/0.32.9-1.tar.gz";
-    name = "0.32.9-1.tar.gz";
-    sha256 = "17bb30f64c56c055e6c5959972a669c2802b3a83347034d3e38ac2b418b755eb";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2param/0.32.10-1.tar.gz";
+    name = "0.32.10-1.tar.gz";
+    sha256 = "2579f1a7cccbc9c57f0f1abde6e0291f97e3c116fd8c74ed3288b07256a5df1a";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2pkg/default.nix
+++ b/distros/jazzy/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, ros2cli }:
 buildRosPackage {
   pname = "ros-jazzy-ros2pkg";
-  version = "0.32.9-r1";
+  version = "0.32.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2pkg/0.32.9-1.tar.gz";
-    name = "0.32.9-1.tar.gz";
-    sha256 = "040e9865899491b41bdddd1fca5463a2406b42558244389a1816605b2bbe03c6";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2pkg/0.32.10-1.tar.gz";
+    name = "0.32.10-1.tar.gz";
+    sha256 = "9186dab46fcee5f1d0c2577af8c0354d2329bae39277b8fdd0a013814352984d";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2run/default.nix
+++ b/distros/jazzy/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-jazzy-ros2run";
-  version = "0.32.9-r1";
+  version = "0.32.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2run/0.32.9-1.tar.gz";
-    name = "0.32.9-1.tar.gz";
-    sha256 = "4660d803875d5a3dcbc4cd7337a5b0f453eda7c77b3e0f6f1ff721017473fea4";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2run/0.32.10-1.tar.gz";
+    name = "0.32.10-1.tar.gz";
+    sha256 = "1ea3a7953cc47c7e2ada5c696a6bb14c0d053c86ae0907cf6da9993a50e920ce";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2service/default.nix
+++ b/distros/jazzy/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, ros2topic, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2service";
-  version = "0.32.9-r1";
+  version = "0.32.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2service/0.32.9-1.tar.gz";
-    name = "0.32.9-1.tar.gz";
-    sha256 = "4c9fddba02612f2fb57cb26dfd6a9c29869ca6d5a3d94e1b33345207be1fb16d";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2service/0.32.10-1.tar.gz";
+    name = "0.32.10-1.tar.gz";
+    sha256 = "553686672a8deb9b65b88676e31b97e9cd44cad0b8c45356c0d8b2cef1d19386";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2test/default.nix
+++ b/distros/jazzy/ros2test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, domain-coordinator, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, ros2cli }:
 buildRosPackage {
   pname = "ros-jazzy-ros2test";
-  version = "0.6.0-r3";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_testing-release/archive/release/jazzy/ros2test/0.6.0-3.tar.gz";
-    name = "0.6.0-3.tar.gz";
-    sha256 = "64a0a75e5569b5fc90869abb59b7c4de34c5d607f16d181039ea396f89a703bf";
+    url = "https://github.com/ros2-gbp/ros_testing-release/archive/release/jazzy/ros2test/0.6.1-1.tar.gz";
+    name = "0.6.1-1.tar.gz";
+    sha256 = "62e869bc7bb0d844a3ac34526375fe3851d5b0aa0a1c2bf4eb9146a51ddba81c";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2topic/default.nix
+++ b/distros/jazzy/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosgraph-msgs, rosidl-runtime-py, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2topic";
-  version = "0.32.9-r1";
+  version = "0.32.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2topic/0.32.9-1.tar.gz";
-    name = "0.32.9-1.tar.gz";
-    sha256 = "6778e2b5e133810f704804911d7a4ebf293258861ffb6c6ea385a794af69a738";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/jazzy/ros2topic/0.32.10-1.tar.gz";
+    name = "0.32.10-1.tar.gz";
+    sha256 = "2ca4ff745a8cfefb538c96c45e9e8d8c880009e07181dab7bc5c1571b7a22f6a";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2trace/default.nix
+++ b/distros/jazzy/ros2trace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, python3Packages, ros2cli, tracetools-trace }:
 buildRosPackage {
   pname = "ros-jazzy-ros2trace";
-  version = "8.2.5-r1";
+  version = "8.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/jazzy/ros2trace/8.2.5-1.tar.gz";
-    name = "8.2.5-1.tar.gz";
-    sha256 = "22e58201c091c2b9ed24eabd1520616e2996c5a3aed58b837b7b4b926cd08c38";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/jazzy/ros2trace/8.2.6-1.tar.gz";
+    name = "8.2.6-1.tar.gz";
+    sha256 = "71cb256ae3b2820aff0f12b58e284a8a3580a4dbc758056859c4f0315b81b25c";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rosbag2-compression-zstd/default.nix
+++ b/distros/jazzy/rosbag2-compression-zstd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcutils, rosbag2-compression, rosbag2-test-common, zstd-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-rosbag2-compression-zstd";
-  version = "0.26.10-r2";
+  version = "0.26.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_compression_zstd/0.26.10-2.tar.gz";
-    name = "0.26.10-2.tar.gz";
-    sha256 = "22fe9ee6a36504365aa02bbc013377176368c3877a0af84ca7bc3a73f02303b9";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_compression_zstd/0.26.11-1.tar.gz";
+    name = "0.26.11-1.tar.gz";
+    sha256 = "025395cc96ce3ceda8d043da7886ad57a4fdc620d8d30d1c1118bad4e4c88d0b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbag2-compression/default.nix
+++ b/distros/jazzy/rosbag2-compression/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rosbag2-compression";
-  version = "0.26.10-r2";
+  version = "0.26.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_compression/0.26.10-2.tar.gz";
-    name = "0.26.10-2.tar.gz";
-    sha256 = "e0b1334eb4393364407a18addca26bc70110b002148fffadd8887104a2bdc3fc";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_compression/0.26.11-1.tar.gz";
+    name = "0.26.11-1.tar.gz";
+    sha256 = "c61531dd93c7c48213545c9d66319a363ea73296c06e7ae53d96bfbdf8a387a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbag2-cpp/default.nix
+++ b/distros/jazzy/rosbag2-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-test-msgdefs, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rosbag2-cpp";
-  version = "0.26.10-r2";
+  version = "0.26.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_cpp/0.26.10-2.tar.gz";
-    name = "0.26.10-2.tar.gz";
-    sha256 = "eb0ac02a77992b1fdd402c2f3382dd83eb71f4c636e56d4f7042291ee6fd0332";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_cpp/0.26.11-1.tar.gz";
+    name = "0.26.11-1.tar.gz";
+    sha256 = "0f806c9ac02f1f58555ff13626a47c00cbe71410df3a7c568f396b1641564e61";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbag2-examples-cpp/default.nix
+++ b/distros/jazzy/rosbag2-examples-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rosbag2-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-rosbag2-examples-cpp";
-  version = "0.26.10-r2";
+  version = "0.26.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_examples_cpp/0.26.10-2.tar.gz";
-    name = "0.26.10-2.tar.gz";
-    sha256 = "8645c994074dfd685ed7c865b48c3302ed8190ff7d6caa0f707255e7bcbf4b8a";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_examples_cpp/0.26.11-1.tar.gz";
+    name = "0.26.11-1.tar.gz";
+    sha256 = "c1a19af6ab7a37a1e1eb6c5dbd122f7417bfe837d68f68cd8c5514ec6f1f9db8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbag2-examples-py/default.nix
+++ b/distros/jazzy/rosbag2-examples-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, python3Packages, rclpy, rosbag2-py, rosidl-runtime-py, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rosbag2-examples-py";
-  version = "0.26.10-r2";
+  version = "0.26.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_examples_py/0.26.10-2.tar.gz";
-    name = "0.26.10-2.tar.gz";
-    sha256 = "9a0028bc8e3eef15b5dda8874510e495d6f7cf0b7dd3472a99756dd7bac932c7";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_examples_py/0.26.11-1.tar.gz";
+    name = "0.26.11-1.tar.gz";
+    sha256 = "1ef0abcd709bb931543a46cc2afee2bd1683a7721681f6670e2f3995ca935791";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rosbag2-interfaces/default.nix
+++ b/distros/jazzy/rosbag2-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-rosbag2-interfaces";
-  version = "0.26.10-r2";
+  version = "0.26.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_interfaces/0.26.10-2.tar.gz";
-    name = "0.26.10-2.tar.gz";
-    sha256 = "cdca762e19fd54adf741d72f80ba6ea5bfe0007c1ea334bb1f7cf2ddc8db27e6";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_interfaces/0.26.11-1.tar.gz";
+    name = "0.26.11-1.tar.gz";
+    sha256 = "5c8c550b48f09336cdb52f7d8a69bdc006ccf68b26d1b0786217f6abab44f3ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbag2-performance-benchmarking-msgs/default.nix
+++ b/distros/jazzy/rosbag2-performance-benchmarking-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, rosidl-typesupport-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-rosbag2-performance-benchmarking-msgs";
-  version = "0.26.10-r2";
+  version = "0.26.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_performance_benchmarking_msgs/0.26.10-2.tar.gz";
-    name = "0.26.10-2.tar.gz";
-    sha256 = "a17d25e2287492e560446122b63d921863a739f2c0cfd6dff1f163af43c160ce";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_performance_benchmarking_msgs/0.26.11-1.tar.gz";
+    name = "0.26.11-1.tar.gz";
+    sha256 = "14e32ffe935ba6120ee717025b77fc678c548363d15c4f13339a310a1def1b84";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbag2-performance-benchmarking/default.nix
+++ b/distros/jazzy/rosbag2-performance-benchmarking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, launch, launch-ros, python3Packages, rclcpp, rmw, ros-testing, ros2bag, ros2launch, rosbag2-compression, rosbag2-cpp, rosbag2-performance-benchmarking-msgs, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-rosbag2-performance-benchmarking";
-  version = "0.26.10-r2";
+  version = "0.26.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_performance_benchmarking/0.26.10-2.tar.gz";
-    name = "0.26.10-2.tar.gz";
-    sha256 = "8ac9ad185b3ed879bf20ffddf921efb21cb2c1e172ed5b1dd9e12a69eab5ca72";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_performance_benchmarking/0.26.11-1.tar.gz";
+    name = "0.26.11-1.tar.gz";
+    sha256 = "01a7ab23330d54ae7cdadc65c1ce574e8197a071a3bb1c62c3b57958a9aa70ce";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbag2-py/default.nix
+++ b/distros/jazzy/rosbag2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, pybind11-vendor, python-cmake-module, python3, python3Packages, rcl-interfaces, rclpy, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-test-msgdefs, rosbag2-transport, rosidl-runtime-py, rpyutils, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rosbag2-py";
-  version = "0.26.10-r2";
+  version = "0.26.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_py/0.26.10-2.tar.gz";
-    name = "0.26.10-2.tar.gz";
-    sha256 = "7ef1b5eed2f7e7bf5604821c761afcc034e3a01739488db5e26d288d239743e6";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_py/0.26.11-1.tar.gz";
+    name = "0.26.11-1.tar.gz";
+    sha256 = "fc85447bd090a807a9654168c5771cfdc95d1524f3c73713c1916ca613c3945b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbag2-storage-default-plugins/default.nix
+++ b/distros/jazzy/rosbag2-storage-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosbag2-storage-mcap, rosbag2-storage-sqlite3 }:
 buildRosPackage {
   pname = "ros-jazzy-rosbag2-storage-default-plugins";
-  version = "0.26.10-r2";
+  version = "0.26.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_storage_default_plugins/0.26.10-2.tar.gz";
-    name = "0.26.10-2.tar.gz";
-    sha256 = "b56996a45bbe1602b51a599e13be2fe661d3e4de5dc5ae6b01face28844810a8";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_storage_default_plugins/0.26.11-1.tar.gz";
+    name = "0.26.11-1.tar.gz";
+    sha256 = "136382a97e9c349c7fee0beabbf027a779b49e0cee185700ac723a6fc8a23d8c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbag2-storage-mcap/default.nix
+++ b/distros/jazzy/rosbag2-storage-mcap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcutils, rosbag2-storage, rosbag2-test-common, std-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-rosbag2-storage-mcap";
-  version = "0.26.10-r2";
+  version = "0.26.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_storage_mcap/0.26.10-2.tar.gz";
-    name = "0.26.10-2.tar.gz";
-    sha256 = "ce33e63ad92521d9fe31ffe352cb1096c800d4c35c0a4e10431556c8ab0503e5";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_storage_mcap/0.26.11-1.tar.gz";
+    name = "0.26.11-1.tar.gz";
+    sha256 = "bf2368b298ab552d0a572d1f2c54a0735f8d5d71733bbaff1f0851ea722353a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbag2-storage-sqlite3/default.nix
+++ b/distros/jazzy/rosbag2-storage-sqlite3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, sqlite3-vendor, std-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-rosbag2-storage-sqlite3";
-  version = "0.26.10-r2";
+  version = "0.26.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_storage_sqlite3/0.26.10-2.tar.gz";
-    name = "0.26.10-2.tar.gz";
-    sha256 = "df30b9ab52c6435dcd8b000871c6c6616292c04aa337c5d7c7283b1ff6d47789";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_storage_sqlite3/0.26.11-1.tar.gz";
+    name = "0.26.11-1.tar.gz";
+    sha256 = "881310174b1b3ca57c7dac645749e5dd5933429f06e960484d8a097682de2a62";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbag2-storage/default.nix
+++ b/distros/jazzy/rosbag2-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcutils, rmw, rosbag2-test-common, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-rosbag2-storage";
-  version = "0.26.10-r2";
+  version = "0.26.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_storage/0.26.10-2.tar.gz";
-    name = "0.26.10-2.tar.gz";
-    sha256 = "4964d28124b5d91f883dcff4ae3aa57f7911671d96c66c7a3ad35f8d3d982f8b";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_storage/0.26.11-1.tar.gz";
+    name = "0.26.11-1.tar.gz";
+    sha256 = "140216359fa394272dbe477b90e1c6c259dc008db96835b327b697400b4bb6ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbag2-test-common/default.nix
+++ b/distros/jazzy/rosbag2-test-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python-cmake-module, rclcpp, rcpputils, rcutils, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rosbag2-test-common";
-  version = "0.26.10-r2";
+  version = "0.26.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_test_common/0.26.10-2.tar.gz";
-    name = "0.26.10-2.tar.gz";
-    sha256 = "5f55a7e67fc496e4d81e48333e6a9268b421e0f0f3a7577b49ce9c37499874a5";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_test_common/0.26.11-1.tar.gz";
+    name = "0.26.11-1.tar.gz";
+    sha256 = "e19b8a875c5ac80ceb9d82fc1b0bd9bc4bbef751d7f00185c9dc7758045d7c71";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbag2-test-msgdefs/default.nix
+++ b/distros/jazzy/rosbag2-test-msgdefs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-jazzy-rosbag2-test-msgdefs";
-  version = "0.26.10-r2";
+  version = "0.26.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_test_msgdefs/0.26.10-2.tar.gz";
-    name = "0.26.10-2.tar.gz";
-    sha256 = "9dac6e7b002f70dc8013c7d995cd85ba78af91af1318e90697c7a4d99bac962c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_test_msgdefs/0.26.11-1.tar.gz";
+    name = "0.26.11-1.tar.gz";
+    sha256 = "930164a8129ee4ca0241ff59abac3d960376afd922a1928a34a4694f6d89cb00";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbag2-tests/default.nix
+++ b/distros/jazzy/rosbag2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-transport, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rosbag2-tests";
-  version = "0.26.10-r2";
+  version = "0.26.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_tests/0.26.10-2.tar.gz";
-    name = "0.26.10-2.tar.gz";
-    sha256 = "af9fa73794a1dd4d2740caa45d7973114a65386f8eb90d6b3a96285b9f6ecb6b";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_tests/0.26.11-1.tar.gz";
+    name = "0.26.11-1.tar.gz";
+    sha256 = "94783c2cc9547854f9bd949c2d21ec196d9962505e79724ed31a179da3e79a92";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbag2-transport/default.nix
+++ b/distros/jazzy/rosbag2-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, composition-interfaces, keyboard-handler, rclcpp, rclcpp-components, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, test-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-rosbag2-transport";
-  version = "0.26.10-r2";
+  version = "0.26.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_transport/0.26.10-2.tar.gz";
-    name = "0.26.10-2.tar.gz";
-    sha256 = "cdcee0d323b8a081a2db2d30284fcfd3942cc6b0f3ede4783179bfc0a10a3c84";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2_transport/0.26.11-1.tar.gz";
+    name = "0.26.11-1.tar.gz";
+    sha256 = "a2c2f87d45c1baae0ef3e8121901206adeb7abb89061b0aa59e920e1bcdddeb2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbag2/default.nix
+++ b/distros/jazzy/rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-tests, rosbag2-transport }:
 buildRosPackage {
   pname = "ros-jazzy-rosbag2";
-  version = "0.26.10-r2";
+  version = "0.26.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2/0.26.10-2.tar.gz";
-    name = "0.26.10-2.tar.gz";
-    sha256 = "f38208b1faacc75ef60ecd6f6ccb875d25244069cf269c239ec42601cdc7c0a0";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/rosbag2/0.26.11-1.tar.gz";
+    name = "0.26.11-1.tar.gz";
+    sha256 = "dbaa012a80a123a2a1f34149bc5b1b745c44104d82e0f743c9026119284ca1d0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbot-controller/default.nix
+++ b/distros/jazzy/rosbot-controller/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_husarion_mecanum_drive_controller, ament-cmake, ament-cmake-pytest, controller-manager, diff-drive-controller, imu-sensor-broadcaster, joint-state-broadcaster, launch, launch-ros, nav2-common, position-controllers, python3Packages, ros2controlcli, rosbot-description, rosbot-hardware-interfaces, rosbot-moveit, rosbot-utils, udev, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, controller-manager, diff-drive-controller, husarion-mecanum-drive-controller, imu-sensor-broadcaster, joint-state-broadcaster, launch, launch-ros, nav2-common, position-controllers, python3Packages, ros2controlcli, rosbot-description, rosbot-hardware-interfaces, rosbot-moveit, rosbot-utils, udev, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-rosbot-controller";
   version = "1.0.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-pytest python3Packages.pytest rosbot-description xacro ];
-  propagatedBuildInputs = [ _unresolved_husarion_mecanum_drive_controller controller-manager diff-drive-controller imu-sensor-broadcaster joint-state-broadcaster launch launch-ros nav2-common position-controllers ros2controlcli rosbot-description rosbot-hardware-interfaces rosbot-moveit rosbot-utils udev xacro ];
+  propagatedBuildInputs = [ controller-manager diff-drive-controller husarion-mecanum-drive-controller imu-sensor-broadcaster joint-state-broadcaster launch launch-ros nav2-common position-controllers ros2controlcli rosbot-description rosbot-hardware-interfaces rosbot-moveit rosbot-utils udev xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/rosidl-adapter/default.nix
+++ b/distros/jazzy/rosidl-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3, python3Packages, rosidl-cli }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-adapter";
-  version = "4.6.7-r1";
+  version = "4.6.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_adapter/4.6.7-1.tar.gz";
-    name = "4.6.7-1.tar.gz";
-    sha256 = "32633a8275206bd68cfa611690caa10ed9d0935efaec44f92b7c44ea6812e7c6";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_adapter/4.6.8-1.tar.gz";
+    name = "4.6.8-1.tar.gz";
+    sha256 = "94b0e796b68c5ab727baa01d7c4c50a1a0444ed76a8ffeed384811570cb289cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-cli/default.nix
+++ b/distros/jazzy/rosidl-cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-cli";
-  version = "4.6.7-r1";
+  version = "4.6.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_cli/4.6.7-1.tar.gz";
-    name = "4.6.7-1.tar.gz";
-    sha256 = "e5ca4c2d46b5ecdd45cc533e13dbfe0a1bcc809422df20a1e84dd16c9981586a";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_cli/4.6.8-1.tar.gz";
+    name = "4.6.8-1.tar.gz";
+    sha256 = "9027b6a9340e9b3f3699525b38f412d425950a0e1dc10ee0b6be11ecfaa0dfed";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rosidl-cmake/default.nix
+++ b/distros/jazzy/rosidl-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python3Packages, rosidl-pycommon }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-cmake";
-  version = "4.6.7-r1";
+  version = "4.6.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_cmake/4.6.7-1.tar.gz";
-    name = "4.6.7-1.tar.gz";
-    sha256 = "9e914e622a29b01132933852bea37c61b77f431c847621e1679a96bf1a6acabd";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_cmake/4.6.8-1.tar.gz";
+    name = "4.6.8-1.tar.gz";
+    sha256 = "76c7e5f17f5b42787393e642a61b71791c04cf30f8440ee247b753a1556d75a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-default-generators/default.nix
+++ b/distros/jazzy/rosidl-default-generators/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-core, ament-lint-auto, ament-lint-common, rosidl-core-generators, service-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-default-generators";
-  version = "1.6.0-r3";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_defaults-release/archive/release/jazzy/rosidl_default_generators/1.6.0-3.tar.gz";
-    name = "1.6.0-3.tar.gz";
-    sha256 = "da6f799804d096e72639c5f9e9683661bc3d5d4fd68e2c01ff0709f0adad2848";
+    url = "https://github.com/ros2-gbp/rosidl_defaults-release/archive/release/jazzy/rosidl_default_generators/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "5326f7a729cdce8cb3b280c1aeab0601616ca8c60ce135b873d21f543736f58d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-default-runtime/default.nix
+++ b/distros/jazzy/rosidl-default-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-core-runtime, service-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-default-runtime";
-  version = "1.6.0-r3";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_defaults-release/archive/release/jazzy/rosidl_default_runtime/1.6.0-3.tar.gz";
-    name = "1.6.0-3.tar.gz";
-    sha256 = "4d35c258c2c758572695d7a6f2d453f13645ea43674b8b8f24be1511a2407c05";
+    url = "https://github.com/ros2-gbp/rosidl_defaults-release/archive/release/jazzy/rosidl_default_runtime/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "435fb0cf9fb8912e39bc4808b0ea5a53a060e968e9c1060d92d7ec4636b0fb68";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-generator-c/default.nix
+++ b/distros/jazzy/rosidl-generator-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rcutils, rosidl-cli, rosidl-cmake, rosidl-generator-type-description, rosidl-parser, rosidl-pycommon, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-generator-c";
-  version = "4.6.7-r1";
+  version = "4.6.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_generator_c/4.6.7-1.tar.gz";
-    name = "4.6.7-1.tar.gz";
-    sha256 = "992bfcfe44479be64636bdc2c12321ba93764d494f3bec28afce2475f0e38c8c";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_generator_c/4.6.8-1.tar.gz";
+    name = "4.6.8-1.tar.gz";
+    sha256 = "1513a7183a6c5df8e928ad53e3ab3bb2771b7ba18332b031bb9532b9fd6e2b33";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-generator-cpp/default.nix
+++ b/distros/jazzy/rosidl-generator-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-type-description, rosidl-parser, rosidl-pycommon, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-generator-cpp";
-  version = "4.6.7-r1";
+  version = "4.6.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_generator_cpp/4.6.7-1.tar.gz";
-    name = "4.6.7-1.tar.gz";
-    sha256 = "c923c67e2b1b15d5c5bc6e45300ff7d82868e68aa3fa348db141e74fb5e20905";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_generator_cpp/4.6.8-1.tar.gz";
+    name = "4.6.8-1.tar.gz";
+    sha256 = "eef678a89563f7128edd3e253a94c9042ba80025aa28840fad46b593f850db6a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-generator-type-description/default.nix
+++ b/distros/jazzy/rosidl-generator-type-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-parser }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-generator-type-description";
-  version = "4.6.7-r1";
+  version = "4.6.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_generator_type_description/4.6.7-1.tar.gz";
-    name = "4.6.7-1.tar.gz";
-    sha256 = "6a7ced39311b71b9f1a5a1686647eaaa36f4805b310e2ebc5d69359a28710a6f";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_generator_type_description/4.6.8-1.tar.gz";
+    name = "4.6.8-1.tar.gz";
+    sha256 = "64cf0ead174fdeffb2674c0c486fcff996e0a3eccb8cb173c1413d4b6193c10c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-parser/default.nix
+++ b/distros/jazzy/rosidl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, rosidl-adapter }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-parser";
-  version = "4.6.7-r1";
+  version = "4.6.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_parser/4.6.7-1.tar.gz";
-    name = "4.6.7-1.tar.gz";
-    sha256 = "9cd7c02fa9a7e5869e76f920bf7105609914c7a779ac26f23e4bc0c4bbf4f2f5";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_parser/4.6.8-1.tar.gz";
+    name = "4.6.8-1.tar.gz";
+    sha256 = "f2ea9b30b0109627fdeeed71478489c293515a32304a64431aa8afa1cc8ab79a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-pycommon/default.nix
+++ b/distros/jazzy/rosidl-pycommon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, rosidl-parser }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-pycommon";
-  version = "4.6.7-r1";
+  version = "4.6.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_pycommon/4.6.7-1.tar.gz";
-    name = "4.6.7-1.tar.gz";
-    sha256 = "48a5fef07d6b1c743af18e2046d2db93689b4864612eca398ff8344a97dfa47b";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_pycommon/4.6.8-1.tar.gz";
+    name = "4.6.8-1.tar.gz";
+    sha256 = "8160a80fc801948832e6f31367de663f8f6a22b8ffe2414e1ad688b3a7672e35";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rosidl-runtime-c/default.nix
+++ b/distros/jazzy/rosidl-runtime-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, performance-test-fixture, rcutils, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-runtime-c";
-  version = "4.6.7-r1";
+  version = "4.6.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_runtime_c/4.6.7-1.tar.gz";
-    name = "4.6.7-1.tar.gz";
-    sha256 = "90707f1a1c4c7f3713d408df9a4ad986acb0f236fd5bb2a6d09c16cff578f286";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_runtime_c/4.6.8-1.tar.gz";
+    name = "4.6.8-1.tar.gz";
+    sha256 = "39c731faf4ceb62d83353881e3640bd3a3d719dd472709d06fee4bac259372b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-runtime-cpp/default.nix
+++ b/distros/jazzy/rosidl-runtime-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, performance-test-fixture, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-runtime-cpp";
-  version = "4.6.7-r1";
+  version = "4.6.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_runtime_cpp/4.6.7-1.tar.gz";
-    name = "4.6.7-1.tar.gz";
-    sha256 = "b492b16a89ac6135f5336408be52ac9a15cc33b1d0038df3e90c5e0b529e035b";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_runtime_cpp/4.6.8-1.tar.gz";
+    name = "4.6.8-1.tar.gz";
+    sha256 = "39916416bc334e6b0cff0e3413f55eeeee1f429d0df317b05884ce18753ebc90";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-runtime-py/default.nix
+++ b/distros/jazzy/rosidl-runtime-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, rosidl-parser, std-msgs, std-srvs, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-runtime-py";
-  version = "0.13.1-r2";
+  version = "0.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_runtime_py-release/archive/release/jazzy/rosidl_runtime_py/0.13.1-2.tar.gz";
-    name = "0.13.1-2.tar.gz";
-    sha256 = "8a90c8537d52ed5c4d36b3c75b25870b74f8c63c8e2357306ff50b35fe6b68f1";
+    url = "https://github.com/ros2-gbp/rosidl_runtime_py-release/archive/release/jazzy/rosidl_runtime_py/0.13.2-1.tar.gz";
+    name = "0.13.2-1.tar.gz";
+    sha256 = "3d308952557454b780ee4d816ff5e515960529c4e555b15335a54d66b6ba5e62";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rosidl-typesupport-c/default.nix
+++ b/distros/jazzy/rosidl-typesupport-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, python3, rcpputils, rcutils, rosidl-cli, rosidl-generator-c, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-c }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-typesupport-c";
-  version = "3.2.2-r1";
+  version = "3.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport-release/archive/release/jazzy/rosidl_typesupport_c/3.2.2-1.tar.gz";
-    name = "3.2.2-1.tar.gz";
-    sha256 = "aa093af8fb375aef508a4693291167ee91f6f526c462e9952c1e1223ddfe6fa6";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport-release/archive/release/jazzy/rosidl_typesupport_c/3.2.3-1.tar.gz";
+    name = "3.2.3-1.tar.gz";
+    sha256 = "666a6693a350a3cd6d12c42c123d2c7688856c9d08e506c2957af03ce49e311a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-typesupport-cpp/default.nix
+++ b/distros/jazzy/rosidl-typesupport-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, performance-test-fixture, python3, rcpputils, rcutils, rosidl-cli, rosidl-generator-c, rosidl-generator-type-description, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-typesupport-cpp";
-  version = "3.2.2-r1";
+  version = "3.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport-release/archive/release/jazzy/rosidl_typesupport_cpp/3.2.2-1.tar.gz";
-    name = "3.2.2-1.tar.gz";
-    sha256 = "0e9021ff53a9d614483c3d09f003b8f2499d927788b98a67f0f1ab113ec99fef";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport-release/archive/release/jazzy/rosidl_typesupport_cpp/3.2.3-1.tar.gz";
+    name = "3.2.3-1.tar.gz";
+    sha256 = "94d7611041673b95c81f80cf749e666ed1d11d0e2db121c4866169b2477ed944";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-typesupport-fastrtps-c/default.nix
+++ b/distros/jazzy/rosidl-typesupport-fastrtps-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, fastcdr, fastrtps-cmake-module, osrf-testing-tools-cpp, performance-test-fixture, python3, rcutils, rmw, rosidl-cli, rosidl-generator-c, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-typesupport-fastrtps-c";
-  version = "3.6.3-r1";
+  version = "3.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/jazzy/rosidl_typesupport_fastrtps_c/3.6.3-1.tar.gz";
-    name = "3.6.3-1.tar.gz";
-    sha256 = "58bbf17112232ec1bfd45f9cc1bc5373fd5706808ad181170d28b2c37de1d593";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/jazzy/rosidl_typesupport_fastrtps_c/3.6.4-1.tar.gz";
+    name = "3.6.4-1.tar.gz";
+    sha256 = "19148cf7ec41ce535a76166f6921d8b7e8d33085622ace0e6e6796f10462a6cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-typesupport-fastrtps-cpp/default.nix
+++ b/distros/jazzy/rosidl-typesupport-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, fastcdr, fastrtps-cmake-module, osrf-testing-tools-cpp, performance-test-fixture, python3, rcutils, rmw, rosidl-cli, rosidl-generator-c, rosidl-generator-cpp, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-typesupport-fastrtps-cpp";
-  version = "3.6.3-r1";
+  version = "3.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/jazzy/rosidl_typesupport_fastrtps_cpp/3.6.3-1.tar.gz";
-    name = "3.6.3-1.tar.gz";
-    sha256 = "21a667fb75b5378a4616b5367120d9d48336f0ecfcb574d5f76b259a3b92f34c";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/jazzy/rosidl_typesupport_fastrtps_cpp/3.6.4-1.tar.gz";
+    name = "3.6.4-1.tar.gz";
+    sha256 = "3160cf2f2d1b21dd2836fa66f2a68c6501aace778f7b6d1dfa5daf1f2bfef091";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-typesupport-interface/default.nix
+++ b/distros/jazzy/rosidl-typesupport-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-typesupport-interface";
-  version = "4.6.7-r1";
+  version = "4.6.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_typesupport_interface/4.6.7-1.tar.gz";
-    name = "4.6.7-1.tar.gz";
-    sha256 = "ebc573daa5494935353b3111fa6b4d377ca797644cf99a0c3315e43d416f147a";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_typesupport_interface/4.6.8-1.tar.gz";
+    name = "4.6.8-1.tar.gz";
+    sha256 = "f703cb11008ff1db483622fca562859a01ccd9c71af80f3cd1908cb59d98ae8e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-typesupport-introspection-c/default.nix
+++ b/distros/jazzy/rosidl-typesupport-introspection-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-typesupport-introspection-c";
-  version = "4.6.7-r1";
+  version = "4.6.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_typesupport_introspection_c/4.6.7-1.tar.gz";
-    name = "4.6.7-1.tar.gz";
-    sha256 = "b1ba6817eec7ad026914de874b41c62b099607159da1033495166166fa90bdf6";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_typesupport_introspection_c/4.6.8-1.tar.gz";
+    name = "4.6.8-1.tar.gz";
+    sha256 = "99693b7b2113e026347f551be746bc686eef423bf8f562c3662d4fc52ce595c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-typesupport-introspection-cpp/default.nix
+++ b/distros/jazzy/rosidl-typesupport-introspection-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidl-typesupport-introspection-c }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-typesupport-introspection-cpp";
-  version = "4.6.7-r1";
+  version = "4.6.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_typesupport_introspection_cpp/4.6.7-1.tar.gz";
-    name = "4.6.7-1.tar.gz";
-    sha256 = "6e7038d6e6ebf160c59a1099c6467614c2cffa9534859a08b443f6d423c6e712";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_typesupport_introspection_cpp/4.6.8-1.tar.gz";
+    name = "4.6.8-1.tar.gz";
+    sha256 = "e3e8d2b73b0ad15df8fcbb1c47c367f1a60aa5a4b94a8455fae65be058b7ff9d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rqt-gui-cpp/default.nix
+++ b/distros/jazzy/rqt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pluginlib, qt-gui-cpp, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-rqt-gui-cpp";
-  version = "1.6.3-r1";
+  version = "1.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/jazzy/rqt_gui_cpp/1.6.3-1.tar.gz";
-    name = "1.6.3-1.tar.gz";
-    sha256 = "cac7f33d85523ed0bd72af32cb7dd27d90fe121124716710cba125f6b27cfa88";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/jazzy/rqt_gui_cpp/1.6.4-1.tar.gz";
+    name = "1.6.4-1.tar.gz";
+    sha256 = "9218ade1ec88c4fd5d4c5abed838137cd1819e9e62291b44d6c4c3c5801a7a90";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rqt-gui-py/default.nix
+++ b/distros/jazzy/rqt-gui-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, qt-gui, rqt-gui }:
 buildRosPackage {
   pname = "ros-jazzy-rqt-gui-py";
-  version = "1.6.3-r1";
+  version = "1.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/jazzy/rqt_gui_py/1.6.3-1.tar.gz";
-    name = "1.6.3-1.tar.gz";
-    sha256 = "b24f797c480d0b686ab8db89e719bd7cd4354bbd566d90b5c0be95caf86b89cd";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/jazzy/rqt_gui_py/1.6.4-1.tar.gz";
+    name = "1.6.4-1.tar.gz";
+    sha256 = "c5e426c07b4020122392eb75860016b9b62f301ff82f363eddb8598ad442cfe0";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rqt-gui/default.nix
+++ b/distros/jazzy/rqt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages, qt-gui, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-rqt-gui";
-  version = "1.6.3-r1";
+  version = "1.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/jazzy/rqt_gui/1.6.3-1.tar.gz";
-    name = "1.6.3-1.tar.gz";
-    sha256 = "242f3899f1b9de5df48e747ceb5fe16f38196033265e887f57696fec116855bc";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/jazzy/rqt_gui/1.6.4-1.tar.gz";
+    name = "1.6.4-1.tar.gz";
+    sha256 = "1efbbe42296ad5937e265aa57a542b6548d7cd9e91adeb85eb35e25fb9b7b82d";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rqt-py-common/default.nix
+++ b/distros/jazzy/rqt-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, python-cmake-module, python-qt-binding, qt-gui, qt5, rclpy, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-rqt-py-common";
-  version = "1.6.3-r1";
+  version = "1.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/jazzy/rqt_py_common/1.6.3-1.tar.gz";
-    name = "1.6.3-1.tar.gz";
-    sha256 = "db713adf27babf3ac838b7d8e1c81bb8f546742e070ec397492b6843df39bce8";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/jazzy/rqt_py_common/1.6.4-1.tar.gz";
+    name = "1.6.4-1.tar.gz";
+    sha256 = "82c750f2491317e5ae235aefe502530452ce8f3e4f7bef4c7dafad46fdba9ab3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rqt/default.nix
+++ b/distros/jazzy/rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages, rqt-gui, rqt-gui-cpp, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-jazzy-rqt";
-  version = "1.6.3-r1";
+  version = "1.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/jazzy/rqt/1.6.3-1.tar.gz";
-    name = "1.6.3-1.tar.gz";
-    sha256 = "64678ceea1a573415231e9771e443a719bbb8d6b17337825f3aa926317f9cd8c";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/jazzy/rqt/1.6.4-1.tar.gz";
+    name = "1.6.4-1.tar.gz";
+    sha256 = "ca5c538a190ff4368fd67a7b8bb87f29bce38fbc9eee86abfecc1ec940a06a77";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rviz-assimp-vendor/default.nix
+++ b/distros/jazzy/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-assimp-vendor";
-  version = "14.1.20-r2";
+  version = "14.1.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_assimp_vendor/14.1.20-2.tar.gz";
-    name = "14.1.20-2.tar.gz";
-    sha256 = "eb3b854f9c3ce0d04380b9999e89ce20596152f238de284cf7cb98b88b00d371";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_assimp_vendor/14.1.21-1.tar.gz";
+    name = "14.1.21-1.tar.gz";
+    sha256 = "edee3580343c0a805370a8e8987d51c522a4bfdfe2535198b68d7663e388f600";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-common/default.nix
+++ b/distros/jazzy/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-common";
-  version = "14.1.20-r2";
+  version = "14.1.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_common/14.1.20-2.tar.gz";
-    name = "14.1.20-2.tar.gz";
-    sha256 = "4295b2413024637c77e101447b68474a84c9d1d06db40751270a12c4a6306fe3";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_common/14.1.21-1.tar.gz";
+    name = "14.1.21-1.tar.gz";
+    sha256 = "d89baeeb3d462de37f95a862db4f2da3019cbbbea855e35d7050d506af73f24f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-default-plugins/default.nix
+++ b/distros/jazzy/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, gz-math-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-default-plugins";
-  version = "14.1.20-r2";
+  version = "14.1.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_default_plugins/14.1.20-2.tar.gz";
-    name = "14.1.20-2.tar.gz";
-    sha256 = "0d119554b4c93c29bad98acbd80812eb88d01c078264a9c20c213ccf5bdd6d23";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_default_plugins/14.1.21-1.tar.gz";
+    name = "14.1.21-1.tar.gz";
+    sha256 = "c050adbafcaba7ed8e1210d7e7879a71f45935e94888679925a4a38030628a9a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-ogre-vendor/default.nix
+++ b/distros/jazzy/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, glew, libGL, libGLU, libx11, libxaw, libxrandr }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-ogre-vendor";
-  version = "14.1.20-r2";
+  version = "14.1.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_ogre_vendor/14.1.20-2.tar.gz";
-    name = "14.1.20-2.tar.gz";
-    sha256 = "366357ccdc55ea7f5ec6881ad832991dbefc619e2488d7f65dbfb025756f4f52";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_ogre_vendor/14.1.21-1.tar.gz";
+    name = "14.1.21-1.tar.gz";
+    sha256 = "4042a78be8f31e57f093ed7db979eb82d95b427c5c5ae2df10599651d2ff12c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-rendering-tests/default.nix
+++ b/distros/jazzy/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-rendering-tests";
-  version = "14.1.20-r2";
+  version = "14.1.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_rendering_tests/14.1.20-2.tar.gz";
-    name = "14.1.20-2.tar.gz";
-    sha256 = "5ef2b98c550576e3df155c748770a4a996ada8b0c5cbd7e5458c7c01c8649663";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_rendering_tests/14.1.21-1.tar.gz";
+    name = "14.1.21-1.tar.gz";
+    sha256 = "e70152b8467efc79f15b5b2f361054ad11ab84812316b8aa71da2d667fdbe53e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-rendering/default.nix
+++ b/distros/jazzy/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-rendering";
-  version = "14.1.20-r2";
+  version = "14.1.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_rendering/14.1.20-2.tar.gz";
-    name = "14.1.20-2.tar.gz";
-    sha256 = "20d1bccb89ea9e0835f1f9a136e046b34f016e64692cc1b7d21eae8a5cf43866";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_rendering/14.1.21-1.tar.gz";
+    name = "14.1.21-1.tar.gz";
+    sha256 = "c0bed7c67e528072f1e348b4fc229389460192333eadc7989414f9df4942664b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-visual-testing-framework/default.nix
+++ b/distros/jazzy/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-visual-testing-framework";
-  version = "14.1.20-r2";
+  version = "14.1.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_visual_testing_framework/14.1.20-2.tar.gz";
-    name = "14.1.20-2.tar.gz";
-    sha256 = "1e6ebbf6a0ade86d756dc6aa913ac65a4ec93f5ed6269724e83ecfad1f48f25a";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_visual_testing_framework/14.1.21-1.tar.gz";
+    name = "14.1.21-1.tar.gz";
+    sha256 = "dea5ca55b706f021077474681de5e12666858f1184ef7e9b58e3364524f99f02";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz2/default.nix
+++ b/distros/jazzy/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rviz2";
-  version = "14.1.20-r2";
+  version = "14.1.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz2/14.1.20-2.tar.gz";
-    name = "14.1.20-2.tar.gz";
-    sha256 = "588ea9e70dab9fc9175dfa1f2437a6743c1b604313a48b3924ecf259187b4f6a";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz2/14.1.21-1.tar.gz";
+    name = "14.1.21-1.tar.gz";
+    sha256 = "c745ebe79ce67130e2d3ccf8c688d32867910b5994e48c99c79c457426985689";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/shared-queues-vendor/default.nix
+++ b/distros/jazzy/shared-queues-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-shared-queues-vendor";
-  version = "0.26.10-r2";
+  version = "0.26.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/shared_queues_vendor/0.26.10-2.tar.gz";
-    name = "0.26.10-2.tar.gz";
-    sha256 = "b29a3156584149896fe38837c3142ca091fa8148b946f84098507f50d9583fe8";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/shared_queues_vendor/0.26.11-1.tar.gz";
+    name = "0.26.11-1.tar.gz";
+    sha256 = "29c3f82fe9e1169d17ce0c385b8d9da0add0baf4b81d0f76eefe605fa7cd3953";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/sm-advanced-recovery-1/default.nix
+++ b/distros/jazzy/sm-advanced-recovery-1/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cl-generic-sensor, cl-keyboard, cl-ros2-timer, rclcpp, smacc2, sr-all-events-go, std-msgs, xterm }:
+buildRosPackage {
+  pname = "ros-jazzy-sm-advanced-recovery-1";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sm_advanced_recovery_1/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "36dbacfe22036e38d6dbe735ce69d9c97b76d9be550206905b2a5ae375adb32b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cl-generic-sensor cl-keyboard cl-ros2-timer rclcpp smacc2 sr-all-events-go std-msgs xterm ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The sm_advanced_recovery_1 package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/sm-atomic-http/default.nix
+++ b/distros/jazzy/sm-atomic-http/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cl-http, cl-ros2-timer, smacc2, xterm }:
+buildRosPackage {
+  pname = "ros-jazzy-sm-atomic-http";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sm_atomic_http/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "bb7a692141a6c7448f4574e17960d91a74e56c1ca382b28e4e122b05352907b0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cl-http cl-ros2-timer smacc2 xterm ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The sm_atomic_http package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/sm-atomic-lifecycle/default.nix
+++ b/distros/jazzy/sm-atomic-lifecycle/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, cl-lifecycle-node, cl-ros2-timer, smacc2, std-msgs, xterm }:
+buildRosPackage {
+  pname = "ros-jazzy-sm-atomic-lifecycle";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sm_atomic_lifecycle/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "a1b3d337f6d94fb63665bac4501bad6dc4431947f0e67ada72842605a354fac5";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ament-cmake-auto cl-lifecycle-node cl-ros2-timer smacc2 std-msgs xterm ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The sm_atomic_lifecycle package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/sm-atomic-mode-states/default.nix
+++ b/distros/jazzy/sm-atomic-mode-states/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cl-ros2-timer, smacc2, xterm }:
+buildRosPackage {
+  pname = "ros-jazzy-sm-atomic-mode-states";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sm_atomic_mode_states/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "efe106f14bbb81d520ccd6098a92fe13cd3fd304af8a0e671041ea721b95a575";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cl-ros2-timer smacc2 xterm ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The sm_atomic_mode_states package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/sm-atomic-performance-trace-1/default.nix
+++ b/distros/jazzy/sm-atomic-performance-trace-1/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cl-ros2-timer, smacc2, xterm }:
+buildRosPackage {
+  pname = "ros-jazzy-sm-atomic-performance-trace-1";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sm_atomic_performance_trace_1/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "c1c60efa60c4a1a0d77627abc295fdf091ef0deafb0f0c31885e4b401140069d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cl-ros2-timer smacc2 xterm ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The sm_atomic_performance_trace_1 package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/sm-atomic-subscribers-performance-test/default.nix
+++ b/distros/jazzy/sm-atomic-subscribers-performance-test/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cl-ros2-timer, smacc2, xterm }:
+buildRosPackage {
+  pname = "ros-jazzy-sm-atomic-subscribers-performance-test";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sm_atomic_subscribers_performance_test/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "e50154647fd3cbacd0909f0d7b8683d4f0dea88d62336461d9300b27924c30f7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cl-ros2-timer smacc2 xterm ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The sm_atomic_subscribers_performance_test package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/sm-atomic/default.nix
+++ b/distros/jazzy/sm-atomic/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cl-ros2-timer, smacc2, xterm }:
+buildRosPackage {
+  pname = "ros-jazzy-sm-atomic";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sm_atomic/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "582b98cc24820fc4cbdd2526bcfff4ff85dc7fb92df4ae8a075eeb6ae11cc420";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cl-ros2-timer smacc2 xterm ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The sm_atomic package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/sm-branching/default.nix
+++ b/distros/jazzy/sm-branching/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cl-ros2-timer, smacc2, xterm }:
+buildRosPackage {
+  pname = "ros-jazzy-sm-branching";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sm_branching/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "a560dd994d8103f4814d0558e833dd92b0828da904eec4833da2058d98bdba07";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cl-ros2-timer smacc2 xterm ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The sm_branching package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/sm-cl-gcalcli-test-1/default.nix
+++ b/distros/jazzy/sm-cl-gcalcli-test-1/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cl-gcalcli, cl-ros2-timer, smacc2 }:
+buildRosPackage {
+  pname = "ros-jazzy-sm-cl-gcalcli-test-1";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sm_cl_gcalcli_test_1/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "eb63a612483d3137dd925f745c86d7edc7bb0cdf95f3627f3684805ce3b16b9c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cl-gcalcli cl-ros2-timer smacc2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Unit test state machine for cl_gcalcli client library";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/sm-cl-keyboard-unit-test-1/default.nix
+++ b/distros/jazzy/sm-cl-keyboard-unit-test-1/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cl-keyboard, cl-ros2-timer, plasma5Packages, smacc2 }:
+buildRosPackage {
+  pname = "ros-jazzy-sm-cl-keyboard-unit-test-1";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sm_cl_keyboard_unit_test_1/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "b0558fa3168bcfb33002b70704ae9e64cd7d0f1008f194e502b653edb40c2177";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cl-keyboard cl-ros2-timer plasma5Packages.konsole smacc2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The sm_cl_keyboard_unit_test_1 package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/sm-cl-px4-mr-test-1/default.nix
+++ b/distros/jazzy/sm-cl-px4-mr-test-1/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, _unresolved_px4_msgs, ament-cmake, cl-px4-mr, cl-ros2-timer, rclcpp, smacc2 }:
+buildRosPackage {
+  pname = "ros-jazzy-sm-cl-px4-mr-test-1";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sm_cl_px4_mr_test_1/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "5bef1f8aec697fbdf89a8c2d1f95747140c08d2c85a6aea0787a292416af3ab0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ _unresolved_px4_msgs cl-px4-mr cl-ros2-timer rclcpp smacc2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "SMACC2 test state machine for cl_px4_mr multirotor client";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/sm-cl-px4-mr-test-2/default.nix
+++ b/distros/jazzy/sm-cl-px4-mr-test-2/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, _unresolved_px4_msgs, ament-cmake, cl-px4-mr, cl-ros2-timer, rclcpp, smacc2 }:
+buildRosPackage {
+  pname = "ros-jazzy-sm-cl-px4-mr-test-2";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sm_cl_px4_mr_test_2/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "bb994c4599e154e20987d5b019c2f2865be9437a45248d433462fdc7284148ab";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ _unresolved_px4_msgs cl-px4-mr cl-ros2-timer rclcpp smacc2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "SMACC2 test state machine for cl_px4_mr new behaviors (hold, yaw, altitude, waypoints, figure-8, barrel roll, return-to-home)";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/sm-cl-ros2-timer-unit-test-1/default.nix
+++ b/distros/jazzy/sm-cl-ros2-timer-unit-test-1/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cl-ros2-timer, smacc2 }:
+buildRosPackage {
+  pname = "ros-jazzy-sm-cl-ros2-timer-unit-test-1";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sm_cl_ros2_timer_unit_test_1/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "a00c5f46eb78ffc311a5fc6bf19b9457ebfa22cc12a63870a976443393ce6f78";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cl-ros2-timer smacc2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The sm_cl_ros2_timer_unit_test_1 package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/sm-coretest-transition-speed-1/default.nix
+++ b/distros/jazzy/sm-coretest-transition-speed-1/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, smacc2 }:
+buildRosPackage {
+  pname = "ros-jazzy-sm-coretest-transition-speed-1";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sm_coretest_transition_speed_1/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "997c8eadfb77aa972c55314a0ad700fc60a3ea746e2fca2fceb76c5c7f58c966";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ smacc2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The sm_coretest_transition_speed_1 package";
+    license = with lib.licenses; [ asl20 "MyLicense" ];
+  };
+}

--- a/distros/jazzy/sm-data-sharing-1/default.nix
+++ b/distros/jazzy/sm-data-sharing-1/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cl-keyboard, cl-ros2-timer, plasma5Packages, smacc2 }:
+buildRosPackage {
+  pname = "ros-jazzy-sm-data-sharing-1";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sm_data_sharing_1/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "469b0ae7e026639f4668c7037294b67caa9bb4baeafb33f449d424a24783bfca";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cl-keyboard cl-ros2-timer plasma5Packages.konsole smacc2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Demonstrates sharing data across multiple states and clients using a state-machine-scoped component on a local client.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/sm-data-sharing-2/default.nix
+++ b/distros/jazzy/sm-data-sharing-2/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cl-keyboard, cl-ros2-timer, plasma5Packages, smacc2 }:
+buildRosPackage {
+  pname = "ros-jazzy-sm-data-sharing-2";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sm_data_sharing_2/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "ef94437609fa04888fa2d705301d8e5e003525dcade8c4c2549e914de29bf89e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cl-keyboard cl-ros2-timer plasma5Packages.konsole smacc2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Demonstrates sharing data across multiple states using a superstate. Client behaviors access the superstate via getParentState() as the behavior-accessible equivalent of context&lt;&gt;().";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/sm-modbus-tcp-relay-test-1/default.nix
+++ b/distros/jazzy/sm-modbus-tcp-relay-test-1/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cl-modbus-tcp-relay, smacc2 }:
+buildRosPackage {
+  pname = "ros-jazzy-sm-modbus-tcp-relay-test-1";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sm_modbus_tcp_relay_test_1/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "3253010aa3a9f212434086e3279e952799c8c0320223da09684f3594dc557db0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cl-modbus-tcp-relay smacc2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Test state machine for cl_modbus_tcp_relay client library";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/sm-multi-stage-1/default.nix
+++ b/distros/jazzy/sm-multi-stage-1/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cl-keyboard, cl-ros2-timer, plasma5Packages, rclcpp, smacc2, sr-all-events-go, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-sm-multi-stage-1";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sm_multi_stage_1/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "27181ed86ca0bcd31f34c7adf98f08b3a175cd7763db54a32a832fb042eb14bd";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cl-keyboard cl-ros2-timer plasma5Packages.konsole rclcpp smacc2 sr-all-events-go std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The sm_multi_stage_1 package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/sm-multithread-test-1/default.nix
+++ b/distros/jazzy/sm-multithread-test-1/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cl-ros2-timer, smacc2 }:
+buildRosPackage {
+  pname = "ros-jazzy-sm-multithread-test-1";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sm_multithread_test_1/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "3ec978ca2ad1603722ae1e95fd58892cb7884457dd969f079f00154ee09f1df4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cl-ros2-timer smacc2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "SMACC2 multi-threaded executor demonstration state machine.
+    This state machine demonstrates the use of ExecutionModel::MULTI_THREAD_SPINNER
+    for concurrent ROS2 callback processing. Addresses GitHub issue #571.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/sm-nav2-gazebo-test-1/default.nix
+++ b/distros/jazzy/sm-nav2-gazebo-test-1/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cl-keyboard, cl-nav2z, cl-ros2-timer, geometry-msgs, nav2-bringup, smacc2, xterm }:
+buildRosPackage {
+  pname = "ros-jazzy-sm-nav2-gazebo-test-1";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sm_nav2_gazebo_test_1/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "8d3f6572043ae0d30f0cc9fb08f4312b4b604ec880d8804813754dae1a216a51";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cl-keyboard cl-nav2z cl-ros2-timer geometry-msgs nav2-bringup smacc2 xterm ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Nav2 unit test state machine for SMACC2";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/sm-pack-ml/default.nix
+++ b/distros/jazzy/sm-pack-ml/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cl-generic-sensor, cl-keyboard, cl-ros2-timer, rclcpp, smacc2, sr-all-events-go, std-msgs, xterm }:
+buildRosPackage {
+  pname = "ros-jazzy-sm-pack-ml";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sm_pack_ml/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "e9a904401927bcca35a42491d787d4ad0ee367bacdd382dcc12711ce217a3154";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cl-generic-sensor cl-keyboard cl-ros2-timer rclcpp smacc2 sr-all-events-go std-msgs xterm ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The sm_pack_ml package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/sm-panda-cl-moveit2z-cb-inventory-isaacsim/default.nix
+++ b/distros/jazzy/sm-panda-cl-moveit2z-cb-inventory-isaacsim/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, cl-keyboard, cl-moveit2z, cl-ros2-timer, controller-manager, joint-state-broadcaster, joint-trajectory-controller, moveit, moveit-planners-chomp, moveit-planners-ompl, moveit-plugins, moveit-resources-panda-moveit-config, moveit-ros-robot-interaction, moveit-simple-controller-manager, moveit-visual-tools, pilz-industrial-motion-planner, plasma5Packages, rclcpp, robot-state-publisher, smacc2, yaml-cpp }:
+buildRosPackage {
+  pname = "ros-jazzy-sm-panda-cl-moveit2z-cb-inventory-isaacsim";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sm_panda_cl_moveit2z_cb_inventory_isaacsim/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "91a74110977666b1b1cb2c27847850b307bc3f7ac34dff3ed6061e3ea7bbc0cc";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ boost cl-keyboard cl-moveit2z cl-ros2-timer controller-manager joint-state-broadcaster joint-trajectory-controller moveit moveit-planners-chomp moveit-planners-ompl moveit-plugins moveit-resources-panda-moveit-config moveit-ros-robot-interaction moveit-simple-controller-manager moveit-visual-tools pilz-industrial-motion-planner plasma5Packages.konsole rclcpp robot-state-publisher smacc2 yaml-cpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The sm_panda_cl_moveit2z_cb_inventory package adapted for Isaac Sim";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/sm-panda-cl-moveit2z-cb-inventory/default.nix
+++ b/distros/jazzy/sm-panda-cl-moveit2z-cb-inventory/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, cl-keyboard, cl-moveit2z, cl-ros2-timer, controller-manager, joint-state-broadcaster, joint-trajectory-controller, moveit, moveit-planners-chomp, moveit-planners-ompl, moveit-plugins, moveit-resources-panda-moveit-config, moveit-ros-robot-interaction, moveit-simple-controller-manager, moveit-visual-tools, pilz-industrial-motion-planner, plasma5Packages, rclcpp, robot-state-publisher, smacc2, yaml-cpp }:
+buildRosPackage {
+  pname = "ros-jazzy-sm-panda-cl-moveit2z-cb-inventory";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sm_panda_cl_moveit2z_cb_inventory/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "7772f2c51e464b940e781b906da6a1b2ea3b4798dfbc5ad2fc46f1e088f30ae7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ boost cl-keyboard cl-moveit2z cl-ros2-timer controller-manager joint-state-broadcaster joint-trajectory-controller moveit moveit-planners-chomp moveit-planners-ompl moveit-plugins moveit-resources-panda-moveit-config moveit-ros-robot-interaction moveit-simple-controller-manager moveit-visual-tools pilz-industrial-motion-planner plasma5Packages.konsole rclcpp robot-state-publisher smacc2 yaml-cpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The sm_panda_cl_moveit2z_cb_inventory package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/sm-simple-action-client/default.nix
+++ b/distros/jazzy/sm-simple-action-client/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-cmake, boost, smacc2, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-sm-simple-action-client";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sm_simple_action_client/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "d53aaaf8f089b166c737148d98c55433d1718c309d44c2b4e19af0e3e4ed226f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ action-tutorials-interfaces boost smacc2 std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The sm_simple_action_client package";
+    license = with lib.licenses; [ asl20 "MyLicense" ];
+  };
+}

--- a/distros/jazzy/sm-three-some/default.nix
+++ b/distros/jazzy/sm-three-some/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cl-generic-sensor, cl-keyboard, cl-ros2-timer, rclcpp, smacc2, sr-all-events-go, std-msgs, xterm }:
+buildRosPackage {
+  pname = "ros-jazzy-sm-three-some";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sm_three_some/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "0763c515e75e6766ee2c03db6b4a94f9f8adf755f6c8be4fb316bdde41c29793";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cl-generic-sensor cl-keyboard cl-ros2-timer rclcpp smacc2 sr-all-events-go std-msgs xterm ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The sm_three_some package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/smacc2-msgs/default.nix
+++ b/distros/jazzy/smacc2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-smacc2-msgs";
-  version = "3.0.1-r1";
+  version = "3.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/smacc2_msgs/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "a23e1ba2b581b4b7da62224c5c667733da1025b76c9988feb2b3aabba6037cd8";
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/smacc2_msgs/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "7a53fa671064f0fdabe8b02ab2ef9f41cce102bf0d46c776f705da053588969b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/smacc2/default.nix
+++ b/distros/jazzy/smacc2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, lttng-ust, rcl, rclcpp, rclcpp-action, smacc2-msgs, tracetools, tracetools-launch, tracetools-trace }:
 buildRosPackage {
   pname = "ros-jazzy-smacc2";
-  version = "3.0.1-r1";
+  version = "3.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/smacc2/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "a59713efe110507c0e598ef3fd3201d51d858c24e9ed2d4b1b2ffa475e64d8b7";
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/smacc2/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "f7f8ecdfd243b391a38bdc84b1a526446322917e80ca5e3b53ce1d103037989c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/spdlog-vendor/default.nix
+++ b/distros/jazzy/spdlog-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-lint-auto, ament-lint-common, spdlog }:
 buildRosPackage {
   pname = "ros-jazzy-spdlog-vendor";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/spdlog_vendor-release/archive/release/jazzy/spdlog_vendor/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "3bafbdfe315b9d3128e46af997bac1a8369994327950f60f487ac1fd75d102cf";
+    url = "https://github.com/ros2-gbp/spdlog_vendor-release/archive/release/jazzy/spdlog_vendor/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "4f88fee8ca69728531c0b74ffab451ba193fc2b97ad208700862dd4461d2c3e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/sqlite3-vendor/default.nix
+++ b/distros/jazzy/sqlite3-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, sqlite }:
 buildRosPackage {
   pname = "ros-jazzy-sqlite3-vendor";
-  version = "0.26.10-r2";
+  version = "0.26.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/sqlite3_vendor/0.26.10-2.tar.gz";
-    name = "0.26.10-2.tar.gz";
-    sha256 = "8744b27178de70f48174fec51ba811562d621f9e7b946b2077560752434fe7e7";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/sqlite3_vendor/0.26.11-1.tar.gz";
+    name = "0.26.11-1.tar.gz";
+    sha256 = "83306b4c6085d7c85b403dfb34b8b6fd09775b9b0effcb711d1d97a1535ffb22";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/sr-all-events-go/default.nix
+++ b/distros/jazzy/sr-all-events-go/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, smacc2, smacc2-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-sr-all-events-go";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sr_all_events_go/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "1423dbdc343f838e152e4d26f1e3049fc1997173a5e48a6d6e92eaf7eaf4a0ca";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ smacc2 smacc2-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The sr_all_events_go package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/sr-conditional/default.nix
+++ b/distros/jazzy/sr-conditional/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, smacc2 }:
+buildRosPackage {
+  pname = "ros-jazzy-sr-conditional";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sr_conditional/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "7515a0d5c34eeffc23e4ce912faa7ea2d719dc1af3e5ed8cc06d0842fde7cc05";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ smacc2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The sr_conditional package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/sr-event-countdown/default.nix
+++ b/distros/jazzy/sr-event-countdown/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, smacc2 }:
+buildRosPackage {
+  pname = "ros-jazzy-sr-event-countdown";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/sr_event_countdown/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "771ae226583c5a0b83af8052903ea1c37c7f90e88eae289207868ba3d1733ec4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ smacc2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The sr_event_countdown package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/test-interface-files/default.nix
+++ b/distros/jazzy/test-interface-files/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-jazzy-test-interface-files";
-  version = "0.11.0-r3";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/test_interface_files-release/archive/release/jazzy/test_interface_files/0.11.0-3.tar.gz";
-    name = "0.11.0-3.tar.gz";
-    sha256 = "7568c6e5f6e5d6f2e3fd16c6392147b169036b2dd69f483101dadeefc0a1cdd5";
+    url = "https://github.com/ros2-gbp/test_interface_files-release/archive/release/jazzy/test_interface_files/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "69de764961a1a24aaf6f0b64a49dcfe028a9381b8c0a0a653683020c7f5541fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-bullet/default.nix
+++ b/distros/jazzy/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-bullet";
-  version = "0.36.20-r1";
+  version = "0.36.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_bullet/0.36.20-1.tar.gz";
-    name = "0.36.20-1.tar.gz";
-    sha256 = "13aee4365f2da6523f89fbe7ac76e29d9e0847d1214dd1293ac701d61925e2b5";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_bullet/0.36.21-1.tar.gz";
+    name = "0.36.21-1.tar.gz";
+    sha256 = "7b3bfdcfddf1b8b4b020073354df7e62f97304590c840de04a8f1d4bebe8722a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-eigen-kdl/default.nix
+++ b/distros/jazzy/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, orocos-kdl-vendor, tf2 }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-eigen-kdl";
-  version = "0.36.20-r1";
+  version = "0.36.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_eigen_kdl/0.36.20-1.tar.gz";
-    name = "0.36.20-1.tar.gz";
-    sha256 = "f8a25d300e875616d65e29bd296f5837a9531d5267d36f2dd4b32ebf13c34d58";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_eigen_kdl/0.36.21-1.tar.gz";
+    name = "0.36.21-1.tar.gz";
+    sha256 = "accf1cfd099c1ee7968b7b78a93dc9b1c1c5b820b9c88ffc0fdc5bd3fe8dd6be";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-eigen/default.nix
+++ b/distros/jazzy/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-eigen";
-  version = "0.36.20-r1";
+  version = "0.36.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_eigen/0.36.20-1.tar.gz";
-    name = "0.36.20-1.tar.gz";
-    sha256 = "7f98029998215b691f31902a875a676f509b524e7ffc8aecabc468598d142eaa";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_eigen/0.36.21-1.tar.gz";
+    name = "0.36.21-1.tar.gz";
+    sha256 = "210f29d8746c94f9c2cb4679d561da579d22d4794a097b3873b5479846f26a4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-geometry-msgs/default.nix
+++ b/distros/jazzy/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, orocos-kdl-vendor, python-cmake-module, python3Packages, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-geometry-msgs";
-  version = "0.36.20-r1";
+  version = "0.36.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_geometry_msgs/0.36.20-1.tar.gz";
-    name = "0.36.20-1.tar.gz";
-    sha256 = "9411638d97fc614dedacb3b89eca50582b5dd9e3474fe2b187ed02c6a7eebcb9";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_geometry_msgs/0.36.21-1.tar.gz";
+    name = "0.36.21-1.tar.gz";
+    sha256 = "a1e88aa532fa3a436b5dc945481180bc29b5f1e99f54e41cb589e6e3163f21e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-kdl/default.nix
+++ b/distros/jazzy/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl-vendor, python-orocos-kdl-vendor, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-kdl";
-  version = "0.36.20-r1";
+  version = "0.36.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_kdl/0.36.20-1.tar.gz";
-    name = "0.36.20-1.tar.gz";
-    sha256 = "7c12a6834bf044b7268d92554b72b4574bac4e2ba53a2914073d1041cfc06c3c";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_kdl/0.36.21-1.tar.gz";
+    name = "0.36.21-1.tar.gz";
+    sha256 = "3884d610d4f07cde231c68382e7b18fc996621e7af42f7881d88a88f6a0356e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-msgs/default.nix
+++ b/distros/jazzy/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-msgs";
-  version = "0.36.20-r1";
+  version = "0.36.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_msgs/0.36.20-1.tar.gz";
-    name = "0.36.20-1.tar.gz";
-    sha256 = "b075a9ee96b69cef2a8b8d1f81c933ac5a1fd292e4e40df4925df9740385b6d8";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_msgs/0.36.21-1.tar.gz";
+    name = "0.36.21-1.tar.gz";
+    sha256 = "0dfebe101a92658fd00176e11163dd86a21b088165017f29597af82ff6ce4d36";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-py/default.nix
+++ b/distros/jazzy/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python-cmake-module, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-py";
-  version = "0.36.20-r1";
+  version = "0.36.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_py/0.36.20-1.tar.gz";
-    name = "0.36.20-1.tar.gz";
-    sha256 = "207d3a3ec0a5464d41aae322cf7a14cdb5acd56a04f0826bbddb7885cc3abe3d";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_py/0.36.21-1.tar.gz";
+    name = "0.36.21-1.tar.gz";
+    sha256 = "722286f98e0b0195db3025f2793b078f90a289d2b3aae71cc2e276d2f497e541";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-ros-py/default.nix
+++ b/distros/jazzy/tf2-ros-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, geometry-msgs, python3Packages, rclpy, sensor-msgs, std-msgs, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-ros-py";
-  version = "0.36.20-r1";
+  version = "0.36.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_ros_py/0.36.20-1.tar.gz";
-    name = "0.36.20-1.tar.gz";
-    sha256 = "9d6aae7251c12c05dd0605ffa78e0ffacb23b0c72c837b2df08d65831c15cc6c";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_ros_py/0.36.21-1.tar.gz";
+    name = "0.36.21-1.tar.gz";
+    sha256 = "4b53e823556f70eb0b9f30c6090e9968fb28ee0d4ecb2b198c11db2f44ec0ced";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/tf2-ros/default.nix
+++ b/distros/jazzy/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, message-filters, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rosgraph-msgs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-ros";
-  version = "0.36.20-r1";
+  version = "0.36.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_ros/0.36.20-1.tar.gz";
-    name = "0.36.20-1.tar.gz";
-    sha256 = "461e522f5a17d3fea053c1267e76068703f3877eb3e55b65c570c1f4d25400c1";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_ros/0.36.21-1.tar.gz";
+    name = "0.36.21-1.tar.gz";
+    sha256 = "648d31b240912f48bb56ad00dbbf1b1bd656d60b74f5c376fa28177b81cbba68";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-sensor-msgs/default.nix
+++ b/distros/jazzy/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometry-msgs, python-cmake-module, python3Packages, rclcpp, sensor-msgs, sensor-msgs-py, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-sensor-msgs";
-  version = "0.36.20-r1";
+  version = "0.36.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_sensor_msgs/0.36.20-1.tar.gz";
-    name = "0.36.20-1.tar.gz";
-    sha256 = "ae1f9bc7003e017777a5cc2bb7a744dc88895fbeb984fbe1f2b23900f665bf2a";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_sensor_msgs/0.36.21-1.tar.gz";
+    name = "0.36.21-1.tar.gz";
+    sha256 = "f8ccca989c4493c6fd7ada046b1fc5e53c6cdcb68928f7fd3f38c2634703d207";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-tools/default.nix
+++ b/distros/jazzy/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, graphviz, python3Packages, rclpy, tf2-msgs, tf2-py, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-tools";
-  version = "0.36.20-r1";
+  version = "0.36.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_tools/0.36.20-1.tar.gz";
-    name = "0.36.20-1.tar.gz";
-    sha256 = "d6fcd65ca24f2d04a3ca68be130dabd5ba36189fca428e904bb7d0c4cff817e5";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_tools/0.36.21-1.tar.gz";
+    name = "0.36.21-1.tar.gz";
+    sha256 = "48b1eb69429323dd9ea06ae676ccd78781ad2ba1a5a29dcc379f41607a1b700d";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/tf2/default.nix
+++ b/distros/jazzy/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, builtin-interfaces, geometry-msgs, rcutils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-tf2";
-  version = "0.36.20-r1";
+  version = "0.36.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2/0.36.20-1.tar.gz";
-    name = "0.36.20-1.tar.gz";
-    sha256 = "80c7463ee0f001e65b9b13994e3779be6095179b79f2b77c0cd832aae5a87512";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2/0.36.21-1.tar.gz";
+    name = "0.36.21-1.tar.gz";
+    sha256 = "674b3e8a4c5f1738509de1e21ee5f63a45787be69a370458b8e29e6185ff640d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tile-map/default.nix
+++ b/distros/jazzy/tile-map/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, glew, jsoncpp, mapviz, pluginlib, qt5, rclcpp, swri-math-util, swri-transform-util, tf2, yaml-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-tile-map";
-  version = "2.6.4-r1";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/tile_map/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "fa60c0f38496eac17e46132bc9317f7c0af82f46a635553cf1776f12816a0e9b";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/tile_map/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "631869cd6de76c0dc656bdc1bdfbeede1d84d1e3405555a3d33747f7fd37b492";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tlsf/default.nix
+++ b/distros/jazzy/tlsf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-jazzy-tlsf";
-  version = "0.9.0-r3";
+  version = "0.9.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tlsf-release/archive/release/jazzy/tlsf/0.9.0-3.tar.gz";
-    name = "0.9.0-3.tar.gz";
-    sha256 = "a066aeacd935a3adbebf3b5b346190d7d310008e2752feefdc3d461e6bc97d37";
+    url = "https://github.com/ros2-gbp/tlsf-release/archive/release/jazzy/tlsf/0.9.1-2.tar.gz";
+    name = "0.9.1-2.tar.gz";
+    sha256 = "cf851acad5b8fe0e80d40df4ecd3a70b13c8c5816c1e165203bee7638d803aff";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/topic-monitor/default.nix
+++ b/distros/jazzy/topic-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, launch, launch-ros, python3Packages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-topic-monitor";
-  version = "0.33.10-r1";
+  version = "0.33.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/topic_monitor/0.33.10-1.tar.gz";
-    name = "0.33.10-1.tar.gz";
-    sha256 = "2c0eb7910d97acf6de91f0cf62c81fa3e84882504818a9c169851ccb00ff03cd";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/topic_monitor/0.33.11-1.tar.gz";
+    name = "0.33.11-1.tar.gz";
+    sha256 = "32069d1f2f01225a5cc3bb991dcaf7fb2fb0391d447533b36e35f33864310683";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/topic-statistics-demo/default.nix
+++ b/distros/jazzy/topic-statistics-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rcutils, sensor-msgs, statistics-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-topic-statistics-demo";
-  version = "0.33.10-r1";
+  version = "0.33.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/topic_statistics_demo/0.33.10-1.tar.gz";
-    name = "0.33.10-1.tar.gz";
-    sha256 = "f42c6470c7ddadc4e079dabaa416038ce9f818879c08a9af33d73ba1603a85c6";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/jazzy/topic_statistics_demo/0.33.11-1.tar.gz";
+    name = "0.33.11-1.tar.gz";
+    sha256 = "71518b354d5772cb53c7f8c5640f80fd18b3d993d810df859e87c2dec96c82cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tracetools-launch/default.nix
+++ b/distros/jazzy/tracetools-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, launch, launch-ros, python3Packages, tracetools-trace }:
 buildRosPackage {
   pname = "ros-jazzy-tracetools-launch";
-  version = "8.2.5-r1";
+  version = "8.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/jazzy/tracetools_launch/8.2.5-1.tar.gz";
-    name = "8.2.5-1.tar.gz";
-    sha256 = "4c2a3a6feefc8ecffa5b5c57544487055f243d89859af0132f81885bb7c0c72c";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/jazzy/tracetools_launch/8.2.6-1.tar.gz";
+    name = "8.2.6-1.tar.gz";
+    sha256 = "59a0e5577cd23778e0580712c6299c9425f2b3b671363e497adfe61f4c2035b9";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/tracetools-read/default.nix
+++ b/distros/jazzy/tracetools-read/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, babeltrace, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-tracetools-read";
-  version = "8.2.5-r1";
+  version = "8.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/jazzy/tracetools_read/8.2.5-1.tar.gz";
-    name = "8.2.5-1.tar.gz";
-    sha256 = "50f92eaefeac38b2febccdc6ad6f93f6c9eb699fde86446db8d202f6f55f1d06";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/jazzy/tracetools_read/8.2.6-1.tar.gz";
+    name = "8.2.6-1.tar.gz";
+    sha256 = "bfc44e8122e308dcdd4abc34df0e463614fc04239d4cdb758088f7f6239d5516";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/tracetools-test/default.nix
+++ b/distros/jazzy/tracetools-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, launch, launch-ros, python3Packages, tracetools-launch, tracetools-read, tracetools-trace }:
 buildRosPackage {
   pname = "ros-jazzy-tracetools-test";
-  version = "8.2.5-r1";
+  version = "8.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/jazzy/tracetools_test/8.2.5-1.tar.gz";
-    name = "8.2.5-1.tar.gz";
-    sha256 = "4805817229c8029993055d4376dd13fa3136ffe7539f567cdf9fc81710570409";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/jazzy/tracetools_test/8.2.6-1.tar.gz";
+    name = "8.2.6-1.tar.gz";
+    sha256 = "82735e341c9e3979937ea854e86a1c0d20cf9f42cb90439c536787e2d4af2d47";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/tracetools-trace/default.nix
+++ b/distros/jazzy/tracetools-trace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, lttngpy, procps, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-tracetools-trace";
-  version = "8.2.5-r1";
+  version = "8.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/jazzy/tracetools_trace/8.2.5-1.tar.gz";
-    name = "8.2.5-1.tar.gz";
-    sha256 = "c51c166544673f77911e9d67db34efe8813734334bbf2745fbf25e4bd9e4e101";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/jazzy/tracetools_trace/8.2.6-1.tar.gz";
+    name = "8.2.6-1.tar.gz";
+    sha256 = "0535722925efc48d6cd072a848b6e1f9131d4dae91c5593d16aab2356a9539c9";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/tracetools/default.nix
+++ b/distros/jazzy/tracetools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lttng-tools, lttng-ust, pkg-config }:
 buildRosPackage {
   pname = "ros-jazzy-tracetools";
-  version = "8.2.5-r1";
+  version = "8.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/jazzy/tracetools/8.2.5-1.tar.gz";
-    name = "8.2.5-1.tar.gz";
-    sha256 = "431a151fd13a2b0a4929cd7567624e124ee5ab943d8cdd82888be7b79d78d060";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/jazzy/tracetools/8.2.6-1.tar.gz";
+    name = "8.2.6-1.tar.gz";
+    sha256 = "d9909b5856cdb01f45255bbff959cd08a166d88345b2ef5bc6a228bb5c3ab242";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/turtlesim/default.nix
+++ b/distros/jazzy/turtlesim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, qt5, rcl-interfaces, rclcpp, rclcpp-action, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-turtlesim";
-  version = "1.8.3-r1";
+  version = "1.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/jazzy/turtlesim/1.8.3-1.tar.gz";
-    name = "1.8.3-1.tar.gz";
-    sha256 = "a4677ca14adeb7fd7fb8402cbfd30035c6b57adbcc98520ba54701342aaabbb7";
+    url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/jazzy/turtlesim/1.8.4-1.tar.gz";
+    name = "1.8.4-1.tar.gz";
+    sha256 = "2e2ffe6a5e87667ed6930618f9a3278d7309a0f036d263191f59aac7fe85a0c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/twist-mux-controller/default.nix
+++ b/distros/jazzy/twist-mux-controller/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, generate-parameter-library, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools }:
+buildRosPackage {
+  pname = "ros-jazzy-twist-mux-controller";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/husarion/husarion_controllers-release/archive/release/jazzy/twist_mux_controller/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "b677346e19df9ee85c6ff4e7c466d1024805e4d6f1da0969ab37c754e1857d97";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ controller-interface generate-parameter-library geometry-msgs hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Controller for managing multiple twist inputs";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/undo-path-global-planner/default.nix
+++ b/distros/jazzy/undo-path-global-planner/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-2d-utils, nav-msgs, nav2-core, nav2-costmap-2d, nav2z-planners-common, rclcpp, tf2, tf2-geometry-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-undo-path-global-planner";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/jazzy/undo_path_global_planner/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "025ecfae0365f087f0e3e10ca92e3c13569df14153011248811b925435fb6d2b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ geometry-msgs nav-2d-utils nav-msgs nav2-core nav2-costmap-2d nav2z-planners-common rclcpp tf2 tf2-geometry-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The undo_path_global_planner package.";
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/jazzy/unique-identifier-msgs/default.nix
+++ b/distros/jazzy/unique-identifier-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-core-generators, rosidl-core-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-unique-identifier-msgs";
-  version = "2.5.0-r3";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/unique_identifier_msgs-release/archive/release/jazzy/unique_identifier_msgs/2.5.0-3.tar.gz";
-    name = "2.5.0-3.tar.gz";
-    sha256 = "e57a72a47faf8472b08a7510336d6b2354ff4b35006569d48449f510853c48e8";
+    url = "https://github.com/ros2-gbp/unique_identifier_msgs-release/archive/release/jazzy/unique_identifier_msgs/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "95d0e969e6ed7a62985d5f5331aad16af276a538d277993deba2b474091a03f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/urdf-parser-plugin/default.nix
+++ b/distros/jazzy/urdf-parser-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, urdfdom-headers }:
 buildRosPackage {
   pname = "ros-jazzy-urdf-parser-plugin";
-  version = "2.10.0-r3";
+  version = "2.10.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/urdf-release/archive/release/jazzy/urdf_parser_plugin/2.10.0-3.tar.gz";
-    name = "2.10.0-3.tar.gz";
-    sha256 = "a036e6ecf0fa77b2deff7a8dee8612ba97c24c49c39f321549cb4d6e1c1b09f0";
+    url = "https://github.com/ros2-gbp/urdf-release/archive/release/jazzy/urdf_parser_plugin/2.10.1-2.tar.gz";
+    name = "2.10.1-2.tar.gz";
+    sha256 = "e412585c995c697c034e01f0592361c65a129c8fb15e0e1bda104874fca4ae9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/urdf/default.nix
+++ b/distros/jazzy/urdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-ros, ament-lint-auto, ament-lint-common, pluginlib, tinyxml2-vendor, urdf-parser-plugin, urdfdom, urdfdom-headers }:
 buildRosPackage {
   pname = "ros-jazzy-urdf";
-  version = "2.10.0-r3";
+  version = "2.10.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/urdf-release/archive/release/jazzy/urdf/2.10.0-3.tar.gz";
-    name = "2.10.0-3.tar.gz";
-    sha256 = "0cd0fb2d61b11905257bc73467f162afce38316f907708460b9c063e1750c972";
+    url = "https://github.com/ros2-gbp/urdf-release/archive/release/jazzy/urdf/2.10.1-2.tar.gz";
+    name = "2.10.1-2.tar.gz";
+    sha256 = "3f8761fecfd4be6cd153580cd1d6631dee2e4df2066e8034feb22eba9bc8c1da";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/urdfdom-headers/default.nix
+++ b/distros/jazzy/urdfdom-headers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-jazzy-urdfdom-headers";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/urdfdom_headers-release/archive/release/jazzy/urdfdom_headers/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "6eb8d5ab496296dc3f31fd0d59bb64728652f8bb6a16c250284026b853c02cc4";
+    url = "https://github.com/ros2-gbp/urdfdom_headers-release/archive/release/jazzy/urdfdom_headers/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "6555d1109477b288e9b5b654d64571a629e283a01347599b58d7d0c2b841c52b";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/zstd-vendor/default.nix
+++ b/distros/jazzy/zstd-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, zstd }:
 buildRosPackage {
   pname = "ros-jazzy-zstd-vendor";
-  version = "0.26.10-r2";
+  version = "0.26.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/zstd_vendor/0.26.10-2.tar.gz";
-    name = "0.26.10-2.tar.gz";
-    sha256 = "4f93141e74d9d0e74ebc89dfacd6726fda7935c49fedd553b9e7fa5da7900f41";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/jazzy/zstd_vendor/0.26.11-1.tar.gz";
+    name = "0.26.11-1.tar.gz";
+    sha256 = "08ee9947a9f83705b0599544c01ab54eb2486bda97ffd5f9c755c3f6e8ed6376";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/fastcdr/default.nix
+++ b/distros/kilted/fastcdr/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cmake }:
+{ lib, buildRosPackage, fetchurl, cmake, gtest }:
 buildRosPackage {
   pname = "ros-kilted-fastcdr";
-  version = "2.3.5-r1";
+  version = "2.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastcdr-release/archive/release/kilted/fastcdr/2.3.5-1.tar.gz";
-    name = "2.3.5-1.tar.gz";
-    sha256 = "b987c1ac52bc04589caf088fee6e4649d59ad365021bdd91cab28cef7affd4a5";
+    url = "https://github.com/ros2-gbp/fastcdr-release/archive/release/kilted/fastcdr/2.3.6-1.tar.gz";
+    name = "2.3.6-1.tar.gz";
+    sha256 = "5947dc643136a676a6326c4e370e46e99c89ba45b7bc15b086496e3f39775a82";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
-  checkInputs = [ ament-cmake ament-cmake-gtest ];
+  checkInputs = [ gtest ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/kilted/foxglove-bridge/default.nix
+++ b/distros/kilted/foxglove-bridge/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, geometry-msgs, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, rosx-introspection, sensor-msgs, std-msgs, std-srvs, websocketpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, geometry-msgs, nlohmann_json, rcl-interfaces, rclcpp, rclcpp-components, rcpputils, rcutils, resource-retriever, ros-environment, rosgraph-msgs, rosidl-typesupport-introspection-cpp, rosx-introspection, sensor-msgs, std-msgs, std-srvs, websocketpp }:
 buildRosPackage {
   pname = "ros-kilted-foxglove-bridge";
-  version = "3.3.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/kilted/foxglove_bridge/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "7cde0c97dde576487549152f75a145803a43a073e839374dcb5f16657fb84aa5";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/kilted/foxglove_bridge/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "2c2c9ebfedeae7932b7d83a9884224a11bb8450f174a40eafe2b0419e4d9c294";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake asio geometry-msgs nlohmann_json ros-environment sensor-msgs ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto openssl std-msgs std-srvs websocketpp ];
-  propagatedBuildInputs = [ ament-index-cpp rclcpp rclcpp-components resource-retriever rosgraph-msgs rosx-introspection std-msgs ];
+  buildInputs = [ ament-cmake geometry-msgs ros-environment sensor-msgs ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto asio nlohmann_json std-msgs std-srvs websocketpp ];
+  propagatedBuildInputs = [ ament-index-cpp rcl-interfaces rclcpp rclcpp-components rcpputils rcutils resource-retriever rosgraph-msgs rosidl-typesupport-introspection-cpp rosx-introspection std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/foxglove-msgs/default.nix
+++ b/distros/kilted/foxglove-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-kilted-foxglove-msgs";
-  version = "3.3.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/kilted/foxglove_msgs/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "8cb8bacde721ec2de539a9b3fc3a1aa5345cd0bc143fb4b92066b8442f19e2bb";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/kilted/foxglove_msgs/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "097d6259f7eb1e6694fb6efca9049cced4b86d2c2e8c9bd501b58138ac66004d";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/generated.nix
+++ b/distros/kilted/generated.nix
@@ -2348,6 +2348,20 @@ self: super: {
 
  rmw-zenoh-cpp = self.callPackage ./rmw-zenoh-cpp {};
 
+ roboplan = self.callPackage ./roboplan {};
+
+ roboplan-example-models = self.callPackage ./roboplan-example-models {};
+
+ roboplan-examples = self.callPackage ./roboplan-examples {};
+
+ roboplan-oink = self.callPackage ./roboplan-oink {};
+
+ roboplan-rrt = self.callPackage ./roboplan-rrt {};
+
+ roboplan-simple-ik = self.callPackage ./roboplan-simple-ik {};
+
+ roboplan-toppra = self.callPackage ./roboplan-toppra {};
+
  robot-calibration = self.callPackage ./robot-calibration {};
 
  robot-calibration-msgs = self.callPackage ./robot-calibration-msgs {};

--- a/distros/kilted/mapviz-interfaces/default.nix
+++ b/distros/kilted/mapviz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-kilted-mapviz-interfaces";
-  version = "2.6.4-r1";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/mapviz_interfaces/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "4133762bc72b2ab3ef45bb5710db751c849fa5b141e359ed5cca28e1fc970a10";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/mapviz_interfaces/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "aed67ce4d4e9230926e4fcaa71eed67a6a76b01d4ea776f4c80501de813996fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mapviz-plugins/default.nix
+++ b/distros/kilted/mapviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, cv-bridge, geometry-msgs, gps-msgs, image-transport, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-sensor-msgs, marti-visualization-msgs, nav-msgs, opencv, pluginlib, qt5, rclcpp, rclcpp-action, ros-environment, sensor-msgs, std-msgs, std-srvs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, tf2, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mapviz-plugins";
-  version = "2.6.4-r1";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/mapviz_plugins/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "1752069cd5a04377a3b514a1f45f423705fef6e707530a96ac8a6e9d6f1578b8";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/mapviz_plugins/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "1c6ca693cb35952ac933a6879e775da4de05b73c3bcef3cfbdd8d847a0d7ee99";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mapviz/default.nix
+++ b/distros/kilted/mapviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, freeglut, geometry-msgs, glew, image-transport, libxi, libxmu, mapviz-interfaces, opencv, pkg-config, pluginlib, qt5, rclcpp, ros-environment, rqt-gui, rqt-gui-cpp, std-srvs, swri-math-util, swri-transform-util, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-kilted-mapviz";
-  version = "2.6.4-r1";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/mapviz/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "7b329a831441aeb74d8d971cf7bf4a04e07e0a037736207920c56a7e96c4b058";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/mapviz/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "fea506bffad6b08e332b55746245d19c41e43259d826a20c6fac679029cb82aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mola-georeferencing/default.nix
+++ b/distros/kilted/mola-georeferencing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, gtsam, mola-common, mola-gtsam-factors, mola-yaml, mp2p-icp, mrpt-libmaps, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-kilted-mola-georeferencing";
-  version = "2.3.0-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/kilted/mola_georeferencing/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "179e07801631b97609def16af16a0c12095873738774a7cbf9589615c72d64aa";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/kilted/mola_georeferencing/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "0ab1a7cebfa83d32606e30d65f5e86a34dbd634664e9ac0526b2d7e6c98afa2c";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-gtsam-factors/default.nix
+++ b/distros/kilted/mola-gtsam-factors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, gtsam, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-kilted-mola-gtsam-factors";
-  version = "2.3.0-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/kilted/mola_gtsam_factors/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "a8c0a9e78051ac084946e31ac32dc31f4326e13c95ffb5392f3bf0836b56e8f6";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/kilted/mola_gtsam_factors/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "234f550cc6d41cbe66e82f70500ad7ed70dbf9c0211b4cc3dd9d8481edeb8245";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-state-estimation-simple/default.nix
+++ b/distros/kilted/mola-state-estimation-simple/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-kilted-mola-state-estimation-simple";
-  version = "2.3.0-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/kilted/mola_state_estimation_simple/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "e084d673b6b6550e49b3065f8665938e5e5313774f9139fa8c898198fc3554ab";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/kilted/mola_state_estimation_simple/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "40e8ec18cb722dce781f6e7448159f730d50a6210ed1e10104ec6d6e80d167f2";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mola-state-estimation-smoother/default.nix
+++ b/distros/kilted/mola-state-estimation-smoother/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, boost, cmake, gtsam, mola-common, mola-gtsam-factors, mola-imu-preintegration, mola-kernel, mola-launcher, mrpt-libobs, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-xmllint, boost, cmake, geometry-msgs, gtsam, launch-testing, launch-testing-ament-cmake, launch-testing-ros, mola-bridge-ros2, mola-common, mola-gtsam-factors, mola-imu-preintegration, mola-kernel, mola-launcher, mrpt-libobs, nav-msgs, rclpy, ros-environment, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-mola-state-estimation-smoother";
-  version = "2.3.0-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/kilted/mola_state_estimation_smoother/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "f1460970c824e8b83cb702af8dfcda89a01cf55bde75837878f97bf7033c49ec";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/kilted/mola_state_estimation_smoother/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "acf6ceb84ad5d70ebb565ad5de4799275e72ed111738e1a606faf8fa6c0ead7a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint boost cmake ros-environment ];
+  checkInputs = [ ament-cmake-pytest geometry-msgs launch-testing launch-testing-ament-cmake launch-testing-ros mola-bridge-ros2 mola-launcher nav-msgs rclpy sensor-msgs tf2-ros ];
   propagatedBuildInputs = [ gtsam mola-common mola-gtsam-factors mola-imu-preintegration mola-kernel mola-launcher mrpt-libobs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 

--- a/distros/kilted/mola-state-estimation/default.nix
+++ b/distros/kilted/mola-state-estimation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, mola-state-estimation-simple, mola-state-estimation-smoother }:
 buildRosPackage {
   pname = "ros-kilted-mola-state-estimation";
-  version = "2.3.0-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/kilted/mola_state_estimation/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "5cda872521874b5e1f4276cd14a26e9d32e962b1442b0d8fb5e0e6b38f993179";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/kilted/mola_state_estimation/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "f78c135f6a2e194bcaf8d1ed61315c85baa10fbe8cfd3c620a6845513a8ed8a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/multires-image/default.nix
+++ b/distros/kilted/multires-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, mapviz, pluginlib, qt5, rclcpp, rclpy, swri-math-util, swri-transform-util, tf2 }:
 buildRosPackage {
   pname = "ros-kilted-multires-image";
-  version = "2.6.4-r1";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/multires_image/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "a3f29f1e1bdf495b6da7997950b06a69e1a13a3a2b28669edf39015334685b8e";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/multires_image/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "1d1e36a4d60db300cda8a54257795b36eb5723e3d8253cd88ac30b3cf1af6fe0";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/novatel-gps-driver/default.nix
+++ b/distros/kilted/novatel-gps-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, boost, diagnostic-msgs, diagnostic-updater, gps-msgs, libpcap, nav-msgs, novatel-gps-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, swri-math-util, swri-roscpp, swri-serial-util, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-kilted-novatel-gps-driver";
-  version = "4.2.0-r5";
+  version = "4.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/kilted/novatel_gps_driver/4.2.0-5.tar.gz";
-    name = "4.2.0-5.tar.gz";
-    sha256 = "ca5ef3cfd845162ff0ca8f363078998086879eafa5fb48bd7be1f56c497ac958";
+    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/kilted/novatel_gps_driver/4.3.0-1.tar.gz";
+    name = "4.3.0-1.tar.gz";
+    sha256 = "9142e8fd6931e5f687c29425902ab210f6eec15feda06a4b64af1ca7acff0f51";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/novatel-gps-msgs/default.nix
+++ b/distros/kilted/novatel-gps-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-novatel-gps-msgs";
-  version = "4.2.0-r5";
+  version = "4.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/kilted/novatel_gps_msgs/4.2.0-5.tar.gz";
-    name = "4.2.0-5.tar.gz";
-    sha256 = "472841cf08f16b32420732a15e9525e48081c4ace4659a8204418f3d9d5859cc";
+    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/kilted/novatel_gps_msgs/4.3.0-1.tar.gz";
+    name = "4.3.0-1.tar.gz";
+    sha256 = "1b4a05778e3e3b65198977793b8ec162dda501e134e40b939126541e723323d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -741,6 +741,19 @@ in {
     ];
   });
 
+  roboplan-examples = rosSuper.roboplan-examples.overrideAttrs ({
+    buildInputs ? [], ...
+  }: {
+    # Prevent cmake from fetching osqp-eigen via git
+    buildInputs = buildInputs ++ [ self.osqp-eigen rosSelf.toppra ];
+  });
+
+  roboplan-toppra = rosSuper.roboplan-toppra.overrideAttrs ({
+    buildInputs ? [], ...
+  }: {
+    buildInputs = buildInputs ++ [ rosSelf.toppra ];
+  });
+
   roboplan-oink = (rosSuper.roboplan-oink.override {
     # https://github.com/tier4/osqp_vendor/issues/26
     osqp-vendor = null;

--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -97,14 +97,14 @@ in {
       # https://github.com/foxglove/foxglove-sdk/blob/main/ros/src/foxglove_bridge/CMakeLists.txt.
       # If the version doesn't match, cmake fails with "Hash mismatch"
       # and we can fix it here.
-      FOXGLOVE_SDK_VERSION = "0.23.1";
+      FOXGLOVE_SDK_VERSION = "0.25.1";
       systemToPlatform = {
         "x86_64-linux" = "x86_64-unknown-linux-gnu";
         "aarch64-linux" = "aarch64-unknown-linux-gnu";
       };
       systemToHash = {
-        "x86_64-linux" = "sha256-uUkpXoDrGpuzVuZXucJXnIhnF/rCkMTkil6YRgY78ug=";
-        "aarch64-linux" = "sha256-7CC88ap2n8m3bYT/PhXA3z8KKz7lbrfuRePx5DBmILw=";
+        "x86_64-linux" = "sha256-C500jfOo6Y0sLO4jYMyfUug7s0RQRN69dx0bRtw1i+Q=";
+        "aarch64-linux" = "sha256-xw41x48ON/O6jQJRzTHzU7sQsf0QYgDcbF9AntTfGRg=";
       };
       FOXGLOVE_SDK_PLATFORM = systemToPlatform.${self.system};
       sdk = self.fetchurl {

--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -741,7 +741,10 @@ in {
     ];
   });
 
-  roboplan-oink = rosSuper.roboplan-oink.overrideAttrs ({
+  roboplan-oink = (rosSuper.roboplan-oink.override {
+    # https://github.com/tier4/osqp_vendor/issues/26
+    osqp-vendor = null;
+  }).overrideAttrs ({
     buildInputs ? [], ...
   }: {
     # Prevent cmake from fetching osqp-eigen via git

--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -741,6 +741,13 @@ in {
     ];
   });
 
+  roboplan-oink = rosSuper.roboplan-oink.overrideAttrs ({
+    buildInputs ? [], ...
+  }: {
+    # Prevent cmake from fetching osqp-eigen via git
+    buildInputs = buildInputs ++ [ self.osqp-eigen ];
+  });
+
   rosidlcpp-generator-core = rosSuper.rosidlcpp-generator-core.override { fmt = self.fmt_9; };
   rosidlcpp-generator-cpp = rosSuper.rosidlcpp-generator-cpp.override { fmt = self.fmt_9; };
   rosidlcpp-generator-py = rosSuper.rosidlcpp-generator-py.override { fmt = self.fmt_9; };

--- a/distros/kilted/roboplan-example-models/default.nix
+++ b/distros/kilted/roboplan-example-models/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, python3Packages }:
+buildRosPackage {
+  pname = "ros-kilted-roboplan-example-models";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/kilted/roboplan_example_models/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "b950d3b994aba5615efbcdde818ab6d04a3e7e286b8bedb22538fe8aa91413f7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  propagatedBuildInputs = [ python3Packages.nanobind ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "Robot descriptions for RoboPlan testing and examples.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kilted/roboplan-examples/default.nix
+++ b/distros/kilted/roboplan-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, roboplan, roboplan-example-models, roboplan-oink, roboplan-rrt, roboplan-simple-ik, roboplan-toppra, xacro }:
+buildRosPackage {
+  pname = "ros-kilted-roboplan-examples";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/kilted/roboplan_examples/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "a716732659218691e1cb2c7260d9cd66e79853a85d752e6ce8cd7478e359f948";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ roboplan roboplan-example-models roboplan-oink roboplan-rrt roboplan-simple-ik roboplan-toppra xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Basic examples of RoboPlan.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kilted/roboplan-oink/default.nix
+++ b/distros/kilted/roboplan-oink/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, gtest, osqp-vendor, python3Packages, roboplan, roboplan-example-models }:
+buildRosPackage {
+  pname = "ros-kilted-roboplan-oink";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/kilted/roboplan_oink/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "d7a65dda272497504ea495c73ee3206a43805bbd704c12168896ce0383b89704";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-gmock gtest roboplan-example-models ];
+  propagatedBuildInputs = [ osqp-vendor python3Packages.nanobind roboplan ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "OInK - Optimal Inverse Kinematics solver for RoboPlan.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kilted/roboplan-rrt/default.nix
+++ b/distros/kilted/roboplan-rrt/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, python3Packages, roboplan, roboplan-example-models }:
+buildRosPackage {
+  pname = "ros-kilted-roboplan-rrt";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/kilted/roboplan_rrt/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "e270716f31d16add095af619e5cf3d4a898d35b524634294f2ddc57e20f6fc02";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest roboplan-example-models ];
+  propagatedBuildInputs = [ python3Packages.nanobind roboplan ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "Rapidly-Exploring Random Tree (RRT) implementation for RoboPlan.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kilted/roboplan-simple-ik/default.nix
+++ b/distros/kilted/roboplan-simple-ik/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, python3Packages, roboplan }:
+buildRosPackage {
+  pname = "ros-kilted-roboplan-simple-ik";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/kilted/roboplan_simple_ik/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "98195123cc54e9399a5e08289fcebaf2af62a43c26896c9c021eb47cc8b02753";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  propagatedBuildInputs = [ python3Packages.nanobind roboplan ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "Simple inverse kinematics solver for RoboPlan.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kilted/roboplan-toppra/default.nix
+++ b/distros/kilted/roboplan-toppra/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, python3Packages, roboplan, roboplan-example-models }:
+buildRosPackage {
+  pname = "ros-kilted-roboplan-toppra";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/kilted/roboplan_toppra/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "d05ee14b524c9049a1f64f041a5bda54490ab6342caae5316187fb02b0ff4ed6";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-gtest roboplan-example-models ];
+  propagatedBuildInputs = [ python3Packages.nanobind roboplan ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "Time Optimal Path Parameterization based on Reachability Analysis (TOPP-RA) wrapper for RoboPlan.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kilted/roboplan/default.nix
+++ b/distros/kilted/roboplan/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, eigen, gtest, pinocchio, python3Packages, roboplan-example-models, tinyxml2-vendor, tl-expected-nixpkgs, yaml-cpp-vendor }:
+buildRosPackage {
+  pname = "ros-kilted-roboplan";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/kilted/roboplan/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "cedec597a6f8029e299fcde2359ad531c317e5b5629e79fb42befa67a8f20b35";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-pytest gtest roboplan-example-models ];
+  propagatedBuildInputs = [ eigen pinocchio python3Packages.nanobind tinyxml2-vendor tl-expected-nixpkgs yaml-cpp-vendor ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "Core types, scene representation, and utilities for RoboPlan.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kilted/swri-cli-tools/default.nix
+++ b/distros/kilted/swri-cli-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, marti-introspection-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, ros2topic }:
 buildRosPackage {
   pname = "ros-kilted-swri-cli-tools";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_cli_tools/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "270158e5755a4d2b92af0278ce25446e607822638e6f953d533fb00c7f0273e1";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_cli_tools/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "7cb4a80dc93c909cabc9ed91450419241908ae231b1fcaf53bfca51953442563";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/swri-console-util/default.nix
+++ b/distros/kilted/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-kilted-swri-console-util";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_console_util/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "7054883bffc116930f84f05dc0302c1d1ec8bfb68444c47f098f7734dbc40eb2";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_console_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "1c69cd147047ffa59b4651499099b8a1a7de55fe9e9e48db3ad382c6a9ff8d22";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/swri-dbw-interface/default.nix
+++ b/distros/kilted/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-kilted-swri-dbw-interface";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_dbw_interface/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "728e70e572fb0dc06a157c6f26fcc226e559694a41154086f590e08d89506f4c";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_dbw_interface/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "6e5681a68e215aaea5ba0c1416621b6fdb92d46a07d5477d06d8e3e5df5663c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/swri-geometry-util/default.nix
+++ b/distros/kilted/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, geos, opencv, pkg-config, tf2 }:
 buildRosPackage {
   pname = "ros-kilted-swri-geometry-util";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_geometry_util/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "92527e9331ba7c0e565f4ca50162ed9ce3ff68598f9c41676b980d99c0d79df5";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_geometry_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "497017b3b231fc865901b848e787c91b46deccf0da5f8ef62db32761be381546";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/swri-image-util/default.nix
+++ b/distros/kilted/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, camera-calibration-parsers, cv-bridge, eigen, image-geometry, image-transport, message-filters, opencv, pkg-config, rcl-interfaces, rclcpp, rclcpp-components, rclpy, swri-geometry-util, swri-math-util, swri-opencv-util, tf2 }:
 buildRosPackage {
   pname = "ros-kilted-swri-image-util";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_image_util/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "5f9d8e47860e4f83e324146641d0a7e8167790d55ba36089042054eaecdd4f9b";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_image_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "869e49caea7012f9bc5ff11e43a1feed6f2ced31eada5b31fd1096fcec8467d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/swri-math-util/default.nix
+++ b/distros/kilted/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, rclcpp }:
 buildRosPackage {
   pname = "ros-kilted-swri-math-util";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_math_util/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "07ec0aefc9a576336fc8c63fba04d7131d1d67077a2bb6270087416d46a9a337";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_math_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "d2ae675ffb63d13dddc76c4a87989765b0fb681d5701e37a141304c054028c20";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/swri-opencv-util/default.nix
+++ b/distros/kilted/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, opencv, swri-math-util }:
 buildRosPackage {
   pname = "ros-kilted-swri-opencv-util";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_opencv_util/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "8bb88a75f3763618835674f64b6d7f09493366f07ebf8cde161601b5b30ad011";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_opencv_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "f666e44e0d54eebaff946bd21e8b68e9771cd593081c022413da681ad1270750";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/swri-roscpp/default.nix
+++ b/distros/kilted/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, diagnostic-msgs, diagnostic-updater, gtest, marti-common-msgs, nav-msgs, rclcpp, ros-environment, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kilted-swri-roscpp";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_roscpp/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "34d51d112e81132f582035122a053f24be59db492b82b7c5d74395943ec86c7a";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_roscpp/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "8e6d53384a86977865f7350755e9ba343f95760b5e20fbad5e006c091d3c5371";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/swri-route-util/default.nix
+++ b/distros/kilted/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-transform-util, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-swri-route-util";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_route_util/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "f4c4cf3f591b2b74df1a472af033e892bd86ba7175404b3830123938bc24573b";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_route_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "4c155d53b5bd134722966dda799ef8a736751f8f4241bb8338abac3f478b161c";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/swri-serial-util/default.nix
+++ b/distros/kilted/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-kilted-swri-serial-util";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_serial_util/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "380731c9dada1fd94dcb959d8e0553e044627302ba63ca3f82f7f1285791196b";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_serial_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "d73a1f46a247ece6279db6c4f38c384cbc0b5edcb1d5e28a106c44561116bbf9";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/swri-transform-util/default.nix
+++ b/distros/kilted/swri-transform-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-index-cpp, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geographiclib, geometry-msgs, geos, gps-msgs, launch-ros, launch-testing, launch-testing-ament-cmake, marti-nav-msgs, opencv, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-kilted-swri-transform-util";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_transform_util/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "50850e3938da224f6828d5f74ba3ce5b97a4a51f43d9fcf6471a61dd5ce49ac7";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_transform_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "ab5fcde89c3fb8d3799987ec2c40b4ebdbba8746f715b8384c399b6c66928e44";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/tile-map/default.nix
+++ b/distros/kilted/tile-map/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, glew, jsoncpp, mapviz, pluginlib, qt5, rclcpp, swri-math-util, swri-transform-util, tf2, yaml-cpp }:
 buildRosPackage {
   pname = "ros-kilted-tile-map";
-  version = "2.6.4-r1";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/tile_map/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "ea103f8575d8c3b15f68fcf5c92c6984e503b73dc9488afedf9b2e76ca0dd695";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/tile_map/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "ccbf35c5ea2190c72010c8fcb9f8f4a4e666567dc0d82285d3092fc368c83ab5";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/visp/default.nix
+++ b/distros/kilted/visp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bzip2, cmake, doxygen, eigen, gsl, libjpeg, liblapack, libpng, libv4l, libx11, libxml2, llvmPackages, nlohmann_json, openblas, opencv, zbar }:
 buildRosPackage {
   pname = "ros-kilted-visp";
-  version = "3.7.0-r6";
+  version = "3.7.0-r7";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/visp-release/archive/release/kilted/visp/3.7.0-6.tar.gz";
-    name = "3.7.0-6.tar.gz";
-    sha256 = "313bc2aa97ba8bedbfaf34533237459abb45e55fe3fbc40051b7610b558f3e45";
+    url = "https://github.com/ros2-gbp/visp-release/archive/release/kilted/visp/3.7.0-7.tar.gz";
+    name = "3.7.0-7.tar.gz";
+    sha256 = "31ce4975f96a8e8e4eb56e00d8ea18ff482cbcc33f6d92934995aad9ef7a4697";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/fastcdr/default.nix
+++ b/distros/lyrical/fastcdr/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cmake }:
+{ lib, buildRosPackage, fetchurl, cmake, gtest }:
 buildRosPackage {
   pname = "ros-lyrical-fastcdr";
-  version = "2.3.5-r3";
+  version = "2.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastcdr-release/archive/release/lyrical/fastcdr/2.3.5-3.tar.gz";
-    name = "2.3.5-3.tar.gz";
-    sha256 = "22fe20e8b25dc38f7d5574a1df39590d79f48472f5f4149f2fa04ed1a9625841";
+    url = "https://github.com/ros2-gbp/fastcdr-release/archive/release/lyrical/fastcdr/2.3.6-1.tar.gz";
+    name = "2.3.6-1.tar.gz";
+    sha256 = "c5891a5df3c00e92b8788db46263e3bcabd2949cd87200bed9033a3dcf2ea357";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
-  checkInputs = [ ament-cmake ament-cmake-gtest ];
+  checkInputs = [ gtest ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/lyrical/foxglove-bridge/default.nix
+++ b/distros/lyrical/foxglove-bridge/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, geometry-msgs, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, rosx-introspection, sensor-msgs, std-msgs, std-srvs, websocketpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, geometry-msgs, nlohmann_json, rcl-interfaces, rclcpp, rclcpp-components, rcpputils, rcutils, resource-retriever, ros-environment, rosgraph-msgs, rosidl-typesupport-introspection-cpp, rosx-introspection, sensor-msgs, std-msgs, std-srvs, websocketpp }:
 buildRosPackage {
   pname = "ros-lyrical-foxglove-bridge";
-  version = "3.2.6-r3";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/lyrical/foxglove_bridge/3.2.6-3.tar.gz";
-    name = "3.2.6-3.tar.gz";
-    sha256 = "8015ed8b65e1c415a8aa69455ec34f810947c5acf7bd06ccbedb62819148c9c3";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/lyrical/foxglove_bridge/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "273d46c1ec95cfd84ef28234d88e13278d205bec569bcbd6d12c229cfdc7a702";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake asio geometry-msgs nlohmann_json ros-environment sensor-msgs ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto openssl std-msgs std-srvs websocketpp ];
-  propagatedBuildInputs = [ ament-index-cpp rclcpp rclcpp-components resource-retriever rosgraph-msgs rosx-introspection std-msgs ];
+  buildInputs = [ ament-cmake geometry-msgs ros-environment sensor-msgs ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto asio nlohmann_json std-msgs std-srvs websocketpp ];
+  propagatedBuildInputs = [ ament-index-cpp rcl-interfaces rclcpp rclcpp-components rcpputils rcutils resource-retriever rosgraph-msgs rosidl-typesupport-introspection-cpp rosx-introspection std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/lyrical/foxglove-msgs/default.nix
+++ b/distros/lyrical/foxglove-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-lyrical-foxglove-msgs";
-  version = "3.2.6-r3";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/lyrical/foxglove_msgs/3.2.6-3.tar.gz";
-    name = "3.2.6-3.tar.gz";
-    sha256 = "16376c9fc653d8413b381302ec58ea5edb6e3814d2f68fd2dc450c543128e6b0";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/lyrical/foxglove_msgs/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "4e2c49b9a3f3ed86ec8861a8862dd9828848414cd55c7fdcf4658cf6a141fd5f";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/foxglove-sdk-vendor/default.nix
+++ b/distros/lyrical/foxglove-sdk-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-lyrical-foxglove-sdk-vendor";
-  version = "0.2.0-r4";
+  version = "0.2.0-r6";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_sdk_vendor-release/archive/release/lyrical/foxglove_sdk_vendor/0.2.0-4.tar.gz";
-    name = "0.2.0-4.tar.gz";
-    sha256 = "4511ba9b7e3f3520606f5580ef2dcf2ea24fee3ea64274671906ea85bab7d247";
+    url = "https://github.com/ros2-gbp/foxglove_sdk_vendor-release/archive/release/lyrical/foxglove_sdk_vendor/0.2.0-6.tar.gz";
+    name = "0.2.0-6.tar.gz";
+    sha256 = "48515c90fb9e66f6b9fa2701d4223a4f2f9bfc9389866c992eee215c821b6af6";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/generated.nix
+++ b/distros/lyrical/generated.nix
@@ -2100,6 +2100,20 @@ self: super: {
 
  rmw-zenoh-cpp = self.callPackage ./rmw-zenoh-cpp {};
 
+ roboplan = self.callPackage ./roboplan {};
+
+ roboplan-example-models = self.callPackage ./roboplan-example-models {};
+
+ roboplan-examples = self.callPackage ./roboplan-examples {};
+
+ roboplan-oink = self.callPackage ./roboplan-oink {};
+
+ roboplan-rrt = self.callPackage ./roboplan-rrt {};
+
+ roboplan-simple-ik = self.callPackage ./roboplan-simple-ik {};
+
+ roboplan-toppra = self.callPackage ./roboplan-toppra {};
+
  robot-arm-demo = self.callPackage ./robot-arm-demo {};
 
  robot-calibration = self.callPackage ./robot-calibration {};

--- a/distros/lyrical/gps-msgs/default.nix
+++ b/distros/lyrical/gps-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-gps-msgs";
-  version = "2.1.2-r3";
+  version = "2.1.2-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/lyrical/gps_msgs/2.1.2-3.tar.gz";
-    name = "2.1.2-3.tar.gz";
-    sha256 = "24ae49e3dbfd29d417edc5e2438f2d716af96ae1707bc84b7e17ec2708d3353a";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/lyrical/gps_msgs/2.1.2-4.tar.gz";
+    name = "2.1.2-4.tar.gz";
+    sha256 = "ed51b31ca52bad4d8f8bac1b178d1ec2200cbfbe573d6fc455bd24af026bd7e8";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/gps-tools/default.nix
+++ b/distros/lyrical/gps-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, gps-msgs, nav-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-gps-tools";
-  version = "2.1.2-r3";
+  version = "2.1.2-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/lyrical/gps_tools/2.1.2-3.tar.gz";
-    name = "2.1.2-3.tar.gz";
-    sha256 = "2d7b24e80557a9217b14bcffe9595d4baa2a686c61b8adda9a7e16edb43abb2e";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/lyrical/gps_tools/2.1.2-4.tar.gz";
+    name = "2.1.2-4.tar.gz";
+    sha256 = "0868a5d933c8e5c00f8667e580a50876d756ad5fb6f1e94082404eb53a89692f";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/gps-umd/default.nix
+++ b/distros/lyrical/gps-umd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gps-msgs, gps-tools, gpsd-client }:
 buildRosPackage {
   pname = "ros-lyrical-gps-umd";
-  version = "2.1.2-r3";
+  version = "2.1.2-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/lyrical/gps_umd/2.1.2-3.tar.gz";
-    name = "2.1.2-3.tar.gz";
-    sha256 = "55931af0ea0d2e228ddb5770fcc32880b1e222c6385b1036d535a709c7e41c7f";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/lyrical/gps_umd/2.1.2-4.tar.gz";
+    name = "2.1.2-4.tar.gz";
+    sha256 = "1fb47878db167f9df854b2b8311a7be69d57660e719d36b8d058687c030f03aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/gpsd-client/default.nix
+++ b/distros/lyrical/gpsd-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gps-msgs, gpsd, pkg-config, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-gpsd-client";
-  version = "2.1.2-r3";
+  version = "2.1.2-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/lyrical/gpsd_client/2.1.2-3.tar.gz";
-    name = "2.1.2-3.tar.gz";
-    sha256 = "0bd45caafba142d176680f6136b0f65eae33787f42986aee5dccba3c6503b5b5";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/lyrical/gpsd_client/2.1.2-4.tar.gz";
+    name = "2.1.2-4.tar.gz";
+    sha256 = "7bb64aa6ea82ac879dfde9d9fc9be686de88fcc1de8f5a16689b7b3836d66d2b";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/linear-feedback-controller/default.nix
+++ b/distros/lyrical/linear-feedback-controller/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_parameter_traits, ament-cmake-auto, ament-cmake-python, ament-lint-auto, control-toolbox, controller-interface, eigen, fmt, generate-parameter-library, gmock-vendor, gtest-vendor, hardware-interface, jrl-cmakemodules, linear-feedback-controller-msgs, message-filters, nav-msgs, pal-statistics, pinocchio, pluginlib, rcl, rclcpp, rclcpp-lifecycle, realtime-tools, rosidl-dynamic-typesupport, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-python, ament-lint-auto, control-toolbox, controller-interface, eigen, fmt, generate-parameter-library, gmock-vendor, gtest-vendor, hardware-interface, jrl-cmakemodules, linear-feedback-controller-msgs, message-filters, nav-msgs, pal-statistics, pinocchio, pluginlib, rcl, rclcpp, rclcpp-lifecycle, realtime-tools, rosidl-dynamic-typesupport, sensor-msgs, tl-expected-nixpkgs }:
 buildRosPackage {
   pname = "ros-lyrical-linear-feedback-controller";
-  version = "3.2.0-r3";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/linear-feedback-controller-release/archive/release/lyrical/linear_feedback_controller/3.2.0-3.tar.gz";
-    name = "3.2.0-3.tar.gz";
-    sha256 = "ce79a5789f11e346b0809386a13a8176877a0b51a4a1ce0aba0b181c85bad94c";
+    url = "https://github.com/ros2-gbp/linear-feedback-controller-release/archive/release/lyrical/linear_feedback_controller/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "0416fdc4e9deaa63a1090681397d26748b14757d6e82eb235d5ad786e0a5fc05";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ _unresolved_parameter_traits ament-cmake-auto ament-cmake-python fmt jrl-cmakemodules ];
+  buildInputs = [ ament-cmake-auto ament-cmake-python fmt jrl-cmakemodules tl-expected-nixpkgs ];
   checkInputs = [ ament-lint-auto gmock-vendor gtest-vendor ];
   propagatedBuildInputs = [ control-toolbox controller-interface eigen generate-parameter-library hardware-interface linear-feedback-controller-msgs message-filters nav-msgs pal-statistics pinocchio pluginlib rcl rclcpp rclcpp-lifecycle realtime-tools rosidl-dynamic-typesupport sensor-msgs ];
   nativeBuildInputs = [ ament-cmake-auto ament-cmake-python ];

--- a/distros/lyrical/marti-can-msgs/default.nix
+++ b/distros/lyrical/marti-can-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-marti-can-msgs";
-  version = "1.6.1-r3";
+  version = "1.6.1-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/lyrical/marti_can_msgs/1.6.1-3.tar.gz";
-    name = "1.6.1-3.tar.gz";
-    sha256 = "46a0364eb5073b340dda6dfb57ac3c51a72a400d4254e03445a06f5b1babaa89";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/lyrical/marti_can_msgs/1.6.1-4.tar.gz";
+    name = "1.6.1-4.tar.gz";
+    sha256 = "1561becb3cd985bae85eb5f791ab20c52a9c04829c5e814c653e94edff487d79";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/marti-common-msgs/default.nix
+++ b/distros/lyrical/marti-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-marti-common-msgs";
-  version = "1.6.1-r3";
+  version = "1.6.1-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/lyrical/marti_common_msgs/1.6.1-3.tar.gz";
-    name = "1.6.1-3.tar.gz";
-    sha256 = "e6f857a8ae3423381c7d07a9d2fb5fe9b1c7137589baaa194712476156e202c7";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/lyrical/marti_common_msgs/1.6.1-4.tar.gz";
+    name = "1.6.1-4.tar.gz";
+    sha256 = "3241d20f0f8ac3d75205696d1ccce3816759eb417862e87848d80a0838eaa07e";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/marti-dbw-msgs/default.nix
+++ b/distros/lyrical/marti-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-marti-dbw-msgs";
-  version = "1.6.1-r3";
+  version = "1.6.1-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/lyrical/marti_dbw_msgs/1.6.1-3.tar.gz";
-    name = "1.6.1-3.tar.gz";
-    sha256 = "fe031c041c7682ca04ab2201fb444a0d7942ba79ba932b4988ab613ef30dc1b9";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/lyrical/marti_dbw_msgs/1.6.1-4.tar.gz";
+    name = "1.6.1-4.tar.gz";
+    sha256 = "f51bf0b3e8f6b752fff6c48dfa939531162e128ecb6cd50850510846e7eeda7e";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/marti-introspection-msgs/default.nix
+++ b/distros/lyrical/marti-introspection-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-marti-introspection-msgs";
-  version = "1.6.1-r3";
+  version = "1.6.1-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/lyrical/marti_introspection_msgs/1.6.1-3.tar.gz";
-    name = "1.6.1-3.tar.gz";
-    sha256 = "ae7366b867ee8fe76b63e9c40fe4d6409c32f697d37af5e900571399fa23134f";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/lyrical/marti_introspection_msgs/1.6.1-4.tar.gz";
+    name = "1.6.1-4.tar.gz";
+    sha256 = "e0c785a3ddb6fb4f0301451a0d1a3d87bcdfcb35da1e0d9d2ba3bfe8667a1cd2";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/marti-nav-msgs/default.nix
+++ b/distros/lyrical/marti-nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geographic-msgs, geometry-msgs, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-marti-nav-msgs";
-  version = "1.6.1-r3";
+  version = "1.6.1-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/lyrical/marti_nav_msgs/1.6.1-3.tar.gz";
-    name = "1.6.1-3.tar.gz";
-    sha256 = "d501746d5b862721ece76343e0049a9da5c0b81b3609ba9ce14854866be005c7";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/lyrical/marti_nav_msgs/1.6.1-4.tar.gz";
+    name = "1.6.1-4.tar.gz";
+    sha256 = "527afa6825955c8693b75e4356e8678359a053f5b1a283295da7b1650955bf13";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/marti-perception-msgs/default.nix
+++ b/distros/lyrical/marti-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-marti-perception-msgs";
-  version = "1.6.1-r3";
+  version = "1.6.1-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/lyrical/marti_perception_msgs/1.6.1-3.tar.gz";
-    name = "1.6.1-3.tar.gz";
-    sha256 = "457f382b5fe8cb7c7561d3aa6a93a64ff5c8e73398e3adad9c252612fd6ecb5b";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/lyrical/marti_perception_msgs/1.6.1-4.tar.gz";
+    name = "1.6.1-4.tar.gz";
+    sha256 = "c770ab0c55aedb1906fae99b1e646488ce0e1ad28b984776ef37e7a78e15799a";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/marti-sensor-msgs/default.nix
+++ b/distros/lyrical/marti-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-lyrical-marti-sensor-msgs";
-  version = "1.6.1-r3";
+  version = "1.6.1-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/lyrical/marti_sensor_msgs/1.6.1-3.tar.gz";
-    name = "1.6.1-3.tar.gz";
-    sha256 = "4299f230fb14567b1f670471cdc674537dc8df9b520686476b14fd63856ac196";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/lyrical/marti_sensor_msgs/1.6.1-4.tar.gz";
+    name = "1.6.1-4.tar.gz";
+    sha256 = "65f5b6423e0a64c3fea90171d296831318cd802293007f311dccd62093c09ae1";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/marti-status-msgs/default.nix
+++ b/distros/lyrical/marti-status-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-marti-status-msgs";
-  version = "1.6.1-r3";
+  version = "1.6.1-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/lyrical/marti_status_msgs/1.6.1-3.tar.gz";
-    name = "1.6.1-3.tar.gz";
-    sha256 = "c8b0bbe962446995dcba6b96d98a6e0924efafcf6fbf22b22be8e585e98a2441";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/lyrical/marti_status_msgs/1.6.1-4.tar.gz";
+    name = "1.6.1-4.tar.gz";
+    sha256 = "8245df717927e4819aa07a4cd848b2785c474d42a0f5152a8daeca3a2b0a9336";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/marti-visualization-msgs/default.nix
+++ b/distros/lyrical/marti-visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-marti-visualization-msgs";
-  version = "1.6.1-r3";
+  version = "1.6.1-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/lyrical/marti_visualization_msgs/1.6.1-3.tar.gz";
-    name = "1.6.1-3.tar.gz";
-    sha256 = "171bb7b0ddb1233e60bb313512b06d668428996eb81f26a07f2f0d09e5f5a7cf";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/lyrical/marti_visualization_msgs/1.6.1-4.tar.gz";
+    name = "1.6.1-4.tar.gz";
+    sha256 = "2571eb48424d2382002663f45004526d4463d2fcc0956bb52e5db360e5e75178";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/mola-georeferencing/default.nix
+++ b/distros/lyrical/mola-georeferencing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, gtsam, mola-common, mola-gtsam-factors, mola-yaml, mp2p-icp, mrpt-libmaps, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-lyrical-mola-georeferencing";
-  version = "2.4.0-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/lyrical/mola_georeferencing/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "1bbd798640133d895ca16ca4c57bce787223df85b41e4d77a51883e23a2b6596";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/lyrical/mola_georeferencing/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "ada72ac767a06b2ec196060b442be09d79d6a89edfdf26cdb777896baeb650dc";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mola-gtsam-factors/default.nix
+++ b/distros/lyrical/mola-gtsam-factors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, gtsam, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-lyrical-mola-gtsam-factors";
-  version = "2.4.0-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/lyrical/mola_gtsam_factors/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "d1ea383e0ffc4c73253d35426d5753a35520391a623ce95eb56969bd7350d4fa";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/lyrical/mola_gtsam_factors/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "639993d1ad3e56e1ab9480b47a156d15c858c3394c86c72132f637bc5a204064";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mola-lidar-odometry/default.nix
+++ b/distros/lyrical/mola-lidar-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-imu-preintegration, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-lyrical-mola-lidar-odometry";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/lyrical/mola_lidar_odometry/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "a80544485e3d93d25d86458e9fcb7ee65827c7c6908492f060b7f1e7d8c59457";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/lyrical/mola_lidar_odometry/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "69df8b95792771a19af89b1ebda1ebd86f69686bd4580f19d48b1e5ee1261da2";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/mola-state-estimation-simple/default.nix
+++ b/distros/lyrical/mola-state-estimation-simple/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-lyrical-mola-state-estimation-simple";
-  version = "2.4.0-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/lyrical/mola_state_estimation_simple/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "40f547adefb62be2f63dc5508347add2ab51060d749e39b59467966e52c69897";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/lyrical/mola_state_estimation_simple/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "beb7f15b839e0c1fb09cf125ac7f30d32901977d61a55802286437013888035a";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mola-state-estimation-smoother/default.nix
+++ b/distros/lyrical/mola-state-estimation-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-xmllint, boost, cmake, geometry-msgs, gtsam, launch-testing, launch-testing-ament-cmake, launch-testing-ros, mola-bridge-ros2, mola-common, mola-gtsam-factors, mola-imu-preintegration, mola-kernel, mola-launcher, mrpt-libobs, nav-msgs, rclpy, ros-environment, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-lyrical-mola-state-estimation-smoother";
-  version = "2.4.0-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/lyrical/mola_state_estimation_smoother/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "2441c6c39365a6a5fd4cca800416dee9bfddac5b3980103c72e26454a887ce45";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/lyrical/mola_state_estimation_smoother/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "dc61de659305998d5f5592d4ce7f77e41962742f07ebaf1c618d276f86e57949";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/mola-state-estimation/default.nix
+++ b/distros/lyrical/mola-state-estimation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, mola-state-estimation-simple, mola-state-estimation-smoother }:
 buildRosPackage {
   pname = "ros-lyrical-mola-state-estimation";
-  version = "2.4.0-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/lyrical/mola_state_estimation/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "ae381c2c6bcb120b4351e1612c2a425eaa4f1768062c59e5347f8789e25d4334";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/lyrical/mola_state_estimation/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "b5df5f693ab1391c12afaf85b97397e28c546cf6c54f3be5887f075301c439bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/motion-capture-tracking-interfaces/default.nix
+++ b/distros/lyrical/motion-capture-tracking-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-motion-capture-tracking-interfaces";
-  version = "1.0.6-r3";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/lyrical/motion_capture_tracking_interfaces/1.0.6-3.tar.gz";
-    name = "1.0.6-3.tar.gz";
-    sha256 = "ea6d84a238922017fc0710797aa15b2510e67212774ddc2388e09f2d56e104ac";
+    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/lyrical/motion_capture_tracking_interfaces/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "6049a04a1b26db3894522134188d599b072b537333cb4787a4f629b5c25aa648";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/motion-capture-tracking/default.nix
+++ b/distros/lyrical/motion-capture-tracking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, motion-capture-tracking-interfaces, pcl, rclcpp, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-lyrical-motion-capture-tracking";
-  version = "1.0.6-r3";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/lyrical/motion_capture_tracking/1.0.6-3.tar.gz";
-    name = "1.0.6-3.tar.gz";
-    sha256 = "b977aac60e97632b62d94e9880d704bc3d305c2ff6f97d160d40c0e2f58e450f";
+    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/lyrical/motion_capture_tracking/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "b7af437679ac5e678993e8b8648d3cf3f5a790cbf5543fa6930f0e78bc2ea869";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/novatel-gps-driver/default.nix
+++ b/distros/lyrical/novatel-gps-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, boost, diagnostic-msgs, diagnostic-updater, gps-msgs, libpcap, nav-msgs, novatel-gps-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, swri-math-util, swri-roscpp, swri-serial-util, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-novatel-gps-driver";
-  version = "4.2.0-r6";
+  version = "4.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/lyrical/novatel_gps_driver/4.2.0-6.tar.gz";
-    name = "4.2.0-6.tar.gz";
-    sha256 = "ec2028469a9f20829944755f38032d3a782c93a98e82a81c4b1be0aba69eaa97";
+    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/lyrical/novatel_gps_driver/4.3.0-1.tar.gz";
+    name = "4.3.0-1.tar.gz";
+    sha256 = "39718ad1537f7d11b7500b3f05759a4bf1ac3b34afa154c17013aa56737fa0c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/novatel-gps-msgs/default.nix
+++ b/distros/lyrical/novatel-gps-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-novatel-gps-msgs";
-  version = "4.2.0-r6";
+  version = "4.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/lyrical/novatel_gps_msgs/4.2.0-6.tar.gz";
-    name = "4.2.0-6.tar.gz";
-    sha256 = "197a745655ef3114441428a34d78a99adcdf97a642abd57e2c164c1a0b3b03c5";
+    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/lyrical/novatel_gps_msgs/4.3.0-1.tar.gz";
+    name = "4.3.0-1.tar.gz";
+    sha256 = "c0687c6da997995d3b7baa1c5f4570cf223b6e4016fa5be9702bf7bc41cb442d";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -84,14 +84,14 @@ in {
       # https://github.com/foxglove/foxglove-sdk/blob/main/ros/src/foxglove_bridge/CMakeLists.txt.
       # If the version doesn't match, cmake fails with "Hash mismatch"
       # and we can fix it here.
-      FOXGLOVE_SDK_VERSION = "0.16.5";
+      FOXGLOVE_SDK_VERSION = "0.25.1";
       systemToPlatform = {
         "x86_64-linux" = "x86_64-unknown-linux-gnu";
         "aarch64-linux" = "aarch64-unknown-linux-gnu";
       };
       systemToHash = {
-        "x86_64-linux" = "sha256-jkln7HRGoGtaBMR7VLzUzs/yrYd24ALvOAPtSnB2hB0=";
-        "aarch64-linux" = "sha256-VMvFfGClUEc+CnX482DvtvokXrt/WC2176ZPHCl+VU8=";
+        "x86_64-linux" = "sha256-C500jfOo6Y0sLO4jYMyfUug7s0RQRN69dx0bRtw1i+Q=";
+        "aarch64-linux" = "sha256-xw41x48ON/O6jQJRzTHzU7sQsf0QYgDcbF9AntTfGRg=";
       };
       FOXGLOVE_SDK_PLATFORM = systemToPlatform.${self.system};
       sdk = self.fetchurl {

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -500,6 +500,13 @@ in {
     propagatedNativeBuildInputs = [ self.qt6.wrapQtAppsHook ];
   };
 
+  roboplan-examples = rosSuper.roboplan-examples.overrideAttrs ({
+    buildInputs ? [], ...
+  }: {
+    # Prevent cmake from fetching osqp-eigen via git
+    buildInputs = buildInputs ++ [ self.osqp-eigen ];
+  });
+
   roboplan-oink = rosSuper.roboplan-oink.overrideAttrs ({
     buildInputs ? [], ...
   }: {

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -500,16 +500,6 @@ in {
     propagatedNativeBuildInputs = [ self.qt6.wrapQtAppsHook ];
   };
 
-  rcdiscover = rosSuper.rcdiscover.overrideAttrs ({
-    postPatch ? "", ...
-  }: {
-    postPatch = postPatch + ''
-      substituteInPlace CMakeLists.txt --replace-fail \
-        "cmake_minimum_required (VERSION 3.1)" \
-        "cmake_minimum_required (VERSION 3.10)"\
-    '';
-  });
-
   rc-genicam-api = rosSuper.rc-genicam-api.overrideAttrs ({
     postPatch ? "", ...
   }: {

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -500,17 +500,6 @@ in {
     propagatedNativeBuildInputs = [ self.qt6.wrapQtAppsHook ];
   };
 
-  rc-genicam-api = rosSuper.rc-genicam-api.overrideAttrs ({
-    postPatch ? "", ...
-  }: {
-    # It's no longer needed to ignore "Error on non-existent target in get_target_property."
-    postPatch = postPatch + ''
-      substituteInPlace cmake/configure_link_libs.cmake --replace-fail \
-        "cmake_policy(SET CMP0045 OLD)" \
-        ""
-    '';
-  });
-
   rosidlcpp-generator-core = rosSuper.rosidlcpp-generator-core.override { fmt = self.fmt_9; };
   rosidlcpp-generator-cpp = rosSuper.rosidlcpp-generator-cpp.override { fmt = self.fmt_9; };
   rosidlcpp-generator-py = rosSuper.rosidlcpp-generator-py.override { fmt = self.fmt_9; };

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -500,6 +500,13 @@ in {
     propagatedNativeBuildInputs = [ self.qt6.wrapQtAppsHook ];
   };
 
+  roboplan-oink = rosSuper.roboplan-oink.overrideAttrs ({
+    buildInputs ? [], ...
+  }: {
+    # Prevent cmake from fetching osqp-eigen via git
+    buildInputs = buildInputs ++ [ self.osqp-eigen ];
+  });
+
   rosidlcpp-generator-core = rosSuper.rosidlcpp-generator-core.override { fmt = self.fmt_9; };
   rosidlcpp-generator-cpp = rosSuper.rosidlcpp-generator-cpp.override { fmt = self.fmt_9; };
   rosidlcpp-generator-py = rosSuper.rosidlcpp-generator-py.override { fmt = self.fmt_9; };

--- a/distros/lyrical/rc-genicam-api/default.nix
+++ b/distros/lyrical/rc-genicam-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, libpng, libusb1, ncurses }:
 buildRosPackage {
   pname = "ros-lyrical-rc-genicam-api";
-  version = "2.8.1-r3";
+  version = "2.8.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_genicam_api-release/archive/release/lyrical/rc_genicam_api/2.8.1-3.tar.gz";
-    name = "2.8.1-3.tar.gz";
-    sha256 = "725473e3080dea7b9e7407b25efd45987fc4fd2ba2c066f65c7e367cfb6ccf16";
+    url = "https://github.com/ros2-gbp/rc_genicam_api-release/archive/release/lyrical/rc_genicam_api/2.8.6-1.tar.gz";
+    name = "2.8.6-1.tar.gz";
+    sha256 = "8893fced64c8e4ce80aef7adf2101da4228c4641d4fe425c5489f5995480ea61";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/rcdiscover/default.nix
+++ b/distros/lyrical/rcdiscover/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-lyrical-rcdiscover";
-  version = "1.1.7-r3";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcdiscover-release/archive/release/lyrical/rcdiscover/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "8d4e77e9f7c1e90e9cbeaf62d1156aa8d197d5b06cd1aa9b2657249bd8e5348e";
+    url = "https://github.com/ros2-gbp/rcdiscover-release/archive/release/lyrical/rcdiscover/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "d2cc0fcced975272f84eae1270c1231b52ca08dc9ee6221cd619bc0f1c1c10bb";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/roboplan-example-models/default.nix
+++ b/distros/lyrical/roboplan-example-models/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, python3Packages }:
+buildRosPackage {
+  pname = "ros-lyrical-roboplan-example-models";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/lyrical/roboplan_example_models/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "d08ee5c7fed2ee36a65a390a700fabbd154526f37b8c3336b64e42b3f8c84037";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  propagatedBuildInputs = [ python3Packages.nanobind ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "Robot descriptions for RoboPlan testing and examples.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/lyrical/roboplan-examples/default.nix
+++ b/distros/lyrical/roboplan-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, roboplan, roboplan-example-models, roboplan-oink, roboplan-rrt, roboplan-simple-ik, roboplan-toppra, xacro }:
+buildRosPackage {
+  pname = "ros-lyrical-roboplan-examples";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/lyrical/roboplan_examples/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "b3d9d8b82c1dbcf6d996ebaa5e8f655d15cc3e1c7c760f9135636dfe029b4d6a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ roboplan roboplan-example-models roboplan-oink roboplan-rrt roboplan-simple-ik roboplan-toppra xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Basic examples of RoboPlan.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/lyrical/roboplan-oink/default.nix
+++ b/distros/lyrical/roboplan-oink/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, gtest, python3Packages, roboplan, roboplan-example-models }:
+buildRosPackage {
+  pname = "ros-lyrical-roboplan-oink";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/lyrical/roboplan_oink/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "82703bf9f3048f5e1073250f48128733305a450d469786b15ca03715359d29c0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-gmock gtest roboplan-example-models ];
+  propagatedBuildInputs = [ python3Packages.nanobind roboplan ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "OInK - Optimal Inverse Kinematics solver for RoboPlan.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/lyrical/roboplan-rrt/default.nix
+++ b/distros/lyrical/roboplan-rrt/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, python3Packages, roboplan, roboplan-example-models }:
+buildRosPackage {
+  pname = "ros-lyrical-roboplan-rrt";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/lyrical/roboplan_rrt/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "c45cc38a2435a7bfc99dc66d4958b88a9bc423332c75137c975b723dd170521d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest roboplan-example-models ];
+  propagatedBuildInputs = [ python3Packages.nanobind roboplan ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "Rapidly-Exploring Random Tree (RRT) implementation for RoboPlan.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/lyrical/roboplan-simple-ik/default.nix
+++ b/distros/lyrical/roboplan-simple-ik/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, python3Packages, roboplan }:
+buildRosPackage {
+  pname = "ros-lyrical-roboplan-simple-ik";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/lyrical/roboplan_simple_ik/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "2950068e5b22ae223a2e78f97593d9a3a5319c312e53d0b011eb56d09cd7a99a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  propagatedBuildInputs = [ python3Packages.nanobind roboplan ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "Simple inverse kinematics solver for RoboPlan.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/lyrical/roboplan-toppra/default.nix
+++ b/distros/lyrical/roboplan-toppra/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, python3Packages, roboplan, roboplan-example-models, toppra }:
+buildRosPackage {
+  pname = "ros-lyrical-roboplan-toppra";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/lyrical/roboplan_toppra/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "f34737b3072b3fcce6af38c1c03d49552c0320e2e6e42596c93f33bbca8227b2";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-gtest roboplan-example-models ];
+  propagatedBuildInputs = [ python3Packages.nanobind roboplan toppra ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "Time Optimal Path Parameterization based on Reachability Analysis (TOPP-RA) wrapper for RoboPlan.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/lyrical/roboplan/default.nix
+++ b/distros/lyrical/roboplan/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, eigen, gtest, pinocchio, python3Packages, roboplan-example-models, tinyxml-2, tl-expected-nixpkgs, yaml-cpp-vendor }:
+buildRosPackage {
+  pname = "ros-lyrical-roboplan";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/lyrical/roboplan/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "2ad571f4cbc10e902f7b9f377792cc45daebfda15d6a6456bddb39d6fd4f89bc";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-pytest gtest roboplan-example-models ];
+  propagatedBuildInputs = [ eigen pinocchio python3Packages.nanobind tinyxml-2 tl-expected-nixpkgs yaml-cpp-vendor ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "Core types, scene representation, and utilities for RoboPlan.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/lyrical/rqt-robot-steering/default.nix
+++ b/distros/lyrical/rqt-robot-steering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, geometry-msgs, python-qt-binding, python3Packages, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-lyrical-rqt-robot-steering";
-  version = "4.0.2-r3";
+  version = "4.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_robot_steering-release/archive/release/lyrical/rqt_robot_steering/4.0.2-3.tar.gz";
-    name = "4.0.2-3.tar.gz";
-    sha256 = "0bbf1e2e93b2eb660e3a4235cf74ae7a886edfd746a7bc8fbbc8946696596a82";
+    url = "https://github.com/ros2-gbp/rqt_robot_steering-release/archive/release/lyrical/rqt_robot_steering/4.1.0-1.tar.gz";
+    name = "4.1.0-1.tar.gz";
+    sha256 = "dec83edfbe6af021503331bd879d491293d8a932f5aae3026cc51722d83efca5";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/swri-cli-tools/default.nix
+++ b/distros/lyrical/swri-cli-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, marti-introspection-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, ros2topic }:
 buildRosPackage {
   pname = "ros-lyrical-swri-cli-tools";
-  version = "3.8.7-r3";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_cli_tools/3.8.7-3.tar.gz";
-    name = "3.8.7-3.tar.gz";
-    sha256 = "f88c6e22b3da24466c7bd249a802849fc6a0d50acef805a6046100fe6763f7c6";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_cli_tools/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "e7e849d026e60f80d85c976265a886d2ebfb951eefe5c7389460bc3616e56ae8";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/swri-console-util/default.nix
+++ b/distros/lyrical/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-lyrical-swri-console-util";
-  version = "3.8.7-r3";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_console_util/3.8.7-3.tar.gz";
-    name = "3.8.7-3.tar.gz";
-    sha256 = "7b965987b8db6bfca284f45751bdb40669ea26c8415618646de9aab4372f55d5";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_console_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "eb69481bafefb47362ad73632b215820e60dc79b21f5f548aa729b8b0d5fcb99";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/swri-dbw-interface/default.nix
+++ b/distros/lyrical/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-lyrical-swri-dbw-interface";
-  version = "3.8.7-r3";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_dbw_interface/3.8.7-3.tar.gz";
-    name = "3.8.7-3.tar.gz";
-    sha256 = "cd44e97c9e723790889dd39236b7cb76c828e5776ba782fd27fb2c5f853408bd";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_dbw_interface/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "e54ce73c410728007e6021180d7c3583c8beba9ea4b84f074f29018932074ecd";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/swri-geometry-util/default.nix
+++ b/distros/lyrical/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, geos, opencv, pkg-config, tf2 }:
 buildRosPackage {
   pname = "ros-lyrical-swri-geometry-util";
-  version = "3.8.7-r3";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_geometry_util/3.8.7-3.tar.gz";
-    name = "3.8.7-3.tar.gz";
-    sha256 = "88e58c91de15ec00a409cb8d08c193f0c71ae41d00c2eda0716d73a3e90e19a0";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_geometry_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "151ce188a6d23bff0bfb09a6a10e3cac34b37057fbad3106186f4e158842edc6";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/swri-image-util/default.nix
+++ b/distros/lyrical/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, camera-calibration-parsers, cv-bridge, eigen, image-geometry, image-transport, message-filters, opencv, pkg-config, rcl-interfaces, rclcpp, rclcpp-components, rclpy, swri-geometry-util, swri-math-util, swri-opencv-util, tf2 }:
 buildRosPackage {
   pname = "ros-lyrical-swri-image-util";
-  version = "3.8.7-r3";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_image_util/3.8.7-3.tar.gz";
-    name = "3.8.7-3.tar.gz";
-    sha256 = "040096636705ef95735bc1ecdb510e03c399f82328eef4643b266898a48b5a3d";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_image_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "1e3322d76aa02250363ba693aa5bc53aad68c9d388b081e28e16f336a76d1274";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/swri-math-util/default.nix
+++ b/distros/lyrical/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, rclcpp }:
 buildRosPackage {
   pname = "ros-lyrical-swri-math-util";
-  version = "3.8.7-r3";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_math_util/3.8.7-3.tar.gz";
-    name = "3.8.7-3.tar.gz";
-    sha256 = "7542d77521304bd0825a84aa2adb1bf294676e737bc93a44950445fea7ffb8ea";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_math_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "af3c747f2c0a4f6d8b8c3ba2b7d4b86197a40443185369e1d1e5467325fb3361";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/swri-opencv-util/default.nix
+++ b/distros/lyrical/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, opencv, swri-math-util }:
 buildRosPackage {
   pname = "ros-lyrical-swri-opencv-util";
-  version = "3.8.7-r3";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_opencv_util/3.8.7-3.tar.gz";
-    name = "3.8.7-3.tar.gz";
-    sha256 = "dfbc2df49a821db27424c574aea9d2fabf7e617035b97df6b233e12e4f786c3b";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_opencv_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "4af892ade2ef2b1e981c1b1ad0f0c4bd3a558eb774cbd432e51ff30ea60c2e5e";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/swri-roscpp/default.nix
+++ b/distros/lyrical/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, diagnostic-msgs, diagnostic-updater, gtest, marti-common-msgs, nav-msgs, rclcpp, ros-environment, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-lyrical-swri-roscpp";
-  version = "3.8.7-r3";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_roscpp/3.8.7-3.tar.gz";
-    name = "3.8.7-3.tar.gz";
-    sha256 = "efedc8bde225570aca102477f91238c48620867b943479bc6b4e0c728c053a59";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_roscpp/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "6654b9221103ef20c0e810f980206c7baae7f7b662459955b2bc8fcdf776423d";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/swri-route-util/default.nix
+++ b/distros/lyrical/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-transform-util, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-swri-route-util";
-  version = "3.8.7-r3";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_route_util/3.8.7-3.tar.gz";
-    name = "3.8.7-3.tar.gz";
-    sha256 = "62d90b9ba1d3b91d7705fdfa4b894cf6f50a405da3c630ffe25342e0bca58127";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_route_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "0d77e66678c15e7e73feba3ac5f6c97bdb6f4d902c1a0c9ccbcb806d9ec05805";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/swri-serial-util/default.nix
+++ b/distros/lyrical/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-lyrical-swri-serial-util";
-  version = "3.8.7-r3";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_serial_util/3.8.7-3.tar.gz";
-    name = "3.8.7-3.tar.gz";
-    sha256 = "33408bd00bc79c5e0f521c36a2b2d6a05e7dba4c81f12d6bf485c75104026b12";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_serial_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "55733b42fedcc2495f82047649f58886a3ce6b3bd24873f9ccd42b9a327c3d8c";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/swri-transform-util/default.nix
+++ b/distros/lyrical/swri-transform-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-index-cpp, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geographiclib, geometry-msgs, geos, gps-msgs, launch-ros, launch-testing, launch-testing-ament-cmake, marti-nav-msgs, opencv, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-lyrical-swri-transform-util";
-  version = "3.8.7-r3";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_transform_util/3.8.7-3.tar.gz";
-    name = "3.8.7-3.tar.gz";
-    sha256 = "00495e0a766eee63e4a0e91154961c669d9455e7fdbbdb0fc8d4779d07b2601f";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_transform_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "37dd76b3b930e5f72e46cc575ff04ee7b8000aa3cc37e58014eb8ad0f5d460df";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/sync-tooling-msgs/default.nix
+++ b/distros/lyrical/sync-tooling-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, protobuf }:
 buildRosPackage {
   pname = "ros-lyrical-sync-tooling-msgs";
-  version = "0.2.7-r3";
+  version = "0.2.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sync_tooling_msgs-release/archive/release/lyrical/sync_tooling_msgs/0.2.7-3.tar.gz";
-    name = "0.2.7-3.tar.gz";
-    sha256 = "89f5dd676cc4aea4e875ea2de02fff46e2362ce71261c35dfb687709e5f6fd30";
+    url = "https://github.com/ros2-gbp/sync_tooling_msgs-release/archive/release/lyrical/sync_tooling_msgs/0.2.10-1.tar.gz";
+    name = "0.2.10-1.tar.gz";
+    sha256 = "32018d3814cd849b07c4501e82f20b2d85b0b3ad20fa32c47cfc9063976c692e";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/visp/default.nix
+++ b/distros/lyrical/visp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bzip2, cmake, doxygen, eigen, gsl, libjpeg, liblapack, libpng, libv4l, libx11, libxml2, llvmPackages, nlohmann_json, openblas, opencv, zbar }:
 buildRosPackage {
   pname = "ros-lyrical-visp";
-  version = "3.7.0-r6";
+  version = "3.7.0-r8";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/visp-release/archive/release/lyrical/visp/3.7.0-6.tar.gz";
-    name = "3.7.0-6.tar.gz";
-    sha256 = "650005c87ec13024be813950d7430737944204786eda27b775ffe1efe0cd2036";
+    url = "https://github.com/ros2-gbp/visp-release/archive/release/lyrical/visp/3.7.0-8.tar.gz";
+    name = "3.7.0-8.tar.gz";
+    sha256 = "72f459d6528230167253bcc091b91dac4f7a3c4da1b80046b9631dff88e53217";
   };
 
   buildType = "cmake";

--- a/distros/rolling/fastcdr/default.nix
+++ b/distros/rolling/fastcdr/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cmake }:
+{ lib, buildRosPackage, fetchurl, cmake, gtest }:
 buildRosPackage {
   pname = "ros-rolling-fastcdr";
-  version = "2.3.5-r2";
+  version = "2.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastcdr-release/archive/release/rolling/fastcdr/2.3.5-2.tar.gz";
-    name = "2.3.5-2.tar.gz";
-    sha256 = "b01dedb21bce8e0fe2195bc56e6796c3d751ae04f553fc7f21ac66f699028200";
+    url = "https://github.com/ros2-gbp/fastcdr-release/archive/release/rolling/fastcdr/2.3.6-1.tar.gz";
+    name = "2.3.6-1.tar.gz";
+    sha256 = "5546c62514d15472b3ca0308c89683399df5514d942b1acc6162e3afb7f1b35b";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
-  checkInputs = [ ament-cmake ament-cmake-gtest ];
+  checkInputs = [ gtest ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/rolling/foxglove-bridge/default.nix
+++ b/distros/rolling/foxglove-bridge/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, geometry-msgs, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, rosx-introspection, sensor-msgs, std-msgs, std-srvs, websocketpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, geometry-msgs, nlohmann_json, rcl-interfaces, rclcpp, rclcpp-components, rcpputils, rcutils, resource-retriever, ros-environment, rosgraph-msgs, rosidl-typesupport-introspection-cpp, rosx-introspection, sensor-msgs, std-msgs, std-srvs, websocketpp }:
 buildRosPackage {
   pname = "ros-rolling-foxglove-bridge";
-  version = "3.3.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "23ee8b2b278a3c5bfc2e37357931acaba414e4acf414d9fe4aecd5910cd75064";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "ecba8901b39de9dd302c1d6be80628b849cb12dc546062bfba5e6b2f22163d0c";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake asio geometry-msgs nlohmann_json ros-environment sensor-msgs ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto openssl std-msgs std-srvs websocketpp ];
-  propagatedBuildInputs = [ ament-index-cpp rclcpp rclcpp-components resource-retriever rosgraph-msgs rosx-introspection std-msgs ];
+  buildInputs = [ ament-cmake geometry-msgs ros-environment sensor-msgs ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto asio nlohmann_json std-msgs std-srvs websocketpp ];
+  propagatedBuildInputs = [ ament-index-cpp rcl-interfaces rclcpp rclcpp-components rcpputils rcutils resource-retriever rosgraph-msgs rosidl-typesupport-introspection-cpp rosx-introspection std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/foxglove-msgs/default.nix
+++ b/distros/rolling/foxglove-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-foxglove-msgs";
-  version = "3.3.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_msgs/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "a84c527dbe5e85fc523462c2bc3dc1250f03ba5d72c24af80e834a6545fe0dca";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_msgs/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "28feaf0f3d61531a82a33b0f0f0f9173c86cdbe54372ca6a036be3c99376934a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -2096,6 +2096,20 @@ self: super: {
 
  rmw-zenoh-cpp = self.callPackage ./rmw-zenoh-cpp {};
 
+ roboplan = self.callPackage ./roboplan {};
+
+ roboplan-example-models = self.callPackage ./roboplan-example-models {};
+
+ roboplan-examples = self.callPackage ./roboplan-examples {};
+
+ roboplan-oink = self.callPackage ./roboplan-oink {};
+
+ roboplan-rrt = self.callPackage ./roboplan-rrt {};
+
+ roboplan-simple-ik = self.callPackage ./roboplan-simple-ik {};
+
+ roboplan-toppra = self.callPackage ./roboplan-toppra {};
+
  robot-arm-demo = self.callPackage ./robot-arm-demo {};
 
  robot-calibration = self.callPackage ./robot-calibration {};

--- a/distros/rolling/linear-feedback-controller/default.nix
+++ b/distros/rolling/linear-feedback-controller/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_parameter_traits, ament-cmake-auto, ament-cmake-python, ament-lint-auto, control-toolbox, controller-interface, eigen, fmt, generate-parameter-library, gmock-vendor, gtest-vendor, hardware-interface, jrl-cmakemodules, linear-feedback-controller-msgs, message-filters, nav-msgs, pal-statistics, pinocchio, pluginlib, rcl, rclcpp, rclcpp-lifecycle, realtime-tools, rosidl-dynamic-typesupport, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-python, ament-lint-auto, control-toolbox, controller-interface, eigen, fmt, generate-parameter-library, gmock-vendor, gtest-vendor, hardware-interface, jrl-cmakemodules, linear-feedback-controller-msgs, message-filters, nav-msgs, pal-statistics, pinocchio, pluginlib, rcl, rclcpp, rclcpp-lifecycle, realtime-tools, rosidl-dynamic-typesupport, sensor-msgs, tl-expected-nixpkgs }:
 buildRosPackage {
   pname = "ros-rolling-linear-feedback-controller";
-  version = "3.2.0-r2";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/linear-feedback-controller-release/archive/release/rolling/linear_feedback_controller/3.2.0-2.tar.gz";
-    name = "3.2.0-2.tar.gz";
-    sha256 = "ce24c5c338f712669367b38425e70d5cbc71be1bd5420288e637b1897296c68e";
+    url = "https://github.com/ros2-gbp/linear-feedback-controller-release/archive/release/rolling/linear_feedback_controller/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "cb4b7488d3a2a65979cad22740e13c65030663ac7a8d87b48f0be112c854d025";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ _unresolved_parameter_traits ament-cmake-auto ament-cmake-python fmt jrl-cmakemodules ];
+  buildInputs = [ ament-cmake-auto ament-cmake-python fmt jrl-cmakemodules tl-expected-nixpkgs ];
   checkInputs = [ ament-lint-auto gmock-vendor gtest-vendor ];
   propagatedBuildInputs = [ control-toolbox controller-interface eigen generate-parameter-library hardware-interface linear-feedback-controller-msgs message-filters nav-msgs pal-statistics pinocchio pluginlib rcl rclcpp rclcpp-lifecycle realtime-tools rosidl-dynamic-typesupport sensor-msgs ];
   nativeBuildInputs = [ ament-cmake-auto ament-cmake-python ];

--- a/distros/rolling/mola-georeferencing/default.nix
+++ b/distros/rolling/mola-georeferencing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, gtsam, mola-common, mola-gtsam-factors, mola-yaml, mp2p-icp, mrpt-libmaps, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-rolling-mola-georeferencing";
-  version = "2.4.0-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_georeferencing/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "6fc18e22d4d9c5f06b92c3c5bfe4c57a1452228d8425f2489a2cda587c6452fb";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_georeferencing/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "00d1439206ebaabf89119290033253a9a76d0c5c170a73dac963cfdcb74a63fa";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-gtsam-factors/default.nix
+++ b/distros/rolling/mola-gtsam-factors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, gtsam, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-rolling-mola-gtsam-factors";
-  version = "2.4.0-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_gtsam_factors/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "786e3b6425ed544272ef2e31dcfd8dae1c00de5c162c15a2ae661db86be72088";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_gtsam_factors/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "7a79571d682952a8f322327b3e6e108d83efed47be48bf4aec0f2b2bc1494c96";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-lidar-odometry/default.nix
+++ b/distros/rolling/mola-lidar-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-imu-preintegration, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-rolling-mola-lidar-odometry";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/rolling/mola_lidar_odometry/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "bfbb80fdecac837a4c1b1d740439b6833a5d5b44341891bd61bc97afc53258d6";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/rolling/mola_lidar_odometry/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "5026f185ce0cd931e8d876b1d835a6822ff0bd3f86fbe2a66e641fc5608b384c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-state-estimation-simple/default.nix
+++ b/distros/rolling/mola-state-estimation-simple/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-state-estimation-simple";
-  version = "2.4.0-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation_simple/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "d2aaa45ab92bf53c349dfa097e828bf6245e3226c103d1002655ac8625333890";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation_simple/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "0cc36227bdf676735a903eef62eb7f5c5647dc2760cf74b9bb5657a9db94d189";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-state-estimation-smoother/default.nix
+++ b/distros/rolling/mola-state-estimation-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-xmllint, boost, cmake, geometry-msgs, gtsam, launch-testing, launch-testing-ament-cmake, launch-testing-ros, mola-bridge-ros2, mola-common, mola-gtsam-factors, mola-imu-preintegration, mola-kernel, mola-launcher, mrpt-libobs, nav-msgs, rclpy, ros-environment, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-mola-state-estimation-smoother";
-  version = "2.4.0-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation_smoother/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "6d29726c9ac20302a9ce709a110849a7e16b1ef5c6f92e47c574323ca8bf51ab";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation_smoother/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "8c21b22c072524d8cf08df23f57a8a79e29bba1260ddc7173cc15daf044e717d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-state-estimation/default.nix
+++ b/distros/rolling/mola-state-estimation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, mola-state-estimation-simple, mola-state-estimation-smoother }:
 buildRosPackage {
   pname = "ros-rolling-mola-state-estimation";
-  version = "2.4.0-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "29524a933fc8a55cc5a397c55415a937f86c9288a8978eed256a9ef472e9a461";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "ded37486f733f8ba92ac6c99a359737183a543b358628a7229f597f0e001fb4a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/motion-capture-tracking-interfaces/default.nix
+++ b/distros/rolling/motion-capture-tracking-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-motion-capture-tracking-interfaces";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/rolling/motion_capture_tracking_interfaces/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "a9aaebcd9753586654e414d8ee848aef6318d873fe1b68ab578f8699c062bf0d";
+    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/rolling/motion_capture_tracking_interfaces/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "86351f4c475b4f032e001bb74e50a14921ee935e21dea6d0d8cac2289331808d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/motion-capture-tracking/default.nix
+++ b/distros/rolling/motion-capture-tracking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, motion-capture-tracking-interfaces, pcl, rclcpp, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-motion-capture-tracking";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/rolling/motion_capture_tracking/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "4e7cc506a83a77ffce366f4713c429636aacfe53dc24b0f798275ef678a203c7";
+    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/rolling/motion_capture_tracking/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "d36b91ca954783c3e9ea8cc81c92a4f77f933f5e3aae6c276c442eff4a102057";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/novatel-gps-driver/default.nix
+++ b/distros/rolling/novatel-gps-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, boost, diagnostic-msgs, diagnostic-updater, gps-msgs, libpcap, nav-msgs, novatel-gps-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, swri-math-util, swri-roscpp, swri-serial-util, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-novatel-gps-driver";
-  version = "4.2.0-r5";
+  version = "4.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/rolling/novatel_gps_driver/4.2.0-5.tar.gz";
-    name = "4.2.0-5.tar.gz";
-    sha256 = "a03a89227270b9420ad32de641adb4f348eec0f3ccf0b91300ecccc38ddf5594";
+    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/rolling/novatel_gps_driver/4.3.0-1.tar.gz";
+    name = "4.3.0-1.tar.gz";
+    sha256 = "6892034c6f9b3d25995c63544de994dd6e605023c485f7def5d2a854bb17823b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/novatel-gps-msgs/default.nix
+++ b/distros/rolling/novatel-gps-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-novatel-gps-msgs";
-  version = "4.2.0-r5";
+  version = "4.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/rolling/novatel_gps_msgs/4.2.0-5.tar.gz";
-    name = "4.2.0-5.tar.gz";
-    sha256 = "9b791a8ef24daaa7b64942d1412c0cefe8f30f9bd488ca8b5bf5450a6bf0166f";
+    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/rolling/novatel_gps_msgs/4.3.0-1.tar.gz";
+    name = "4.3.0-1.tar.gz";
+    sha256 = "74915f7e834a0b07d37b112603ac3c026cdfc3c9ae5b9166daf147321a1e57d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -477,17 +477,6 @@ in {
     propagatedNativeBuildInputs = [ self.qt6.wrapQtAppsHook ];
   };
 
-  rc-genicam-api = rosSuper.rc-genicam-api.overrideAttrs ({
-    postPatch ? "", ...
-  }: {
-    # It's no longer needed to ignore "Error on non-existent target in get_target_property."
-    postPatch = postPatch + ''
-      substituteInPlace cmake/configure_link_libs.cmake --replace-fail \
-        "cmake_policy(SET CMP0045 OLD)" \
-        ""
-    '';
-  });
-
   rosidlcpp-generator-core = rosSuper.rosidlcpp-generator-core.override { fmt = self.fmt_9; };
   rosidlcpp-generator-cpp = rosSuper.rosidlcpp-generator-cpp.override { fmt = self.fmt_9; };
   rosidlcpp-generator-py = rosSuper.rosidlcpp-generator-py.override { fmt = self.fmt_9; };

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -477,6 +477,13 @@ in {
     propagatedNativeBuildInputs = [ self.qt6.wrapQtAppsHook ];
   };
 
+  roboplan-oink = rosSuper.roboplan-oink.overrideAttrs ({
+    buildInputs ? [], ...
+  }: {
+    # Prevent cmake from fetching osqp-eigen via git
+    buildInputs = buildInputs ++ [ self.osqp-eigen ];
+  });
+
   rosidlcpp-generator-core = rosSuper.rosidlcpp-generator-core.override { fmt = self.fmt_9; };
   rosidlcpp-generator-cpp = rosSuper.rosidlcpp-generator-cpp.override { fmt = self.fmt_9; };
   rosidlcpp-generator-py = rosSuper.rosidlcpp-generator-py.override { fmt = self.fmt_9; };

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -84,14 +84,14 @@ in {
       # https://github.com/foxglove/foxglove-sdk/blob/main/ros/src/foxglove_bridge/CMakeLists.txt.
       # If the version doesn't match, cmake fails with "Hash mismatch"
       # and we can fix it here.
-      FOXGLOVE_SDK_VERSION = "0.16.5";
+      FOXGLOVE_SDK_VERSION = "0.25.1";
       systemToPlatform = {
         "x86_64-linux" = "x86_64-unknown-linux-gnu";
         "aarch64-linux" = "aarch64-unknown-linux-gnu";
       };
       systemToHash = {
-        "x86_64-linux" = "sha256-jkln7HRGoGtaBMR7VLzUzs/yrYd24ALvOAPtSnB2hB0=";
-        "aarch64-linux" = "sha256-VMvFfGClUEc+CnX482DvtvokXrt/WC2176ZPHCl+VU8=";
+        "x86_64-linux" = "sha256-C500jfOo6Y0sLO4jYMyfUug7s0RQRN69dx0bRtw1i+Q=";
+        "aarch64-linux" = "sha256-xw41x48ON/O6jQJRzTHzU7sQsf0QYgDcbF9AntTfGRg=";
       };
       FOXGLOVE_SDK_PLATFORM = systemToPlatform.${self.system};
       sdk = self.fetchurl {

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -477,16 +477,6 @@ in {
     propagatedNativeBuildInputs = [ self.qt6.wrapQtAppsHook ];
   };
 
-  rcdiscover = rosSuper.rcdiscover.overrideAttrs ({
-    postPatch ? "", ...
-  }: {
-    postPatch = postPatch + ''
-      substituteInPlace CMakeLists.txt --replace-fail \
-        "cmake_minimum_required (VERSION 3.1)" \
-        "cmake_minimum_required (VERSION 3.10)"\
-    '';
-  });
-
   rc-genicam-api = rosSuper.rc-genicam-api.overrideAttrs ({
     postPatch ? "", ...
   }: {

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -477,7 +477,10 @@ in {
     propagatedNativeBuildInputs = [ self.qt6.wrapQtAppsHook ];
   };
 
-  roboplan-oink = rosSuper.roboplan-oink.overrideAttrs ({
+  roboplan-oink = (rosSuper.roboplan-oink.override {
+    # https://github.com/tier4/osqp_vendor/issues/26
+    osqp-vendor = null;
+  }).overrideAttrs ({
     buildInputs ? [], ...
   }: {
     # Prevent cmake from fetching osqp-eigen via git

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -477,6 +477,19 @@ in {
     propagatedNativeBuildInputs = [ self.qt6.wrapQtAppsHook ];
   };
 
+  roboplan-examples = rosSuper.roboplan-examples.overrideAttrs ({
+    buildInputs ? [], ...
+  }: {
+    # Prevent cmake from fetching osqp-eigen via git
+    buildInputs = buildInputs ++ [ self.osqp-eigen rosSelf.toppra ];
+  });
+
+  roboplan-toppra = rosSuper.roboplan-toppra.overrideAttrs ({
+    buildInputs ? [], ...
+  }: {
+    buildInputs = buildInputs ++ [ rosSelf.toppra ];
+  });
+
   roboplan-oink = (rosSuper.roboplan-oink.override {
     # https://github.com/tier4/osqp_vendor/issues/26
     osqp-vendor = null;

--- a/distros/rolling/rc-genicam-api/default.nix
+++ b/distros/rolling/rc-genicam-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, libpng, libusb1, ncurses }:
 buildRosPackage {
   pname = "ros-rolling-rc-genicam-api";
-  version = "2.8.1-r2";
+  version = "2.8.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_genicam_api-release/archive/release/rolling/rc_genicam_api/2.8.1-2.tar.gz";
-    name = "2.8.1-2.tar.gz";
-    sha256 = "3f9c4fc034975583f3bd5110ffd45e0bd08a5cffd71332c9a1bdc90587656104";
+    url = "https://github.com/ros2-gbp/rc_genicam_api-release/archive/release/rolling/rc_genicam_api/2.8.6-1.tar.gz";
+    name = "2.8.6-1.tar.gz";
+    sha256 = "07d0f7909d0b0ac71c1d48eaab6984ab41b325128a98fed41e40ba82fb2c185e";
   };
 
   buildType = "cmake";

--- a/distros/rolling/rcdiscover/default.nix
+++ b/distros/rolling/rcdiscover/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-rolling-rcdiscover";
-  version = "1.1.7-r2";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcdiscover-release/archive/release/rolling/rcdiscover/1.1.7-2.tar.gz";
-    name = "1.1.7-2.tar.gz";
-    sha256 = "fe9b69308135b8ea6b6a79665ae76af308e60038a8c36cf3c997a7fed78dcfc8";
+    url = "https://github.com/ros2-gbp/rcdiscover-release/archive/release/rolling/rcdiscover/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "20357c79c0de956852382fb9fefba97812591dae091983280788fd444df468b5";
   };
 
   buildType = "cmake";

--- a/distros/rolling/roboplan-example-models/default.nix
+++ b/distros/rolling/roboplan-example-models/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-roboplan-example-models";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/rolling/roboplan_example_models/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "47316ad81a8f0996125527c82049836994fc45aab0dc97fd25d8e59cd0788f80";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  propagatedBuildInputs = [ python3Packages.nanobind ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "Robot descriptions for RoboPlan testing and examples.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/roboplan-examples/default.nix
+++ b/distros/rolling/roboplan-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, roboplan, roboplan-example-models, roboplan-oink, roboplan-rrt, roboplan-simple-ik, roboplan-toppra, xacro }:
+buildRosPackage {
+  pname = "ros-rolling-roboplan-examples";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/rolling/roboplan_examples/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "e20f723ae0c00cbbf89553288a54cc0393b19f92dd72ed65ec8d432f0e86d41f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ roboplan roboplan-example-models roboplan-oink roboplan-rrt roboplan-simple-ik roboplan-toppra xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Basic examples of RoboPlan.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/roboplan-oink/default.nix
+++ b/distros/rolling/roboplan-oink/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, gtest, osqp-vendor, python3Packages, roboplan, roboplan-example-models }:
+buildRosPackage {
+  pname = "ros-rolling-roboplan-oink";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/rolling/roboplan_oink/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "c2b93369334a32e2d71c95115a0f00d4b8c760244babf66e0d926e9472abc164";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-gmock gtest roboplan-example-models ];
+  propagatedBuildInputs = [ osqp-vendor python3Packages.nanobind roboplan ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "OInK - Optimal Inverse Kinematics solver for RoboPlan.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/roboplan-rrt/default.nix
+++ b/distros/rolling/roboplan-rrt/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, python3Packages, roboplan, roboplan-example-models }:
+buildRosPackage {
+  pname = "ros-rolling-roboplan-rrt";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/rolling/roboplan_rrt/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "3005697d442b454d08779eba6fee73563ac62ae6dd6875ae2464294a5c9619c8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest roboplan-example-models ];
+  propagatedBuildInputs = [ python3Packages.nanobind roboplan ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "Rapidly-Exploring Random Tree (RRT) implementation for RoboPlan.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/roboplan-simple-ik/default.nix
+++ b/distros/rolling/roboplan-simple-ik/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, python3Packages, roboplan }:
+buildRosPackage {
+  pname = "ros-rolling-roboplan-simple-ik";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/rolling/roboplan_simple_ik/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "b955d05b320a7a50226aa3873589f111b4f1ba030bd0a43d588b5d9b48687a31";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  propagatedBuildInputs = [ python3Packages.nanobind roboplan ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "Simple inverse kinematics solver for RoboPlan.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/roboplan-toppra/default.nix
+++ b/distros/rolling/roboplan-toppra/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, python3Packages, roboplan, roboplan-example-models }:
+buildRosPackage {
+  pname = "ros-rolling-roboplan-toppra";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/rolling/roboplan_toppra/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "0cb6bcadf2f2133a0090b4e06195b62cdf84446d41d4a0c1f5d4a046cae5f095";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-gtest roboplan-example-models ];
+  propagatedBuildInputs = [ python3Packages.nanobind roboplan ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "Time Optimal Path Parameterization based on Reachability Analysis (TOPP-RA) wrapper for RoboPlan.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/roboplan/default.nix
+++ b/distros/rolling/roboplan/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, eigen, gtest, pinocchio, python3Packages, roboplan-example-models, tinyxml-2, tl-expected-nixpkgs, yaml-cpp-vendor }:
+buildRosPackage {
+  pname = "ros-rolling-roboplan";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/rolling/roboplan/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "159eb411e43c595c61d5779923cf5750c9217497586e8876913d7b7908a011b4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-pytest gtest roboplan-example-models ];
+  propagatedBuildInputs = [ eigen pinocchio python3Packages.nanobind tinyxml-2 tl-expected-nixpkgs yaml-cpp-vendor ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "Core types, scene representation, and utilities for RoboPlan.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/rqt-robot-steering/default.nix
+++ b/distros/rolling/rqt-robot-steering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, geometry-msgs, python-qt-binding, python3Packages, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-robot-steering";
-  version = "4.0.2-r2";
+  version = "5.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_robot_steering-release/archive/release/rolling/rqt_robot_steering/4.0.2-2.tar.gz";
-    name = "4.0.2-2.tar.gz";
-    sha256 = "0f1bdd1c3ed276a177944384af60efb52e72e397ff0e9978fc230d90da6aa1fb";
+    url = "https://github.com/ros2-gbp/rqt_robot_steering-release/archive/release/rolling/rqt_robot_steering/5.0.0-1.tar.gz";
+    name = "5.0.0-1.tar.gz";
+    sha256 = "dbefab5180d6d1843461e39e1f5fdbf8cc68f53605601dc05ccac0d949b48442";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/swri-cli-tools/default.nix
+++ b/distros/rolling/swri-cli-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, marti-introspection-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, ros2topic }:
 buildRosPackage {
   pname = "ros-rolling-swri-cli-tools";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_cli_tools/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "6ec0a6b810ee004503879450a7725b682e26b13879a6bf5dc666ac77b5eaa5ac";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_cli_tools/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "14345b284b3763dc352f5f00db11222eee3b78b5d5621e74cd6d4494b38c2f77";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/swri-console-util/default.nix
+++ b/distros/rolling/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-swri-console-util";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_console_util/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "540d5c557f0d60e1eb832da605bcfc714b095843edcda808bf03645f86f2822d";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_console_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "51dae7b23d35f89e48d83b63687cfda3debca21feb225751031fa6d99be5db5f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-dbw-interface/default.nix
+++ b/distros/rolling/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-swri-dbw-interface";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_dbw_interface/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "b513d38529ad944dfcc56eca86f9795c92b473088dfa29bfe63f5b05c0742982";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_dbw_interface/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "2720b285457bedecaf7a8566a1439ec3756c1f679d44b2008c4ba9cfd15e9e4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-geometry-util/default.nix
+++ b/distros/rolling/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, geos, opencv, pkg-config, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-swri-geometry-util";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_geometry_util/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "8f90e4b973f11f21d9d33bc2496124cdbb815388b04fd8e118b1effb03aaaa4a";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_geometry_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "6b247323af10b493d103fd6b4d6b3889e4e7b1c66772666b4c3f66523b972f52";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-image-util/default.nix
+++ b/distros/rolling/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, camera-calibration-parsers, cv-bridge, eigen, image-geometry, image-transport, message-filters, opencv, pkg-config, rcl-interfaces, rclcpp, rclcpp-components, rclpy, swri-geometry-util, swri-math-util, swri-opencv-util, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-swri-image-util";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_image_util/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "bb5b7d97eef181510793691c8d7dd3000d75bfe0c199745e2e02e8e077a9ad9e";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_image_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "6b6ce51ddac97d21ab5504bb310f7ba0b05273f6574f2b2aac4d15b0867b43bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-math-util/default.nix
+++ b/distros/rolling/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-swri-math-util";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_math_util/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "7ba06c8976f26ddc3d312f7072d8bfe4fdcb42cc7dc6d379bfcaae725cf6f5c2";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_math_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "80a486f834f83f0bdd213822ef20bce9dcedb4b5e281e1daa288af6cea0154ae";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-opencv-util/default.nix
+++ b/distros/rolling/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, opencv, swri-math-util }:
 buildRosPackage {
   pname = "ros-rolling-swri-opencv-util";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_opencv_util/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "33fbee3ea9f9ee199c4ca5e2782e1b45b8dc53916342e5aa043f594da8152fbc";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_opencv_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "ee91cb67667491041265a8a447827c834dd761c27dfbac3494b3ea17ca86284c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-roscpp/default.nix
+++ b/distros/rolling/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, diagnostic-msgs, diagnostic-updater, gtest, marti-common-msgs, nav-msgs, rclcpp, ros-environment, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-swri-roscpp";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_roscpp/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "022617bcec9aa90f34f281e49d3a925f04ef3220d143a26c338f1bf590f19af2";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_roscpp/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "ff0075095596883b3d4f4bf35058cb4e8bb321b0b9cddf505737f7f51b1fab22";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-route-util/default.nix
+++ b/distros/rolling/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-transform-util, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-swri-route-util";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_route_util/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "4bc39e4534cfd77915ce7f68d762f6949a20b237a4922c639227089375cd167d";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_route_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "65a27961c7b1563a9e0a5d69eff87a09e466b52007df637bf12486d2d320eed6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-serial-util/default.nix
+++ b/distros/rolling/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-swri-serial-util";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_serial_util/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "14da434681945e2b1f33b795c54d4ec6e5017ce1d2da8b39cf838186cbba9e65";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_serial_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "613b5df9733b5eb817b91149e8c863100e202d5d689fb38dc6f02b50696aac7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-transform-util/default.nix
+++ b/distros/rolling/swri-transform-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-index-cpp, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geographiclib, geometry-msgs, geos, gps-msgs, launch-ros, launch-testing, launch-testing-ament-cmake, marti-nav-msgs, opencv, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-swri-transform-util";
-  version = "3.8.9-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_transform_util/3.8.9-1.tar.gz";
-    name = "3.8.9-1.tar.gz";
-    sha256 = "13bc8a2b21cc0805e512b2189709168c5f671de03361bf3d0e663344ccdb562f";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_transform_util/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "ea2ada08e06d46e9a21aaedbae4e6361600d79f85611310a479ecc922ae1a70f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sync-tooling-msgs/default.nix
+++ b/distros/rolling/sync-tooling-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, protobuf }:
 buildRosPackage {
   pname = "ros-rolling-sync-tooling-msgs";
-  version = "0.2.9-r1";
+  version = "0.2.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sync_tooling_msgs-release/archive/release/rolling/sync_tooling_msgs/0.2.9-1.tar.gz";
-    name = "0.2.9-1.tar.gz";
-    sha256 = "23c14e0da7d679ddeb42440217627c7668896fdc023db7c46bba9dc950fce842";
+    url = "https://github.com/ros2-gbp/sync_tooling_msgs-release/archive/release/rolling/sync_tooling_msgs/0.2.10-1.tar.gz";
+    name = "0.2.10-1.tar.gz";
+    sha256 = "c3a55f66afab01808108c4d1bd80be8477795e4db43ba69097a8e469269b7b75";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/visp/default.nix
+++ b/distros/rolling/visp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bzip2, cmake, doxygen, eigen, gsl, libjpeg, liblapack, libpng, libv4l, libx11, libxml2, llvmPackages, nlohmann_json, openblas, opencv, zbar }:
 buildRosPackage {
   pname = "ros-rolling-visp";
-  version = "3.7.0-r5";
+  version = "3.7.0-r7";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/visp-release/archive/release/rolling/visp/3.7.0-5.tar.gz";
-    name = "3.7.0-5.tar.gz";
-    sha256 = "78ff38cdba82ae9de552373e4992c4d41307c3b07435fcf25a853c350a11f0b0";
+    url = "https://github.com/ros2-gbp/visp-release/archive/release/rolling/visp/3.7.0-7.tar.gz";
+    name = "3.7.0-7.tar.gz";
+    sha256 = "f91ecb0132713c296f9f5cfb8b350ee9ce1d96200694e591b1cc5a4eda665e51";
   };
 
   buildType = "cmake";

--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
     "rosdistro": {
       "flake": false,
       "locked": {
-        "lastModified": 1780067887,
-        "narHash": "sha256-zb6ubdTFku4W8Mjb651VWJL1tWBP6BJg0iXcKypT29M=",
+        "lastModified": 1780665549,
+        "narHash": "sha256-QzobMKNpcpS4uWETzPxXkt0F66Sji15N+xsK1JcEWDU=",
         "owner": "ros",
         "repo": "rosdistro",
-        "rev": "1c698d63a1a2d31dd24502a41bb1139eeb00e876",
+        "rev": "bcec45c05427f0ad6860cb323695995d8cb1e4bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'kilted', 'lyrical', 'rolling'] from nix-ros-overlay commit 8d1a3b100ca995fb4002f0bb2ca53e53fe7ab898.
This pull request was generated by running the following command:

```
superflore-gen-nix --dry-run --output-repository-path . --all --tar-archive-dir /home/runner/.ros/tar --upstream-branch develop
```

Changes:
========
Humble Changes:
---------------
* *clearpath-common 1.3.10-r1 --> 1.3.11-r1*
* *clearpath-control 1.3.10-r1 --> 1.3.11-r1*
* *clearpath-customization 1.3.10-r1 --> 1.3.11-r1*
* *clearpath-description 1.3.10-r1 --> 1.3.11-r1*
* *clearpath-generator-common 1.3.10-r1 --> 1.3.11-r1*
* *clearpath-manipulators 1.3.10-r1 --> 1.3.11-r1*
* *clearpath-manipulators-description 1.3.10-r1 --> 1.3.11-r1*
* *clearpath-mounts-description 1.3.10-r1 --> 1.3.11-r1*
* *clearpath-platform-description 1.3.10-r1 --> 1.3.11-r1*
* *clearpath-sensors-description 1.3.10-r1 --> 1.3.11-r1*
* *compass-msgs 0.2.4-r1 --> 0.3.0-r1*
* *continental-msgs 1.0.0-r1 --> 1.1.1-r1*
* *continental-srvs 1.0.0-r1 --> 1.1.1-r1*
* *foxglove-bridge 3.3.0-r1 --> 3.4.1-r1*
* *foxglove-msgs 3.3.0-r1 --> 3.4.1-r1*
* *fusioncore-core 0.2.4-r1 --> 0.3.0-r1*
* *fusioncore-datasets 0.2.4-r1 --> 0.3.0-r1*
* *fusioncore-gazebo 0.2.4-r1 --> 0.3.0-r1*
* *fusioncore-ros 0.2.4-r1 --> 0.3.0-r1*
* *mapviz 2.6.4-r1 --> 2.6.5-r1*
* *mapviz-interfaces 2.6.4-r1 --> 2.6.5-r1*
* *mapviz-plugins 2.6.4-r1 --> 2.6.5-r1*
* *mola-georeferencing 2.4.0-r1 --> 2.4.2-r1*
* *mola-gtsam-factors 2.4.0-r1 --> 2.4.2-r1*
* *mola-lidar-odometry 2.2.0-r1 --> 2.2.1-r1*
* *mola-state-estimation 2.4.0-r1 --> 2.4.2-r1*
* *mola-state-estimation-simple 2.4.0-r1 --> 2.4.2-r1*
* *mola-state-estimation-smoother 2.4.0-r1 --> 2.4.2-r1*
* *multires-image 2.6.4-r1 --> 2.6.5-r1*
* *nebula 1.0.0-r1 --> 1.1.1-r1*
* *nebula-continental 1.0.0-r1 --> 1.1.1-r1*
* *nebula-continental-common 1.0.0-r1 --> 1.1.1-r1*
* *nebula-continental-decoders 1.0.0-r1 --> 1.1.1-r1*
* *nebula-continental-hw-interfaces 1.0.0-r1 --> 1.1.1-r1*
* *nebula-core-common 1.0.0-r1 --> 1.1.1-r1*
* *nebula-core-decoders 1.0.0-r1 --> 1.1.1-r1*
* *nebula-core-hw-interfaces 1.0.0-r1 --> 1.1.1-r1*
* *nebula-core-ros 1.0.0-r1 --> 1.1.1-r1*
* *nebula-hesai 1.0.0-r1 --> 1.1.1-r1*
* *nebula-hesai-common 1.0.0-r1 --> 1.1.1-r1*
* *nebula-hesai-decoders 1.0.0-r1 --> 1.1.1-r1*
* *nebula-hesai-hw-interfaces 1.0.0-r1 --> 1.1.1-r1*
* *nebula-msgs 1.0.0-r1 --> 1.1.1-r1*
* *nebula-robosense 1.0.0-r1 --> 1.1.1-r1*
* *nebula-robosense-common 1.0.0-r1 --> 1.1.1-r1*
* *nebula-robosense-decoders 1.0.0-r1 --> 1.1.1-r1*
* *nebula-robosense-hw-interfaces 1.0.0-r1 --> 1.1.1-r1*
* *nebula-sample 1.0.0-r1 --> 1.1.1-r1*
* *nebula-sample-common 1.0.0-r1 --> 1.1.1-r1*
* *nebula-sample-decoders 1.0.0-r1 --> 1.1.1-r1*
* *nebula-sample-hw-interfaces 1.0.0-r1 --> 1.1.1-r1*
* *nebula-velodyne 1.0.0-r1 --> 1.1.1-r1*
* *nebula-velodyne-common 1.0.0-r1 --> 1.1.1-r1*
* *nebula-velodyne-decoders 1.0.0-r1 --> 1.1.1-r1*
* *nebula-velodyne-hw-interfaces 1.0.0-r1 --> 1.1.1-r1*
* *novatel-gps-driver 4.2.1-r1 --> 4.3.0-r1*
* *novatel-gps-msgs 4.2.1-r1 --> 4.3.0-r1*
* *pandar-msgs 1.0.0-r1 --> 1.1.1-r1*
* *robosense-msgs 1.0.0-r1 --> 1.1.1-r1*
* *rosidl-adapter 3.1.8-r1 --> 3.1.9-r1*
* *rosidl-cli 3.1.8-r1 --> 3.1.9-r1*
* *rosidl-cmake 3.1.8-r1 --> 3.1.9-r1*
* *rosidl-generator-c 3.1.8-r1 --> 3.1.9-r1*
* *rosidl-generator-cpp 3.1.8-r1 --> 3.1.9-r1*
* *rosidl-parser 3.1.8-r1 --> 3.1.9-r1*
* *rosidl-runtime-c 3.1.8-r1 --> 3.1.9-r1*
* *rosidl-runtime-cpp 3.1.8-r1 --> 3.1.9-r1*
* *rosidl-typesupport-interface 3.1.8-r1 --> 3.1.9-r1*
* *rosidl-typesupport-introspection-c 3.1.8-r1 --> 3.1.9-r1*
* *rosidl-typesupport-introspection-cpp 3.1.8-r1 --> 3.1.9-r1*
* *swri-cli-tools 3.8.9-r1 --> 3.9.0-r1*
* *swri-console-util 3.8.9-r1 --> 3.9.0-r1*
* *swri-dbw-interface 3.8.9-r1 --> 3.9.0-r1*
* *swri-geometry-util 3.8.9-r1 --> 3.9.0-r1*
* *swri-image-util 3.8.9-r1 --> 3.9.0-r1*
* *swri-math-util 3.8.9-r1 --> 3.9.0-r1*
* *swri-opencv-util 3.8.9-r1 --> 3.9.0-r1*
* *swri-roscpp 3.8.9-r1 --> 3.9.0-r1*
* *swri-route-util 3.8.9-r1 --> 3.9.0-r1*
* *swri-serial-util 3.8.9-r1 --> 3.9.0-r1*
* *swri-transform-util 3.8.9-r1 --> 3.9.0-r1*
* *sync-tooling-msgs 0.2.9-r1 --> 0.2.10-r1*
* *tile-map 2.6.4-r1 --> 2.6.5-r1*
* *visp 3.7.0-r7 --> 3.7.0-r8*

Jazzy Changes:
--------------
* *action-tutorials-cpp 0.33.10-r1 --> 0.33.11-r1*
* *action-tutorials-interfaces 0.33.10-r1 --> 0.33.11-r1*
* *action-tutorials-py 0.33.10-r1 --> 0.33.11-r1*
* *ament-cmake-ros 0.12.0-r3 --> 0.12.1-r1*
* *backward-global-planner 3.1.0-r2*
* *backward-local-planner 3.1.0-r2*
* *cl-foundation-pose 3.1.0-r2*
* *cl-gcalcli 3.1.0-r2*
* *cl-generic-sensor 3.1.0-r2*
* *cl-http 3.1.0-r2*
* *cl-keyboard 3.1.0-r2*
* *cl-lifecycle-node 3.1.0-r2*
* *cl-mission-tracker 3.1.0-r2*
* *cl-modbus-tcp-relay 3.1.0-r2*
* *cl-moveit2z 3.1.0-r2*
* *cl-nav2z 3.1.0-r2*
* *cl-px4-mr 3.1.0-r2*
* *cl-ros2-timer 3.1.0-r2*
* *class-loader 2.7.0-r3 --> 2.7.1-r1*
* *clearpath-config 2.9.3-r1 --> 2.9.4-r1*
* *composition 0.33.10-r1 --> 0.33.11-r1*
* *console-bridge-vendor 1.7.1-r3 --> 1.7.2-r1*
* *demo-nodes-cpp 0.33.10-r1 --> 0.33.11-r1*
* *demo-nodes-cpp-native 0.33.10-r1 --> 0.33.11-r1*
* *demo-nodes-py 0.33.10-r1 --> 0.33.11-r1*
* *domain-coordinator 0.12.0-r3 --> 0.12.1-r1*
* *dummy-map-server 0.33.10-r1 --> 0.33.11-r1*
* *dummy-robot-bringup 0.33.10-r1 --> 0.33.11-r1*
* *dummy-sensors 0.33.10-r1 --> 0.33.11-r1*
* *eg-conditional-generator 3.1.0-r2*
* *eg-random-generator 3.1.0-r2*
* *eigen3-cmake-module 0.3.0-r3 --> 0.3.1-r1*
* *example-interfaces 0.12.0-r3 --> 0.12.1-r1*
* *examples-tf2-py 0.36.20-r1 --> 0.36.21-r1*
* *fastrtps-cmake-module 3.6.3-r1 --> 3.6.4-r1*
* *forward-global-planner 3.1.0-r2*
* *forward-local-planner 3.1.0-r2*
* *foxglove-bridge 3.3.0-r1 --> 3.4.1-r1*
* *foxglove-msgs 3.3.0-r1 --> 3.4.1-r1*
* *geometry2 0.36.20-r1 --> 0.36.21-r1*
* *husarion-mecanum-drive-controller 0.1.0-r1*
* *image-tools 0.33.10-r1 --> 0.33.11-r1*
* *intra-process-demo 0.33.10-r1 --> 0.33.11-r1*
* *launch 3.4.10-r1 --> 3.4.11-r1*
* *launch-pytest 3.4.10-r1 --> 3.4.11-r1*
* *launch-ros 0.26.11-r1 --> 0.26.12-r1*
* *launch-testing 3.4.10-r1 --> 3.4.11-r1*
* *launch-testing-ament-cmake 3.4.10-r1 --> 3.4.11-r1*
* *launch-testing-ros 0.26.11-r1 --> 0.26.12-r1*
* *launch-xml 3.4.10-r1 --> 3.4.11-r1*
* *launch-yaml 3.4.10-r1 --> 3.4.11-r1*
* *liblz4-vendor 0.26.10-r2 --> 0.26.11-r1*
* *libyaml-vendor 1.6.3-r2 --> 1.6.4-r2*
* *lifecycle 0.33.10-r1 --> 0.33.11-r1*
* *lifecycle-py 0.33.10-r1 --> 0.33.11-r1*
* *logging-demo 0.33.10-r1 --> 0.33.11-r1*
* *low-pass-filter 0.1.0-r1*
* *lttngpy 8.2.5-r1 --> 8.2.6-r1*
* *mapviz 2.6.4-r1 --> 2.6.5-r1*
* *mapviz-interfaces 2.6.4-r1 --> 2.6.5-r1*
* *mapviz-plugins 2.6.4-r1 --> 2.6.5-r1*
* *mcap-vendor 0.26.10-r2 --> 0.26.11-r1*
* *mimick-vendor 0.6.2-r1 --> 0.6.3-r1*
* *multires-image 2.6.4-r1 --> 2.6.5-r1*
* *nav2z-planners-common 3.1.0-r2*
* *orocos-kdl-vendor 0.5.1-r2 --> 0.5.2-r1*
* *pendulum-control 0.33.10-r1 --> 0.33.11-r1*
* *pendulum-msgs 0.33.10-r1 --> 0.33.11-r1*
* *performance-test-fixture 0.2.1-r2 --> 0.2.2-r1*
* *pure-spinning-local-planner 3.1.0-r2*
* *python-orocos-kdl-vendor 0.5.1-r2 --> 0.5.2-r1*
* *quality-of-service-demo-cpp 0.33.10-r1 --> 0.33.11-r1*
* *quality-of-service-demo-py 0.33.10-r1 --> 0.33.11-r1*
* *rcdiscover 1.1.7-r2 --> 2.1.2-r1*
* *rcl 9.2.9-r1 --> 9.2.10-r1*
* *rcl-action 9.2.9-r1 --> 9.2.10-r1*
* *rcl-lifecycle 9.2.9-r1 --> 9.2.10-r1*
* *rcl-yaml-param-parser 9.2.9-r1 --> 9.2.10-r1*
* *rclcpp 28.1.18-r1 --> 28.1.19-r1*
* *rclcpp-action 28.1.18-r1 --> 28.1.19-r1*
* *rclcpp-components 28.1.18-r1 --> 28.1.19-r1*
* *rclcpp-lifecycle 28.1.18-r1 --> 28.1.19-r1*
* *rcpputils 2.11.3-r1 --> 2.11.4-r1*
* *rcutils 6.7.5-r1 --> 6.7.6-r1*
* *rmw-fastrtps-cpp 8.4.3-r1 --> 8.4.4-r1*
* *rmw-fastrtps-dynamic-cpp 8.4.3-r1 --> 8.4.4-r1*
* *rmw-fastrtps-shared-cpp 8.4.3-r1 --> 8.4.4-r1*
* *robot-state-publisher 3.3.3-r3 --> 3.3.4-r1*
* *ros-testing 0.6.0-r3 --> 0.6.1-r1*
* *ros2action 0.32.9-r1 --> 0.32.10-r1*
* *ros2bag 0.26.10-r2 --> 0.26.11-r1*
* *ros2cli 0.32.9-r1 --> 0.32.10-r1*
* *ros2cli-test-interfaces 0.32.9-r1 --> 0.32.10-r1*
* *ros2component 0.32.9-r1 --> 0.32.10-r1*
* *ros2doctor 0.32.9-r1 --> 0.32.10-r1*
* *ros2interface 0.32.9-r1 --> 0.32.10-r1*
* *ros2launch 0.26.11-r1 --> 0.26.12-r1*
* *ros2lifecycle 0.32.9-r1 --> 0.32.10-r1*
* *ros2lifecycle-test-fixtures 0.32.9-r1 --> 0.32.10-r1*
* *ros2multicast 0.32.9-r1 --> 0.32.10-r1*
* *ros2node 0.32.9-r1 --> 0.32.10-r1*
* *ros2param 0.32.9-r1 --> 0.32.10-r1*
* *ros2pkg 0.32.9-r1 --> 0.32.10-r1*
* *ros2run 0.32.9-r1 --> 0.32.10-r1*
* *ros2service 0.32.9-r1 --> 0.32.10-r1*
* *ros2test 0.6.0-r3 --> 0.6.1-r1*
* *ros2topic 0.32.9-r1 --> 0.32.10-r1*
* *ros2trace 8.2.5-r1 --> 8.2.6-r1*
* *rosbag2 0.26.10-r2 --> 0.26.11-r1*
* *rosbag2-compression 0.26.10-r2 --> 0.26.11-r1*
* *rosbag2-compression-zstd 0.26.10-r2 --> 0.26.11-r1*
* *rosbag2-cpp 0.26.10-r2 --> 0.26.11-r1*
* *rosbag2-examples-cpp 0.26.10-r2 --> 0.26.11-r1*
* *rosbag2-examples-py 0.26.10-r2 --> 0.26.11-r1*
* *rosbag2-interfaces 0.26.10-r2 --> 0.26.11-r1*
* *rosbag2-performance-benchmarking 0.26.10-r2 --> 0.26.11-r1*
* *rosbag2-performance-benchmarking-msgs 0.26.10-r2 --> 0.26.11-r1*
* *rosbag2-py 0.26.10-r2 --> 0.26.11-r1*
* *rosbag2-storage 0.26.10-r2 --> 0.26.11-r1*
* *rosbag2-storage-default-plugins 0.26.10-r2 --> 0.26.11-r1*
* *rosbag2-storage-mcap 0.26.10-r2 --> 0.26.11-r1*
* *rosbag2-storage-sqlite3 0.26.10-r2 --> 0.26.11-r1*
* *rosbag2-test-common 0.26.10-r2 --> 0.26.11-r1*
* *rosbag2-test-msgdefs 0.26.10-r2 --> 0.26.11-r1*
* *rosbag2-tests 0.26.10-r2 --> 0.26.11-r1*
* *rosbag2-transport 0.26.10-r2 --> 0.26.11-r1*
* *rosidl-adapter 4.6.7-r1 --> 4.6.8-r1*
* *rosidl-cli 4.6.7-r1 --> 4.6.8-r1*
* *rosidl-cmake 4.6.7-r1 --> 4.6.8-r1*
* *rosidl-default-generators 1.6.0-r3 --> 1.6.1-r1*
* *rosidl-default-runtime 1.6.0-r3 --> 1.6.1-r1*
* *rosidl-generator-c 4.6.7-r1 --> 4.6.8-r1*
* *rosidl-generator-cpp 4.6.7-r1 --> 4.6.8-r1*
* *rosidl-generator-type-description 4.6.7-r1 --> 4.6.8-r1*
* *rosidl-parser 4.6.7-r1 --> 4.6.8-r1*
* *rosidl-pycommon 4.6.7-r1 --> 4.6.8-r1*
* *rosidl-runtime-c 4.6.7-r1 --> 4.6.8-r1*
* *rosidl-runtime-cpp 4.6.7-r1 --> 4.6.8-r1*
* *rosidl-runtime-py 0.13.1-r2 --> 0.13.2-r1*
* *rosidl-typesupport-c 3.2.2-r1 --> 3.2.3-r1*
* *rosidl-typesupport-cpp 3.2.2-r1 --> 3.2.3-r1*
* *rosidl-typesupport-fastrtps-c 3.6.3-r1 --> 3.6.4-r1*
* *rosidl-typesupport-fastrtps-cpp 3.6.3-r1 --> 3.6.4-r1*
* *rosidl-typesupport-interface 4.6.7-r1 --> 4.6.8-r1*
* *rosidl-typesupport-introspection-c 4.6.7-r1 --> 4.6.8-r1*
* *rosidl-typesupport-introspection-cpp 4.6.7-r1 --> 4.6.8-r1*
* *rqt 1.6.3-r1 --> 1.6.4-r1*
* *rqt-gui 1.6.3-r1 --> 1.6.4-r1*
* *rqt-gui-cpp 1.6.3-r1 --> 1.6.4-r1*
* *rqt-gui-py 1.6.3-r1 --> 1.6.4-r1*
* *rqt-py-common 1.6.3-r1 --> 1.6.4-r1*
* *rviz-assimp-vendor 14.1.20-r2 --> 14.1.21-r1*
* *rviz-common 14.1.20-r2 --> 14.1.21-r1*
* *rviz-default-plugins 14.1.20-r2 --> 14.1.21-r1*
* *rviz-ogre-vendor 14.1.20-r2 --> 14.1.21-r1*
* *rviz-rendering 14.1.20-r2 --> 14.1.21-r1*
* *rviz-rendering-tests 14.1.20-r2 --> 14.1.21-r1*
* *rviz-visual-testing-framework 14.1.20-r2 --> 14.1.21-r1*
* *rviz2 14.1.20-r2 --> 14.1.21-r1*
* *shared-queues-vendor 0.26.10-r2 --> 0.26.11-r1*
* *sm-advanced-recovery-1 3.1.0-r2*
* *sm-atomic 3.1.0-r2*
* *sm-atomic-http 3.1.0-r2*
* *sm-atomic-lifecycle 3.1.0-r2*
* *sm-atomic-mode-states 3.1.0-r2*
* *sm-atomic-performance-trace-1 3.1.0-r2*
* *sm-atomic-subscribers-performance-test 3.1.0-r2*
* *sm-branching 3.1.0-r2*
* *sm-cl-gcalcli-test-1 3.1.0-r2*
* *sm-cl-keyboard-unit-test-1 3.1.0-r2*
* *sm-cl-px4-mr-test-1 3.1.0-r2*
* *sm-cl-px4-mr-test-2 3.1.0-r2*
* *sm-cl-ros2-timer-unit-test-1 3.1.0-r2*
* *sm-coretest-transition-speed-1 3.1.0-r2*
* *sm-data-sharing-1 3.1.0-r2*
* *sm-data-sharing-2 3.1.0-r2*
* *sm-modbus-tcp-relay-test-1 3.1.0-r2*
* *sm-multi-stage-1 3.1.0-r2*
* *sm-multithread-test-1 3.1.0-r2*
* *sm-nav2-gazebo-test-1 3.1.0-r2*
* *sm-pack-ml 3.1.0-r2*
* *sm-panda-cl-moveit2z-cb-inventory 3.1.0-r2*
* *sm-panda-cl-moveit2z-cb-inventory-isaacsim 3.1.0-r2*
* *sm-simple-action-client 3.1.0-r2*
* *sm-three-some 3.1.0-r2*
* *smacc2 3.0.1-r1 --> 3.1.0-r2*
* *smacc2-msgs 3.0.1-r1 --> 3.1.0-r2*
* *spdlog-vendor 1.6.1-r1 --> 1.6.2-r1*
* *sqlite3-vendor 0.26.10-r2 --> 0.26.11-r1*
* *sr-all-events-go 3.1.0-r2*
* *sr-conditional 3.1.0-r2*
* *sr-event-countdown 3.1.0-r2*
* *test-interface-files 0.11.0-r3 --> 0.11.1-r1*
* *tf2 0.36.20-r1 --> 0.36.21-r1*
* *tf2-bullet 0.36.20-r1 --> 0.36.21-r1*
* *tf2-eigen 0.36.20-r1 --> 0.36.21-r1*
* *tf2-eigen-kdl 0.36.20-r1 --> 0.36.21-r1*
* *tf2-geometry-msgs 0.36.20-r1 --> 0.36.21-r1*
* *tf2-kdl 0.36.20-r1 --> 0.36.21-r1*
* *tf2-msgs 0.36.20-r1 --> 0.36.21-r1*
* *tf2-py 0.36.20-r1 --> 0.36.21-r1*
* *tf2-ros 0.36.20-r1 --> 0.36.21-r1*
* *tf2-ros-py 0.36.20-r1 --> 0.36.21-r1*
* *tf2-sensor-msgs 0.36.20-r1 --> 0.36.21-r1*
* *tf2-tools 0.36.20-r1 --> 0.36.21-r1*
* *tile-map 2.6.4-r1 --> 2.6.5-r1*
* *tlsf 0.9.0-r3 --> 0.9.1-r2*
* *topic-monitor 0.33.10-r1 --> 0.33.11-r1*
* *topic-statistics-demo 0.33.10-r1 --> 0.33.11-r1*
* *tracetools 8.2.5-r1 --> 8.2.6-r1*
* *tracetools-launch 8.2.5-r1 --> 8.2.6-r1*
* *tracetools-read 8.2.5-r1 --> 8.2.6-r1*
* *tracetools-test 8.2.5-r1 --> 8.2.6-r1*
* *tracetools-trace 8.2.5-r1 --> 8.2.6-r1*
* *turtlesim 1.8.3-r1 --> 1.8.4-r1*
* *twist-mux-controller 0.1.0-r1*
* *undo-path-global-planner 3.1.0-r2*
* *unique-identifier-msgs 2.5.0-r3 --> 2.5.1-r1*
* *urdf 2.10.0-r3 --> 2.10.1-r2*
* *urdf-parser-plugin 2.10.0-r3 --> 2.10.1-r2*
* *urdfdom-headers 1.1.2-r1 --> 1.1.3-r1*
* *zstd-vendor 0.26.10-r2 --> 0.26.11-r1*

Kilted Changes:
---------------
* *fastcdr 2.3.5-r1 --> 2.3.6-r1*
* *foxglove-bridge 3.3.0-r1 --> 3.4.1-r1*
* *foxglove-msgs 3.3.0-r1 --> 3.4.1-r1*
* *mapviz 2.6.4-r1 --> 2.6.5-r1*
* *mapviz-interfaces 2.6.4-r1 --> 2.6.5-r1*
* *mapviz-plugins 2.6.4-r1 --> 2.6.5-r1*
* *mola-georeferencing 2.3.0-r1 --> 2.4.2-r1*
* *mola-gtsam-factors 2.3.0-r1 --> 2.4.2-r1*
* *mola-state-estimation 2.3.0-r1 --> 2.4.2-r1*
* *mola-state-estimation-simple 2.3.0-r1 --> 2.4.2-r1*
* *mola-state-estimation-smoother 2.3.0-r1 --> 2.4.2-r1*
* *multires-image 2.6.4-r1 --> 2.6.5-r1*
* *novatel-gps-driver 4.2.0-r5 --> 4.3.0-r1*
* *novatel-gps-msgs 4.2.0-r5 --> 4.3.0-r1*
* *roboplan 0.4.0-r1*
* *roboplan-example-models 0.4.0-r1*
* *roboplan-examples 0.4.0-r1*
* *roboplan-oink 0.4.0-r1*
* *roboplan-rrt 0.4.0-r1*
* *roboplan-simple-ik 0.4.0-r1*
* *roboplan-toppra 0.4.0-r1*
* *swri-cli-tools 3.8.9-r1 --> 3.9.0-r1*
* *swri-console-util 3.8.9-r1 --> 3.9.0-r1*
* *swri-dbw-interface 3.8.9-r1 --> 3.9.0-r1*
* *swri-geometry-util 3.8.9-r1 --> 3.9.0-r1*
* *swri-image-util 3.8.9-r1 --> 3.9.0-r1*
* *swri-math-util 3.8.9-r1 --> 3.9.0-r1*
* *swri-opencv-util 3.8.9-r1 --> 3.9.0-r1*
* *swri-roscpp 3.8.9-r1 --> 3.9.0-r1*
* *swri-route-util 3.8.9-r1 --> 3.9.0-r1*
* *swri-serial-util 3.8.9-r1 --> 3.9.0-r1*
* *swri-transform-util 3.8.9-r1 --> 3.9.0-r1*
* *tile-map 2.6.4-r1 --> 2.6.5-r1*
* *visp 3.7.0-r6 --> 3.7.0-r7*

Lyrical Changes:
----------------
* *fastcdr 2.3.5-r3 --> 2.3.6-r1*
* *foxglove-bridge 3.2.6-r3 --> 3.4.1-r1*
* *foxglove-msgs 3.2.6-r3 --> 3.4.1-r1*
* *foxglove-sdk-vendor 0.2.0-r4 --> 0.2.0-r6*
* *gps-msgs 2.1.2-r3 --> 2.1.2-r4*
* *gps-tools 2.1.2-r3 --> 2.1.2-r4*
* *gps-umd 2.1.2-r3 --> 2.1.2-r4*
* *gpsd-client 2.1.2-r3 --> 2.1.2-r4*
* *linear-feedback-controller 3.2.0-r3 --> 4.0.1-r1*
* *marti-can-msgs 1.6.1-r3 --> 1.6.1-r4*
* *marti-common-msgs 1.6.1-r3 --> 1.6.1-r4*
* *marti-dbw-msgs 1.6.1-r3 --> 1.6.1-r4*
* *marti-introspection-msgs 1.6.1-r3 --> 1.6.1-r4*
* *marti-nav-msgs 1.6.1-r3 --> 1.6.1-r4*
* *marti-perception-msgs 1.6.1-r3 --> 1.6.1-r4*
* *marti-sensor-msgs 1.6.1-r3 --> 1.6.1-r4*
* *marti-status-msgs 1.6.1-r3 --> 1.6.1-r4*
* *marti-visualization-msgs 1.6.1-r3 --> 1.6.1-r4*
* *mola-georeferencing 2.4.0-r1 --> 2.4.2-r1*
* *mola-gtsam-factors 2.4.0-r1 --> 2.4.2-r1*
* *mola-lidar-odometry 2.2.0-r1 --> 2.2.1-r1*
* *mola-state-estimation 2.4.0-r1 --> 2.4.2-r1*
* *mola-state-estimation-simple 2.4.0-r1 --> 2.4.2-r1*
* *mola-state-estimation-smoother 2.4.0-r1 --> 2.4.2-r1*
* *motion-capture-tracking 1.0.6-r3 --> 1.0.8-r1*
* *motion-capture-tracking-interfaces 1.0.6-r3 --> 1.0.8-r1*
* *novatel-gps-driver 4.2.0-r6 --> 4.3.0-r1*
* *novatel-gps-msgs 4.2.0-r6 --> 4.3.0-r1*
* *rc-genicam-api 2.8.1-r3 --> 2.8.6-r1*
* *rcdiscover 1.1.7-r3 --> 2.1.2-r1*
* *roboplan 0.4.0-r1*
* *roboplan-example-models 0.4.0-r1*
* *roboplan-examples 0.4.0-r1*
* *roboplan-oink 0.4.0-r1*
* *roboplan-rrt 0.4.0-r1*
* *roboplan-simple-ik 0.4.0-r1*
* *roboplan-toppra 0.4.0-r1*
* *rqt-robot-steering 4.0.2-r3 --> 4.1.0-r1*
* *swri-cli-tools 3.8.7-r3 --> 3.9.0-r1*
* *swri-console-util 3.8.7-r3 --> 3.9.0-r1*
* *swri-dbw-interface 3.8.7-r3 --> 3.9.0-r1*
* *swri-geometry-util 3.8.7-r3 --> 3.9.0-r1*
* *swri-image-util 3.8.7-r3 --> 3.9.0-r1*
* *swri-math-util 3.8.7-r3 --> 3.9.0-r1*
* *swri-opencv-util 3.8.7-r3 --> 3.9.0-r1*
* *swri-roscpp 3.8.7-r3 --> 3.9.0-r1*
* *swri-route-util 3.8.7-r3 --> 3.9.0-r1*
* *swri-serial-util 3.8.7-r3 --> 3.9.0-r1*
* *swri-transform-util 3.8.7-r3 --> 3.9.0-r1*
* *sync-tooling-msgs 0.2.7-r3 --> 0.2.10-r1*
* *visp 3.7.0-r6 --> 3.7.0-r8*

Rolling Changes:
----------------
* *fastcdr 2.3.5-r2 --> 2.3.6-r1*
* *foxglove-bridge 3.3.0-r1 --> 3.4.1-r1*
* *foxglove-msgs 3.3.0-r1 --> 3.4.1-r1*
* *linear-feedback-controller 3.2.0-r2 --> 4.0.1-r1*
* *mola-georeferencing 2.4.0-r1 --> 2.4.2-r1*
* *mola-gtsam-factors 2.4.0-r1 --> 2.4.2-r1*
* *mola-lidar-odometry 2.2.0-r1 --> 2.2.1-r1*
* *mola-state-estimation 2.4.0-r1 --> 2.4.2-r1*
* *mola-state-estimation-simple 2.4.0-r1 --> 2.4.2-r1*
* *mola-state-estimation-smoother 2.4.0-r1 --> 2.4.2-r1*
* *motion-capture-tracking 1.0.7-r1 --> 1.0.8-r1*
* *motion-capture-tracking-interfaces 1.0.7-r1 --> 1.0.8-r1*
* *novatel-gps-driver 4.2.0-r5 --> 4.3.0-r1*
* *novatel-gps-msgs 4.2.0-r5 --> 4.3.0-r1*
* *rc-genicam-api 2.8.1-r2 --> 2.8.6-r1*
* *rcdiscover 1.1.7-r2 --> 2.1.2-r1*
* *roboplan 0.4.0-r1*
* *roboplan-example-models 0.4.0-r1*
* *roboplan-examples 0.4.0-r1*
* *roboplan-oink 0.4.0-r1*
* *roboplan-rrt 0.4.0-r1*
* *roboplan-simple-ik 0.4.0-r1*
* *roboplan-toppra 0.4.0-r1*
* *rqt-robot-steering 4.0.2-r2 --> 5.0.0-r1*
* *swri-cli-tools 3.8.9-r1 --> 3.9.0-r1*
* *swri-console-util 3.8.9-r1 --> 3.9.0-r1*
* *swri-dbw-interface 3.8.9-r1 --> 3.9.0-r1*
* *swri-geometry-util 3.8.9-r1 --> 3.9.0-r1*
* *swri-image-util 3.8.9-r1 --> 3.9.0-r1*
* *swri-math-util 3.8.9-r1 --> 3.9.0-r1*
* *swri-opencv-util 3.8.9-r1 --> 3.9.0-r1*
* *swri-roscpp 3.8.9-r1 --> 3.9.0-r1*
* *swri-route-util 3.8.9-r1 --> 3.9.0-r1*
* *swri-serial-util 3.8.9-r1 --> 3.9.0-r1*
* *swri-transform-util 3.8.9-r1 --> 3.9.0-r1*
* *sync-tooling-msgs 0.2.9-r1 --> 0.2.10-r1*
* *visp 3.7.0-r5 --> 3.7.0-r7*


No missing dependencies.