### PR TITLE
rosdistro sync, Fri Jun 12 17:50:26 2026

### DIFF
--- a/distros/humble/agni-tf-tools/default.nix
+++ b/distros/humble/agni-tf-tools/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, angles, boost, eigen, geometry-msgs, interactive-markers, pluginlib, rclcpp, rviz-common, rviz-default-plugins, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-humble-agni-tf-tools";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/agni_tf_tools-release/archive/release/humble/agni_tf_tools/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "415bd7cb949b889c267faabca35454ae33b149dfc20c3c9146438457a1897350";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake eigen ];
+  propagatedBuildInputs = [ angles boost geometry-msgs interactive-markers pluginlib rclcpp rviz-common rviz-default-plugins std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "This package provides a gui program as well as a rviz plugin to publish static transforms.
+  Both support the transformation between various Euler angle representations.
+  The rviz plugin also allows to configure the transform with an interactive marker.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/aruco-msgs/default.nix
+++ b/distros/humble/aruco-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "5.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/aruco_ros-release/archive/release/humble/aruco_msgs/5.0.5-1.tar.gz";
+    url = "https://github.com/ros2-gbp/aruco_ros-release/archive/release/humble/aruco_msgs/5.0.5-1.tar.gz";
     name = "5.0.5-1.tar.gz";
     sha256 = "74a41f58f6b1b9764f24e0b391abe60418565a7039be0f0726a2f5922359e2e8";
   };

--- a/distros/humble/aruco-ros/default.nix
+++ b/distros/humble/aruco-ros/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "5.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/aruco_ros-release/archive/release/humble/aruco_ros/5.0.5-1.tar.gz";
+    url = "https://github.com/ros2-gbp/aruco_ros-release/archive/release/humble/aruco_ros/5.0.5-1.tar.gz";
     name = "5.0.5-1.tar.gz";
     sha256 = "741e24bca41690a6dfb0b46c1e6f4220c65f6faee626565aa9a8846be80c9202";
   };

--- a/distros/humble/aruco/default.nix
+++ b/distros/humble/aruco/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "5.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/aruco_ros-release/archive/release/humble/aruco/5.0.5-1.tar.gz";
+    url = "https://github.com/ros2-gbp/aruco_ros-release/archive/release/humble/aruco/5.0.5-1.tar.gz";
     name = "5.0.5-1.tar.gz";
     sha256 = "3d6aeb345bef23dabeeb474e0cd527029f3ffd4c8197b0a3c0d22b78391e5bff";
   };

--- a/distros/humble/audio-capture/default.nix
+++ b/distros/humble/audio-capture/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, audio-common-msgs, boost, diagnostic-updater, gst_all_1, launch-xml, rclcpp, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-humble-audio-capture";
+  version = "0.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/audio_common-release/archive/release/humble/audio_capture/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "b5145e3ac1bd8f907c675c6de7183230f07ca2acdc72ba91ec0e1ea714aecceb";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake boost ];
+  propagatedBuildInputs = [ audio-common-msgs diagnostic-updater gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good gst_all_1.gst-plugins-ugly gst_all_1.gstreamer launch-xml rclcpp rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Transports audio from a source to a destination. Audio sources can come
+      from a microphone or file. The destination can play the audio or save it
+      to an mp3 file.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/audio-common-msgs/default.nix
+++ b/distros/humble/audio-common-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-audio-common-msgs";
+  version = "0.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/audio_common-release/archive/release/humble/audio_common_msgs/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "baa479592981820dc1608033053ec62c0ee4ba85378bf3f9392dc3633529edf9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "Messages for transmitting audio via ROS";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/audio-common/default.nix
+++ b/distros/humble/audio-common/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, audio-capture, audio-common-msgs, audio-play, sound-play, sound-play-msgs }:
+buildRosPackage {
+  pname = "ros-humble-audio-common";
+  version = "0.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/audio_common-release/archive/release/humble/audio_common/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "d4af899bb69a2d8f88ff7b01a0309f150e29fb62e6231921a3a1a7b197bdf835";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ audio-capture audio-common-msgs audio-play sound-play sound-play-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Common code for working with audio in ROS";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/audio-play/default.nix
+++ b/distros/humble/audio-play/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, audio-common-msgs, boost, gst_all_1, launch-xml, rclcpp, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-humble-audio-play";
+  version = "0.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/audio_common-release/archive/release/humble/audio_play/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "1d8c8076496c36fd9e43fd16451075b9d6926731e2fddaee46bcd7c1d6f23c50";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake boost ];
+  propagatedBuildInputs = [ audio-common-msgs gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good gst_all_1.gst-plugins-ugly gst_all_1.gstreamer launch-xml rclcpp rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Outputs audio to a speaker from a source node.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/automatika-embodied-agents/default.nix
+++ b/distros/humble/automatika-embodied-agents/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, automatika-ros-sugar, builtin-interfaces, python3Packages, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-automatika-embodied-agents";
-  version = "0.7.1-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/automatika_embodied_agents-release/archive/release/humble/automatika_embodied_agents/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "cfddd029ad6c569baa68ebc0fbf53d57cc258b379afe731aceac1b3af1d4d02a";
+    url = "https://github.com/ros2-gbp/automatika_embodied_agents-release/archive/release/humble/automatika_embodied_agents/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "639803acece6d6c30505ca1ff3ab1e46e26c0c67435da447c2e22199220b9616";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/automatika-ros-sugar/default.nix
+++ b/distros/humble/automatika-ros-sugar/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-index-python, ament-lint-auto, builtin-interfaces, geometry-msgs, launch, launch-testing, lifecycle-msgs, nav-msgs, python3Packages, rclcpp, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-automatika-ros-sugar";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/automatika_ros_sugar-release/archive/release/humble/automatika_ros_sugar/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "defedf3fa55bc11502332b68b34b4d66ffd420f37899c8d6d89b6ef7dc911f21";
+    url = "https://github.com/ros2-gbp/automatika_ros_sugar-release/archive/release/humble/automatika_ros_sugar/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "0faadb73e9176bfe4f8632dff5b21432249a4bc6b33b715e4fb55e1fd53b099a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/camera-ros/default.nix
+++ b/distros/humble/camera-ros/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-pep257, ament-cmake-pyflakes, ament-cmake-xmllint, ament-index-python, ament-lint-auto, camera-info-manager, clang, cv-bridge, libcamera, rclcpp, rclcpp-components, ros2launch, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-pep257, ament-cmake-pyflakes, ament-cmake-xmllint, ament-index-python, ament-lint-auto, camera-info-manager, clang, cv-bridge, diagnostic-msgs, libcamera, rclcpp, rclcpp-components, ros2launch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-camera-ros";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/camera_ros-release/archive/release/humble/camera_ros/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "e0c8db78d0b6b968dd9b2eab25c942439ace25e5b236e650cd5a0e3ed75877d3";
+    url = "https://github.com/ros2-gbp/camera_ros-release/archive/release/humble/camera_ros/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "4d8b078dce0202de3030dde236dd046a260db4bdbcd83222956f05f5a0d96719";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-mypy ament-cmake-pep257 ament-cmake-pyflakes ament-cmake-xmllint ament-lint-auto clang ];
-  propagatedBuildInputs = [ ament-index-python camera-info-manager cv-bridge libcamera rclcpp rclcpp-components ros2launch sensor-msgs ];
+  propagatedBuildInputs = [ ament-index-python camera-info-manager cv-bridge diagnostic-msgs libcamera rclcpp rclcpp-components ros2launch sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/crazyflie-examples/default.nix
+++ b/distros/humble/crazyflie-examples/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, crazyflie-py, python3Packages, rclpy }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, crazyflie-py, geometry-msgs, nav-msgs, python3Packages, rclpy, sensor-msgs, tf-transformations, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-crazyflie-examples";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie_examples/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "b6a5c3c69fc47fbd6890dbb6b760a4245a01c175fd407829b5a19bada2e2ada1";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie_examples/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "22ec3032d4f9e3b8871c007b3e890751a04c1ed403eea2f4d6536f25239a85fc";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-cmake-pytest ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
-  propagatedBuildInputs = [ crazyflie-py rclpy ];
+  propagatedBuildInputs = [ crazyflie-py geometry-msgs nav-msgs rclpy sensor-msgs tf-transformations tf2-ros ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/humble/crazyflie-interfaces/default.nix
+++ b/distros/humble/crazyflie-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-crazyflie-interfaces";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie_interfaces/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "e9ecc4cd57648c66acab1646a7953dbddd628c215e79fa9b845d3392704e8daa";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie_interfaces/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "f6355b9743093a55dae657266b2001a510c7b4dd37c5a300f75afea81e3dc38a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/crazyflie-py/default.nix
+++ b/distros/humble/crazyflie-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, crazyflie-interfaces, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-crazyflie-py";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie_py/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "be0e37ff2f287ae728b83e8237e314d6c190427f997f7859893f9ffd33187320";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie_py/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "d63148e532f83ca157df316ae576ad5e53b5c2c242727a20e0db3208362d17fc";
   };
 
   buildType = "ament_python";

--- a/distros/humble/crazyflie-server-py/default.nix
+++ b/distros/humble/crazyflie-server-py/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, crazyflie-interfaces, geometry-msgs, motion-capture-tracking-interfaces, nav-msgs, python3Packages, rcl-interfaces, rclpy, sensor-msgs, std-msgs, std-srvs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-crazyflie-server-py";
+  version = "1.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie_server_py/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "6d3d3bd41afe93acb5ae74b96afd4e8056beed1a55a6b1813da488b9a60ba31a";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-flake8 ament-pep257 python3Packages.pytest ];
+  propagatedBuildInputs = [ crazyflie-interfaces geometry-msgs motion-capture-tracking-interfaces nav-msgs rcl-interfaces rclpy sensor-msgs std-msgs std-srvs tf2-ros ];
+
+  meta = {
+    description = "Python Crazyflie server node for Crazyswarm2";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/crazyflie-sim/default.nix
+++ b/distros/humble/crazyflie-sim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, crazyflie-interfaces, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-crazyflie-sim";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie_sim/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "d31c150fa0c3014b34a063e79ad1f799dc7906e501130477b100d1610af6f4d2";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie_sim/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "5b43d920dfc7a9990e80ec38be6b3cdf60c0a56b9786256609b10359a5383b0f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/crazyflie/default.nix
+++ b/distros/humble/crazyflie/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, boost, crazyflie-interfaces, eigen, geometry-msgs, libusb1, motion-capture-tracking-interfaces, rclcpp, ros-environment, sensor-msgs, std-srvs, tf-transformations, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, boost, crazyflie-interfaces, eigen, geometry-msgs, libusb1, motion-capture-tracking-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-crazyflie";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "ea2ade526fb77767d6f814f1a61255dd56a3040671e6cd8adc8a1a54cd0c40fa";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "4cc586df5293e7aa24edd4c5277ddb474625e18d855f7c1e8f811d7772c12ef7";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ boost crazyflie-interfaces eigen geometry-msgs libusb1 motion-capture-tracking-interfaces rclcpp ros-environment sensor-msgs std-srvs tf-transformations tf2-ros ];
+  propagatedBuildInputs = [ boost crazyflie-interfaces eigen geometry-msgs libusb1 motion-capture-tracking-interfaces nav-msgs rclcpp ros-environment sensor-msgs std-srvs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/humble/depthai-bridge-v3/default.nix
+++ b/distros/humble/depthai-bridge-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-info-manager, composition-interfaces, cv-bridge, depthai-ros-msgs-v3, depthai-v3, ffmpeg-image-transport-msgs, image-transport, nav-msgs, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-bridge-v3";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_bridge_v3/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "f8241e157dfb8ae97f4f1824b4f79eb3cc26df7caca9bc1e5d0ec06ef70b900f";
+    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_bridge_v3/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "c36c0631133ed057d0fab2b87b542c612a5a3662bc20099b47e68e8a212bb3c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-descriptions-v3/default.nix
+++ b/distros/humble/depthai-descriptions-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-descriptions-v3";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_descriptions_v3/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "5ef85c063e68d2c0c2777aa1aa77af3b924511100b46ce5b948eaddceef8c92f";
+    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_descriptions_v3/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "2251035d632cd4b4c7b0cbefd9037c2200ad27c6b48002ca60d3ad0ff4fae72e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-examples-v3/default.nix
+++ b/distros/humble/depthai-examples-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, backward-ros, camera-info-manager, cv-bridge, depth-image-proc, depthai-bridge-v3, depthai-descriptions-v3, depthai-ros-msgs-v3, depthai-v3, foxglove-msgs, image-transport, nav-msgs, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-examples-v3";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_examples_v3/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "4bef5abf542d52f1e93dd437c4251973f2d247a55b233e41f56e1b40c3aa16fb";
+    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_examples_v3/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "32d3433c78a7d355129e702b7415e3a912d1b5e402986c326edf999d012465bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-filters-v3/default.nix
+++ b/distros/humble/depthai-filters-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, depthai-ros-msgs-v3, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-filters-v3";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_filters_v3/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "f85ec0998f77c8587e91d04b7b470d770516f77591c18335111bb07b37d5a63a";
+    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_filters_v3/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "b75e49bbf680e56061f50329436b110d09cdab4d35057aca34fea38095b8c757";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros-driver-v3/default.nix
+++ b/distros/humble/depthai-ros-driver-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-python, backward-ros, camera-calibration, camera-info-manager, cv-bridge, depthai-bridge-v3, depthai-descriptions-v3, depthai-ros-msgs-v3, depthai-v3, diagnostic-msgs, diagnostic-updater, ffmpeg-image-transport-msgs, geometry-msgs, image-pipeline, image-transport, image-transport-plugins, nav-msgs, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, tf2-ros, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-driver-v3";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_ros_driver_v3/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "a455cbac9b00e1f6fcf844845b8f4added41d7885ff984ee7e3b7fe957a733fd";
+    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_ros_driver_v3/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "2d506dbc69d64131909eb48906c5e71f531cf29b2573cbf6eff6c8f5c1a2fe24";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros-msgs-v3/default.nix
+++ b/distros/humble/depthai-ros-msgs-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-msgs-v3";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_ros_msgs_v3/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "98e2df1ae8d233e49073912d73f9e8999af461bb1f5240bef593dd67169cf4bd";
+    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_ros_msgs_v3/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "a8eae13e00aa18eadde2e9d7c3b3d5cbff81e748f96b7bffc23c67364f7b5521";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros-v3/default.nix
+++ b/distros/humble/depthai-ros-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai-bridge-v3, depthai-descriptions-v3, depthai-examples-v3, depthai-filters-v3, depthai-ros-driver-v3, depthai-ros-msgs-v3, depthai-v3 }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-v3";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_ros_v3/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "78e58a73be7359afcd94b6ef575ce2be35d88fd122024d71e05d6f4abfe11dcd";
+    url = "https://github.com/luxonis/depthai-ros-v3-release/archive/release/humble/depthai_ros_v3/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "7713ae4c2362f97ef41b436db8246a15489378dd9ded4f22a268875481524806";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-v3/default.nix
+++ b/distros/humble/depthai-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, curl, fmt, gfortran, libtar, libusb1, nlohmann_json, opencv, ros-environment, spdlog, udev, unzip, zip }:
 buildRosPackage {
   pname = "ros-humble-depthai-v3";
-  version = "3.6.1-r2";
+  version = "3.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-v3-release/archive/release/humble/depthai_v3/3.6.1-2.tar.gz";
-    name = "3.6.1-2.tar.gz";
-    sha256 = "a1b4304d1facd92c1b09fcf6ff29e25b23d0e89bd75db68145018643f42f6373";
+    url = "https://github.com/luxonis/depthai-core-v3-release/archive/release/humble/depthai_v3/3.7.1-1.tar.gz";
+    name = "3.7.1-1.tar.gz";
+    sha256 = "dfc029e7d10cd0e6539c2a8fc478ce6ca13fe8067946c005d9ac4114ef1e3ffd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/eigenpy/default.nix
+++ b/distros/humble/eigenpy/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
+{ lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, jrl-cmakemodules, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-eigenpy";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/humble/eigenpy/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "8202b9de326e31a147bebcabf33b45f2e70db182c1cbb51e90c1f9f62545cb4c";
+    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/humble/eigenpy/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "f22f74034b16c0685f0639d14c8b2a2f5b0139771d89d12be1ba3080fdb1cafe";
   };
 
   buildType = "cmake";
-  buildInputs = [ cmake doxygen git ];
+  buildInputs = [ cmake doxygen git jrl-cmakemodules ];
   propagatedBuildInputs = [ boost eigen python3 python3Packages.numpy python3Packages.scipy ];
   nativeBuildInputs = [ cmake ];
 
   meta = {
     description = "Bindings between Numpy and Eigen using Boost.Python";
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ "BSD-2-Clause" ];
   };
 }

--- a/distros/humble/generate-parameter-library-py/default.nix
+++ b/distros/humble/generate-parameter-library-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-generate-parameter-library-py";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library_py/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "00cd1667fd17bb84f92e4f9393139aa0c9b1a571558925409a418717816cdbda";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library_py/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "a1922ba0e579c040ed9c82e0de65a2794f16412d27e28283e21b669bf3485279";
   };
 
   buildType = "ament_python";

--- a/distros/humble/generate-parameter-library/default.nix
+++ b/distros/humble/generate-parameter-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, fmt, generate-parameter-library-py, parameter-traits, rclcpp, rclcpp-lifecycle, rclpy, rsl, tcb-span, tl-expected, tl-expected-nixpkgs }:
 buildRosPackage {
   pname = "ros-humble-generate-parameter-library";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "1c568817d4b46160415396c3bb07ccae26033b4bbaa21edf7a4790c45d2b7fc0";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "14fefb70cd21e3b8432d76f8ecd7b03bdabf07ef4e71722a49f1ade87f375913";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -40,6 +40,8 @@ self: super: {
 
  affordance-primitives = self.callPackage ./affordance-primitives {};
 
+ agni-tf-tools = self.callPackage ./agni-tf-tools {};
+
  agnocast = self.callPackage ./agnocast {};
 
  agnocast-cie-config-msgs = self.callPackage ./agnocast-cie-config-msgs {};
@@ -321,6 +323,14 @@ self: super: {
  async-web-server-cpp = self.callPackage ./async-web-server-cpp {};
 
  at-sonde-ros-driver = self.callPackage ./at-sonde-ros-driver {};
+
+ audio-capture = self.callPackage ./audio-capture {};
+
+ audio-common = self.callPackage ./audio-common {};
+
+ audio-common-msgs = self.callPackage ./audio-common-msgs {};
+
+ audio-play = self.callPackage ./audio-play {};
 
  automatika-embodied-agents = self.callPackage ./automatika-embodied-agents {};
 
@@ -813,6 +823,8 @@ self: super: {
  crazyflie-interfaces = self.callPackage ./crazyflie-interfaces {};
 
  crazyflie-py = self.callPackage ./crazyflie-py {};
+
+ crazyflie-server-py = self.callPackage ./crazyflie-server-py {};
 
  crazyflie-sim = self.callPackage ./crazyflie-sim {};
 
@@ -1910,6 +1922,8 @@ self: super: {
 
  lifecycle-py = self.callPackage ./lifecycle-py {};
 
+ linear-feedback-controller = self.callPackage ./linear-feedback-controller {};
+
  linear-feedback-controller-msgs = self.callPackage ./linear-feedback-controller-msgs {};
 
  lms1xx = self.callPackage ./lms1xx {};
@@ -2078,6 +2092,8 @@ self: super: {
 
  mola-input-rawlog = self.callPackage ./mola-input-rawlog {};
 
+ mola-input-rosbag1 = self.callPackage ./mola-input-rosbag1 {};
+
  mola-input-rosbag2 = self.callPackage ./mola-input-rosbag2 {};
 
  mola-input-video = self.callPackage ./mola-input-video {};
@@ -2226,9 +2242,51 @@ self: super: {
 
  mrpt-apps = self.callPackage ./mrpt-apps {};
 
+ mrpt-apps-cli = self.callPackage ./mrpt-apps-cli {};
+
+ mrpt-apps-gui = self.callPackage ./mrpt-apps-gui {};
+
+ mrpt-bayes = self.callPackage ./mrpt-bayes {};
+
+ mrpt-common = self.callPackage ./mrpt-common {};
+
+ mrpt-comms = self.callPackage ./mrpt-comms {};
+
+ mrpt-config = self.callPackage ./mrpt-config {};
+
+ mrpt-containers = self.callPackage ./mrpt-containers {};
+
+ mrpt-core = self.callPackage ./mrpt-core {};
+
+ mrpt-data = self.callPackage ./mrpt-data {};
+
+ mrpt-examples-cpp = self.callPackage ./mrpt-examples-cpp {};
+
+ mrpt-expr = self.callPackage ./mrpt-expr {};
+
  mrpt-generic-sensor = self.callPackage ./mrpt-generic-sensor {};
 
+ mrpt-graphs = self.callPackage ./mrpt-graphs {};
+
+ mrpt-graphslam = self.callPackage ./mrpt-graphslam {};
+
+ mrpt-gui = self.callPackage ./mrpt-gui {};
+
+ mrpt-hwdrivers = self.callPackage ./mrpt-hwdrivers {};
+
+ mrpt-img = self.callPackage ./mrpt-img {};
+
+ mrpt-imgui = self.callPackage ./mrpt-imgui {};
+
+ mrpt-io = self.callPackage ./mrpt-io {};
+
+ mrpt-kinematics = self.callPackage ./mrpt-kinematics {};
+
  mrpt-libapps = self.callPackage ./mrpt-libapps {};
+
+ mrpt-libapps-cli = self.callPackage ./mrpt-libapps-cli {};
+
+ mrpt-libapps-gui = self.callPackage ./mrpt-libapps-gui {};
 
  mrpt-libbase = self.callPackage ./mrpt-libbase {};
 
@@ -2256,13 +2314,23 @@ self: super: {
 
  mrpt-map-server = self.callPackage ./mrpt-map-server {};
 
+ mrpt-maps = self.callPackage ./mrpt-maps {};
+
+ mrpt-math = self.callPackage ./mrpt-math {};
+
  mrpt-msgs = self.callPackage ./mrpt-msgs {};
 
  mrpt-msgs-bridge = self.callPackage ./mrpt-msgs-bridge {};
 
+ mrpt-nav = self.callPackage ./mrpt-nav {};
+
  mrpt-nav-interfaces = self.callPackage ./mrpt-nav-interfaces {};
 
  mrpt-navigation = self.callPackage ./mrpt-navigation {};
+
+ mrpt-obs = self.callPackage ./mrpt-obs {};
+
+ mrpt-opengl = self.callPackage ./mrpt-opengl {};
 
  mrpt-path-planning = self.callPackage ./mrpt-path-planning {};
 
@@ -2270,7 +2338,13 @@ self: super: {
 
  mrpt-pointcloud-pipeline = self.callPackage ./mrpt-pointcloud-pipeline {};
 
+ mrpt-poses = self.callPackage ./mrpt-poses {};
+
+ mrpt-random = self.callPackage ./mrpt-random {};
+
  mrpt-reactivenav2d = self.callPackage ./mrpt-reactivenav2d {};
+
+ mrpt-rtti = self.callPackage ./mrpt-rtti {};
 
  mrpt-sensor-bumblebee-stereo = self.callPackage ./mrpt-sensor-bumblebee-stereo {};
 
@@ -2284,9 +2358,23 @@ self: super: {
 
  mrpt-sensors = self.callPackage ./mrpt-sensors {};
 
+ mrpt-serialization = self.callPackage ./mrpt-serialization {};
+
+ mrpt-slam = self.callPackage ./mrpt-slam {};
+
+ mrpt-system = self.callPackage ./mrpt-system {};
+
+ mrpt-tfest = self.callPackage ./mrpt-tfest {};
+
+ mrpt-topography = self.callPackage ./mrpt-topography {};
+
  mrpt-tps-astar-planner = self.callPackage ./mrpt-tps-astar-planner {};
 
  mrpt-tutorials = self.callPackage ./mrpt-tutorials {};
+
+ mrpt-typemeta = self.callPackage ./mrpt-typemeta {};
+
+ mrpt-viz = self.callPackage ./mrpt-viz {};
 
  mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
 
@@ -2309,6 +2397,8 @@ self: super: {
  namosim = self.callPackage ./namosim {};
 
  nanoeigenpy = self.callPackage ./nanoeigenpy {};
+
+ nanoflann = self.callPackage ./nanoflann {};
 
  nao-button-sim = self.callPackage ./nao-button-sim {};
 
@@ -3264,6 +3354,8 @@ self: super: {
 
  ros2-medkit-serialization = self.callPackage ./ros2-medkit-serialization {};
 
+ ros2-medkit-sovd-service-interface = self.callPackage ./ros2-medkit-sovd-service-interface {};
+
  ros2-medkit-topic-beacon = self.callPackage ./ros2-medkit-topic-beacon {};
 
  ros2-ouster = self.callPackage ./ros2-ouster {};
@@ -3411,6 +3503,8 @@ self: super: {
  rosbag2-transport = self.callPackage ./rosbag2-transport {};
 
  rosbag2rawlog = self.callPackage ./rosbag2rawlog {};
+
+ rosbag-timing-inspector = self.callPackage ./rosbag-timing-inspector {};
 
  rosbridge-library = self.callPackage ./rosbridge-library {};
 
@@ -3624,6 +3718,8 @@ self: super: {
 
  sbg-driver = self.callPackage ./sbg-driver {};
 
+ scan-2d-merger = self.callPackage ./scan-2d-merger {};
+
  scenario-execution = self.callPackage ./scenario-execution {};
 
  scenario-execution-control = self.callPackage ./scenario-execution-control {};
@@ -3753,6 +3849,10 @@ self: super: {
  sol-vendor = self.callPackage ./sol-vendor {};
 
  sophus = self.callPackage ./sophus {};
+
+ sound-play = self.callPackage ./sound-play {};
+
+ sound-play-msgs = self.callPackage ./sound-play-msgs {};
 
  spacenav = self.callPackage ./spacenav {};
 
@@ -4285,6 +4385,8 @@ self: super: {
  velodyne-pointcloud = self.callPackage ./velodyne-pointcloud {};
 
  velodyne-simulator = self.callPackage ./velodyne-simulator {};
+
+ video-to-image-msg-publisher = self.callPackage ./video-to-image-msg-publisher {};
 
  vimbax-camera = self.callPackage ./vimbax-camera {};
 

--- a/distros/humble/geometric-shapes/default.nix
+++ b/distros/humble/geometric-shapes/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, assimp, boost, console-bridge-vendor, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometry-msgs, octomap, pkg-config, qhull, random-numbers, rclcpp, resource-retriever, rosidl-default-generators, rosidl-default-runtime, shape-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, assimp, boost, console-bridge-vendor, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometry-msgs, pkg-config, qhull, random-numbers, rclcpp, resource-retriever, rosidl-default-generators, rosidl-default-runtime, shape-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-geometric-shapes";
-  version = "2.3.2-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometric_shapes-release/archive/release/humble/geometric_shapes/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "f8a71ab84cb80045f4c7848e797e46ea1110c7912859169929270612c46ddf11";
+    url = "https://github.com/ros2-gbp/geometric_shapes-release/archive/release/humble/geometric_shapes/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "52c4a7935e5ae30d15fcbd4cc880d962fef8cf0abf14af8682a6060bb46e35c6";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake pkg-config rosidl-default-generators ];
   checkInputs = [ ament-cmake-copyright ament-cmake-gtest ament-lint-auto ament-lint-cmake ];
-  propagatedBuildInputs = [ assimp boost console-bridge-vendor eigen eigen-stl-containers eigen3-cmake-module fcl geometry-msgs octomap qhull random-numbers rclcpp resource-retriever rosidl-default-runtime shape-msgs visualization-msgs ];
+  propagatedBuildInputs = [ assimp boost console-bridge-vendor eigen eigen-stl-containers eigen3-cmake-module fcl geometry-msgs qhull random-numbers rclcpp resource-retriever rosidl-default-runtime shape-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module rosidl-default-generators ];
 
   meta = {

--- a/distros/humble/kompass-interfaces/default.nix
+++ b/distros/humble/kompass-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-kompass-interfaces";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kompass-release/archive/release/humble/kompass_interfaces/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "5bab4b6037da00ca498bb628f471860ba863a0e26dbf6bc6194a645e8916eb2f";
+    url = "https://github.com/ros2-gbp/kompass-release/archive/release/humble/kompass_interfaces/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "0bdbdef649747a8261f4249b691f1e6c965a3bedbcf27e680c2b62d52e1d2bde";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kompass/default.nix
+++ b/distros/humble/kompass/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, automatika-ros-sugar, kompass-interfaces, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-kompass";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kompass-release/archive/release/humble/kompass/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "cee6245ee0277323d51b750f3719bf584b05038773d26ca6ccae6c85e0706ad7";
+    url = "https://github.com/ros2-gbp/kompass-release/archive/release/humble/kompass/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "708ecec868b83e105b1d224b381b99d185a2a114e7b294743cc8ab59cd75f02d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/linear-feedback-controller/default.nix
+++ b/distros/humble/linear-feedback-controller/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-python, ament-lint-auto, control-toolbox, controller-interface, eigen, fmt, generate-parameter-library, gmock-vendor, gtest-vendor, hardware-interface, jrl-cmakemodules, linear-feedback-controller-msgs, message-filters, nav-msgs, pal-statistics, pinocchio, pluginlib, rcl, rclcpp, rclcpp-lifecycle, realtime-tools, sensor-msgs, tl-expected-nixpkgs }:
+buildRosPackage {
+  pname = "ros-humble-linear-feedback-controller";
+  version = "4.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/linear-feedback-controller-release/archive/release/humble/linear_feedback_controller/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "2b7e300f791ae4c99d695171703317110e26ddaf6563bb8379ba41963a3dfb7b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto ament-cmake-python fmt jrl-cmakemodules tl-expected-nixpkgs ];
+  checkInputs = [ ament-lint-auto gmock-vendor gtest-vendor ];
+  propagatedBuildInputs = [ control-toolbox controller-interface eigen generate-parameter-library hardware-interface linear-feedback-controller-msgs message-filters nav-msgs pal-statistics pinocchio pluginlib rcl rclcpp rclcpp-lifecycle realtime-tools sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake-auto ament-cmake-python ];
+
+  meta = {
+    description = "roscontrol controller package conputing a linear feedback. The user needs
+    to provide a model of the robot and a list of controlled joint and the
+    controller computes a linear feedback on the user defined state.";
+    license = with lib.licenses; [ "BSD-2-Clause" ];
+  };
+}

--- a/distros/humble/mavlink/default.nix
+++ b/distros/humble/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mavlink";
-  version = "2026.3.3-r1";
+  version = "2026.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/humble/mavlink/2026.3.3-1.tar.gz";
-    name = "2026.3.3-1.tar.gz";
-    sha256 = "66cd10f5323c61f2f3e842a6f12f76ae94b63b2fee9cee0a5f2284874d6b7692";
+    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/humble/mavlink/2026.6.6-1.tar.gz";
+    name = "2026.6.6-1.tar.gz";
+    sha256 = "a9078b6aa6aad465af760cde3f31d79b0d21b3feeabf062e6849439346bcc4d7";
   };
 
   buildType = "cmake";

--- a/distros/humble/microstrain-inertial-description/default.nix
+++ b/distros/humble/microstrain-inertial-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, xacro }:
 buildRosPackage {
   pname = "ros-humble-microstrain-inertial-description";
-  version = "4.8.0-r1";
+  version = "4.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_description/4.8.0-1.tar.gz";
-    name = "4.8.0-1.tar.gz";
-    sha256 = "97df2694c44a75bd74c5b24187535519b7ce455c600d11f8b2c803fa95c4db51";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_description/4.9.0-1.tar.gz";
+    name = "4.9.0-1.tar.gz";
+    sha256 = "a1779a12214e75bc1d7196b360efc25c0fe38f3278ba2dee6ff4cad3d3261add";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/microstrain-inertial-driver/default.nix
+++ b/distros/humble/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-target-dependencies, ament-cpplint, diagnostic-aggregator, diagnostic-updater, eigen, geographiclib, geometry-msgs, git, lifecycle-msgs, microstrain-inertial-msgs, nav-msgs, nmea-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, rtcm-msgs, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-microstrain-inertial-driver";
-  version = "4.8.0-r1";
+  version = "4.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_driver/4.8.0-1.tar.gz";
-    name = "4.8.0-1.tar.gz";
-    sha256 = "c8afe93b89b1e572fedcdf62f1486b32b15be454423952c0b1a22605664f1c2c";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_driver/4.9.0-1.tar.gz";
+    name = "4.9.0-1.tar.gz";
+    sha256 = "c5c0c5943107f3a6ff07f4e30ec37f0dfa537111b0a1af9fbe380c3647a17a14";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/microstrain-inertial-examples/default.nix
+++ b/distros/humble/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-driver, rviz-imu-plugin, rviz2, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-microstrain-inertial-examples";
-  version = "4.8.0-r1";
+  version = "4.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_examples/4.8.0-1.tar.gz";
-    name = "4.8.0-1.tar.gz";
-    sha256 = "d833dfffaac64ccf2244e94374707f4d763dfac73e83d898fdbde0e2e78d46a1";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_examples/4.9.0-1.tar.gz";
+    name = "4.9.0-1.tar.gz";
+    sha256 = "e054b5d52086661ed07674bacfd67f3854d9d8873bd6f017c2dd90d570f49c2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/microstrain-inertial-msgs/default.nix
+++ b/distros/humble/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-microstrain-inertial-msgs";
-  version = "4.8.0-r1";
+  version = "4.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_msgs/4.8.0-1.tar.gz";
-    name = "4.8.0-1.tar.gz";
-    sha256 = "233eec3dc35844ec90bb1e5060d4ae73e93ddf2baa2619457a4a649681dd9162";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_msgs/4.9.0-1.tar.gz";
+    name = "4.9.0-1.tar.gz";
+    sha256 = "ae95f9dedae44b729eadd57de9aab16905b6f13b1ce88b3427531a1a82b79f87";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/microstrain-inertial-rqt/default.nix
+++ b/distros/humble/microstrain-inertial-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, microstrain-inertial-msgs, nav-msgs, rclpy, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-microstrain-inertial-rqt";
-  version = "4.8.0-r1";
+  version = "4.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_rqt/4.8.0-1.tar.gz";
-    name = "4.8.0-1.tar.gz";
-    sha256 = "be8fc6e828a411d246186589d8de886ed96497733480a79587cde89ae0ab3a04";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_rqt/4.9.0-1.tar.gz";
+    name = "4.9.0-1.tar.gz";
+    sha256 = "3a5adda478fee14766a804aa52106b915dd79fc47cf2ac5ef8759101846f9659";
   };
 
   buildType = "ament_python";

--- a/distros/humble/mola-input-rosbag1/default.nix
+++ b/distros/humble/mola-input-rosbag1/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, bzip2, cmake, geometry-msgs, lz4, mola-common, mola-kernel, mrpt-libmaps, mrpt-libobs, opencv, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-mola-input-rosbag1";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_input_rosbag1-release/archive/release/humble/mola_input_rosbag1/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "14cdabb273fc7b7996e7e664704c92c466e0bed1f70f8024c2e4b315b06d2a3e";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ boost bzip2 geometry-msgs lz4 mola-common mola-kernel mrpt-libmaps mrpt-libobs opencv opencv.cxxdev tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "MOLA DataSource from ROS1 bag files that does not need a ROS1 installation";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/mrpt-apps-cli/default.nix
+++ b/distros/humble/mrpt-apps-cli/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, mrpt-libapps-cli }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-apps-cli";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_apps_cli/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "4ea583fa15f177d645f1d2ac82ff3882afdb61d62f6387c8cc2e2f3831ea9bf8";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mrpt-common mrpt-libapps-cli ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "MRPT command line applications";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-apps-gui/default.nix
+++ b/distros/humble/mrpt-apps-gui/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, mrpt-common, mrpt-graphslam, mrpt-kinematics, mrpt-libapps-gui, mrpt-nav }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-apps-gui";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_apps_gui/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "4762b798a886e90c2d68518fab384ad6b2699e064c10dbfab0fdaea516896953";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen ];
+  propagatedBuildInputs = [ mrpt-common mrpt-graphslam mrpt-kinematics mrpt-libapps-gui mrpt-nav ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "MRPT graphical user interface applications";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-bayes/default.nix
+++ b/distros/humble/mrpt-bayes/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, mrpt-common, mrpt-config, mrpt-math, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-bayes";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_bayes/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "0c833f3dcc9adb430e8e6c9bce5ae77e331dcfc088f7bd7ea99b2dd279853f45";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-common mrpt-config mrpt-math ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_bayes";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-common/default.nix
+++ b/distros/humble/mrpt-common/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, gtest }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-common";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_common/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "9664f84d65cfe094a8cfd66d53a33657b32c8cf2a42fded071593c12f0c3fa46";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  checkInputs = [ gtest ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Common CMake scripts to all MRPT modules";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-comms/default.nix
+++ b/distros/humble/mrpt-comms/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, mrpt-io, mrpt-poses, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-comms";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_comms/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "64cad55d277e4e93c7e333fb3b939d4d33cf618f6bb86ffa466b605f9f5a9db4";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake python3 python3Packages.pybind11 ];
+  checkInputs = [ mrpt-poses ];
+  propagatedBuildInputs = [ mrpt-common mrpt-io ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_comms";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-config/default.nix
+++ b/distros/humble/mrpt-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, mrpt-expr, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-config";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_config/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "98a74a8252ee6d9e1cfc7ad93d404ca055f3c11cafaf2f777553eee183a1149e";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-common mrpt-expr ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_config";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-containers/default.nix
+++ b/distros/humble/mrpt-containers/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, mrpt-core, mrpt-typemeta, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-containers";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_containers/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "54a613d271207a2734819d0b18984de0a5e33663229b8f3f358f2e12ad176a63";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-common mrpt-core mrpt-typemeta ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_containers";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-core/default.nix
+++ b/distros/humble/mrpt-core/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-core";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_core/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "6aeeea37f68f3c23a67a8e47c6e2939d488f84ec2471e96d92c7120ea4559a2a";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-common ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_core";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-data/default.nix
+++ b/distros/humble/mrpt-data/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-data";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_data/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "a8c0301cd771c28e7a5671a4ecd5ea1d4a7f7da9195494f0868432b302544579";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "MRPT shared data files: test datasets and example config files";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-examples-cpp/default.nix
+++ b/distros/humble/mrpt-examples-cpp/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, glfw3, mrpt-common, mrpt-data, mrpt-graphslam, mrpt-gui, mrpt-imgui, mrpt-libapps-cli, mrpt-libapps-gui, mrpt-nav }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-examples-cpp";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_examples_cpp/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "87a3cd59ca11524d44c4075b0a3a8c9f55367dadcc5ba51448365ec57df08e79";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake glfw3 ];
+  propagatedBuildInputs = [ mrpt-common mrpt-data mrpt-graphslam mrpt-gui mrpt-imgui mrpt-libapps-cli mrpt-libapps-gui mrpt-nav ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "C++ examples demonstrating MRPT functionality";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-expr/default.nix
+++ b/distros/humble/mrpt-expr/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, mrpt-system, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-expr";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_expr/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "3ced6a77adedcca3a1b79bba441746650cefcd66bee2cccc6b1afa018b7865b8";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-common mrpt-system ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_expr";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-graphs/default.nix
+++ b/distros/humble/mrpt-graphs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, mrpt-common, mrpt-io, mrpt-poses, mrpt-viz, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-graphs";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_graphs/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "9338e38268ec86f17f49aac5e2ba86a048b54cfed9551e2511d6e499ed9f648c";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen python3 python3Packages.pybind11 ];
+  checkInputs = [ python3Packages.numpy ];
+  propagatedBuildInputs = [ mrpt-common mrpt-io mrpt-poses mrpt-viz ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_graphs";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-graphslam/default.nix
+++ b/distros/humble/mrpt-graphslam/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, mrpt-gui, mrpt-slam }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-graphslam";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_graphslam/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "70e59f3832bad26f4f7e288943b98799560cf71de4e33c3d5b22af9120c6ab4b";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen ];
+  propagatedBuildInputs = [ mrpt-gui mrpt-slam ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_graphslam";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-gui/default.nix
+++ b/distros/humble/mrpt-gui/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, glfw3, libGL, libGLU, libxrandr, libxxf86vm, mrpt-opengl, python3, python3Packages, qt5, wxGTK32 }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-gui";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_gui/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "43c1dda142cbd6d23162ce3b923da8c85e0722b83f98c01566b134307b077873";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake libGL libGLU libxrandr libxxf86vm python3 python3Packages.pybind11 qt5.qtbase wxGTK32 ];
+  propagatedBuildInputs = [ eigen glfw3 mrpt-opengl ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_gui";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-hwdrivers/default.nix
+++ b/distros/humble/mrpt-hwdrivers/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-comms, mrpt-maps, mrpt-viz }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-hwdrivers";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_hwdrivers/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "cda3ad221211573802565046f1c8606b6c70224ab5cc50be57842cad1b1bce8f";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mrpt-comms mrpt-maps mrpt-viz ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_hwdrivers";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-img/default.nix
+++ b/distros/humble/mrpt-img/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, glfw3, mrpt-common, mrpt-config, mrpt-io, mrpt-math, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-img";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_img/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "f1b0b677c6e9ea1170e8ce9a1ebee5beeb9be3c62f7eea8e109a94942f604d55";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen glfw3 python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-common mrpt-config mrpt-io mrpt-math ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_img";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-imgui/default.nix
+++ b/distros/humble/mrpt-imgui/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-opengl }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-imgui";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_imgui/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "583ab7908f58b1622d9946a46d3686737c751754f5341de5df7706b63929ad0d";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mrpt-opengl ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_imgui, wrapping rendering objects as a Dear ImGUI component";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-io/default.nix
+++ b/distros/humble/mrpt-io/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, mrpt-system, python3, python3Packages, zstd }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-io";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_io/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "8cc7c6fc5a8a14bc2d58036d5f4ea0b762be1d06580aa7d78eee6fb334673328";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake python3 python3Packages.pybind11 zstd ];
+  propagatedBuildInputs = [ mrpt-common mrpt-system ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_io";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-kinematics/default.nix
+++ b/distros/humble/mrpt-kinematics/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, mrpt-viz, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-kinematics";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_kinematics/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "e600709e6742a114b63a7f5d7ee5ba82489aef7742ae873047f3d4f18200b715";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake python3 python3Packages.pybind11 ];
+  checkInputs = [ python3Packages.numpy ];
+  propagatedBuildInputs = [ mrpt-common mrpt-viz ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_kinematics";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-libapps-cli/default.nix
+++ b/distros/humble/mrpt-libapps-cli/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cli11, cmake, mrpt-hwdrivers, mrpt-slam, mrpt-topography }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-libapps-cli";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_libapps_cli/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "4f90881299bf5c6ff8ae92d6853b745725ac7d5865ec8d04e3b400d7e5c98277";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ cli11 mrpt-hwdrivers mrpt-slam mrpt-topography ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_libapps_cli";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-libapps-gui/default.nix
+++ b/distros/humble/mrpt-libapps-gui/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, mrpt-gui, mrpt-libapps-cli, wxGTK32 }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-libapps-gui";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_libapps_gui/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "0d09af0b7c125001cac56e557f3d7fb85b487b83de9f03b4af34e8f9da31bf24";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen wxGTK32 ];
+  propagatedBuildInputs = [ mrpt-gui mrpt-libapps-cli ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_libapps_gui";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-maps/default.nix
+++ b/distros/humble/mrpt-maps/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, mrpt-graphs, mrpt-obs, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-maps";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_maps/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "7800ffa93bccff7e8309cc50fd87157d70678473268e1e69a4746ca536056b84";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-graphs mrpt-obs ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_maps";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-math/default.nix
+++ b/distros/humble/mrpt-math/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, mrpt-common, mrpt-io, mrpt-random, mrpt-serialization, mrpt-system, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-math";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_math/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "0fd2836c8f47f5bcd5e3649ad9148b34e10400292bda8e9a808eeb38bd7aff60";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen python3 python3Packages.pybind11 ];
+  checkInputs = [ mrpt-io ];
+  propagatedBuildInputs = [ mrpt-common mrpt-random mrpt-serialization mrpt-system ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_math";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-nav/default.nix
+++ b/distros/humble/mrpt-nav/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, mrpt-kinematics, mrpt-maps, mrpt-viz }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-nav";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_nav/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "6d36d7b32bdad58cd73004f6a87cd605da3f4f5116bfa8a19962677b2b414456";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen ];
+  propagatedBuildInputs = [ mrpt-kinematics mrpt-maps mrpt-viz ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_nav";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-obs/default.nix
+++ b/distros/humble/mrpt-obs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, mrpt-common, mrpt-tfest, mrpt-viz, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-obs";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_obs/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "1c27a8fe13a03c00486deaeafd66cc08b829b85e98dc28d486f3ddf285fc2e0d";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-common mrpt-tfest mrpt-viz ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_obs";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-opengl/default.nix
+++ b/distros/humble/mrpt-opengl/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, libGL, libGLU, mrpt-img, mrpt-poses, mrpt-viz }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-opengl";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_opengl/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "07a1103d485a43e19b2bff72ba0bb4d3bde271abb9ce2b679a98aad1cb73ad59";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen libGL libGLU ];
+  propagatedBuildInputs = [ mrpt-img mrpt-poses mrpt-viz ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_opengl";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-poses/default.nix
+++ b/distros/humble/mrpt-poses/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, mrpt-bayes, mrpt-common, mrpt-io, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-poses";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_poses/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "5a12c8078a4224169f9331e987c3c3fd1a737e724c55bcc890db66b302c20de8";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen python3 python3Packages.pybind11 ];
+  checkInputs = [ mrpt-io ];
+  propagatedBuildInputs = [ mrpt-bayes mrpt-common ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_poses";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-random/default.nix
+++ b/distros/humble/mrpt-random/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-random";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_random/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "27e8d7b1ea0e4691fbf4ed595b59d2d14fc7f0d16eafe97bbf47d9e357ac48c1";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-common ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_random";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-rtti/default.nix
+++ b/distros/humble/mrpt-rtti/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, mrpt-core, mrpt-typemeta, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-rtti";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_rtti/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "f420bfa20b466951c4ccac23aa8be88a310419304e724c7da18164991d8c7f95";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-common mrpt-core mrpt-typemeta ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_rtti";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-serialization/default.nix
+++ b/distros/humble/mrpt-serialization/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, mrpt-rtti, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-serialization";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_serialization/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "ae2721d1ba145a905e2f971bd51182a3d1ee4e8956fcd544c5595cd905334f89";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-common mrpt-rtti ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_serialization";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-slam/default.nix
+++ b/distros/humble/mrpt-slam/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, mrpt-maps, mrpt-topography, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-slam";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_slam/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "4ad15976c0fce90c2b0f4862b5fdeebb4f7fadb548bd1b890d6816841e5d9d07";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen python3 python3Packages.pybind11 ];
+  checkInputs = [ python3Packages.numpy ];
+  propagatedBuildInputs = [ mrpt-maps mrpt-topography ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_slam";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-system/default.nix
+++ b/distros/humble/mrpt-system/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, mrpt-containers, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-system";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_system/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "ad7e5e7e1527a535437bdabd57af5fcb8d9b1e4fdf65e8dd91424ccfeb3f1fcb";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-common mrpt-containers ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_system";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-tfest/default.nix
+++ b/distros/humble/mrpt-tfest/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, mrpt-common, mrpt-poses, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-tfest";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_tfest/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "5ed3b18c45bd03d71094aa4f749057c7ff3d0446c0760959ad8e13aa3147a7ad";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen python3 python3Packages.pybind11 ];
+  checkInputs = [ python3Packages.numpy ];
+  propagatedBuildInputs = [ mrpt-common mrpt-poses ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_tfest";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-topography/default.nix
+++ b/distros/humble/mrpt-topography/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, mrpt-math, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-topography";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_topography/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "48ca32cf65e84ec73f0ee39fcaffcd776d9048e0bd85f316e8651c3941634c5b";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake python3 python3Packages.pybind11 ];
+  checkInputs = [ python3Packages.numpy ];
+  propagatedBuildInputs = [ mrpt-common mrpt-math ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_topography";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-typemeta/default.nix
+++ b/distros/humble/mrpt-typemeta/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-typemeta";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_typemeta/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "6b2b0ab29ac1498e8f80ec299fabbc007cc48e344dd3c34fe9205f28e5140fd4";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mrpt-common ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_typemeta";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-viz/default.nix
+++ b/distros/humble/mrpt-viz/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, cmake, eigen, mrpt-common, mrpt-img, mrpt-poses, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-viz";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/humble/mrpt_viz/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "4eda71b5406728bc7e20eca261b6e34512b7034978a5d4d7dc33d5c85c9bd67f";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ assimp cmake eigen python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-common mrpt-img mrpt-poses ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_viz";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/nanoflann/default.nix
+++ b/distros/humble/nanoflann/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, gtest }:
+buildRosPackage {
+  pname = "ros-humble-nanoflann";
+  version = "1.10.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/nanoflann-release/archive/release/humble/nanoflann/1.10.1-1.tar.gz";
+    name = "1.10.1-1.tar.gz";
+    sha256 = "b2b54fdd3629465a342e3ea26201cfd3a9873d85cc9dbd3840681b470630b460";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  checkInputs = [ gtest ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "nanoflann: a C++11 header-only library for Nearest Neighbor (NN) search
+    with KD-trees, optimized for point clouds and Eigen matrices.";
+    license = with lib.licenses; [ "BSD-2-Clause" ];
+  };
+}

--- a/distros/humble/omni-base-2dnav/default.nix
+++ b/distros/humble/omni-base-2dnav/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_2dnav/2.22.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/omni_base_navigation-release/archive/release/humble/omni_base_2dnav/2.22.0-1.tar.gz";
     name = "2.22.0-1.tar.gz";
     sha256 = "38a21b1dd51215c43b870e8281dd05f5da12f80da17c18b07f1e43cd7a42edec";
   };

--- a/distros/humble/omni-base-bringup/default.nix
+++ b/distros/humble/omni-base-bringup/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_bringup/2.15.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/omni_base_robot-release/archive/release/humble/omni_base_bringup/2.15.1-1.tar.gz";
     name = "2.15.1-1.tar.gz";
     sha256 = "2d30aeb78fc9dbfe3117875f9c76ef5b3c6a0559604de7fac45df65b43e42a1c";
   };

--- a/distros/humble/omni-base-controller-configuration/default.nix
+++ b/distros/humble/omni-base-controller-configuration/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_controller_configuration/2.15.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/omni_base_robot-release/archive/release/humble/omni_base_controller_configuration/2.15.1-1.tar.gz";
     name = "2.15.1-1.tar.gz";
     sha256 = "3991f79176d731d4396bf12167e9340dc06e24d03b0339d06110941e750289da";
   };

--- a/distros/humble/omni-base-description/default.nix
+++ b/distros/humble/omni-base-description/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_description/2.15.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/omni_base_robot-release/archive/release/humble/omni_base_description/2.15.1-1.tar.gz";
     name = "2.15.1-1.tar.gz";
     sha256 = "80d7995dc5f5eb25a9481285dec9f10b3e471c3fb807eed337df1af51ee777a3";
   };

--- a/distros/humble/omni-base-gazebo/default.nix
+++ b/distros/humble/omni-base-gazebo/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_simulation-release/archive/release/humble/omni_base_gazebo/2.11.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/omni_base_simulation-release/archive/release/humble/omni_base_gazebo/2.11.1-1.tar.gz";
     name = "2.11.1-1.tar.gz";
     sha256 = "b8bc8235dde51e19c3b3607aa3c64b8b513b37ae8418c37d0d5ecc23f5a5157d";
   };

--- a/distros/humble/omni-base-laser-sensors/default.nix
+++ b/distros/humble/omni-base-laser-sensors/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_laser_sensors/2.22.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/omni_base_navigation-release/archive/release/humble/omni_base_laser_sensors/2.22.0-1.tar.gz";
     name = "2.22.0-1.tar.gz";
     sha256 = "63bbd464df949ad79d0b1b368e6368777428f76e4f6b51062dccf54275322b0f";
   };

--- a/distros/humble/omni-base-navigation/default.nix
+++ b/distros/humble/omni-base-navigation/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_navigation/2.22.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/omni_base_navigation-release/archive/release/humble/omni_base_navigation/2.22.0-1.tar.gz";
     name = "2.22.0-1.tar.gz";
     sha256 = "d72331a3c98cbfeaa68178622f6752a3079bec96a7a420d77d40bb970fa7950c";
   };

--- a/distros/humble/omni-base-rgbd-sensors/default.nix
+++ b/distros/humble/omni-base-rgbd-sensors/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_rgbd_sensors/2.22.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/omni_base_navigation-release/archive/release/humble/omni_base_rgbd_sensors/2.22.0-1.tar.gz";
     name = "2.22.0-1.tar.gz";
     sha256 = "7f3634246fbb2815b089558bdbda3df2845a166d459aeb57086850e740091b37";
   };

--- a/distros/humble/omni-base-robot/default.nix
+++ b/distros/humble/omni-base-robot/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_robot/2.15.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/omni_base_robot-release/archive/release/humble/omni_base_robot/2.15.1-1.tar.gz";
     name = "2.15.1-1.tar.gz";
     sha256 = "11c602e78bd96cca04ca4ca03c7cf5e5a9d04f42a6165f2a4caad063612d9c68";
   };

--- a/distros/humble/omni-base-simulation/default.nix
+++ b/distros/humble/omni-base-simulation/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_simulation-release/archive/release/humble/omni_base_simulation/2.11.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/omni_base_simulation-release/archive/release/humble/omni_base_simulation/2.11.1-1.tar.gz";
     name = "2.11.1-1.tar.gz";
     sha256 = "d6cf7a10d8c7709ccad9d81e4f1d3071ac367e12685428d13a8fc75f03ed2c67";
   };

--- a/distros/humble/orbbec-camera-msgs/default.nix
+++ b/distros/humble/orbbec-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-orbbec-camera-msgs";
-  version = "2.7.6-r1";
+  version = "2.8.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/orbbec_camera_v2-release/archive/release/humble/orbbec_camera_msgs/2.7.6-1.tar.gz";
-    name = "2.7.6-1.tar.gz";
-    sha256 = "6f8da5df0061770618ca2ca811d5849b73632ed67426710780f66ba2cd06c50d";
+    url = "https://github.com/ros2-gbp/orbbec_camera_v2-release/archive/release/humble/orbbec_camera_msgs/2.8.6-1.tar.gz";
+    name = "2.8.6-1.tar.gz";
+    sha256 = "009ef4240916a9670fee89010282c1c9fe7ec40053e64a899b100da5632a0afb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/orbbec-camera/default.nix
+++ b/distros/humble/orbbec-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, backward-ros, builtin-interfaces, camera-info-manager, cv-bridge, diagnostic-msgs, diagnostic-updater, gflags, glog, image-publisher, image-transport, libGL, libGLU, nlohmann_json, openssl, orbbec-camera-msgs, rclcpp, rclcpp-components, sensor-msgs, statistics-msgs, std-msgs, std-srvs, tf2, tf2-msgs, tf2-ros, tf2-sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-orbbec-camera";
-  version = "2.7.6-r1";
+  version = "2.8.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/orbbec_camera_v2-release/archive/release/humble/orbbec_camera/2.7.6-1.tar.gz";
-    name = "2.7.6-1.tar.gz";
-    sha256 = "ae61263e574aa2c150b673d2711238fe88d9e990244efc25239031509ebe3c9e";
+    url = "https://github.com/ros2-gbp/orbbec_camera_v2-release/archive/release/humble/orbbec_camera/2.8.6-1.tar.gz";
+    name = "2.8.6-1.tar.gz";
+    sha256 = "25fac44731c0faac3b2e7cea6a118e3d0154fdab4c615a3d519b4697570a3aae";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/orbbec-description/default.nix
+++ b/distros/humble/orbbec-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-orbbec-description";
-  version = "2.7.6-r1";
+  version = "2.8.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/orbbec_camera_v2-release/archive/release/humble/orbbec_description/2.7.6-1.tar.gz";
-    name = "2.7.6-1.tar.gz";
-    sha256 = "4b118b714f68277adda61d7f6feb2b00920f0cba8e3c22c44d1d630c108c08b5";
+    url = "https://github.com/ros2-gbp/orbbec_camera_v2-release/archive/release/humble/orbbec_description/2.8.6-1.tar.gz";
+    name = "2.8.6-1.tar.gz";
+    sha256 = "4a1a3ecd8caa2c21d01bbdc608b04f343bee73b4ef70ad075dfb8b13b9f46ccd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -859,6 +859,14 @@ in with lib; {
     buildInputs = buildInputs ++ [ self.libfyaml ];
   });
 
+  mrpt-gui = rosSuper.mrpt-gui.overrideAttrs ({
+    buildInputs ? [], nativeBuildInputs ? [], ...
+  }: {
+    # Add dependencies for vendored nanogui
+    nativeBuildInputs = nativeBuildInputs ++ [ self.pkg-config ];
+    buildInputs = buildInputs ++ [ self.wayland-scanner ];
+  });
+
   mrpt-io = rosSuper.mrpt-io.overrideAttrs ({
     buildInputs ? [], ...
   }: {

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -341,6 +341,16 @@ in with lib; {
     propagatedBuildInputs = propagatedBuildInputs ++ [ self.qt5.qtbase ];
   });
 
+  geometric-shapes = rosSuper.geometric-shapes.overrideAttrs ({
+    postPatch ? "", ...
+  }: {
+    # https://github.com/moveit/geometric_shapes/issues/270
+    postPatch = postPatch + ''
+      substituteInPlace CMakeLists.txt --replace-fail \
+        "random_numbers::random_numbers" "\''${random_numbers_LIBRARIES}"
+    '';
+  });
+
   google-benchmark-vendor = lib.patchExternalProjectGit rosSuper.google-benchmark-vendor {
     url = "https://github.com/google/benchmark.git";
     rev = "c05843a9f622db08ad59804c190f98879b76beba";

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -866,6 +866,13 @@ in with lib; {
     buildInputs = buildInputs ++ [ self.zlib ];
   });
 
+  mrpt-maps = rosSuper.mrpt-maps.overrideAttrs ({
+    buildInputs ? [], ...
+  }: {
+    # Don't use vendored octomap
+    buildInputs = buildInputs ++ [ self.octomap ];
+  });
+
   mrpt-viz = rosSuper.mrpt-viz.overrideAttrs ({
     buildInputs ? [], nativeBuildInputs ? [], ...
   }: {

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -859,6 +859,13 @@ in with lib; {
     buildInputs = buildInputs ++ [ self.libfyaml ];
   });
 
+  mrpt-io = rosSuper.mrpt-io.overrideAttrs ({
+    buildInputs ? [], ...
+  }: {
+    # Don't use built-in zlib
+    buildInputs = buildInputs ++ [ self.zlib ];
+  });
+
   mrt-cmake-modules = rosSuper.mrt-cmake-modules.overrideAttrs ({
     patches ? [], ...
   }: {

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -866,6 +866,14 @@ in with lib; {
     buildInputs = buildInputs ++ [ self.zlib ];
   });
 
+  mrpt-viz = rosSuper.mrpt-viz.overrideAttrs ({
+    buildInputs ? [], nativeBuildInputs ? [], ...
+  }: {
+    # Don't use vendored assimp
+    nativeBuildInputs = nativeBuildInputs ++ [ self.pkg-config ];
+    buildInputs = buildInputs ++ [ self.assimp ];
+  });
+
   mrt-cmake-modules = rosSuper.mrt-cmake-modules.overrideAttrs ({
     patches ? [], ...
   }: {

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -851,6 +851,14 @@ in with lib; {
     ];
   });
 
+  mrpt-containers = rosSuper.mrpt-containers.overrideAttrs ({
+    buildInputs ? [], nativeBuildInputs ? [], ...
+  }: {
+    # Don't use vendored libfyaml
+    nativeBuildInputs = nativeBuildInputs ++ [ self.pkg-config ];
+    buildInputs = buildInputs ++ [ self.libfyaml ];
+  });
+
   mrt-cmake-modules = rosSuper.mrt-cmake-modules.overrideAttrs ({
     patches ? [], ...
   }: {

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -881,6 +881,13 @@ in with lib; {
     buildInputs = buildInputs ++ [ self.octomap ];
   });
 
+  mrpt-opengl = rosSuper.mrpt-opengl.overrideAttrs ({
+    propagatedBuildInputs ? [], ...
+  }: {
+    # TODO: Remove after https://github.com/MRPT/mrpt/pull/1368 is merged and released
+    propagatedBuildInputs = propagatedBuildInputs ++ [ self.libGL ];
+  });
+
   mrpt-viz = rosSuper.mrpt-viz.overrideAttrs ({
     buildInputs ? [], nativeBuildInputs ? [], ...
   }: {

--- a/distros/humble/pal-gazebo-plugins/default.nix
+++ b/distros/humble/pal-gazebo-plugins/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "4.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_gazebo_plugins-release/archive/release/humble/pal_gazebo_plugins/4.1.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pal_gazebo_plugins-release/archive/release/humble/pal_gazebo_plugins/4.1.1-1.tar.gz";
     name = "4.1.1-1.tar.gz";
     sha256 = "d9edf38dc2530cadebae019a468bb429edc21f9bfeef8ba6a04a4d90c1b96bf6";
   };

--- a/distros/humble/pal-gazebo-worlds/default.nix
+++ b/distros/humble/pal-gazebo-worlds/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "4.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_gazebo_worlds-ros2-release/archive/release/humble/pal_gazebo_worlds/4.14.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pal_gazebo_worlds-release/archive/release/humble/pal_gazebo_worlds/4.14.0-1.tar.gz";
     name = "4.14.0-1.tar.gz";
     sha256 = "793995909ccd88f0fd39ff37d1fd99677546979cc660f45d1140d2eed30b2320";
   };

--- a/distros/humble/pal-gripper-controller-configuration/default.nix
+++ b/distros/humble/pal-gripper-controller-configuration/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "3.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper_controller_configuration/3.6.5-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pal_gripper-release/archive/release/humble/pal_gripper_controller_configuration/3.6.5-1.tar.gz";
     name = "3.6.5-1.tar.gz";
     sha256 = "cc540414f9ab74afa34eb98799a5f8b2f42df7f5b79a288ede36d02bdfbd2c5b";
   };

--- a/distros/humble/pal-gripper-description/default.nix
+++ b/distros/humble/pal-gripper-description/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "3.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper_description/3.6.5-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pal_gripper-release/archive/release/humble/pal_gripper_description/3.6.5-1.tar.gz";
     name = "3.6.5-1.tar.gz";
     sha256 = "a86d12d87c17f237620455c962b43b7f2c396c714e2dccd0e2ab92cbc114114b";
   };

--- a/distros/humble/pal-gripper-simulation/default.nix
+++ b/distros/humble/pal-gripper-simulation/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "3.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper_simulation/3.6.5-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pal_gripper-release/archive/release/humble/pal_gripper_simulation/3.6.5-1.tar.gz";
     name = "3.6.5-1.tar.gz";
     sha256 = "63ec2a3f6a2642c7ab3affdab5f14c2821903539591e092b5bbb60ffcf022d7c";
   };

--- a/distros/humble/pal-gripper/default.nix
+++ b/distros/humble/pal-gripper/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "3.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper/3.6.5-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pal_gripper-release/archive/release/humble/pal_gripper/3.6.5-1.tar.gz";
     name = "3.6.5-1.tar.gz";
     sha256 = "e7006b8a1a2e0cd59d7e3ae107a7dd133fdc8e09ddbe8e4ee23b448690af24f8";
   };

--- a/distros/humble/pal-hey5-controller-configuration/default.nix
+++ b/distros/humble/pal-hey5-controller-configuration/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_hey5-release/archive/release/humble/pal_hey5_controller_configuration/4.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pal_hey5-release/archive/release/humble/pal_hey5_controller_configuration/4.2.0-1.tar.gz";
     name = "4.2.0-1.tar.gz";
     sha256 = "e27336661c2fcda598b68eb94daf378238e4165bb1d366c386e7f4f45f0f6eb7";
   };

--- a/distros/humble/pal-hey5-description/default.nix
+++ b/distros/humble/pal-hey5-description/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_hey5-release/archive/release/humble/pal_hey5_description/4.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pal_hey5-release/archive/release/humble/pal_hey5_description/4.2.0-1.tar.gz";
     name = "4.2.0-1.tar.gz";
     sha256 = "04ffb3c764bf09b3b0f1b16b818d8bd4b3c7d2cf9ab8229a825200ce3ae90d4a";
   };

--- a/distros/humble/pal-hey5/default.nix
+++ b/distros/humble/pal-hey5/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_hey5-release/archive/release/humble/pal_hey5/4.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pal_hey5-release/archive/release/humble/pal_hey5/4.2.0-1.tar.gz";
     name = "4.2.0-1.tar.gz";
     sha256 = "aadeee6a18df940f052a8eca1b15dc779ab74b4275f8091fd65682338648b32e";
   };

--- a/distros/humble/pal-maps/default.nix
+++ b/distros/humble/pal-maps/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_maps-release/archive/release/humble/pal_maps/0.5.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pal_maps-release/archive/release/humble/pal_maps/0.5.0-1.tar.gz";
     name = "0.5.0-1.tar.gz";
     sha256 = "35437800bb8350bdc2d5fc0ebbc9c9769db59182cb40e86d8b090f0e15032b0e";
   };

--- a/distros/humble/pal-navigation-cfg-bringup/default.nix
+++ b/distros/humble/pal-navigation-cfg-bringup/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "3.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_navigation_cfg_public-release/archive/release/humble/pal_navigation_cfg_bringup/3.0.6-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pal_navigation_cfg_public-release/archive/release/humble/pal_navigation_cfg_bringup/3.0.6-1.tar.gz";
     name = "3.0.6-1.tar.gz";
     sha256 = "73e72a705143ed51a8b26724e8f7f6174373cdcf52226d012b469b97d128737c";
   };

--- a/distros/humble/pal-navigation-cfg-params/default.nix
+++ b/distros/humble/pal-navigation-cfg-params/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "3.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_navigation_cfg_public-release/archive/release/humble/pal_navigation_cfg_params/3.0.6-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pal_navigation_cfg_public-release/archive/release/humble/pal_navigation_cfg_params/3.0.6-1.tar.gz";
     name = "3.0.6-1.tar.gz";
     sha256 = "935d30bd7d704129ff689388e523769e20a7f8d8593bcb21534e2e9356f8a1d4";
   };

--- a/distros/humble/pal-navigation-cfg/default.nix
+++ b/distros/humble/pal-navigation-cfg/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "3.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_navigation_cfg_public-release/archive/release/humble/pal_navigation_cfg/3.0.6-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pal_navigation_cfg_public-release/archive/release/humble/pal_navigation_cfg/3.0.6-1.tar.gz";
     name = "3.0.6-1.tar.gz";
     sha256 = "7d647883ca25b21a9b14fb1bfc2cdd19bc04764a11a9201f1ce9cdb8058be7c0";
   };

--- a/distros/humble/pal-robotiq-controller-configuration/default.nix
+++ b/distros/humble/pal-robotiq-controller-configuration/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_robotiq_gripper-release/archive/release/humble/pal_robotiq_controller_configuration/2.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pal_robotiq_gripper-release/archive/release/humble/pal_robotiq_controller_configuration/2.2.0-1.tar.gz";
     name = "2.2.0-1.tar.gz";
     sha256 = "b911b8b0efebd0d3b49779928303fa8a55be9c7e30c1db172ce0d26f6c343aa2";
   };

--- a/distros/humble/pal-robotiq-description/default.nix
+++ b/distros/humble/pal-robotiq-description/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_robotiq_gripper-release/archive/release/humble/pal_robotiq_description/2.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pal_robotiq_gripper-release/archive/release/humble/pal_robotiq_description/2.2.0-1.tar.gz";
     name = "2.2.0-1.tar.gz";
     sha256 = "2d93c2253e4d0f019761b5caea45ff70b7ac8476e08f24b9d5b242e7a862fd8c";
   };

--- a/distros/humble/pal-robotiq-gripper/default.nix
+++ b/distros/humble/pal-robotiq-gripper/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_robotiq_gripper-release/archive/release/humble/pal_robotiq_gripper/2.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pal_robotiq_gripper-release/archive/release/humble/pal_robotiq_gripper/2.2.0-1.tar.gz";
     name = "2.2.0-1.tar.gz";
     sha256 = "375b6c4bd92ef0be10cc221475ec9602a00c89b042b8774e6fdb8ea24f17d37a";
   };

--- a/distros/humble/parameter-traits/default.nix
+++ b/distros/humble/parameter-traits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, fmt, rclcpp, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-humble-parameter-traits";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/parameter_traits/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "c59cd431230702bfa1c68dc24ebaf0e4495bf4c7e01c2deefccf2537f4fa53bf";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/parameter_traits/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "42a00307b305d8ecd9c1f4c66d7284256f45348d893a16b1a5f604a148249ba0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-2dnav/default.nix
+++ b/distros/humble/pmb2-2dnav/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_2dnav/4.21.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pmb2_navigation-release/archive/release/humble/pmb2_2dnav/4.21.0-1.tar.gz";
     name = "4.21.0-1.tar.gz";
     sha256 = "eb521aec60721b0736df6bcc1e245fb86eb3e03be9c783146f4bee8cbcc2492d";
   };

--- a/distros/humble/pmb2-bringup/default.nix
+++ b/distros/humble/pmb2-bringup/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "5.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_bringup/5.11.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pmb2_robot-release/archive/release/humble/pmb2_bringup/5.11.2-1.tar.gz";
     name = "5.11.2-1.tar.gz";
     sha256 = "068765fc61a5ae962ee271ce9ccf0f3d15eb68aa25d90f7b77fba359a6083e47";
   };

--- a/distros/humble/pmb2-controller-configuration/default.nix
+++ b/distros/humble/pmb2-controller-configuration/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "5.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_controller_configuration/5.11.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pmb2_robot-release/archive/release/humble/pmb2_controller_configuration/5.11.2-1.tar.gz";
     name = "5.11.2-1.tar.gz";
     sha256 = "b3c2b86012c57108b28f393ae01511d91b3548e3c1931ce35dfdbbcc4e6232d5";
   };

--- a/distros/humble/pmb2-description/default.nix
+++ b/distros/humble/pmb2-description/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "5.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_description/5.11.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pmb2_robot-release/archive/release/humble/pmb2_description/5.11.2-1.tar.gz";
     name = "5.11.2-1.tar.gz";
     sha256 = "3f34e000c74962f3cf4af49d00364594326b8099d7db1da7b2c704c8f8cffc99";
   };

--- a/distros/humble/pmb2-gazebo/default.nix
+++ b/distros/humble/pmb2-gazebo/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "4.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_simulation-release/archive/release/humble/pmb2_gazebo/4.11.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pmb2_simulation-release/archive/release/humble/pmb2_gazebo/4.11.1-1.tar.gz";
     name = "4.11.1-1.tar.gz";
     sha256 = "277ec96e4c2edb7b7ff4fd09e2860013de574b052f4edf6a533193aa8da2d954";
   };

--- a/distros/humble/pmb2-laser-sensors/default.nix
+++ b/distros/humble/pmb2-laser-sensors/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_laser_sensors/4.21.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pmb2_navigation-release/archive/release/humble/pmb2_laser_sensors/4.21.0-1.tar.gz";
     name = "4.21.0-1.tar.gz";
     sha256 = "8209f31b26bbf48f1efe8d212481ccc2e86315b91aab2c8c0697bf5c32997461";
   };

--- a/distros/humble/pmb2-navigation/default.nix
+++ b/distros/humble/pmb2-navigation/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_navigation/4.21.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pmb2_navigation-release/archive/release/humble/pmb2_navigation/4.21.0-1.tar.gz";
     name = "4.21.0-1.tar.gz";
     sha256 = "7144a6890c2bdfda1cc76e8df9efadb41117382be64e4486b82b74b243f788df";
   };

--- a/distros/humble/pmb2-rgbd-sensors/default.nix
+++ b/distros/humble/pmb2-rgbd-sensors/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_rgbd_sensors/4.21.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pmb2_navigation-release/archive/release/humble/pmb2_rgbd_sensors/4.21.0-1.tar.gz";
     name = "4.21.0-1.tar.gz";
     sha256 = "7bf7367538499ca8d66c5f5e59910d8b7f22eb4eb3dc8213634fa8e975b86f70";
   };

--- a/distros/humble/pmb2-robot/default.nix
+++ b/distros/humble/pmb2-robot/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "5.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_robot/5.11.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pmb2_robot-release/archive/release/humble/pmb2_robot/5.11.2-1.tar.gz";
     name = "5.11.2-1.tar.gz";
     sha256 = "8daab235b18f618fb76f3639874ae1ac8254f92f3a290dcc29ad8945b3e28f8a";
   };

--- a/distros/humble/pmb2-simulation/default.nix
+++ b/distros/humble/pmb2-simulation/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "4.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_simulation-release/archive/release/humble/pmb2_simulation/4.11.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pmb2_simulation-release/archive/release/humble/pmb2_simulation/4.11.1-1.tar.gz";
     name = "4.11.1-1.tar.gz";
     sha256 = "7c1e02261caefcc397467ebc8fcb4161e0c3b33564801e1558a956583b450ac0";
   };

--- a/distros/humble/ros-gz-bridge/default.nix
+++ b/distros/humble/ros-gz-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actuator-msgs, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, gps-msgs, ignition, launch-ros, launch-testing, launch-testing-ament-cmake, nav-msgs, pkg-config, rclcpp, rclcpp-components, ros-gz-interfaces, rosgraph-msgs, sensor-msgs, std-msgs, tf2-msgs, trajectory-msgs, vision-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-ros-gz-bridge";
-  version = "0.244.24-r1";
+  version = "0.244.25-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_gz_bridge/0.244.24-1.tar.gz";
-    name = "0.244.24-1.tar.gz";
-    sha256 = "eb40f2120be370326b6024bd4581eba51648d959d10b9198ebb22dfb1f65bae4";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_gz_bridge/0.244.25-1.tar.gz";
+    name = "0.244.25-1.tar.gz";
+    sha256 = "db0098cfc07743a535b672e8b48c318a1766a4a24a3095e2e84cc1d3026ba375";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-gz-image/default.nix
+++ b/distros/humble/ros-gz-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ignition, image-transport, pkg-config, rclcpp, ros-gz-bridge, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros-gz-image";
-  version = "0.244.24-r1";
+  version = "0.244.25-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_gz_image/0.244.24-1.tar.gz";
-    name = "0.244.24-1.tar.gz";
-    sha256 = "ebbd1f1bb8dd3fc9fa101ff6dc91a08f0cbbfa73a6a38e3a849d37d4606a2c8b";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_gz_image/0.244.25-1.tar.gz";
+    name = "0.244.25-1.tar.gz";
+    sha256 = "b539a2666ea56e1e553ad0ccfea9e77d3c61f098d93bf4da1e5fc95da5672ec1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-gz-interfaces/default.nix
+++ b/distros/humble/ros-gz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros-gz-interfaces";
-  version = "0.244.24-r1";
+  version = "0.244.25-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_gz_interfaces/0.244.24-1.tar.gz";
-    name = "0.244.24-1.tar.gz";
-    sha256 = "684afd88fac93e0b37a7f428a63cabfc7aa38b2ae5962e0fae10a0722824b306";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_gz_interfaces/0.244.25-1.tar.gz";
+    name = "0.244.25-1.tar.gz";
+    sha256 = "cb771aae8dbe24b74249b8d79ea329d76042d410e1aaf7ee3acb3b3403d468c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-gz-sim-demos/default.nix
+++ b/distros/humble/ros-gz-sim-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, _unresolved_ignition-gazebo6, ament-cmake, ament-lint-auto, ament-lint-common, image-transport-plugins, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, rqt-image-view, rqt-plot, rqt-topic, rviz2, sdformat-urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-ros-gz-sim-demos";
-  version = "0.244.24-r1";
+  version = "0.244.25-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_gz_sim_demos/0.244.24-1.tar.gz";
-    name = "0.244.24-1.tar.gz";
-    sha256 = "d0664229329a5ef443cf977e5dcf65c36407daa31eb7d32fb58f5f3ef3cfd8c9";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_gz_sim_demos/0.244.25-1.tar.gz";
+    name = "0.244.25-1.tar.gz";
+    sha256 = "daf290602dce7764eb2ebae421e64363be1bac83e359ffb9b819f751c94b8685";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-gz-sim/default.nix
+++ b/distros/humble/ros-gz-sim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, _unresolved_ignition-gazebo6, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, gflags, ignition, pkg-config, rclcpp, ros2pkg, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros-gz-sim";
-  version = "0.244.24-r1";
+  version = "0.244.25-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_gz_sim/0.244.24-1.tar.gz";
-    name = "0.244.24-1.tar.gz";
-    sha256 = "c3afa524e4cbe74acaa97d4a207e1320ad19f817fe0a47856d7762b560211fa0";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_gz_sim/0.244.25-1.tar.gz";
+    name = "0.244.25-1.tar.gz";
+    sha256 = "fc0f85e7917517bad289f3c458884718c2bd967fc6f99db5ebfebb5f8988f052";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-gz/default.nix
+++ b/distros/humble/ros-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz-bridge, ros-gz-image, ros-gz-sim, ros-gz-sim-demos }:
 buildRosPackage {
   pname = "ros-humble-ros-gz";
-  version = "0.244.24-r1";
+  version = "0.244.25-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_gz/0.244.24-1.tar.gz";
-    name = "0.244.24-1.tar.gz";
-    sha256 = "d4e24e22cf92f3ab1212b7e300e58a516b7668caa0abc867e6d4cf268061fbf8";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_gz/0.244.25-1.tar.gz";
+    name = "0.244.25-1.tar.gz";
+    sha256 = "d1e26269f13033eb50086635936b6149b7ad965fd77bdcd6ce98b6d42cb7acec";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-ign-bridge/default.nix
+++ b/distros/humble/ros-ign-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ros-gz-bridge }:
 buildRosPackage {
   pname = "ros-humble-ros-ign-bridge";
-  version = "0.244.24-r1";
+  version = "0.244.25-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_bridge/0.244.24-1.tar.gz";
-    name = "0.244.24-1.tar.gz";
-    sha256 = "8de1e9588717f3b8c79a150675d1ab9d24d30dc346136e61bb3dd9a99dcfbbff";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_bridge/0.244.25-1.tar.gz";
+    name = "0.244.25-1.tar.gz";
+    sha256 = "c275cfa0170de8ae719d885bd03200d2f9c96f78003b899eff38901269e0a17a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-ign-gazebo-demos/default.nix
+++ b/distros/humble/ros-ign-gazebo-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz-sim-demos }:
 buildRosPackage {
   pname = "ros-humble-ros-ign-gazebo-demos";
-  version = "0.244.24-r1";
+  version = "0.244.25-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_gazebo_demos/0.244.24-1.tar.gz";
-    name = "0.244.24-1.tar.gz";
-    sha256 = "6bcb40628aede25340cb65b150251d852bf833375eb132dd02c24019b52cb628";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_gazebo_demos/0.244.25-1.tar.gz";
+    name = "0.244.25-1.tar.gz";
+    sha256 = "1cb95e9860fe0a8464bfa7767598a96bf40b4970ac9c54efd57a541e74552fcd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-ign-gazebo/default.nix
+++ b/distros/humble/ros-ign-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ros-gz-sim }:
 buildRosPackage {
   pname = "ros-humble-ros-ign-gazebo";
-  version = "0.244.24-r1";
+  version = "0.244.25-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_gazebo/0.244.24-1.tar.gz";
-    name = "0.244.24-1.tar.gz";
-    sha256 = "eac11d0cd9c49c7061a6ebf4ed6ecdd11861943d69a1731493082907f7c83f9d";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_gazebo/0.244.25-1.tar.gz";
+    name = "0.244.25-1.tar.gz";
+    sha256 = "720b96c480788954609fa907978610c93fcd9bfe4a299b6dc1093d22ee615390";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-ign-image/default.nix
+++ b/distros/humble/ros-ign-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ros-gz-image }:
 buildRosPackage {
   pname = "ros-humble-ros-ign-image";
-  version = "0.244.24-r1";
+  version = "0.244.25-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_image/0.244.24-1.tar.gz";
-    name = "0.244.24-1.tar.gz";
-    sha256 = "b64b869a7d758d74aea2b6d401a3f784a670c0a424d2e8fcdaca778cc27f242a";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_image/0.244.25-1.tar.gz";
+    name = "0.244.25-1.tar.gz";
+    sha256 = "e3cc967ca90881ed3bd83c9321d3ee21463b9c3e3bcd1ae764460184cd6aa308";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-ign-interfaces/default.nix
+++ b/distros/humble/ros-ign-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, ros-gz-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros-ign-interfaces";
-  version = "0.244.24-r1";
+  version = "0.244.25-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_interfaces/0.244.24-1.tar.gz";
-    name = "0.244.24-1.tar.gz";
-    sha256 = "5e3ac9be984b288188ca101dd55e06a47c870198bec6e422945291eff45a7da6";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_interfaces/0.244.25-1.tar.gz";
+    name = "0.244.25-1.tar.gz";
+    sha256 = "3cba67c68588effe4ca27102e7b76e188680071c29b3ae898f41f86aa83b977a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-ign/default.nix
+++ b/distros/humble/ros-ign/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz, ros-ign-bridge, ros-ign-gazebo, ros-ign-gazebo-demos, ros-ign-image }:
 buildRosPackage {
   pname = "ros-humble-ros-ign";
-  version = "0.244.24-r1";
+  version = "0.244.25-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign/0.244.24-1.tar.gz";
-    name = "0.244.24-1.tar.gz";
-    sha256 = "dd09936024c55d5176b1eff4960253f783225397b0eb5ad3a2db2323f2b63a19";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign/0.244.25-1.tar.gz";
+    name = "0.244.25-1.tar.gz";
+    sha256 = "f85137e1da5c1a9df73275cadc0a471e945abb14809e51792d6811343fc718d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-medkit-beacon-common/default.nix
+++ b/distros/humble/ros2-medkit-beacon-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nlohmann_json, rclcpp, ros2-medkit-cmake, ros2-medkit-gateway, ros2-medkit-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-beacon-common";
-  version = "0.4.0-r1";
+  version = "0.5.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_beacon_common/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "cffe3beb8884bc517d90e0193774bc4a2227b9e0ed0301745fc1a424342f14a9";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_beacon_common/0.5.0-2.tar.gz";
+    name = "0.5.0-2.tar.gz";
+    sha256 = "1d8fd3d72aa417c9eaaf94d7341a7fcfbf1920e03b773b8d0782c43c9b03e064";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-medkit-cmake/default.nix
+++ b/distros/humble/ros2-medkit-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-cmake";
-  version = "0.4.0-r1";
+  version = "0.5.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_cmake/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "15a7ce58d079af8d57efb06d2353d6c3bc81d3cdf37429ba6ac33c09e019d869";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_cmake/0.5.0-2.tar.gz";
+    name = "0.5.0-2.tar.gz";
+    sha256 = "019392dba11a638a92ce7c35c0872aff592fafa44c6a21a51363f9855264cce7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-medkit-diagnostic-bridge/default.nix
+++ b/distros/humble/ros2-medkit-diagnostic-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch-testing-ament-cmake, launch-testing-ros, rclcpp, ros2-medkit-cmake, ros2-medkit-fault-manager, ros2-medkit-fault-reporter, ros2-medkit-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-diagnostic-bridge";
-  version = "0.4.0-r1";
+  version = "0.5.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_diagnostic_bridge/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "acffd66f57657adab36e7a55930c26cceaabea718a781712251b3a12e388d19a";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_diagnostic_bridge/0.5.0-2.tar.gz";
+    name = "0.5.0-2.tar.gz";
+    sha256 = "5c2d64f3a30be7cf5038f3ae6c6d867cb54d0d9ce7fb04b435da32dc8ef176ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-medkit-fault-manager/default.nix
+++ b/distros/humble/ros2-medkit-fault-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-testing-ament-cmake, launch-testing-ros, nlohmann_json, rclcpp, ros2-medkit-cmake, ros2-medkit-msgs, ros2-medkit-serialization, rosbag2-cpp, rosbag2-storage, rosbag2-storage-mcap, sensor-msgs, sqlite, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-fault-manager";
-  version = "0.4.0-r1";
+  version = "0.5.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_fault_manager/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "c496c6e61f35feefb35ac86815eae2e721a1ac565183808afafe9f81ba4c2d96";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_fault_manager/0.5.0-2.tar.gz";
+    name = "0.5.0-2.tar.gz";
+    sha256 = "120a8351c2653f563a2520a9a86fb8b6367b057de8309ed8ccd07a43348b2770";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-medkit-fault-reporter/default.nix
+++ b/distros/humble/ros2-medkit-fault-reporter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-testing-ament-cmake, launch-testing-ros, rclcpp, ros2-medkit-cmake, ros2-medkit-fault-manager, ros2-medkit-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-fault-reporter";
-  version = "0.4.0-r1";
+  version = "0.5.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_fault_reporter/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "85f531130c77a3fffc6c61d038849e756ecf5e77a75e68b3528e1846922b6db0";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_fault_reporter/0.5.0-2.tar.gz";
+    name = "0.5.0-2.tar.gz";
+    sha256 = "a530517b9d5f2b01b69c234a2802db7cbae9f5eaa2478041da52e316446007c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-medkit-gateway/default.nix
+++ b/distros/humble/ros2-medkit-gateway/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, example-interfaces, httplib, nlohmann_json, openssl, rcl-interfaces, rclcpp, rclcpp-action, ros2-medkit-cmake, ros2-medkit-msgs, ros2-medkit-serialization, rosidl-parser, rosidl-runtime-py, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, sensor-msgs, sqlite, std-msgs, std-srvs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-gateway";
-  version = "0.4.0-r1";
+  version = "0.5.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_gateway/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "c1fa272f9790acf5b8e4a347883b325a4ab89334ab34dc374a2c1bcd57362712";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_gateway/0.5.0-2.tar.gz";
+    name = "0.5.0-2.tar.gz";
+    sha256 = "f95a34a7f40fe7e685d10344033afd9ae1a574762a9ba4a4913c04e11d567704";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-medkit-graph-provider/default.nix
+++ b/distros/humble/ros2-medkit-graph-provider/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, httplib, nlohmann_json, openssl, rclcpp, ros2-medkit-cmake, ros2-medkit-gateway, ros2-medkit-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, nlohmann_json, rclcpp, ros2-medkit-cmake, ros2-medkit-gateway, ros2-medkit-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-graph-provider";
-  version = "0.4.0-r1";
+  version = "0.5.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_graph_provider/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "c096582617a25711b607a2a914da0c6980763bcbc0e97ce0bb3d6269620fb1df";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_graph_provider/0.5.0-2.tar.gz";
+    name = "0.5.0-2.tar.gz";
+    sha256 = "dcf126846ef8b714b8878572508a432f7d11db94a31e1346c573cd39d0a64bc3";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros2-medkit-cmake ];
   checkInputs = [ ament-cmake-clang-format ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ diagnostic-msgs httplib nlohmann_json openssl rclcpp ros2-medkit-gateway ros2-medkit-msgs ];
+  propagatedBuildInputs = [ diagnostic-msgs nlohmann_json rclcpp ros2-medkit-gateway ros2-medkit-msgs ];
   nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
 
   meta = {

--- a/distros/humble/ros2-medkit-integration-tests/default.nix
+++ b/distros/humble/ros2-medkit-integration-tests/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, diagnostic-msgs, example-interfaces, launch-ros, launch-testing, launch-testing-ament-cmake, python3Packages, rcl-interfaces, rclcpp, rclcpp-action, ros2-medkit-cmake, ros2-medkit-fault-manager, ros2-medkit-gateway, ros2-medkit-graph-provider, ros2-medkit-linux-introspection, ros2-medkit-msgs, ros2-medkit-param-beacon, ros2-medkit-topic-beacon, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-integration-tests";
-  version = "0.4.0-r1";
+  version = "0.5.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_integration_tests/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "ce6dae2978f36345e32447543ddc83281708b12b7981f130d2197fc94307f163";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_integration_tests/0.5.0-2.tar.gz";
+    name = "0.5.0-2.tar.gz";
+    sha256 = "2f34d651e2514e15097d55ecd01d30aa4886fb8efe98c5a2769a64757adc1040";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ros2-medkit-cmake ];
-  checkInputs = [ ament-index-python launch-ros launch-testing launch-testing-ament-cmake python3Packages.requests ros2-medkit-fault-manager ros2-medkit-gateway ros2-medkit-graph-provider ros2-medkit-linux-introspection ros2-medkit-param-beacon ros2-medkit-topic-beacon ];
+  checkInputs = [ ament-index-python launch-ros launch-testing launch-testing-ament-cmake python3Packages.jsonschema python3Packages.requests ros2-medkit-fault-manager ros2-medkit-gateway ros2-medkit-graph-provider ros2-medkit-linux-introspection ros2-medkit-param-beacon ros2-medkit-topic-beacon ];
   propagatedBuildInputs = [ diagnostic-msgs example-interfaces rcl-interfaces rclcpp rclcpp-action ros2-medkit-msgs sensor-msgs std-msgs std-srvs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ros2-medkit-cmake ];
 

--- a/distros/humble/ros2-medkit-linux-introspection/default.nix
+++ b/distros/humble/ros2-medkit-linux-introspection/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, httplib, nlohmann_json, openssl, ros2-medkit-cmake, ros2-medkit-gateway, systemd }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, nlohmann_json, pkg-config, ros2-medkit-cmake, ros2-medkit-gateway, systemd }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-linux-introspection";
-  version = "0.4.0-r1";
+  version = "0.5.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_linux_introspection/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "341f72c7182c187023d37f12988a54049b31dbaf564b8ddb1544af5f4b9fb26d";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_linux_introspection/0.5.0-2.tar.gz";
+    name = "0.5.0-2.tar.gz";
+    sha256 = "589f9175f372a7bf5b61eec9250fdb886ca8518ec4e3945d76448be8748196b9";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ros2-medkit-cmake ];
+  buildInputs = [ ament-cmake pkg-config ros2-medkit-cmake ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ];
-  propagatedBuildInputs = [ httplib nlohmann_json openssl ros2-medkit-gateway systemd ];
-  nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
+  propagatedBuildInputs = [ nlohmann_json ros2-medkit-gateway systemd ];
+  nativeBuildInputs = [ ament-cmake pkg-config ros2-medkit-cmake ];
 
   meta = {
     description = "Linux introspection plugins for ros2_medkit gateway - procfs, systemd, and container";

--- a/distros/humble/ros2-medkit-msgs/default.nix
+++ b/distros/humble/ros2-medkit-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-msgs";
-  version = "0.4.0-r1";
+  version = "0.5.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_msgs/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "8b3e5ac1708f3cc2fb9bfb4aa5e7f7ed0bbc13a2e0dafe7ec3a2c941a6cef834";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_msgs/0.5.0-2.tar.gz";
+    name = "0.5.0-2.tar.gz";
+    sha256 = "07542235f245ea6af0707195772193b72c4275720100b7c843554cf34ccd4f1b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-medkit-param-beacon/default.nix
+++ b/distros/humble/ros2-medkit-param-beacon/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-lint-auto, ament-lint-common, httplib, nlohmann_json, openssl, rclcpp, ros2-medkit-beacon-common, ros2-medkit-cmake, ros2-medkit-gateway }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-lint-auto, ament-lint-common, nlohmann_json, rclcpp, ros2-medkit-beacon-common, ros2-medkit-cmake, ros2-medkit-gateway }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-param-beacon";
-  version = "0.4.0-r1";
+  version = "0.5.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_param_beacon/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "8444b50f6f0d693d7331a6d15f406bd38d566e6383f30d3614a1d5df0ed2bc7b";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_param_beacon/0.5.0-2.tar.gz";
+    name = "0.5.0-2.tar.gz";
+    sha256 = "8fe18a032dd3efb3523e67f13edc134c3c3575b30b44ace41eefa636e27fd5bf";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros2-medkit-cmake ];
   checkInputs = [ ament-cmake-clang-format ament-cmake-gmock ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ httplib nlohmann_json openssl rclcpp ros2-medkit-beacon-common ros2-medkit-gateway ];
+  propagatedBuildInputs = [ nlohmann_json rclcpp ros2-medkit-beacon-common ros2-medkit-gateway ];
   nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
 
   meta = {

--- a/distros/humble/ros2-medkit-serialization/default.nix
+++ b/distros/humble/ros2-medkit-serialization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nlohmann_json, rclcpp, rcpputils, rcutils, ros2-medkit-cmake, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, sensor-msgs, std-msgs, std-srvs, test-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-serialization";
-  version = "0.4.0-r1";
+  version = "0.5.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_serialization/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "1ef00917f70b6b56bbd99e623eb5fea364a48fcd599dd739c5d60be581581441";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_serialization/0.5.0-2.tar.gz";
+    name = "0.5.0-2.tar.gz";
+    sha256 = "0e1061f920ff04dae014d66d006ef09bcebee8a6877bf946a3fb5a89b1eb9988";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-medkit-sovd-service-interface/default.nix
+++ b/distros/humble/ros2-medkit-sovd-service-interface/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nlohmann_json, rclcpp, ros2-medkit-cmake, ros2-medkit-gateway, ros2-medkit-msgs }:
+buildRosPackage {
+  pname = "ros-humble-ros2-medkit-sovd-service-interface";
+  version = "0.5.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_sovd_service_interface/0.5.0-2.tar.gz";
+    name = "0.5.0-2.tar.gz";
+    sha256 = "a30f8fc3cb57422355536eb4c40d7b516638988b38e7ae6016e592819f9c6b1a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros2-medkit-cmake ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ nlohmann_json rclcpp ros2-medkit-gateway ros2-medkit-msgs ];
+  nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
+
+  meta = {
+    description = "SOVD Service Interface plugin - exposes medkit entity tree and fault data via ROS 2 services";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/ros2-medkit-topic-beacon/default.nix
+++ b/distros/humble/ros2-medkit-topic-beacon/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, httplib, nlohmann_json, openssl, rclcpp, ros2-medkit-beacon-common, ros2-medkit-cmake, ros2-medkit-gateway, ros2-medkit-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, nlohmann_json, rclcpp, ros2-medkit-beacon-common, ros2-medkit-cmake, ros2-medkit-gateway, ros2-medkit-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-topic-beacon";
-  version = "0.4.0-r1";
+  version = "0.5.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_topic_beacon/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "6447c27a79c75cc4900cb976ef1fc7d5adf76dd74ba6bcd8a92f92b327c72ffd";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_topic_beacon/0.5.0-2.tar.gz";
+    name = "0.5.0-2.tar.gz";
+    sha256 = "2e0a048ce3f8a51fb4aa11bd85ea7becd2c55cd22d05b0ed53273304e2a8620a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros2-medkit-cmake ];
   checkInputs = [ ament-cmake-clang-format ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ diagnostic-msgs httplib nlohmann_json openssl rclcpp ros2-medkit-beacon-common ros2-medkit-gateway ros2-medkit-msgs ];
+  propagatedBuildInputs = [ diagnostic-msgs nlohmann_json rclcpp ros2-medkit-beacon-common ros2-medkit-gateway ros2-medkit-msgs ];
   nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
 
   meta = {

--- a/distros/humble/rosbag-timing-inspector/default.nix
+++ b/distros/humble/rosbag-timing-inspector/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, glfw3, libGL, libGLU, rosbag2-cpp, rosbag2-storage }:
+buildRosPackage {
+  pname = "ros-humble-rosbag-timing-inspector";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbag_timing_inspector-release/archive/release/humble/rosbag_timing_inspector/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "715684751cf28b41c0a719a26c2485f309e229bc4a8b5216fa00b0c5c3f2e156";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake glfw3 libGL libGLU ];
+  propagatedBuildInputs = [ rosbag2-cpp rosbag2-storage ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "GUI tool to visualize and analyze message timing from ROS2 bags (mcap or db3).";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/rqt-tf-tree/default.nix
+++ b/distros/humble/rqt-tf-tree/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-dotgraph, rclpy, rqt-graph, rqt-gui, rqt-gui-py, tf2-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, python-qt-binding, python3Packages, qt-dotgraph, rclpy, rqt-graph, rqt-gui, rqt-gui-py, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-rqt-tf-tree";
-  version = "1.0.6-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_tf_tree-release/archive/release/humble/rqt_tf_tree/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "a5915bddfccfc9173f8642171820c124c0eb03b5aadb9a54482db068ecabd8b8";
+    url = "https://github.com/ros2-gbp/rqt_tf_tree-release/archive/release/humble/rqt_tf_tree/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "080bb2980ddb54ba06c780f35f5ad20c7acb4bf3939a0fae2d37757ce3cd5e62";
   };
 
   buildType = "ament_python";
-  checkInputs = [ python3Packages.mock python3Packages.pytest ];
+  checkInputs = [ ament-flake8 ament-pep257 python3Packages.mock python3Packages.pytest ];
   propagatedBuildInputs = [ python-qt-binding qt-dotgraph rclpy rqt-graph rqt-gui rqt-gui-py tf2-msgs tf2-ros ];
 
   meta = {

--- a/distros/humble/scan-2d-merger/default.nix
+++ b/distros/humble/scan-2d-merger/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-scan-2d-merger";
+  version = "2.0.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/ali-pahlevani/2D_Scan_Merger_ROS2-release/archive/release/humble/scan_2d_merger/2.0.0-3.tar.gz";
+    name = "2.0.0-3.tar.gz";
+    sha256 = "92c16192a01914c3a698d3dc22c3b7f3a82c0a741251f43db01bf5d9846b60a8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ];
+
+  meta = {
+    description = "A laser scan merger for 1 to N 2D LiDARs, with approximate-time synchronization.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/sound-play-msgs/default.nix
+++ b/distros/humble/sound-play-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-humble-sound-play-msgs";
+  version = "0.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/audio_common-release/archive/release/humble/sound_play_msgs/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "cf661b6f1d02cb719c54f08efedf780e5133cb647f61a37db6c6cb07d873d2c5";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "Messages for transmitting sound via ROS with sound_play";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/sound-play/default.nix
+++ b/distros/humble/sound-play/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, _unresolved_festival, action-msgs, ament-cmake, ament-cmake-python, ament-index-python, boost, gst_all_1, launch-xml, python3Packages, rclpy, sound-play-msgs }:
+buildRosPackage {
+  pname = "ros-humble-sound-play";
+  version = "0.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/audio_common-release/archive/release/humble/sound_play/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "32b0b38f91bdc547c814791ac4e52739b8997c3c140bb40c1e8c944a26fdf16b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python boost python3Packages.setuptools ];
+  propagatedBuildInputs = [ _unresolved_festival action-msgs ament-index-python gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good gst_all_1.gst-plugins-ugly gst_all_1.gstreamer launch-xml python3Packages.pygobject3 rclpy sound-play-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python python3Packages.setuptools ];
+
+  meta = {
+    description = "sound_play provides a ROS node that translates commands on a ROS topic (<tt>robotsound</tt>) into sounds. The node supports built-in sounds, playing OGG/WAV files, and doing speech synthesis via festival. C++ and Python bindings allow this node to be used without understanding the details of the message format, allowing faster development and resilience to message format changes.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/talos-bringup/default.nix
+++ b/distros/humble/talos-bringup/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.10.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/talos_robot-release/archive/release/humble/talos_bringup/2.10.3-1.tar.gz";
+    url = "https://github.com/ros2-gbp/talos_robot-release/archive/release/humble/talos_bringup/2.10.3-1.tar.gz";
     name = "2.10.3-1.tar.gz";
     sha256 = "9afc9ef5541b41dea8d8a04048e58d761ef8d30d42872e123d348e9aa622939a";
   };

--- a/distros/humble/talos-controller-configuration/default.nix
+++ b/distros/humble/talos-controller-configuration/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.10.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/talos_robot-release/archive/release/humble/talos_controller_configuration/2.10.3-1.tar.gz";
+    url = "https://github.com/ros2-gbp/talos_robot-release/archive/release/humble/talos_controller_configuration/2.10.3-1.tar.gz";
     name = "2.10.3-1.tar.gz";
     sha256 = "40d1879b819ff2e1a556ec01ebc993854be86f5b7517cbc168e85b5d2f51915c";
   };

--- a/distros/humble/talos-description-calibration/default.nix
+++ b/distros/humble/talos-description-calibration/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.10.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/talos_robot-release/archive/release/humble/talos_description_calibration/2.10.3-1.tar.gz";
+    url = "https://github.com/ros2-gbp/talos_robot-release/archive/release/humble/talos_description_calibration/2.10.3-1.tar.gz";
     name = "2.10.3-1.tar.gz";
     sha256 = "e1e67ef5fc02269c764496636f31829c9b65c601520b51d8c786072c4bcfbdfb";
   };

--- a/distros/humble/talos-description-inertial/default.nix
+++ b/distros/humble/talos-description-inertial/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.10.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/talos_robot-release/archive/release/humble/talos_description_inertial/2.10.3-1.tar.gz";
+    url = "https://github.com/ros2-gbp/talos_robot-release/archive/release/humble/talos_description_inertial/2.10.3-1.tar.gz";
     name = "2.10.3-1.tar.gz";
     sha256 = "d8386d06b8fc9c2787cf78e35b4544150cb01766506414fa3cb8aef5cea401c5";
   };

--- a/distros/humble/talos-description/default.nix
+++ b/distros/humble/talos-description/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.10.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/talos_robot-release/archive/release/humble/talos_description/2.10.3-1.tar.gz";
+    url = "https://github.com/ros2-gbp/talos_robot-release/archive/release/humble/talos_description/2.10.3-1.tar.gz";
     name = "2.10.3-1.tar.gz";
     sha256 = "a28cb874e15ce760c4665a95123eed2bcd3f5bd755c440eeb2e2eae35a702d13";
   };

--- a/distros/humble/talos-gazebo/default.nix
+++ b/distros/humble/talos-gazebo/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/talos_simulation-release/archive/release/humble/talos_gazebo/2.0.3-1.tar.gz";
+    url = "https://github.com/ros2-gbp/talos_simulation-release/archive/release/humble/talos_gazebo/2.0.3-1.tar.gz";
     name = "2.0.3-1.tar.gz";
     sha256 = "5f62ee1fcea3d5ff3243b70a4effc59a1a10fa91fa29daa4d2f03a0752cf4010";
   };

--- a/distros/humble/talos-moveit-config/default.nix
+++ b/distros/humble/talos-moveit-config/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/talos_moveit_config-release/archive/release/humble/talos_moveit_config/2.0.4-1.tar.gz";
+    url = "https://github.com/ros2-gbp/talos_moveit_config-release/archive/release/humble/talos_moveit_config/2.0.4-1.tar.gz";
     name = "2.0.4-1.tar.gz";
     sha256 = "18b0fb6fd0d223da419bbf4c9ca654396c41ad440f89f172dfd827afbac0e9c6";
   };

--- a/distros/humble/talos-robot/default.nix
+++ b/distros/humble/talos-robot/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.10.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/talos_robot-release/archive/release/humble/talos_robot/2.10.3-1.tar.gz";
+    url = "https://github.com/ros2-gbp/talos_robot-release/archive/release/humble/talos_robot/2.10.3-1.tar.gz";
     name = "2.10.3-1.tar.gz";
     sha256 = "fb1be6f6cf622510c2e05adbd59629a2a7aed96e3cc1a74806fd3856df61fde2";
   };

--- a/distros/humble/tcb-span/default.nix
+++ b/distros/humble/tcb-span/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-humble-tcb-span";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/humble/tcb_span/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "60e2ef202656429ba5f8684ed91b36106514d58865c223e107b792cc53fe6caf";
+    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/humble/tcb_span/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "23cd9f050b54eedda072bf2899575f1b4592dbe918079115ff80a52857a8539a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-2dnav/default.nix
+++ b/distros/humble/tiago-2dnav/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "4.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_2dnav/4.12.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/tiago_navigation-release/archive/release/humble/tiago_2dnav/4.12.0-1.tar.gz";
     name = "4.12.0-1.tar.gz";
     sha256 = "21075d7d20dbc39d2814e2629fa598f06faaa16b45290a167857a2e89a9114ae";
   };

--- a/distros/humble/tiago-bringup/default.nix
+++ b/distros/humble/tiago-bringup/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "4.24.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_bringup/4.24.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/tiago_robot-release/archive/release/humble/tiago_bringup/4.24.1-1.tar.gz";
     name = "4.24.1-1.tar.gz";
     sha256 = "4d4f2bc5fc13c4b4374a28ae77b4e74b66a859cb9e6c803bc1b6c4b05ddde86b";
   };

--- a/distros/humble/tiago-controller-configuration/default.nix
+++ b/distros/humble/tiago-controller-configuration/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "4.24.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_controller_configuration/4.24.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/tiago_robot-release/archive/release/humble/tiago_controller_configuration/4.24.1-1.tar.gz";
     name = "4.24.1-1.tar.gz";
     sha256 = "7fa719ce012cd7c37d3d5a8c1501ed7905161cfd10adf3ac02e666d8dd666c48";
   };

--- a/distros/humble/tiago-description/default.nix
+++ b/distros/humble/tiago-description/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "4.24.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_description/4.24.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/tiago_robot-release/archive/release/humble/tiago_description/4.24.1-1.tar.gz";
     name = "4.24.1-1.tar.gz";
     sha256 = "1b77df7138bb265816e3218086cab3db3d7052cfcedc7f5942675e6551e16c24";
   };

--- a/distros/humble/tiago-gazebo/default.nix
+++ b/distros/humble/tiago-gazebo/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "4.10.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_simulation-release/archive/release/humble/tiago_gazebo/4.10.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/tiago_simulation-release/archive/release/humble/tiago_gazebo/4.10.1-1.tar.gz";
     name = "4.10.1-1.tar.gz";
     sha256 = "761435b42817a6d9b00cdec0985df9d75e6695f529114846a63bc76bb193765a";
   };

--- a/distros/humble/tiago-laser-sensors/default.nix
+++ b/distros/humble/tiago-laser-sensors/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "4.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_laser_sensors/4.12.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/tiago_navigation-release/archive/release/humble/tiago_laser_sensors/4.12.0-1.tar.gz";
     name = "4.12.0-1.tar.gz";
     sha256 = "cd5b668d6d0b1d2efa694177db71a21a5904eae2f1dd45a99621073fde879340";
   };

--- a/distros/humble/tiago-moveit-config/default.nix
+++ b/distros/humble/tiago-moveit-config/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "3.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_moveit_config-release/archive/release/humble/tiago_moveit_config/3.1.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/tiago_moveit_config-release/archive/release/humble/tiago_moveit_config/3.1.2-1.tar.gz";
     name = "3.1.2-1.tar.gz";
     sha256 = "9e681ab6e59a8a1edb16fe4c5e29463cdfcc18eae842d769a8336f602ffcb72f";
   };

--- a/distros/humble/tiago-navigation/default.nix
+++ b/distros/humble/tiago-navigation/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "4.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_navigation/4.12.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/tiago_navigation-release/archive/release/humble/tiago_navigation/4.12.0-1.tar.gz";
     name = "4.12.0-1.tar.gz";
     sha256 = "d8c10d212a4eb13f29b7d6655f6d69c7107f27a82b3d1ca43f43e215466ec666";
   };

--- a/distros/humble/tiago-rgbd-sensors/default.nix
+++ b/distros/humble/tiago-rgbd-sensors/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "4.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_rgbd_sensors/4.12.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/tiago_navigation-release/archive/release/humble/tiago_rgbd_sensors/4.12.0-1.tar.gz";
     name = "4.12.0-1.tar.gz";
     sha256 = "49630d48734c6d1c53aa57763147a7d8228ff1927aa957d927c5fce6efabc111";
   };

--- a/distros/humble/tiago-robot/default.nix
+++ b/distros/humble/tiago-robot/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "4.24.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_robot/4.24.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/tiago_robot-release/archive/release/humble/tiago_robot/4.24.1-1.tar.gz";
     name = "4.24.1-1.tar.gz";
     sha256 = "4786e7e298bc2fef9b3659b92d89376facddaa2a7df16d092782663462ebd646";
   };

--- a/distros/humble/tiago-simulation/default.nix
+++ b/distros/humble/tiago-simulation/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "4.10.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_simulation-release/archive/release/humble/tiago_simulation/4.10.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/tiago_simulation-release/archive/release/humble/tiago_simulation/4.10.1-1.tar.gz";
     name = "4.10.1-1.tar.gz";
     sha256 = "9bda2186fc940f1adc97c04914fca9fbe859602dad9e4e401ab37fb1c8ce4bab";
   };

--- a/distros/humble/tl-expected/default.nix
+++ b/distros/humble/tl-expected/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-tl-expected";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/humble/tl_expected/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "b6dd1ffe57daca08a8c939b1fd0c93a8fb2c6c2daae43a73ef92fc309bb342ba";
+    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/humble/tl_expected/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "f4dc048e00ec2e52ee7dbc0b4827152d8e31d0bf9d6d8fabbec6d9f0ba63dc8d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/video-to-image-msg-publisher/default.nix
+++ b/distros/humble/video-to-image-msg-publisher/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-lint-auto, ament-lint-common, cv-bridge, opencv, rclcpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-humble-video-to-image-msg-publisher";
+  version = "0.9.5-r8";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/video_to_image_msg_publisher-release/archive/release/humble/video_to_image_msg_publisher/0.9.5-8.tar.gz";
+    name = "0.9.5-8.tar.gz";
+    sha256 = "0e0cff67387694919b659b735db71818581dfb5b123935d3b3fc1fafd5b567e3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge opencv opencv.cxxdev rclcpp sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ];
+
+  meta = {
+    description = "A simple node that publishes sensor_msgs/Image messages from a specified video file";
+    license = with lib.licenses; [ gpl2 ];
+  };
+}

--- a/distros/jazzy/actionlib-msgs/default.nix
+++ b/distros/jazzy/actionlib-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-actionlib-msgs";
-  version = "5.3.7-r1";
+  version = "5.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/actionlib_msgs/5.3.7-1.tar.gz";
-    name = "5.3.7-1.tar.gz";
-    sha256 = "9858689e51a0ffe6196267125fefab947d8d5d78daa1d70d96233afc08e9a3ec";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/actionlib_msgs/5.3.8-1.tar.gz";
+    name = "5.3.8-1.tar.gz";
+    sha256 = "4cfac91b98101ea1afaa07076c4fd6039f3dcbacda9aa40fcab19a48dd4baf22";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/aruco-msgs/default.nix
+++ b/distros/jazzy/aruco-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "5.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/aruco_ros-release/archive/release/jazzy/aruco_msgs/5.0.5-1.tar.gz";
+    url = "https://github.com/ros2-gbp/aruco_ros-release/archive/release/jazzy/aruco_msgs/5.0.5-1.tar.gz";
     name = "5.0.5-1.tar.gz";
     sha256 = "30e0cebc80df8d1a3ae3f31792ddb859d83d0b3d35910303735b9045ebaba315";
   };

--- a/distros/jazzy/aruco-ros/default.nix
+++ b/distros/jazzy/aruco-ros/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "5.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/aruco_ros-release/archive/release/jazzy/aruco_ros/5.0.5-1.tar.gz";
+    url = "https://github.com/ros2-gbp/aruco_ros-release/archive/release/jazzy/aruco_ros/5.0.5-1.tar.gz";
     name = "5.0.5-1.tar.gz";
     sha256 = "a6184c66040493c17c3622de6f98ae4960f7a7c1588d6cabf603f1cfc41b24aa";
   };

--- a/distros/jazzy/aruco/default.nix
+++ b/distros/jazzy/aruco/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "5.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/aruco_ros-release/archive/release/jazzy/aruco/5.0.5-1.tar.gz";
+    url = "https://github.com/ros2-gbp/aruco_ros-release/archive/release/jazzy/aruco/5.0.5-1.tar.gz";
     name = "5.0.5-1.tar.gz";
     sha256 = "488ace2de0ec55f71ec3d3d5aead000ad53fcbb6b71550019b6703b02e9578bc";
   };

--- a/distros/jazzy/behaviortree-cpp-v3/default.nix
+++ b/distros/jazzy/behaviortree-cpp-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, cppzmq, ncurses, rclcpp, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-behaviortree-cpp-v3";
-  version = "3.8.6-r3";
+  version = "3.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp-release/archive/release/jazzy/behaviortree_cpp_v3/3.8.6-3.tar.gz";
-    name = "3.8.6-3.tar.gz";
-    sha256 = "d59fb320088e67483d4a498b51dd283f57b1863ded76ba17832cf4842b3aa030";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp-release/archive/release/jazzy/behaviortree_cpp_v3/3.8.8-1.tar.gz";
+    name = "3.8.8-1.tar.gz";
+    sha256 = "e16d969bc07b66ac3e737350b8c5daf781270db2682e5ff8b40c06dec2793dd3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/common-interfaces/default.nix
+++ b/distros/jazzy/common-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, geometry-msgs, nav-msgs, sensor-msgs, shape-msgs, std-msgs, std-srvs, stereo-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-common-interfaces";
-  version = "5.3.7-r1";
+  version = "5.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/common_interfaces/5.3.7-1.tar.gz";
-    name = "5.3.7-1.tar.gz";
-    sha256 = "c1aaa87d2b397c6b5564f51e69a2b99c92ea93e6bc72f281c0561677b1376c17";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/common_interfaces/5.3.8-1.tar.gz";
+    name = "5.3.8-1.tar.gz";
+    sha256 = "8a9113a1848ec91f1cb60514b90d6b5f54f18786a5f9d7a5ba0bf1af80b56014";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/diagnostic-msgs/default.nix
+++ b/distros/jazzy/diagnostic-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-diagnostic-msgs";
-  version = "5.3.7-r1";
+  version = "5.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/diagnostic_msgs/5.3.7-1.tar.gz";
-    name = "5.3.7-1.tar.gz";
-    sha256 = "19a5f3353c6e3eb1e67756b426c89b085ba24d189abd6755371d5c77ce992cbf";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/diagnostic_msgs/5.3.8-1.tar.gz";
+    name = "5.3.8-1.tar.gz";
+    sha256 = "650932b68ae1b6256933dac08b343681d57191439cda233607cc3dd07e389ba4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/geometric-shapes/default.nix
+++ b/distros/jazzy/geometric-shapes/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, assimp, boost, console-bridge-vendor, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometry-msgs, octomap, pkg-config, qhull, random-numbers, rclcpp, resource-retriever, rosidl-default-generators, rosidl-default-runtime, shape-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, assimp, boost, console-bridge-vendor, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometry-msgs, pkg-config, qhull, random-numbers, rclcpp, resource-retriever, rosidl-default-generators, rosidl-default-runtime, shape-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-geometric-shapes";
-  version = "2.3.2-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometric_shapes-release/archive/release/jazzy/geometric_shapes/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "b6cb558184c91b3b4c2b33d40ae814689a69d8c0894a1ae0bb2de5fa3a3d2a88";
+    url = "https://github.com/ros2-gbp/geometric_shapes-release/archive/release/jazzy/geometric_shapes/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "2f8331892b33350a96c4e53f7800f1ab828a78649d4853d1930c32acc4e9d910";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake pkg-config rosidl-default-generators ];
   checkInputs = [ ament-cmake-copyright ament-cmake-gtest ament-lint-auto ament-lint-cmake ];
-  propagatedBuildInputs = [ assimp boost console-bridge-vendor eigen eigen-stl-containers eigen3-cmake-module fcl geometry-msgs octomap qhull random-numbers rclcpp resource-retriever rosidl-default-runtime shape-msgs visualization-msgs ];
+  propagatedBuildInputs = [ assimp boost console-bridge-vendor eigen eigen-stl-containers eigen3-cmake-module fcl geometry-msgs qhull random-numbers rclcpp resource-retriever rosidl-default-runtime shape-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module rosidl-default-generators ];
 
   meta = {

--- a/distros/jazzy/geometry-msgs/default.nix
+++ b/distros/jazzy/geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-geometry-msgs";
-  version = "5.3.7-r1";
+  version = "5.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/geometry_msgs/5.3.7-1.tar.gz";
-    name = "5.3.7-1.tar.gz";
-    sha256 = "e63d4033760b3b54b06609e46ee516fa83e72afdbd0ad96087d9bcffcf5472b4";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/geometry_msgs/5.3.8-1.tar.gz";
+    name = "5.3.8-1.tar.gz";
+    sha256 = "1228c530eff1bb8169c79344d0364bccc596f9767456b661ca4d5ca503423c7f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/message-filters/default.nix
+++ b/distros/jazzy/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, builtin-interfaces, python-cmake-module, rclcpp, rclcpp-lifecycle, rclpy, rcutils, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-message-filters";
-  version = "4.11.15-r1";
+  version = "4.11.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/jazzy/message_filters/4.11.15-1.tar.gz";
-    name = "4.11.15-1.tar.gz";
-    sha256 = "ee2c6d1dd9ac0753ab55e70f13a83a93b6b972c8516fbbe1c4d657c66e428103";
+    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/jazzy/message_filters/4.11.16-1.tar.gz";
+    name = "4.11.16-1.tar.gz";
+    sha256 = "202aa8b7089335d108ac50485b836c138f120813c6523ed32cca8460c6d34d80";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav-msgs/default.nix
+++ b/distros/jazzy/nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav-msgs";
-  version = "5.3.7-r1";
+  version = "5.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/nav_msgs/5.3.7-1.tar.gz";
-    name = "5.3.7-1.tar.gz";
-    sha256 = "e9241a52c4b2812e23536d163556aac55677215c4cf7be0a2a37f256481260f5";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/nav_msgs/5.3.8-1.tar.gz";
+    name = "5.3.8-1.tar.gz";
+    sha256 = "612889d4c4b15349b3cfabba3bc61da9d50ba77db12c50f801a999de35fc417c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -329,6 +329,16 @@ in {
 
   gazebo = self.gazebo_11;
 
+  geometric-shapes = rosSuper.geometric-shapes.overrideAttrs ({
+    postPatch ? "", ...
+  }: {
+    # https://github.com/moveit/geometric_shapes/issues/270
+    postPatch = postPatch + ''
+      substituteInPlace CMakeLists.txt --replace-fail \
+        "random_numbers::random_numbers" "\''${random_numbers_LIBRARIES}"
+    '';
+  });
+
   google-benchmark-vendor = lib.patchExternalProjectGit rosSuper.google-benchmark-vendor {
     url = "https://github.com/google/benchmark.git";
     rev = "344117638c8ff7e239044fd0fa7085839fc03021";

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -329,17 +329,6 @@ in {
 
   gazebo = self.gazebo_11;
 
-  geometric-shapes = rosSuper.geometric-shapes.overrideAttrs({
-      postPatch ? "", ...
-  }: {
-      # Remove workaround for Ubuntu-specific dependency hell issue
-      postPatch = postPatch + ''
-        substituteInPlace CMakeLists.txt --replace-fail \
-          'find_package(octomap 1.9.7...<1.10.0 REQUIRED)' \
-          'find_package(octomap REQUIRED)'
-      '';
-  });
-
   google-benchmark-vendor = lib.patchExternalProjectGit rosSuper.google-benchmark-vendor {
     url = "https://github.com/google/benchmark.git";
     rev = "344117638c8ff7e239044fd0fa7085839fc03021";

--- a/distros/jazzy/rcl-action/default.nix
+++ b/distros/jazzy/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rcl-action";
-  version = "9.2.10-r1";
+  version = "9.2.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/jazzy/rcl_action/9.2.10-1.tar.gz";
-    name = "9.2.10-1.tar.gz";
-    sha256 = "d6b6b5bba68cc5266dd77599fd5835409945e87a001db7a0920456ad144592ac";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/jazzy/rcl_action/9.2.11-1.tar.gz";
+    name = "9.2.11-1.tar.gz";
+    sha256 = "fd59cfc52c5a287f5c7e83267a65590db236386638bfaba8a2cf34e793a2ad3c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rcl-lifecycle/default.nix
+++ b/distros/jazzy/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-jazzy-rcl-lifecycle";
-  version = "9.2.10-r1";
+  version = "9.2.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/jazzy/rcl_lifecycle/9.2.10-1.tar.gz";
-    name = "9.2.10-1.tar.gz";
-    sha256 = "1e56079c9be2ca0674623fc573e8e8253ddc0d03093d547ea7a182a5476c0045";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/jazzy/rcl_lifecycle/9.2.11-1.tar.gz";
+    name = "9.2.11-1.tar.gz";
+    sha256 = "b3e138ca8efed940e5e30b97e9e0a5303ddaf361d7f4d685edae9ef36f935c75";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rcl-yaml-param-parser/default.nix
+++ b/distros/jazzy/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-jazzy-rcl-yaml-param-parser";
-  version = "9.2.10-r1";
+  version = "9.2.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/jazzy/rcl_yaml_param_parser/9.2.10-1.tar.gz";
-    name = "9.2.10-1.tar.gz";
-    sha256 = "949922938dc9653f138448d1a249a2e1457bcc3ce81831947c4e2d27bb5c1b39";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/jazzy/rcl_yaml_param_parser/9.2.11-1.tar.gz";
+    name = "9.2.11-1.tar.gz";
+    sha256 = "c3e58ca1a56d512419240eabf23a9dadbd8d54a9b051a289c1551603e03b8d58";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rcl/default.nix
+++ b/distros/jazzy/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, rosidl-runtime-cpp, service-msgs, test-msgs, tracetools, type-description-interfaces }:
 buildRosPackage {
   pname = "ros-jazzy-rcl";
-  version = "9.2.10-r1";
+  version = "9.2.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/jazzy/rcl/9.2.10-1.tar.gz";
-    name = "9.2.10-1.tar.gz";
-    sha256 = "0d3c8317ec8320bc76a58203db8f1b91853e7fc02fbec153ed69707eaa308287";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/jazzy/rcl/9.2.11-1.tar.gz";
+    name = "9.2.11-1.tar.gz";
+    sha256 = "1d803a00b0436ee63f968498194e7ae754a006dba6d611d68072b30864fcf1ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rclcpp-action/default.nix
+++ b/distros/jazzy/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rclcpp-action";
-  version = "28.1.19-r1";
+  version = "28.1.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp_action/28.1.19-1.tar.gz";
-    name = "28.1.19-1.tar.gz";
-    sha256 = "50525c801475e946283e11233c0dd0c2bfe24508ab69130e76c803087c21f4e6";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp_action/28.1.21-1.tar.gz";
+    name = "28.1.21-1.tar.gz";
+    sha256 = "a5ad9987ad9808e0b400d6f4c393ee241e3121f7ec5120c5f77ff03235b43920";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rclcpp-components/default.nix
+++ b/distros/jazzy/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rclcpp-components";
-  version = "28.1.19-r1";
+  version = "28.1.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp_components/28.1.19-1.tar.gz";
-    name = "28.1.19-1.tar.gz";
-    sha256 = "4bf1ee2193b98eaa33af0ec7940fd5bbc64fce26e0f866bd95e807ffa0b4fbc6";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp_components/28.1.21-1.tar.gz";
+    name = "28.1.21-1.tar.gz";
+    sha256 = "e1f6b281c58233773191b34d2fd1182a9ff082d468bcc0e7020ff6d24d4d9d5d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rclcpp-lifecycle/default.nix
+++ b/distros/jazzy/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rclcpp-lifecycle";
-  version = "28.1.19-r1";
+  version = "28.1.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp_lifecycle/28.1.19-1.tar.gz";
-    name = "28.1.19-1.tar.gz";
-    sha256 = "90e277ae20becd285969de1eeef0ccd70ca9de843d85f496f8c97c2e75e596f7";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp_lifecycle/28.1.21-1.tar.gz";
+    name = "28.1.21-1.tar.gz";
+    sha256 = "eb66f2fb6766724d0a8168d25cd4360e7c0f63c673c54a0ec0f881858451d611";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rclcpp/default.nix
+++ b/distros/jazzy/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-jazzy-rclcpp";
-  version = "28.1.19-r1";
+  version = "28.1.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp/28.1.19-1.tar.gz";
-    name = "28.1.19-1.tar.gz";
-    sha256 = "55e4e62f0231a6e33289a9c32dc40929c03da5911bed073c4843154ff0458ecb";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp/28.1.21-1.tar.gz";
+    name = "28.1.21-1.tar.gz";
+    sha256 = "3601b9de8292e2877e0df7719f130fe668f5f3358adad1fc801142798e0d25a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-adapter/default.nix
+++ b/distros/jazzy/rosidl-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3, python3Packages, rosidl-cli }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-adapter";
-  version = "4.6.8-r1";
+  version = "4.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_adapter/4.6.8-1.tar.gz";
-    name = "4.6.8-1.tar.gz";
-    sha256 = "94b0e796b68c5ab727baa01d7c4c50a1a0444ed76a8ffeed384811570cb289cf";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_adapter/4.6.9-1.tar.gz";
+    name = "4.6.9-1.tar.gz";
+    sha256 = "8331ae2ca7625324f2430f15a1c6741a59029c9b180a8f58276d0be1fd58cfb4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-cli/default.nix
+++ b/distros/jazzy/rosidl-cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-cli";
-  version = "4.6.8-r1";
+  version = "4.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_cli/4.6.8-1.tar.gz";
-    name = "4.6.8-1.tar.gz";
-    sha256 = "9027b6a9340e9b3f3699525b38f412d425950a0e1dc10ee0b6be11ecfaa0dfed";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_cli/4.6.9-1.tar.gz";
+    name = "4.6.9-1.tar.gz";
+    sha256 = "4733fbb3dabd509cbcf48671fc4838bb49cacfa8e320935d029304e1dcbfb329";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rosidl-cmake/default.nix
+++ b/distros/jazzy/rosidl-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python3Packages, rosidl-pycommon }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-cmake";
-  version = "4.6.8-r1";
+  version = "4.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_cmake/4.6.8-1.tar.gz";
-    name = "4.6.8-1.tar.gz";
-    sha256 = "76c7e5f17f5b42787393e642a61b71791c04cf30f8440ee247b753a1556d75a2";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_cmake/4.6.9-1.tar.gz";
+    name = "4.6.9-1.tar.gz";
+    sha256 = "8695766e4823cd2cdbc25de40d308177c2fa58d882b5000b57a2413bc81b9861";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-generator-c/default.nix
+++ b/distros/jazzy/rosidl-generator-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rcutils, rosidl-cli, rosidl-cmake, rosidl-generator-type-description, rosidl-parser, rosidl-pycommon, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-generator-c";
-  version = "4.6.8-r1";
+  version = "4.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_generator_c/4.6.8-1.tar.gz";
-    name = "4.6.8-1.tar.gz";
-    sha256 = "1513a7183a6c5df8e928ad53e3ab3bb2771b7ba18332b031bb9532b9fd6e2b33";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_generator_c/4.6.9-1.tar.gz";
+    name = "4.6.9-1.tar.gz";
+    sha256 = "20f976bbeb36d1f7f37bf2918de255382dc7367efa02bf5d1e6ead98de346b6d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-generator-cpp/default.nix
+++ b/distros/jazzy/rosidl-generator-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-type-description, rosidl-parser, rosidl-pycommon, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-generator-cpp";
-  version = "4.6.8-r1";
+  version = "4.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_generator_cpp/4.6.8-1.tar.gz";
-    name = "4.6.8-1.tar.gz";
-    sha256 = "eef678a89563f7128edd3e253a94c9042ba80025aa28840fad46b593f850db6a";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_generator_cpp/4.6.9-1.tar.gz";
+    name = "4.6.9-1.tar.gz";
+    sha256 = "389fca14b082979f4f3f0712a6f43c18144d64981a3f8c0413086df45736ed8f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-generator-type-description/default.nix
+++ b/distros/jazzy/rosidl-generator-type-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-parser }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-generator-type-description";
-  version = "4.6.8-r1";
+  version = "4.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_generator_type_description/4.6.8-1.tar.gz";
-    name = "4.6.8-1.tar.gz";
-    sha256 = "64cf0ead174fdeffb2674c0c486fcff996e0a3eccb8cb173c1413d4b6193c10c";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_generator_type_description/4.6.9-1.tar.gz";
+    name = "4.6.9-1.tar.gz";
+    sha256 = "bbb39332718002360d0364251b0bbade5838ce651a54415f7b51e87e45f3801e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-parser/default.nix
+++ b/distros/jazzy/rosidl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, rosidl-adapter }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-parser";
-  version = "4.6.8-r1";
+  version = "4.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_parser/4.6.8-1.tar.gz";
-    name = "4.6.8-1.tar.gz";
-    sha256 = "f2ea9b30b0109627fdeeed71478489c293515a32304a64431aa8afa1cc8ab79a";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_parser/4.6.9-1.tar.gz";
+    name = "4.6.9-1.tar.gz";
+    sha256 = "7844d16536f12b0b39af06b8a136d49f3d72279b54eadcf13b0550f12263fe62";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-pycommon/default.nix
+++ b/distros/jazzy/rosidl-pycommon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, rosidl-parser }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-pycommon";
-  version = "4.6.8-r1";
+  version = "4.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_pycommon/4.6.8-1.tar.gz";
-    name = "4.6.8-1.tar.gz";
-    sha256 = "8160a80fc801948832e6f31367de663f8f6a22b8ffe2414e1ad688b3a7672e35";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_pycommon/4.6.9-1.tar.gz";
+    name = "4.6.9-1.tar.gz";
+    sha256 = "6a7283cdacc7096365ae8aeea313d2ef0693eec5e0ffdbcc3217b6b4137f5daa";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rosidl-runtime-c/default.nix
+++ b/distros/jazzy/rosidl-runtime-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, performance-test-fixture, rcutils, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-runtime-c";
-  version = "4.6.8-r1";
+  version = "4.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_runtime_c/4.6.8-1.tar.gz";
-    name = "4.6.8-1.tar.gz";
-    sha256 = "39c731faf4ceb62d83353881e3640bd3a3d719dd472709d06fee4bac259372b5";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_runtime_c/4.6.9-1.tar.gz";
+    name = "4.6.9-1.tar.gz";
+    sha256 = "46f546b71c1301dc79a9097a164973cccf91ba23255f8da2b813e6ced6d3efc1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-runtime-cpp/default.nix
+++ b/distros/jazzy/rosidl-runtime-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, performance-test-fixture, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-runtime-cpp";
-  version = "4.6.8-r1";
+  version = "4.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_runtime_cpp/4.6.8-1.tar.gz";
-    name = "4.6.8-1.tar.gz";
-    sha256 = "39916416bc334e6b0cff0e3413f55eeeee1f429d0df317b05884ce18753ebc90";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_runtime_cpp/4.6.9-1.tar.gz";
+    name = "4.6.9-1.tar.gz";
+    sha256 = "1d574f17a814bde257eeca74afc36282db4f27fd585319de46e70b4b0fb0e735";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-typesupport-interface/default.nix
+++ b/distros/jazzy/rosidl-typesupport-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-typesupport-interface";
-  version = "4.6.8-r1";
+  version = "4.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_typesupport_interface/4.6.8-1.tar.gz";
-    name = "4.6.8-1.tar.gz";
-    sha256 = "f703cb11008ff1db483622fca562859a01ccd9c71af80f3cd1908cb59d98ae8e";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_typesupport_interface/4.6.9-1.tar.gz";
+    name = "4.6.9-1.tar.gz";
+    sha256 = "3549ab24edd5841f236ddf326dc3ab4e0b7065f678eda09dc1365b200a6985a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-typesupport-introspection-c/default.nix
+++ b/distros/jazzy/rosidl-typesupport-introspection-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-typesupport-introspection-c";
-  version = "4.6.8-r1";
+  version = "4.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_typesupport_introspection_c/4.6.8-1.tar.gz";
-    name = "4.6.8-1.tar.gz";
-    sha256 = "99693b7b2113e026347f551be746bc686eef423bf8f562c3662d4fc52ce595c2";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_typesupport_introspection_c/4.6.9-1.tar.gz";
+    name = "4.6.9-1.tar.gz";
+    sha256 = "2dbfbbd1c53bae3c31558a35b7cc7cf8ed9171e805e6f6f410597d10fa890e1f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosidl-typesupport-introspection-cpp/default.nix
+++ b/distros/jazzy/rosidl-typesupport-introspection-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidl-typesupport-introspection-c }:
 buildRosPackage {
   pname = "ros-jazzy-rosidl-typesupport-introspection-cpp";
-  version = "4.6.8-r1";
+  version = "4.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_typesupport_introspection_cpp/4.6.8-1.tar.gz";
-    name = "4.6.8-1.tar.gz";
-    sha256 = "e3e8d2b73b0ad15df8fcbb1c47c367f1a60aa5a4b94a8455fae65be058b7ff9d";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/jazzy/rosidl_typesupport_introspection_cpp/4.6.9-1.tar.gz";
+    name = "4.6.9-1.tar.gz";
+    sha256 = "d2987ab1c35bbbde25c4fc4cc1350afbb0c0f4b3e5772f8560ee5853c57b7f91";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-assimp-vendor/default.nix
+++ b/distros/jazzy/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-assimp-vendor";
-  version = "14.1.21-r1";
+  version = "14.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_assimp_vendor/14.1.21-1.tar.gz";
-    name = "14.1.21-1.tar.gz";
-    sha256 = "edee3580343c0a805370a8e8987d51c522a4bfdfe2535198b68d7663e388f600";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_assimp_vendor/14.1.22-1.tar.gz";
+    name = "14.1.22-1.tar.gz";
+    sha256 = "6c22e1d5f4c0bc2905d0c2da374bc55cf6ec3726f848bb2e8f78275766f29b11";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-common/default.nix
+++ b/distros/jazzy/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-common";
-  version = "14.1.21-r1";
+  version = "14.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_common/14.1.21-1.tar.gz";
-    name = "14.1.21-1.tar.gz";
-    sha256 = "d89baeeb3d462de37f95a862db4f2da3019cbbbea855e35d7050d506af73f24f";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_common/14.1.22-1.tar.gz";
+    name = "14.1.22-1.tar.gz";
+    sha256 = "9baf7991a3eb76ec0d7f321090b7f09e2a449dc726107c14955902d8dd0846bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-default-plugins/default.nix
+++ b/distros/jazzy/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, gz-math-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-default-plugins";
-  version = "14.1.21-r1";
+  version = "14.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_default_plugins/14.1.21-1.tar.gz";
-    name = "14.1.21-1.tar.gz";
-    sha256 = "c050adbafcaba7ed8e1210d7e7879a71f45935e94888679925a4a38030628a9a";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_default_plugins/14.1.22-1.tar.gz";
+    name = "14.1.22-1.tar.gz";
+    sha256 = "32f8e21b0dd7dc8d2741390ecd67a57b5613776ac60614f08aac2b69f9be233b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-ogre-vendor/default.nix
+++ b/distros/jazzy/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, glew, libGL, libGLU, libx11, libxaw, libxrandr }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-ogre-vendor";
-  version = "14.1.21-r1";
+  version = "14.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_ogre_vendor/14.1.21-1.tar.gz";
-    name = "14.1.21-1.tar.gz";
-    sha256 = "4042a78be8f31e57f093ed7db979eb82d95b427c5c5ae2df10599651d2ff12c9";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_ogre_vendor/14.1.22-1.tar.gz";
+    name = "14.1.22-1.tar.gz";
+    sha256 = "4fc4da8e1311f9ce4e219408773cb3e4c09c02e330cc196c69701e08addc55ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-rendering-tests/default.nix
+++ b/distros/jazzy/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-rendering-tests";
-  version = "14.1.21-r1";
+  version = "14.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_rendering_tests/14.1.21-1.tar.gz";
-    name = "14.1.21-1.tar.gz";
-    sha256 = "e70152b8467efc79f15b5b2f361054ad11ab84812316b8aa71da2d667fdbe53e";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_rendering_tests/14.1.22-1.tar.gz";
+    name = "14.1.22-1.tar.gz";
+    sha256 = "50066e99a1714a03aea8cee53d49db5dc338521e5f05e9d9252bbda793128156";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-rendering/default.nix
+++ b/distros/jazzy/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-rendering";
-  version = "14.1.21-r1";
+  version = "14.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_rendering/14.1.21-1.tar.gz";
-    name = "14.1.21-1.tar.gz";
-    sha256 = "c0bed7c67e528072f1e348b4fc229389460192333eadc7989414f9df4942664b";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_rendering/14.1.22-1.tar.gz";
+    name = "14.1.22-1.tar.gz";
+    sha256 = "422e4583585d64320b9e3702d62fa590d8beade7db007ad3feee1c070b83ee93";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-visual-testing-framework/default.nix
+++ b/distros/jazzy/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-visual-testing-framework";
-  version = "14.1.21-r1";
+  version = "14.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_visual_testing_framework/14.1.21-1.tar.gz";
-    name = "14.1.21-1.tar.gz";
-    sha256 = "dea5ca55b706f021077474681de5e12666858f1184ef7e9b58e3364524f99f02";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_visual_testing_framework/14.1.22-1.tar.gz";
+    name = "14.1.22-1.tar.gz";
+    sha256 = "1a53261e07672d10fbd48d1adc08f1aec2fbd171a4ff73b401921e20583a306c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz2/default.nix
+++ b/distros/jazzy/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rviz2";
-  version = "14.1.21-r1";
+  version = "14.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz2/14.1.21-1.tar.gz";
-    name = "14.1.21-1.tar.gz";
-    sha256 = "c745ebe79ce67130e2d3ccf8c688d32867910b5994e48c99c79c457426985689";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz2/14.1.22-1.tar.gz";
+    name = "14.1.22-1.tar.gz";
+    sha256 = "68255248a99f62adbcb5d3205b20139ce7f8e2bfcbb8c13c2708a47a4dcfbbbc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/sensor-msgs-py/default.nix
+++ b/distros/jazzy/sensor-msgs-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-sensor-msgs-py";
-  version = "5.3.7-r1";
+  version = "5.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/sensor_msgs_py/5.3.7-1.tar.gz";
-    name = "5.3.7-1.tar.gz";
-    sha256 = "98ca9adf90592fbe39c71b31b8acd03bf962893e62e2625e38c63661e8d8452c";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/sensor_msgs_py/5.3.8-1.tar.gz";
+    name = "5.3.8-1.tar.gz";
+    sha256 = "99ab0f98cceadb7dde3ea3981fae736156846adba4e1642a5c50da80852bd9d0";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/sensor-msgs/default.nix
+++ b/distros/jazzy/sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-sensor-msgs";
-  version = "5.3.7-r1";
+  version = "5.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/sensor_msgs/5.3.7-1.tar.gz";
-    name = "5.3.7-1.tar.gz";
-    sha256 = "9d56eb93934cbc2191657c46f8f5f35abe9070fd4fe5bde1d78ec69af3283eb5";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/sensor_msgs/5.3.8-1.tar.gz";
+    name = "5.3.8-1.tar.gz";
+    sha256 = "1b8689e2a4906afcb5adb084d8e14994dc28557ca40dde3ec7d39f0c950a9c66";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/shape-msgs/default.nix
+++ b/distros/jazzy/shape-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-shape-msgs";
-  version = "5.3.7-r1";
+  version = "5.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/shape_msgs/5.3.7-1.tar.gz";
-    name = "5.3.7-1.tar.gz";
-    sha256 = "8eada8b5f543315b13f797f4f2fb0f351764eecd2e9e22bd442d5121b9600e0a";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/shape_msgs/5.3.8-1.tar.gz";
+    name = "5.3.8-1.tar.gz";
+    sha256 = "f8bb22ad10a981d9171b1090c90cd6b2f713e3014bbc3522f45979d687383fbb";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/std-msgs/default.nix
+++ b/distros/jazzy/std-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-std-msgs";
-  version = "5.3.7-r1";
+  version = "5.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/std_msgs/5.3.7-1.tar.gz";
-    name = "5.3.7-1.tar.gz";
-    sha256 = "01fe874815561dab23478841e0a17a50655fce6454460b2631ef202a9c1ad3bb";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/std_msgs/5.3.8-1.tar.gz";
+    name = "5.3.8-1.tar.gz";
+    sha256 = "c5c8a5fd6d9b4098d4c3575d9949acad09506b29be31b1e2b80c7e013245f673";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/std-srvs/default.nix
+++ b/distros/jazzy/std-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-std-srvs";
-  version = "5.3.7-r1";
+  version = "5.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/std_srvs/5.3.7-1.tar.gz";
-    name = "5.3.7-1.tar.gz";
-    sha256 = "1c291cab586a29afa4533c71ed92439c60788a373ee432d336c6490b119bdeef";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/std_srvs/5.3.8-1.tar.gz";
+    name = "5.3.8-1.tar.gz";
+    sha256 = "d1dff427c79373e0c8b7ea4efe3dd009c9b54c01f37f787225d9f5046444d5cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/stereo-msgs/default.nix
+++ b/distros/jazzy/stereo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-stereo-msgs";
-  version = "5.3.7-r1";
+  version = "5.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/stereo_msgs/5.3.7-1.tar.gz";
-    name = "5.3.7-1.tar.gz";
-    sha256 = "c2767da576d38f057c9e799c054f2420c3bd67b75bf9bf7c361ac9651a09edf7";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/stereo_msgs/5.3.8-1.tar.gz";
+    name = "5.3.8-1.tar.gz";
+    sha256 = "4faed91837443aa239a0358474a44a78a47d2cddb29fe1ff2e409ffb8560a33a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/trajectory-msgs/default.nix
+++ b/distros/jazzy/trajectory-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-trajectory-msgs";
-  version = "5.3.7-r1";
+  version = "5.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/trajectory_msgs/5.3.7-1.tar.gz";
-    name = "5.3.7-1.tar.gz";
-    sha256 = "784238a8d623ced8dbd7fbc147c2608e871da66acfa06848d3762b0a775d8f76";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/trajectory_msgs/5.3.8-1.tar.gz";
+    name = "5.3.8-1.tar.gz";
+    sha256 = "b52426fb62490581d25a2e80da6a7de3b5e9bcc52470698612d652478aaa63fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/visualization-msgs/default.nix
+++ b/distros/jazzy/visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-visualization-msgs";
-  version = "5.3.7-r1";
+  version = "5.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/visualization_msgs/5.3.7-1.tar.gz";
-    name = "5.3.7-1.tar.gz";
-    sha256 = "d8208ae2d45ca0fd041cb7164a0fe7944111112e840e6814b21fca79aef2ad48";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/visualization_msgs/5.3.8-1.tar.gz";
+    name = "5.3.8-1.tar.gz";
+    sha256 = "72f6cb12e141a2b397e44131d87888d53f5b27318b2c832217601ca9b435b79c";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/audio-capture/default.nix
+++ b/distros/kilted/audio-capture/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, audio-common-msgs, boost, diagnostic-updater, gst_all_1, launch-xml, rclcpp, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-kilted-audio-capture";
+  version = "0.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/audio_common-release/archive/release/kilted/audio_capture/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "2cd217b7c9fdd37827d3b44630f0db1e5ab8ade86182c10aa720bd1be91526af";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake boost ];
+  propagatedBuildInputs = [ audio-common-msgs diagnostic-updater gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good gst_all_1.gst-plugins-ugly gst_all_1.gstreamer launch-xml rclcpp rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Transports audio from a source to a destination. Audio sources can come
+      from a microphone or file. The destination can play the audio or save it
+      to an mp3 file.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/audio-common-msgs/default.nix
+++ b/distros/kilted/audio-common-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-audio-common-msgs";
+  version = "0.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/audio_common-release/archive/release/kilted/audio_common_msgs/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "b16bb87d7e555f6504052366909bc79c36d0e7387186ce7bbc810708a50d3b95";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "Messages for transmitting audio via ROS";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/audio-common/default.nix
+++ b/distros/kilted/audio-common/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, audio-capture, audio-common-msgs, audio-play, sound-play, sound-play-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-audio-common";
+  version = "0.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/audio_common-release/archive/release/kilted/audio_common/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "6d0c2a13e0565f9f9205410d3924b1ce1a2971c16d69b89bf3f04b78287ddedf";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ audio-capture audio-common-msgs audio-play sound-play sound-play-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Common code for working with audio in ROS";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/audio-play/default.nix
+++ b/distros/kilted/audio-play/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, audio-common-msgs, boost, gst_all_1, launch-xml, rclcpp, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-kilted-audio-play";
+  version = "0.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/audio_common-release/archive/release/kilted/audio_play/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "68d15267a53af3615606a4e734335024b2403562e1842f83f62f4f2610a5b5d2";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake boost ];
+  propagatedBuildInputs = [ audio-common-msgs gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good gst_all_1.gst-plugins-ugly gst_all_1.gstreamer launch-xml rclcpp rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Outputs audio to a speaker from a source node.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/automatika-embodied-agents/default.nix
+++ b/distros/kilted/automatika-embodied-agents/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, automatika-ros-sugar, builtin-interfaces, python3Packages, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-automatika-embodied-agents";
-  version = "0.7.1-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/automatika_embodied_agents-release/archive/release/kilted/automatika_embodied_agents/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "5b9084b27dc2fb33915ee45120f4ed4cde9f1c4655e893ad8bc078a20e2450d0";
+    url = "https://github.com/ros2-gbp/automatika_embodied_agents-release/archive/release/kilted/automatika_embodied_agents/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "a9487243ecbc3216bc661427e4f912e5851d7966445b7fd9df7071c93e42ccd3";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/automatika-ros-sugar/default.nix
+++ b/distros/kilted/automatika-ros-sugar/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-index-python, ament-lint-auto, builtin-interfaces, geometry-msgs, launch, launch-testing, lifecycle-msgs, nav-msgs, python3Packages, rclcpp, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-automatika-ros-sugar";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/automatika_ros_sugar-release/archive/release/kilted/automatika_ros_sugar/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "68ddb11bbdac2677a50386cdb232df2c4851f035fd30ba2e8a86c0f7dffc6be9";
+    url = "https://github.com/ros2-gbp/automatika_ros_sugar-release/archive/release/kilted/automatika_ros_sugar/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "35b440a65ee6539684d3758005558fc6c7dbefeab1dd3432d7df5dcb94bbef4b";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/depthai-bridge/default.nix
+++ b/distros/kilted/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-info-manager, composition-interfaces, cv-bridge, depthai, depthai-ros-msgs, ffmpeg-image-transport-msgs, image-transport, nav-msgs, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-kilted-depthai-bridge";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_bridge/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "f23e0c3a8828c0b11cf3aa4ce2f41e54f4310a45266f0200c8bd3c064ed42d2d";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_bridge/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "03270055bca875fe40b3929162712100198de2580132393af6c7446e81b53fb3";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/depthai-descriptions/default.nix
+++ b/distros/kilted/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-kilted-depthai-descriptions";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_descriptions/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "f343204edc52a9cc3180289b8f416c3f735c8ac8da44be6275253eddf2ce0651";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_descriptions/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "83c9bd8919a31c241a24dccab7a1e6965d18853dc78f6a5a0a98f4957848e0c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/depthai-examples/default.nix
+++ b/distros/kilted/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, backward-ros, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, nav-msgs, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-kilted-depthai-examples";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_examples/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "4c5e13b0797a29570702d202b564d30b2a4ef78a01286493ec93a68c59074af8";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_examples/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "2cfd3d1c031d9cc556e6c5f13c502a2c11afc28717701cbab3167d89a603be85";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/depthai-filters/default.nix
+++ b/distros/kilted/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, depthai-ros-msgs, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-depthai-filters";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_filters/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "8911468120d12521067039560865249d580b48d770e36d4e20b36f3f1d547413";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_filters/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "c81c0e08b7a08a42427a3f3c38d61181cabfc8afe5fb4c50536b622247797c3d";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/depthai-ros-driver/default.nix
+++ b/distros/kilted/depthai-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-python, backward-ros, camera-calibration, camera-info-manager, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, ffmpeg-image-transport-msgs, geometry-msgs, image-pipeline, image-transport, image-transport-plugins, nav-msgs, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, tf2-ros, vision-msgs }:
 buildRosPackage {
   pname = "ros-kilted-depthai-ros-driver";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_ros_driver/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "d788f50d5a9f7e3957f5d17d087f24e01fc2a270648ccd571d919b1cbdc5134e";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_ros_driver/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "93fb706f779fb2c437bbc8fbc0ffb8f02353cac22dfa2b3a302ddcdb660a05f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/depthai-ros-msgs/default.nix
+++ b/distros/kilted/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-kilted-depthai-ros-msgs";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_ros_msgs/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "2428cebdd00bdf59e121b5fd7293dc0a3ce4a628f32425deb9437ae19685e10a";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_ros_msgs/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "24fa7bfd368aae91a6aff642f33d3cdd59b2bc4cba6de37f26e0c69c00a338c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/depthai-ros/default.nix
+++ b/distros/kilted/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-kilted-depthai-ros";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai-ros/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "109a75818c20ac267f71c18fa08e2c0383bfa3fea9d1a010c57bd72d58bb05c2";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai-ros/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "5730d23cd134d4ea51c395b5e08dd47fc0d01e248538d114a84af50d19ca6bf3";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/depthai/default.nix
+++ b/distros/kilted/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, curl, fmt, gfortran, libtar, libusb1, nlohmann_json, opencv, ros-environment, spdlog, udev, unzip, zip }:
 buildRosPackage {
   pname = "ros-kilted-depthai";
-  version = "3.6.1-r2";
+  version = "3.7.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/kilted/depthai/3.6.1-2.tar.gz";
-    name = "3.6.1-2.tar.gz";
-    sha256 = "5d455901f77d022fb841039d7b7c0cd22504c2289721976f0681d8d28679669b";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/kilted/depthai/3.7.1-3.tar.gz";
+    name = "3.7.1-3.tar.gz";
+    sha256 = "b24cf842426d7c9a0919d075ae214ffeca66e18a9e61e0b03550bb5dff893fc3";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/eigenpy/default.nix
+++ b/distros/kilted/eigenpy/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
+{ lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, jrl-cmakemodules, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-kilted-eigenpy";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/kilted/eigenpy/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "51b50a70a64398eb254064557686574fa13b959e3de7df108993edc6c0cb8a95";
+    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/kilted/eigenpy/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "02ec3bd466b48aa14eaa1fd1725aaf7fba6929bbe4cfe0ba3e5bd23de6d382fd";
   };
 
   buildType = "cmake";
-  buildInputs = [ cmake doxygen git ];
+  buildInputs = [ cmake doxygen git jrl-cmakemodules ];
   propagatedBuildInputs = [ boost eigen python3 python3Packages.numpy python3Packages.scipy ];
   nativeBuildInputs = [ cmake ];
 
   meta = {
     description = "Bindings between Numpy and Eigen using Boost.Python";
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ "BSD-2-Clause" ];
   };
 }

--- a/distros/kilted/generate-parameter-library-py/default.nix
+++ b/distros/kilted/generate-parameter-library-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-kilted-generate-parameter-library-py";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/kilted/generate_parameter_library_py/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "b8c62442fe0e9258d828830f9e1d07b2cdefa72d729027ef62ca68493c0dbca8";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/kilted/generate_parameter_library_py/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "10bac64229cfcc4cd011a107dd2c2646211eb2ad6bb0b6ea9697f78ca4f3f058";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/generate-parameter-library/default.nix
+++ b/distros/kilted/generate-parameter-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, fmt, generate-parameter-library-py, parameter-traits, rclcpp, rclcpp-lifecycle, rclpy, rsl, tcb-span, tl-expected, tl-expected-nixpkgs }:
 buildRosPackage {
   pname = "ros-kilted-generate-parameter-library";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/kilted/generate_parameter_library/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "15a549e55212539a3c3a888e2a68eade9c6cf6428f17d83fdf480272c02fa0b4";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/kilted/generate_parameter_library/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "68ca14f1c7fe4a71741ac4237e68d8c83c071d4c0673b4604d9687ae01b77253";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/generated.nix
+++ b/distros/kilted/generated.nix
@@ -196,6 +196,14 @@ self: super: {
 
  async-web-server-cpp = self.callPackage ./async-web-server-cpp {};
 
+ audio-capture = self.callPackage ./audio-capture {};
+
+ audio-common = self.callPackage ./audio-common {};
+
+ audio-common-msgs = self.callPackage ./audio-common-msgs {};
+
+ audio-play = self.callPackage ./audio-play {};
+
  auto-apms-behavior-tree = self.callPackage ./auto-apms-behavior-tree {};
 
  auto-apms-behavior-tree-core = self.callPackage ./auto-apms-behavior-tree-core {};
@@ -1326,6 +1334,8 @@ self: super: {
 
  lifecycle-py = self.callPackage ./lifecycle-py {};
 
+ linear-feedback-controller = self.callPackage ./linear-feedback-controller {};
+
  linear-feedback-controller-msgs = self.callPackage ./linear-feedback-controller-msgs {};
 
  linux-isolate-process = self.callPackage ./linux-isolate-process {};
@@ -1443,6 +1453,8 @@ self: super: {
  mola-input-ouster = self.callPackage ./mola-input-ouster {};
 
  mola-input-rawlog = self.callPackage ./mola-input-rawlog {};
+
+ mola-input-rosbag1 = self.callPackage ./mola-input-rosbag1 {};
 
  mola-input-rosbag2 = self.callPackage ./mola-input-rosbag2 {};
 
@@ -1683,6 +1695,8 @@ self: super: {
  mvsim = self.callPackage ./mvsim {};
 
  nanoeigenpy = self.callPackage ./nanoeigenpy {};
+
+ nanoflann = self.callPackage ./nanoflann {};
 
  nao-button-sim = self.callPackage ./nao-button-sim {};
 
@@ -2530,6 +2544,8 @@ self: super: {
 
  rosbag2rawlog = self.callPackage ./rosbag2rawlog {};
 
+ rosbag-timing-inspector = self.callPackage ./rosbag-timing-inspector {};
+
  rosbridge-library = self.callPackage ./rosbridge-library {};
 
  rosbridge-msgs = self.callPackage ./rosbridge-msgs {};
@@ -2876,6 +2892,10 @@ self: super: {
 
  sophus = self.callPackage ./sophus {};
 
+ sound-play = self.callPackage ./sound-play {};
+
+ sound-play-msgs = self.callPackage ./sound-play-msgs {};
+
  spacenav = self.callPackage ./spacenav {};
 
  spatio-temporal-voxel-layer = self.callPackage ./spatio-temporal-voxel-layer {};
@@ -3211,6 +3231,8 @@ self: super: {
  velodyne-msgs = self.callPackage ./velodyne-msgs {};
 
  velodyne-pointcloud = self.callPackage ./velodyne-pointcloud {};
+
+ video-to-image-msg-publisher = self.callPackage ./video-to-image-msg-publisher {};
 
  vision-msgs = self.callPackage ./vision-msgs {};
 

--- a/distros/kilted/kompass-interfaces/default.nix
+++ b/distros/kilted/kompass-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-kompass-interfaces";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kompass-release/archive/release/kilted/kompass_interfaces/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "18511ff7362acf5189f8d8e5e1dcaa5c094ad37d2a971783d99aed88a63f4996";
+    url = "https://github.com/ros2-gbp/kompass-release/archive/release/kilted/kompass_interfaces/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "020c6563f0b12d6a8c75df545703003fad43b259d1e69a2e9c81aa07a7954184";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/kompass/default.nix
+++ b/distros/kilted/kompass/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, automatika-ros-sugar, kompass-interfaces, python3Packages }:
 buildRosPackage {
   pname = "ros-kilted-kompass";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kompass-release/archive/release/kilted/kompass/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "4f7463d11aa7aab4b45885a04a90c37953f6df32317022f6648947dab69b1773";
+    url = "https://github.com/ros2-gbp/kompass-release/archive/release/kilted/kompass/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "3eb8d3fac66ed57b5f65ef9569930b0587bf313f1cca157203ae21d3ad4ff798";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/linear-feedback-controller/default.nix
+++ b/distros/kilted/linear-feedback-controller/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-python, ament-lint-auto, control-toolbox, controller-interface, eigen, fmt, generate-parameter-library, gmock-vendor, gtest-vendor, hardware-interface, jrl-cmakemodules, linear-feedback-controller-msgs, message-filters, nav-msgs, pal-statistics, pinocchio, pluginlib, rcl, rclcpp, rclcpp-lifecycle, realtime-tools, rosidl-dynamic-typesupport, sensor-msgs, tl-expected-nixpkgs }:
+buildRosPackage {
+  pname = "ros-kilted-linear-feedback-controller";
+  version = "4.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/linear-feedback-controller-release/archive/release/kilted/linear_feedback_controller/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "75f01640effb1acf533f88976da9ea0621056ae1ba9d7149e4c9e042037bbf00";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto ament-cmake-python fmt jrl-cmakemodules tl-expected-nixpkgs ];
+  checkInputs = [ ament-lint-auto gmock-vendor gtest-vendor ];
+  propagatedBuildInputs = [ control-toolbox controller-interface eigen generate-parameter-library hardware-interface linear-feedback-controller-msgs message-filters nav-msgs pal-statistics pinocchio pluginlib rcl rclcpp rclcpp-lifecycle realtime-tools rosidl-dynamic-typesupport sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake-auto ament-cmake-python ];
+
+  meta = {
+    description = "roscontrol controller package conputing a linear feedback. The user needs
+    to provide a model of the robot and a list of controlled joint and the
+    controller computes a linear feedback on the user defined state.";
+    license = with lib.licenses; [ "BSD-2-Clause" ];
+  };
+}

--- a/distros/kilted/mavlink/default.nix
+++ b/distros/kilted/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-kilted-mavlink";
-  version = "2026.3.3-r1";
+  version = "2026.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/kilted/mavlink/2026.3.3-1.tar.gz";
-    name = "2026.3.3-1.tar.gz";
-    sha256 = "125d87b265b14c0e0d793621cf62b07cebc5089bf4562e8afd84a0f0b46ca62a";
+    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/kilted/mavlink/2026.6.6-1.tar.gz";
+    name = "2026.6.6-1.tar.gz";
+    sha256 = "b1a8fca91ba2657383185a1b71987284bb5d6f47c5fabae859f3663871b0d3a1";
   };
 
   buildType = "cmake";

--- a/distros/kilted/microstrain-inertial-description/default.nix
+++ b/distros/kilted/microstrain-inertial-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, xacro }:
 buildRosPackage {
   pname = "ros-kilted-microstrain-inertial-description";
-  version = "4.8.0-r1";
+  version = "4.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/kilted/microstrain_inertial_description/4.8.0-1.tar.gz";
-    name = "4.8.0-1.tar.gz";
-    sha256 = "0b00929c90806b389697a8fdffc97389b725365c5a7d2b3c62d6453c9de6a31c";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/kilted/microstrain_inertial_description/4.9.0-1.tar.gz";
+    name = "4.9.0-1.tar.gz";
+    sha256 = "240533f0ef3ed5223fd3f10ecd6ba6906c8190993261b1c095298196aef2b1fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/microstrain-inertial-driver/default.nix
+++ b/distros/kilted/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-target-dependencies, ament-cpplint, diagnostic-aggregator, diagnostic-updater, eigen, geographiclib, geometry-msgs, git, lifecycle-msgs, microstrain-inertial-msgs, nav-msgs, nmea-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, rtcm-msgs, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-microstrain-inertial-driver";
-  version = "4.8.0-r1";
+  version = "4.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/kilted/microstrain_inertial_driver/4.8.0-1.tar.gz";
-    name = "4.8.0-1.tar.gz";
-    sha256 = "3ec824aaf0daaed417a5a8d7dde58fdff360e83db306c0795c2e6690e26103af";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/kilted/microstrain_inertial_driver/4.9.0-1.tar.gz";
+    name = "4.9.0-1.tar.gz";
+    sha256 = "d85e07c32c6d5792d937a6234a164799c332f4c179eae6984545c8420058a388";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/microstrain-inertial-examples/default.nix
+++ b/distros/kilted/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-driver, rviz-imu-plugin, rviz2, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-microstrain-inertial-examples";
-  version = "4.8.0-r1";
+  version = "4.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/kilted/microstrain_inertial_examples/4.8.0-1.tar.gz";
-    name = "4.8.0-1.tar.gz";
-    sha256 = "1d06a0a3eb2ee7d4066e460885628eeb8af7c416ff0fbac7a4ce62550beb97fa";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/kilted/microstrain_inertial_examples/4.9.0-1.tar.gz";
+    name = "4.9.0-1.tar.gz";
+    sha256 = "015f088bf4d375b89bd66bdc78ba152a0d7eb7a01fdc5193ea821ea637be0896";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/microstrain-inertial-msgs/default.nix
+++ b/distros/kilted/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-microstrain-inertial-msgs";
-  version = "4.8.0-r1";
+  version = "4.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/kilted/microstrain_inertial_msgs/4.8.0-1.tar.gz";
-    name = "4.8.0-1.tar.gz";
-    sha256 = "8738ef67c07ab20f12bcbb81fc1a03e133ad0a6b48b9cc85c9fe9b18a673a172";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/kilted/microstrain_inertial_msgs/4.9.0-1.tar.gz";
+    name = "4.9.0-1.tar.gz";
+    sha256 = "42639e9f8986a3dd60fcd8ebb56b25469c49750926abaa06357755b61f33c3b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/microstrain-inertial-rqt/default.nix
+++ b/distros/kilted/microstrain-inertial-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, microstrain-inertial-msgs, nav-msgs, rclpy, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-microstrain-inertial-rqt";
-  version = "4.8.0-r1";
+  version = "4.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/kilted/microstrain_inertial_rqt/4.8.0-1.tar.gz";
-    name = "4.8.0-1.tar.gz";
-    sha256 = "6127cb48ffa2a93bc93b073b48091d4f697d8ced422a92ddfd92cd79c4d05cde";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/kilted/microstrain_inertial_rqt/4.9.0-1.tar.gz";
+    name = "4.9.0-1.tar.gz";
+    sha256 = "665e1fd37957cba4482e20a0dd12535e84e4acfe02ae73c5710f0633cd7cc84a";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/mola-input-rosbag1/default.nix
+++ b/distros/kilted/mola-input-rosbag1/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, bzip2, cmake, geometry-msgs, lz4, mola-common, mola-kernel, mrpt-libmaps, mrpt-libobs, opencv, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-kilted-mola-input-rosbag1";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_input_rosbag1-release/archive/release/kilted/mola_input_rosbag1/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "4bb79c734502d9abb0d62b4b20d3e73a6813861cce611978230f50718927db12";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ boost bzip2 geometry-msgs lz4 mola-common mola-kernel mrpt-libmaps mrpt-libobs opencv opencv.cxxdev tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "MOLA DataSource from ROS1 bag files that does not need a ROS1 installation";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/kilted/nanoflann/default.nix
+++ b/distros/kilted/nanoflann/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, gtest }:
+buildRosPackage {
+  pname = "ros-kilted-nanoflann";
+  version = "1.10.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/nanoflann-release/archive/release/kilted/nanoflann/1.10.1-1.tar.gz";
+    name = "1.10.1-1.tar.gz";
+    sha256 = "bc2e27b15dd1cab07f85bc6d67e6ab1d0be2ea31061a82890e20a8b78a677828";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  checkInputs = [ gtest ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "nanoflann: a C++11 header-only library for Nearest Neighbor (NN) search
+    with KD-trees, optimized for point clouds and Eigen matrices.";
+    license = with lib.licenses; [ "BSD-2-Clause" ];
+  };
+}

--- a/distros/kilted/parameter-traits/default.nix
+++ b/distros/kilted/parameter-traits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, fmt, rclcpp, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-kilted-parameter-traits";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/kilted/parameter_traits/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "377757b4ded60825ca61f384908d67c02915d6399c076399c2c92c4d7584380b";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/kilted/parameter_traits/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "f14c4e025db3ffcc51aa648fa8a8bb234772c6cd42ad8e360b853b37a7e9eae3";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros-gz-bridge/default.nix
+++ b/distros/kilted/ros-gz-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actuator-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, gps-msgs, gz-msgs-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, marine-acoustic-msgs, nav-msgs, pkg-config, rclcpp, rclcpp-components, ros-gz-interfaces, rosgraph-msgs, rosidl-pycommon, sensor-msgs, std-msgs, tf2-msgs, trajectory-msgs, vision-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-kilted-ros-gz-bridge";
-  version = "2.1.16-r1";
+  version = "2.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/kilted/ros_gz_bridge/2.1.16-1.tar.gz";
-    name = "2.1.16-1.tar.gz";
-    sha256 = "2dc7b19fee3747614ec568c2ec24d44da3068e9de6e29a48b6ec9be3fcb2f0f0";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/kilted/ros_gz_bridge/2.1.17-1.tar.gz";
+    name = "2.1.17-1.tar.gz";
+    sha256 = "da4e33f75c50cf426ac60802df7689d623f5953c54ebb6f715f7da332d793110";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros-gz-image/default.nix
+++ b/distros/kilted/ros-gz-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-msgs-vendor, gz-transport-vendor, image-transport, pkg-config, rclcpp, ros-gz-bridge, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ros-gz-image";
-  version = "2.1.16-r1";
+  version = "2.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/kilted/ros_gz_image/2.1.16-1.tar.gz";
-    name = "2.1.16-1.tar.gz";
-    sha256 = "68f1995a79c0497ef961e2df22daef8c2c4b44264a4099516c72757639ed3f6e";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/kilted/ros_gz_image/2.1.17-1.tar.gz";
+    name = "2.1.17-1.tar.gz";
+    sha256 = "0b1c8317844fd671e9c66b883b463ab88a3757a34c15dbc573647af403cf6650";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros-gz-interfaces/default.nix
+++ b/distros/kilted/ros-gz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ros-gz-interfaces";
-  version = "2.1.16-r1";
+  version = "2.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/kilted/ros_gz_interfaces/2.1.16-1.tar.gz";
-    name = "2.1.16-1.tar.gz";
-    sha256 = "62643825130748c740850d97155cf03e1ca572cb9a2757774554809c67482d4f";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/kilted/ros_gz_interfaces/2.1.17-1.tar.gz";
+    name = "2.1.17-1.tar.gz";
+    sha256 = "e3000c6251a6a90e2d93665993501f32e013a6aefd11941120e6be77393f94ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros-gz-sim-demos/default.nix
+++ b/distros/kilted/ros-gz-sim-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-sim-vendor, image-transport-plugins, marine-acoustic-msgs, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, rqt-image-view, rqt-plot, rqt-topic, rviz-imu-plugin, rviz2, sdformat-urdf, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-kilted-ros-gz-sim-demos";
-  version = "2.1.16-r1";
+  version = "2.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/kilted/ros_gz_sim_demos/2.1.16-1.tar.gz";
-    name = "2.1.16-1.tar.gz";
-    sha256 = "e5c3673b496cc1737a2eb581f9b69a4beb392ea3d0f23c11ba73519a5fc09d5b";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/kilted/ros_gz_sim_demos/2.1.17-1.tar.gz";
+    name = "2.1.17-1.tar.gz";
+    sha256 = "7065a208755af40d4640d8d8c4e5000002430f01532c04580c82d25c8ebe0a2b";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros-gz-sim/default.nix
+++ b/distros/kilted/ros-gz-sim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, cli11, geometry-msgs, gflags, gz-math-vendor, gz-msgs-vendor, gz-sim-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, pkg-config, rclcpp, rclcpp-action, rclcpp-components, rcpputils, ros-gz-bridge, ros-gz-interfaces, ros2pkg, simulation-interfaces, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-ros-gz-sim";
-  version = "2.1.16-r1";
+  version = "2.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/kilted/ros_gz_sim/2.1.16-1.tar.gz";
-    name = "2.1.16-1.tar.gz";
-    sha256 = "bbb5f606f7c462a39f4eec9485c9edce1b54f1038a62290aa0aeca68bf0cd441";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/kilted/ros_gz_sim/2.1.17-1.tar.gz";
+    name = "2.1.17-1.tar.gz";
+    sha256 = "2a50565a397c3ef4c0dd8e348810c2eeee414067ee1b3f0daae39e3e91ef2d04";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ros-gz/default.nix
+++ b/distros/kilted/ros-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz-bridge, ros-gz-image, ros-gz-sim, ros-gz-sim-demos }:
 buildRosPackage {
   pname = "ros-kilted-ros-gz";
-  version = "2.1.16-r1";
+  version = "2.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/kilted/ros_gz/2.1.16-1.tar.gz";
-    name = "2.1.16-1.tar.gz";
-    sha256 = "01f4cfaba60caf4380a98f244b12f4900a5ca8ec7f8901ae4c93178d713357ee";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/kilted/ros_gz/2.1.17-1.tar.gz";
+    name = "2.1.17-1.tar.gz";
+    sha256 = "b625d30344d54bcce1beffe9a42c0a1cdf42556afdd2f903f2ef0150dd2b823a";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rosbag-timing-inspector/default.nix
+++ b/distros/kilted/rosbag-timing-inspector/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, glfw3, libGL, libGLU, rosbag2-cpp, rosbag2-storage }:
+buildRosPackage {
+  pname = "ros-kilted-rosbag-timing-inspector";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbag_timing_inspector-release/archive/release/kilted/rosbag_timing_inspector/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "df5e4e11fd5a3005f62f55f7f139deb034b5cdfcef38fc18e9702e981c0b3fd9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake glfw3 libGL libGLU ];
+  propagatedBuildInputs = [ rosbag2-cpp rosbag2-storage ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "GUI tool to visualize and analyze message timing from ROS2 bags (mcap or db3).";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kilted/rqt-tf-tree/default.nix
+++ b/distros/kilted/rqt-tf-tree/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-dotgraph, rclpy, rqt-graph, rqt-gui, rqt-gui-py, tf2-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, python-qt-binding, python3Packages, qt-dotgraph, rclpy, rqt-graph, rqt-gui, rqt-gui-py, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-rqt-tf-tree";
-  version = "1.0.6-r2";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_tf_tree-release/archive/release/kilted/rqt_tf_tree/1.0.6-2.tar.gz";
-    name = "1.0.6-2.tar.gz";
-    sha256 = "a8bc00b75c011da207616c827e05d5dbd6ffcb704fe59a3e9b28e8767cc803e3";
+    url = "https://github.com/ros2-gbp/rqt_tf_tree-release/archive/release/kilted/rqt_tf_tree/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "d34585f6932cc91274a0076bdea90fb06906363fab54aea379a8b054491a6416";
   };
 
   buildType = "ament_python";
-  checkInputs = [ python3Packages.mock python3Packages.pytest ];
+  checkInputs = [ ament-flake8 ament-pep257 python3Packages.mock python3Packages.pytest ];
   propagatedBuildInputs = [ python-qt-binding qt-dotgraph rclpy rqt-graph rqt-gui rqt-gui-py tf2-msgs tf2-ros ];
 
   meta = {

--- a/distros/kilted/sound-play-msgs/default.nix
+++ b/distros/kilted/sound-play-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-kilted-sound-play-msgs";
+  version = "0.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/audio_common-release/archive/release/kilted/sound_play_msgs/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "e74b95b03db6b180461abe16ccd377cdc8f985365662d926f71b8289cda964ca";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "Messages for transmitting sound via ROS with sound_play";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/sound-play/default.nix
+++ b/distros/kilted/sound-play/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, _unresolved_festival, action-msgs, ament-cmake, ament-cmake-python, ament-index-python, boost, gst_all_1, launch-xml, python3Packages, rclpy, sound-play-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-sound-play";
+  version = "0.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/audio_common-release/archive/release/kilted/sound_play/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "f8762f8d1cbef43225753a7fa1899f4171e1136316535d5beb7144c9889cf6ca";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python boost python3Packages.setuptools ];
+  propagatedBuildInputs = [ _unresolved_festival action-msgs ament-index-python gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good gst_all_1.gst-plugins-ugly gst_all_1.gstreamer launch-xml python3Packages.pygobject3 rclpy sound-play-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python python3Packages.setuptools ];
+
+  meta = {
+    description = "sound_play provides a ROS node that translates commands on a ROS topic (<tt>robotsound</tt>) into sounds. The node supports built-in sounds, playing OGG/WAV files, and doing speech synthesis via festival. C++ and Python bindings allow this node to be used without understanding the details of the message format, allowing faster development and resilience to message format changes.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/tcb-span/default.nix
+++ b/distros/kilted/tcb-span/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-kilted-tcb-span";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/kilted/tcb_span/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "6244ba182622fbb2432a5ee2f896dffe69ca70ad9c3276f2f393c001423873cf";
+    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/kilted/tcb_span/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "8732900d6547cbd82f3d9ae0a91cdf9447434cdbf28fcce05076db6bfa18f69d";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/tl-expected/default.nix
+++ b/distros/kilted/tl-expected/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-kilted-tl-expected";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/kilted/tl_expected/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "7229b674ba5ad8defe79a5ddc8382db142ad12c90f0f2c88ebae1f3314bf77db";
+    url = "https://github.com/ros2-gbp/cpp_polyfills-release/archive/release/kilted/tl_expected/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "d67dcc9fd8ffc45f2e2f233974bb041a5fe6a87b7a577ab52a3247b077b02436";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/video-to-image-msg-publisher/default.nix
+++ b/distros/kilted/video-to-image-msg-publisher/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-lint-auto, ament-lint-common, cv-bridge, opencv, rclcpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-video-to-image-msg-publisher";
+  version = "0.9.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/video_to_image_msg_publisher-release/archive/release/kilted/video_to_image_msg_publisher/0.9.5-1.tar.gz";
+    name = "0.9.5-1.tar.gz";
+    sha256 = "69ed5dc834158c7fc9fb88ddb845380c2b5d3a0dd3b9dfff49f94c1d01075211";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge opencv opencv.cxxdev rclcpp sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ];
+
+  meta = {
+    description = "A simple node that publishes sensor_msgs/Image messages from a specified video file";
+    license = with lib.licenses; [ gpl2 ];
+  };
+}

--- a/distros/lyrical/agni-tf-tools/default.nix
+++ b/distros/lyrical/agni-tf-tools/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, angles, boost, eigen, geometry-msgs, interactive-markers, pluginlib, rclcpp, rviz-common, rviz-default-plugins, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-agni-tf-tools";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/agni_tf_tools-release/archive/release/lyrical/agni_tf_tools/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "22021db12c16c0d52d6c71ced9b4eb348ab10d3f89f11ff7ce6e5a9879a496a8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake eigen ];
+  propagatedBuildInputs = [ angles boost geometry-msgs interactive-markers pluginlib rclcpp rviz-common rviz-default-plugins std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "This package provides a gui program as well as a rviz plugin to publish static transforms.
+  Both support the transformation between various Euler angle representations.
+  The rviz plugin also allows to configure the transform with an interactive marker.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/ament-black/default.nix
+++ b/distros/lyrical/ament-black/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-lyrical-ament-black";
-  version = "0.2.6-r3";
+  version = "0.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/lyrical/ament_black/0.2.6-3.tar.gz";
-    name = "0.2.6-3.tar.gz";
-    sha256 = "4090066c7214c983e2ed202d87fe4508641bfe8fb4dd3126bdd21a8e5ab60406";
+    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/lyrical/ament_black/0.2.7-1.tar.gz";
+    name = "0.2.7-1.tar.gz";
+    sha256 = "051b984526f2745445668d1ccbb82549b19439a1d4d37f7310db48e33d8c26c4";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/ament-cmake-black/default.nix
+++ b/distros/lyrical/ament-cmake-black/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-black, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-lyrical-ament-cmake-black";
-  version = "0.2.6-r3";
+  version = "0.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/lyrical/ament_cmake_black/0.2.6-3.tar.gz";
-    name = "0.2.6-3.tar.gz";
-    sha256 = "7e8895fa7af68d0dd2302bc07b991c8dbbc320362b6dfeab61d0f7d0be930b62";
+    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/lyrical/ament_cmake_black/0.2.7-1.tar.gz";
+    name = "0.2.7-1.tar.gz";
+    sha256 = "3601bd1feb07d937ae0425eb3aa55918b13381c8b2203e7ad9fcbf301f39e32b";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/audio-capture/default.nix
+++ b/distros/lyrical/audio-capture/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, audio-common-msgs, boost, diagnostic-updater, gst_all_1, launch-xml, rclcpp, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-lyrical-audio-capture";
+  version = "0.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/audio_common-release/archive/release/lyrical/audio_capture/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "352d35144ca63adcb46d9d889ce6e5dc92e958b1b7b81d4a288cd90c7823006b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake boost ];
+  propagatedBuildInputs = [ audio-common-msgs diagnostic-updater gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good gst_all_1.gst-plugins-ugly gst_all_1.gstreamer launch-xml rclcpp rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Transports audio from a source to a destination. Audio sources can come
+      from a microphone or file. The destination can play the audio or save it
+      to an mp3 file.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/audio-common-msgs/default.nix
+++ b/distros/lyrical/audio-common-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-audio-common-msgs";
+  version = "0.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/audio_common-release/archive/release/lyrical/audio_common_msgs/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "09e87a3b5af9703c1dc67b9863ea5e66ee4313dc8968e6ddf8d12049215cd29b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "Messages for transmitting audio via ROS";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/audio-common/default.nix
+++ b/distros/lyrical/audio-common/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, audio-capture, audio-common-msgs, audio-play, sound-play, sound-play-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-audio-common";
+  version = "0.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/audio_common-release/archive/release/lyrical/audio_common/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "1ca48d469c828009be291fa8fa8d97bfedf505322fed2f379c81db6db1b2f4f9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ audio-capture audio-common-msgs audio-play sound-play sound-play-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Common code for working with audio in ROS";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/audio-play/default.nix
+++ b/distros/lyrical/audio-play/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, audio-common-msgs, boost, gst_all_1, launch-xml, rclcpp, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-lyrical-audio-play";
+  version = "0.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/audio_common-release/archive/release/lyrical/audio_play/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "049bf5e81bfcd9e851127b84982a9cdf78d99cc1a998cce87efa535c4b86e0a6";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake boost ];
+  propagatedBuildInputs = [ audio-common-msgs gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good gst_all_1.gst-plugins-ugly gst_all_1.gstreamer launch-xml rclcpp rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Outputs audio to a speaker from a source node.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/automatika-ros-sugar/default.nix
+++ b/distros/lyrical/automatika-ros-sugar/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-index-python, ament-lint-auto, builtin-interfaces, geometry-msgs, launch, launch-testing, lifecycle-msgs, nav-msgs, python3Packages, rclcpp, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-lyrical-automatika-ros-sugar";
-  version = "0.6.1-r3";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/automatika_ros_sugar-release/archive/release/lyrical/automatika_ros_sugar/0.6.1-3.tar.gz";
-    name = "0.6.1-3.tar.gz";
-    sha256 = "f86c2fdd40679968590c0d6b3d98fe2bece8e5032b67f102fdd7fa24505e6e81";
+    url = "https://github.com/ros2-gbp/automatika_ros_sugar-release/archive/release/lyrical/automatika_ros_sugar/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "b6f2357ddf1ba90b483a2e9143f65e8c81ab03bef51421b2ab6d409bdc8f4072";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/camera-calibration-parsers/default.nix
+++ b/distros/lyrical/camera-calibration-parsers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-lyrical-camera-calibration-parsers";
-  version = "6.4.9-r1";
+  version = "6.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/lyrical/camera_calibration_parsers/6.4.9-1.tar.gz";
-    name = "6.4.9-1.tar.gz";
-    sha256 = "d366c597c3bd56119150ba6487105d61301260d144e4a51af5159d8bd774b355";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/lyrical/camera_calibration_parsers/6.4.10-1.tar.gz";
+    name = "6.4.10-1.tar.gz";
+    sha256 = "3da4f7847106279004e40b6a55d527311f753c2ffc22afa60b168dc1347e5249";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/camera-info-manager-py/default.nix
+++ b/distros/lyrical/camera-info-manager-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, python3Packages, rclpy, sensor-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-camera-info-manager-py";
-  version = "6.4.9-r1";
+  version = "6.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/lyrical/camera_info_manager_py/6.4.9-1.tar.gz";
-    name = "6.4.9-1.tar.gz";
-    sha256 = "05e48222653ad85a70586eddc2ffcbce488c3ac685aa9571dc0232c5d720907e";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/lyrical/camera_info_manager_py/6.4.10-1.tar.gz";
+    name = "6.4.10-1.tar.gz";
+    sha256 = "02cfd12b73815298956d98adbd28bf915d2f83df5015aea2cf533d7a4386c8b3";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/camera-info-manager/default.nix
+++ b/distros/lyrical/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rclcpp-lifecycle, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-camera-info-manager";
-  version = "6.4.9-r1";
+  version = "6.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/lyrical/camera_info_manager/6.4.9-1.tar.gz";
-    name = "6.4.9-1.tar.gz";
-    sha256 = "a34664d4e31cb62ebbeec37692e5dff486b41cf12fe51fdc61d088053d1cfb7f";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/lyrical/camera_info_manager/6.4.10-1.tar.gz";
+    name = "6.4.10-1.tar.gz";
+    sha256 = "486a23941a847758dbc98e77328695cab6f5df33a281e890609e16a1bd9ed9f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/camera-ros/default.nix
+++ b/distros/lyrical/camera-ros/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-pep257, ament-cmake-pyflakes, ament-cmake-xmllint, ament-index-python, ament-lint-auto, camera-info-manager, clang, cv-bridge, image-view, libcamera, rclcpp, rclcpp-components, ros2launch, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-pep257, ament-cmake-pyflakes, ament-cmake-xmllint, ament-index-python, ament-lint-auto, camera-info-manager, clang, cv-bridge, diagnostic-msgs, image-view, libcamera, rclcpp, rclcpp-components, ros2launch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-camera-ros";
-  version = "0.6.0-r3";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/camera_ros-release/archive/release/lyrical/camera_ros/0.6.0-3.tar.gz";
-    name = "0.6.0-3.tar.gz";
-    sha256 = "1eb62b44bab9ef091f534913e8c0c47e6bf37dcb7f2818a93843178ef2829e94";
+    url = "https://github.com/ros2-gbp/camera_ros-release/archive/release/lyrical/camera_ros/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "0f0e9887caf63dbc758c47308512361fbdb1f8ed1848528af93518e429c7e670";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-mypy ament-cmake-pep257 ament-cmake-pyflakes ament-cmake-xmllint ament-lint-auto clang ];
-  propagatedBuildInputs = [ ament-index-python camera-info-manager cv-bridge image-view libcamera rclcpp rclcpp-components ros2launch sensor-msgs ];
+  propagatedBuildInputs = [ ament-index-python camera-info-manager cv-bridge diagnostic-msgs image-view libcamera rclcpp rclcpp-components ros2launch sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/lyrical/crazyflie-examples/default.nix
+++ b/distros/lyrical/crazyflie-examples/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, crazyflie-py, geometry-msgs, nav-msgs, python3Packages, rclpy, sensor-msgs, tf-transformations, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-crazyflie-examples";
+  version = "1.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/lyrical/crazyflie_examples/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "b5ac63464bc2c2645dba2e66a1a16e496de760464f32c174eb105e168d881b1a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-pytest ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
+  propagatedBuildInputs = [ crazyflie-py geometry-msgs nav-msgs rclpy sensor-msgs tf-transformations tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "Examples for the Crazyswarm2 ROS stack";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/lyrical/crazyflie-interfaces/default.nix
+++ b/distros/lyrical/crazyflie-interfaces/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-lyrical-crazyflie-interfaces";
+  version = "1.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/lyrical/crazyflie_interfaces/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "a6dd7d99660d53b070f831cea4a434dcec3e5e2828ea0a4f71a1a842fba6f11c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-cmake-cppcheck ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "Interfaces for Crazyswarm2 package.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/lyrical/crazyflie-py/default.nix
+++ b/distros/lyrical/crazyflie-py/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, crazyflie-interfaces, python3Packages, rclpy }:
+buildRosPackage {
+  pname = "ros-lyrical-crazyflie-py";
+  version = "1.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/lyrical/crazyflie_py/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "fc63a40653898e3dcee90c79642402fd80ee531ac1d5da5601b3c3125099db49";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
+  propagatedBuildInputs = [ crazyflie-interfaces rclpy ];
+
+  meta = {
+    description = "Simple Python Interface for Crayzswarm2";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/lyrical/crazyflie-server-py/default.nix
+++ b/distros/lyrical/crazyflie-server-py/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, crazyflie-interfaces, geometry-msgs, motion-capture-tracking-interfaces, nav-msgs, python3Packages, rcl-interfaces, rclpy, sensor-msgs, std-msgs, std-srvs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-crazyflie-server-py";
+  version = "1.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/lyrical/crazyflie_server_py/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "325569872256d91ea69cdbdec70f7e710e7cebe974e08a56d1a80477ac5bb58a";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-flake8 ament-pep257 python3Packages.pytest ];
+  propagatedBuildInputs = [ crazyflie-interfaces geometry-msgs motion-capture-tracking-interfaces nav-msgs rcl-interfaces rclpy sensor-msgs std-msgs std-srvs tf2-ros ];
+
+  meta = {
+    description = "Python Crazyflie server node for Crazyswarm2";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/lyrical/crazyflie-sim/default.nix
+++ b/distros/lyrical/crazyflie-sim/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, crazyflie-interfaces, python3Packages, rclpy }:
+buildRosPackage {
+  pname = "ros-lyrical-crazyflie-sim";
+  version = "1.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/lyrical/crazyflie_sim/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "dc6ec2fc17498aa912679faea69a0ac96b87af79b73c8220f3433a69c57590e4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-pytest ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
+  propagatedBuildInputs = [ crazyflie-interfaces rclpy ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "Simulator for the Crazyswarm2 ROS stack";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/lyrical/crazyflie/default.nix
+++ b/distros/lyrical/crazyflie/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, boost, crazyflie-interfaces, eigen, geometry-msgs, libusb1, motion-capture-tracking-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, std-srvs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-crazyflie";
+  version = "1.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/lyrical/crazyflie/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "307a9cdb4ad07da62a28980cda7bfae14a3553cc07fe471e2239142cc0c9606c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ boost crazyflie-interfaces eigen geometry-msgs libusb1 motion-capture-tracking-interfaces nav-msgs rclcpp ros-environment sensor-msgs std-srvs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "ROS 2 Package for Bitcraze Crazyflie robots";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/lyrical/cuda-buffer-backend-msgs/default.nix
+++ b/distros/lyrical/cuda-buffer-backend-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-lyrical-cuda-buffer-backend-msgs";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/lyrical/cuda_buffer_backend_msgs/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "984ccf49d945fc1ba8b32e18b464baba6cf01d90684731ff23ce4ae762281be7";
+    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/lyrical/cuda_buffer_backend_msgs/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "71a1e164d493df5bab6c720df0718d1cd5a75fdbf0259b352dd1177944f98e2f";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/cuda-buffer-backend/default.nix
+++ b/distros/lyrical/cuda-buffer-backend/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cuda-buffer, cuda-buffer-backend-msgs, launch-ros, launch-testing, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-components, rcutils, rosidl-buffer-backend, rosidl-buffer-backend-registry, rosidl-runtime-cpp, rosidl-typesupport-cpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-cuda-buffer-backend";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/lyrical/cuda_buffer_backend/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "aa077ce9aac5ccb09864355bbfd6fb075fb92521c4431a22499b701cb1acb6f4";
+    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/lyrical/cuda_buffer_backend/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "9d8bf241afe0616ea8863d4c32103226e8b1e54579a136b198fa2bda9ff5e1d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/cuda-buffer/default.nix
+++ b/distros/lyrical/cuda-buffer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cuda-buffer-backend-msgs, cudaPackages, rcutils, rmw, rosidl-buffer }:
 buildRosPackage {
   pname = "ros-lyrical-cuda-buffer";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/lyrical/cuda_buffer/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "53ff6ea45f8166b2c3f2385da29cd0c9f2fcb8e1efc8d33ce07c0dec7637e772";
+    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/lyrical/cuda_buffer/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "cb1c3b8b08febf16676710e9969c2b59202bc302f6b92592c6d5c4cf4dd5e82e";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/dataspeed-can-msg-filters/default.nix
+++ b/distros/lyrical/dataspeed-can-msg-filters/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, rclcpp }:
+buildRosPackage {
+  pname = "ros-lyrical-dataspeed-can-msg-filters";
+  version = "2.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/lyrical/dataspeed_can_msg_filters/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "b059f85b6a6ed59f74689edd734e307aba6f8a490b520c94df9020a75609b991";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ can-msgs rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Time synchronize multiple CAN messages to get a single callback";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/dataspeed-can-msgs/default.nix
+++ b/distros/lyrical/dataspeed-can-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-dataspeed-can-msgs";
+  version = "2.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/lyrical/dataspeed_can_msgs/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "3e87603f27cf4f890a63c3b01ca4feba6c23f4f626dce6e8aeb1ff89de31947f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Controller Area Network (CAN) messages";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/dataspeed-can-tools/default.nix
+++ b/distros/lyrical/dataspeed-can-tools/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, dataspeed-can-msgs, rclcpp, rosbag2-cpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-dataspeed-can-tools";
+  version = "2.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/lyrical/dataspeed_can_tools/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "ada29272fd306ae548a6a5f5c282e91d1675e55c6b7d2473a0ec872e199feec2";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ can-msgs dataspeed-can-msgs rclcpp rosbag2-cpp std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "CAN bus introspection";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/dataspeed-can-usb/default.nix
+++ b/distros/lyrical/dataspeed-can-usb/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, lusb, rclcpp, rclcpp-components, std-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-dataspeed-can-usb";
+  version = "2.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/lyrical/dataspeed_can_usb/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "69ca9e62cd3453607c5245cf0d9c5b5ae6aadaf4c9abcc40b6d7a5e7e57f26f0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ can-msgs lusb rclcpp rclcpp-components std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Driver to interface with the Dataspeed Inc. USB CAN Tool";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/dataspeed-can/default.nix
+++ b/distros/lyrical/dataspeed-can/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, dataspeed-can-msg-filters, dataspeed-can-msgs, dataspeed-can-tools, dataspeed-can-usb }:
+buildRosPackage {
+  pname = "ros-lyrical-dataspeed-can";
+  version = "2.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/lyrical/dataspeed_can/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "da3618d1f9fcf2edeb5d615569f2ec036e508fc044e1c757eff866d56397e3b4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ dataspeed-can-msg-filters dataspeed-can-msgs dataspeed-can-tools dataspeed-can-usb ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "CAN bus tools using Dataspeed hardware";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/eigenpy/default.nix
+++ b/distros/lyrical/eigenpy/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
+{ lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, jrl-cmakemodules, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-lyrical-eigenpy";
-  version = "3.12.0-r3";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/lyrical/eigenpy/3.12.0-3.tar.gz";
-    name = "3.12.0-3.tar.gz";
-    sha256 = "58c6227ae478a86bcd169361693e73dd3a5931467d0599a88b5849cf6d4e82ec";
+    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/lyrical/eigenpy/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "e528c573e294369e8b3323d08d91dd63766f1a973f4e4d4328e5149f1b587f0a";
   };
 
   buildType = "cmake";
-  buildInputs = [ cmake doxygen git ];
+  buildInputs = [ cmake doxygen git jrl-cmakemodules ];
   propagatedBuildInputs = [ boost eigen python3 python3Packages.numpy python3Packages.scipy ];
   nativeBuildInputs = [ cmake ];
 
   meta = {
     description = "Bindings between Numpy and Eigen using Boost.Python";
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ "BSD-2-Clause" ];
   };
 }

--- a/distros/lyrical/generate-parameter-library-py/default.nix
+++ b/distros/lyrical/generate-parameter-library-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-lyrical-generate-parameter-library-py";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/lyrical/generate_parameter_library_py/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "9b221851d81d73136ea78d019edca2376cdded025fe640818d8462fe0cb5e94f";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/lyrical/generate_parameter_library_py/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "d6d3ac483596fe7e0fd4d322bf89376701ceb98ae38c8fca55b06a1ab0351e28";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/generate-parameter-library/default.nix
+++ b/distros/lyrical/generate-parameter-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, fmt, generate-parameter-library-py, rclcpp, rclcpp-lifecycle, rclpy, rsl, tcb-span, tl-expected-nixpkgs }:
 buildRosPackage {
   pname = "ros-lyrical-generate-parameter-library";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/lyrical/generate_parameter_library/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "1ed91d540f684130a2532a970b10afbb04ea4b0082a9808fa3779b9a4b035f63";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/lyrical/generate_parameter_library/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "205b14512064854357a3efe5d5460f92c4cae9dc51fb1641d62dcfa604b65ef6";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/generated.nix
+++ b/distros/lyrical/generated.nix
@@ -26,6 +26,8 @@ self: super: {
 
  admittance-controller = self.callPackage ./admittance-controller {};
 
+ agni-tf-tools = self.callPackage ./agni-tf-tools {};
+
  ament-acceleration = self.callPackage ./ament-acceleration {};
 
  ament-black = self.callPackage ./ament-black {};
@@ -195,6 +197,14 @@ self: super: {
  async-web-server-cpp = self.callPackage ./async-web-server-cpp {};
 
  at-sonde-ros-driver = self.callPackage ./at-sonde-ros-driver {};
+
+ audio-capture = self.callPackage ./audio-capture {};
+
+ audio-common = self.callPackage ./audio-common {};
+
+ audio-common-msgs = self.callPackage ./audio-common-msgs {};
+
+ audio-play = self.callPackage ./audio-play {};
 
  auto-apms-behavior-tree = self.callPackage ./auto-apms-behavior-tree {};
 
@@ -434,6 +444,18 @@ self: super: {
 
  cras-topic-tools = self.callPackage ./cras-topic-tools {};
 
+ crazyflie = self.callPackage ./crazyflie {};
+
+ crazyflie-examples = self.callPackage ./crazyflie-examples {};
+
+ crazyflie-interfaces = self.callPackage ./crazyflie-interfaces {};
+
+ crazyflie-py = self.callPackage ./crazyflie-py {};
+
+ crazyflie-server-py = self.callPackage ./crazyflie-server-py {};
+
+ crazyflie-sim = self.callPackage ./crazyflie-sim {};
+
  crocoddyl = self.callPackage ./crocoddyl {};
 
  crx-kinematics = self.callPackage ./crx-kinematics {};
@@ -487,6 +509,16 @@ self: super: {
  data-tamer-msgs = self.callPackage ./data-tamer-msgs {};
 
  data-tamer-tools = self.callPackage ./data-tamer-tools {};
+
+ dataspeed-can = self.callPackage ./dataspeed-can {};
+
+ dataspeed-can-msg-filters = self.callPackage ./dataspeed-can-msg-filters {};
+
+ dataspeed-can-msgs = self.callPackage ./dataspeed-can-msgs {};
+
+ dataspeed-can-tools = self.callPackage ./dataspeed-can-tools {};
+
+ dataspeed-can-usb = self.callPackage ./dataspeed-can-usb {};
 
  delphi-esr-msgs = self.callPackage ./delphi-esr-msgs {};
 
@@ -1184,6 +1216,8 @@ self: super: {
 
  lttngpy = self.callPackage ./lttngpy {};
 
+ lusb = self.callPackage ./lusb {};
+
  lz4-cmake-module = self.callPackage ./lz4-cmake-module {};
 
  magic-enum = self.callPackage ./magic-enum {};
@@ -1295,6 +1329,8 @@ self: super: {
  mola-input-paris-luco-dataset = self.callPackage ./mola-input-paris-luco-dataset {};
 
  mola-input-rawlog = self.callPackage ./mola-input-rawlog {};
+
+ mola-input-rosbag1 = self.callPackage ./mola-input-rosbag1 {};
 
  mola-input-rosbag2 = self.callPackage ./mola-input-rosbag2 {};
 
@@ -1529,6 +1565,8 @@ self: super: {
  mvsim = self.callPackage ./mvsim {};
 
  nanoeigenpy = self.callPackage ./nanoeigenpy {};
+
+ nanoflann = self.callPackage ./nanoflann {};
 
  nao-button-sim = self.callPackage ./nao-button-sim {};
 
@@ -2144,6 +2182,34 @@ self: super: {
 
  ros2-fmt-logger = self.callPackage ./ros2-fmt-logger {};
 
+ ros2-medkit-beacon-common = self.callPackage ./ros2-medkit-beacon-common {};
+
+ ros2-medkit-cmake = self.callPackage ./ros2-medkit-cmake {};
+
+ ros2-medkit-diagnostic-bridge = self.callPackage ./ros2-medkit-diagnostic-bridge {};
+
+ ros2-medkit-fault-manager = self.callPackage ./ros2-medkit-fault-manager {};
+
+ ros2-medkit-fault-reporter = self.callPackage ./ros2-medkit-fault-reporter {};
+
+ ros2-medkit-gateway = self.callPackage ./ros2-medkit-gateway {};
+
+ ros2-medkit-graph-provider = self.callPackage ./ros2-medkit-graph-provider {};
+
+ ros2-medkit-integration-tests = self.callPackage ./ros2-medkit-integration-tests {};
+
+ ros2-medkit-linux-introspection = self.callPackage ./ros2-medkit-linux-introspection {};
+
+ ros2-medkit-msgs = self.callPackage ./ros2-medkit-msgs {};
+
+ ros2-medkit-param-beacon = self.callPackage ./ros2-medkit-param-beacon {};
+
+ ros2-medkit-serialization = self.callPackage ./ros2-medkit-serialization {};
+
+ ros2-medkit-sovd-service-interface = self.callPackage ./ros2-medkit-sovd-service-interface {};
+
+ ros2-medkit-topic-beacon = self.callPackage ./ros2-medkit-topic-beacon {};
+
  ros2-snapshot = self.callPackage ./ros2-snapshot {};
 
  ros2-socketcan = self.callPackage ./ros2-socketcan {};
@@ -2598,6 +2664,10 @@ self: super: {
 
  sophus = self.callPackage ./sophus {};
 
+ sound-play = self.callPackage ./sound-play {};
+
+ sound-play-msgs = self.callPackage ./sound-play-msgs {};
+
  spacenav = self.callPackage ./spacenav {};
 
  spdlog-vendor = self.callPackage ./spdlog-vendor {};
@@ -2925,6 +2995,8 @@ self: super: {
  velodyne-msgs = self.callPackage ./velodyne-msgs {};
 
  velodyne-pointcloud = self.callPackage ./velodyne-pointcloud {};
+
+ video-to-image-msg-publisher = self.callPackage ./video-to-image-msg-publisher {};
 
  vision-msgs = self.callPackage ./vision-msgs {};
 

--- a/distros/lyrical/geometric-shapes/default.nix
+++ b/distros/lyrical/geometric-shapes/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, assimp, boost, console-bridge-vendor, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometry-msgs, octomap, pkg-config, qhull, random-numbers, rclcpp, resource-retriever, rosidl-default-generators, rosidl-default-runtime, shape-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, assimp, boost, console-bridge-vendor, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometry-msgs, pkg-config, qhull, random-numbers, rclcpp, resource-retriever, rosidl-default-generators, rosidl-default-runtime, shape-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-geometric-shapes";
-  version = "2.3.3-r3";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometric_shapes-release/archive/release/lyrical/geometric_shapes/2.3.3-3.tar.gz";
-    name = "2.3.3-3.tar.gz";
-    sha256 = "17a972f14287c74c1f0faded37fa0fbb60b37ebdbe27631f0475f21dbcd715ad";
+    url = "https://github.com/ros2-gbp/geometric_shapes-release/archive/release/lyrical/geometric_shapes/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "ce9e1672f8d182137e5039392101483d217f5ecade08b0fb3f31cb9132b1e203";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake pkg-config rosidl-default-generators ];
   checkInputs = [ ament-cmake-copyright ament-cmake-gtest ament-lint-auto ament-lint-cmake ];
-  propagatedBuildInputs = [ assimp boost console-bridge-vendor eigen eigen-stl-containers eigen3-cmake-module fcl geometry-msgs octomap qhull random-numbers rclcpp resource-retriever rosidl-default-runtime shape-msgs visualization-msgs ];
+  propagatedBuildInputs = [ assimp boost console-bridge-vendor eigen eigen-stl-containers eigen3-cmake-module fcl geometry-msgs qhull random-numbers rclcpp resource-retriever rosidl-default-runtime shape-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module rosidl-default-generators ];
 
   meta = {

--- a/distros/lyrical/gz-cmake-vendor/default.nix
+++ b/distros/lyrical/gz-cmake-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, pkg-config }:
 buildRosPackage {
   pname = "ros-lyrical-gz-cmake-vendor";
-  version = "0.4.4-r3";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_cmake_vendor-release/archive/release/lyrical/gz_cmake_vendor/0.4.4-3.tar.gz";
-    name = "0.4.4-3.tar.gz";
-    sha256 = "dbc2b7f40abe60be546c6fe6e1fed307282095a37bd014b0fceeaff098e55470";
+    url = "https://github.com/ros2-gbp/gz_cmake_vendor-release/archive/release/lyrical/gz_cmake_vendor/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "6f35516515c60bb4dafb4e463673ef3dfa2527d9ef46cacb344ffdde193a7b5f";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake pkg-config ];
 
   meta = {
-    description = "Vendor package for: gz-cmake 5.1.0
+    description = "Vendor package for: gz-cmake 5.1.1
 
     Gazebo CMake : CMake Modules for Gazebo Projects";
     license = with lib.licenses; [ asl20 ];

--- a/distros/lyrical/gz-cmake-vendor/vendored-source.json
+++ b/distros/lyrical/gz-cmake-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_cmake_vendor": {
     "url": "https://github.com/gazebosim/gz-cmake.git",
-    "rev": "gz-cmake5_5.1.0",
-    "hash": "sha256-o7JI3K1VuM1MKG0Wq0QUtyRI8cfBnHsW2mFuoapEQW8="
+    "rev": "gz-cmake5_5.1.1",
+    "hash": "sha256-bp3qaLuE/0sf6u4ZVOGsuJVkuEm2IS0zB0vHMVE0g/g="
   }
 }

--- a/distros/lyrical/gz-physics-vendor/default.nix
+++ b/distros/lyrical/gz-physics-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, bullet, cmake, eigen, gbenchmark, gz-cmake-vendor, gz-common-vendor, gz-dartsim-vendor, gz-math-vendor, gz-plugin-vendor, gz-utils-vendor, sdformat-vendor }:
 buildRosPackage {
   pname = "ros-lyrical-gz-physics-vendor";
-  version = "0.4.3-r3";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_physics_vendor-release/archive/release/lyrical/gz_physics_vendor/0.4.3-3.tar.gz";
-    name = "0.4.3-3.tar.gz";
-    sha256 = "7f7fe340958f9ae879eb04a83ef8dafb0f3ba83e9120eb5a0c130e65d4d74923";
+    url = "https://github.com/ros2-gbp/gz_physics_vendor-release/archive/release/lyrical/gz_physics_vendor/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "7d1a9bbdc34a9e453c777ed845fdd81701674af9ce54263cb05193672cf76458";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-physics 9.1.0
+    description = "Vendor package for: gz-physics 9.3.0
 
     Gazebo Physics : Physics classes and functions for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/lyrical/gz-physics-vendor/vendored-source.json
+++ b/distros/lyrical/gz-physics-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_physics_vendor": {
     "url": "https://github.com/gazebosim/gz-physics.git",
-    "rev": "gz-physics9_9.1.0",
-    "hash": "sha256-9JM/vtDOOfwpmc4cu1XEE0FSgaYBaLAD7dCvqI7MuMY="
+    "rev": "gz-physics9_9.3.0",
+    "hash": "sha256-HUydNVfOX/nWi0a29CcFlM2dCt9hqfsafJR61WkBPIw="
   }
 }

--- a/distros/lyrical/gz-sim-vendor/default.nix
+++ b/distros/lyrical/gz-sim-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, binutils, cmake, elfutils, freeglut, freeimage, gbenchmark, glew, gz-cmake-vendor, gz-common-vendor, gz-fuel-tools-vendor, gz-gui-vendor, gz-math-vendor, gz-msgs-vendor, gz-physics-vendor, gz-plugin-vendor, gz-rendering-vendor, gz-sensors-vendor, gz-tools-vendor, gz-transport-vendor, gz-utils-vendor, libdwarf, libwebsockets, libxi, libxmu, protobuf, python3Packages, qt6, sdformat-vendor, tinyxml-2, util-linux, xorg }:
 buildRosPackage {
   pname = "ros-lyrical-gz-sim-vendor";
-  version = "0.4.4-r3";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_sim_vendor-release/archive/release/lyrical/gz_sim_vendor/0.4.4-3.tar.gz";
-    name = "0.4.4-3.tar.gz";
-    sha256 = "77ba9e9247cc9c0f6e9ab718f13e2a4849362a240ebb92d4ee82f15ecae092a0";
+    url = "https://github.com/ros2-gbp/gz_sim_vendor-release/archive/release/lyrical/gz_sim_vendor/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "2046e6bdcdd0fd86c9afba94b2ef52eadd5c877b21916b75e1c52b78e03f9c32";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-sim 10.1.1
+    description = "Vendor package for: gz-sim 10.4.0
 
     Gazebo Sim : A Robotic Simulator";
     license = with lib.licenses; [ asl20 ];

--- a/distros/lyrical/gz-sim-vendor/vendored-source.json
+++ b/distros/lyrical/gz-sim-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_sim_vendor": {
     "url": "https://github.com/gazebosim/gz-sim.git",
-    "rev": "gz-sim10_10.1.1",
-    "hash": "sha256-pFzpusR7bJAQOZqTGZ79DP9fMIcKNl2gbWW+Zw5tNgs="
+    "rev": "gz-sim10_10.4.0",
+    "hash": "sha256-3QKqSvEI8wa0z/LOmLjGeuWYIEQ999xLtdoeX+DA2rk="
   }
 }

--- a/distros/lyrical/image-common/default.nix
+++ b/distros/lyrical/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-lyrical-image-common";
-  version = "6.4.9-r1";
+  version = "6.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/lyrical/image_common/6.4.9-1.tar.gz";
-    name = "6.4.9-1.tar.gz";
-    sha256 = "830b4fa2b5f76cbe3ae1e3e8ab6ae97d91c5a72ddd9617aee6371d47a57a2455";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/lyrical/image_common/6.4.10-1.tar.gz";
+    name = "6.4.10-1.tar.gz";
+    sha256 = "5edb5df3db88c8e3f8fc82d2482d2de1555e749d6ef445c8be160ab89c9423ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/image-transport-py/default.nix
+++ b/distros/lyrical/image-transport-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, image-transport, python3, python3Packages, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-image-transport-py";
-  version = "6.4.9-r1";
+  version = "6.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/lyrical/image_transport_py/6.4.9-1.tar.gz";
-    name = "6.4.9-1.tar.gz";
-    sha256 = "43694bf25896fa418ac55121928e04d88468764899007b50737730f4f7252dcf";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/lyrical/image_transport_py/6.4.10-1.tar.gz";
+    name = "6.4.10-1.tar.gz";
+    sha256 = "20af2aa8ab865f687282ffddf01f4b6870a2cdf2f5004432147e24155ddfa429";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/image-transport/default.nix
+++ b/distros/lyrical/image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-lyrical-image-transport";
-  version = "6.4.9-r1";
+  version = "6.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/lyrical/image_transport/6.4.9-1.tar.gz";
-    name = "6.4.9-1.tar.gz";
-    sha256 = "edd54ce8b25afbd9e9a8761edc19a0dc8357d4cf00061325ddca372e15b7fd90";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/lyrical/image_transport/6.4.10-1.tar.gz";
+    name = "6.4.10-1.tar.gz";
+    sha256 = "8c3e8f603372e0a0521dacde436b7d523940d141b44e10ae71db2b021d6beca1";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/kompass-interfaces/default.nix
+++ b/distros/lyrical/kompass-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-kompass-interfaces";
-  version = "0.4.1-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kompass-release/archive/release/lyrical/kompass_interfaces/0.4.1-3.tar.gz";
-    name = "0.4.1-3.tar.gz";
-    sha256 = "d19323868419577aa203cdb1f1b64ce1908b1be68d62c8ddf271bbdbc9d5765a";
+    url = "https://github.com/ros2-gbp/kompass-release/archive/release/lyrical/kompass_interfaces/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "e004d2b20776ca24aa59b9ffb5bec34fd62c0d336b53ee7473f9462edeaa5116";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/kompass/default.nix
+++ b/distros/lyrical/kompass/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, automatika-ros-sugar, kompass-interfaces, python3Packages }:
 buildRosPackage {
   pname = "ros-lyrical-kompass";
-  version = "0.4.1-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kompass-release/archive/release/lyrical/kompass/0.4.1-3.tar.gz";
-    name = "0.4.1-3.tar.gz";
-    sha256 = "31bdbec8b9b20f7d28e09a6fec6c8c6daa4a3a25c1f2ba7aea6d66006c9c673f";
+    url = "https://github.com/ros2-gbp/kompass-release/archive/release/lyrical/kompass/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "41f59bb8b2d3bbf7f5391fb2c0be967afead3bb4d878d97d4a57800f9a100e36";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/libtorch-vendor/default.nix
+++ b/distros/lyrical/libtorch-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-lyrical-libtorch-vendor";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/lyrical/libtorch_vendor/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "4be2495cd5214d91ddb6671389a4d42448d765b9e2ed2eb9326bcf8d53f219cc";
+    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/lyrical/libtorch_vendor/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "a7780fbde8afb0d20f6f73872c37aa42f25897fac090000be7f63a528c47efda";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/lusb/default.nix
+++ b/distros/lyrical/lusb/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, libusb1, pkg-config }:
+buildRosPackage {
+  pname = "ros-lyrical-lusb";
+  version = "2.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/lusb-release/archive/release/lyrical/lusb/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "9c024046fcfd24db585f6b0a1ed5978453bc1d619c594d6bc68278a128b69c67";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake pkg-config ];
+  propagatedBuildInputs = [ libusb1 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Library for interfacing to USB devices";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/mavlink/default.nix
+++ b/distros/lyrical/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-lyrical-mavlink";
-  version = "2026.3.3-r3";
+  version = "2026.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/lyrical/mavlink/2026.3.3-3.tar.gz";
-    name = "2026.3.3-3.tar.gz";
-    sha256 = "763ada687256d14b0f6ea23deea188ce7451bcd93f317f0b462151eb513aafa3";
+    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/lyrical/mavlink/2026.6.6-1.tar.gz";
+    name = "2026.6.6-1.tar.gz";
+    sha256 = "abffa69483a124366f703be994058b1f809749b8716aff013cad29eeac4129df";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mola-input-rosbag1/default.nix
+++ b/distros/lyrical/mola-input-rosbag1/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, bzip2, cmake, geometry-msgs, lz4, mola-common, mola-kernel, mrpt-libmaps, mrpt-libobs, opencv, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-mola-input-rosbag1";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_input_rosbag1-release/archive/release/lyrical/mola_input_rosbag1/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "2bb6a7643426248555b3396e4470baf71eb94dee94d4bf06b8c2e69e16b2c7c6";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ boost bzip2 geometry-msgs lz4 mola-common mola-kernel mrpt-libmaps mrpt-libobs opencv opencv.cxxdev tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "MOLA DataSource from ROS1 bag files that does not need a ROS1 installation";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/lyrical/nanoflann/default.nix
+++ b/distros/lyrical/nanoflann/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, gtest }:
+buildRosPackage {
+  pname = "ros-lyrical-nanoflann";
+  version = "1.10.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/nanoflann-release/archive/release/lyrical/nanoflann/1.10.1-1.tar.gz";
+    name = "1.10.1-1.tar.gz";
+    sha256 = "654605e93bd8b18fb94f06c1db9236b49fddb548e063bb82722a9042a3f244d5";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  checkInputs = [ gtest ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "nanoflann: a C++11 header-only library for Nearest Neighbor (NN) search
+    with KD-trees, optimized for point clouds and Eigen matrices.";
+    license = with lib.licenses; [ "BSD-2-Clause" ];
+  };
+}

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -126,17 +126,6 @@ in {
 
   gazebo = self.gazebo_11;
 
-  geometric-shapes = rosSuper.geometric-shapes.overrideAttrs({
-      postPatch ? "", ...
-  }: {
-      # Remove workaround for Ubuntu-specific dependency hell issue
-      postPatch = postPatch + ''
-        substituteInPlace CMakeLists.txt --replace-fail \
-          'find_package(octomap 1.9.7...<1.10.0 REQUIRED)' \
-          'find_package(octomap REQUIRED)'
-      '';
-  });
-
   google-benchmark-vendor = lib.patchExternalProjectGit rosSuper.google-benchmark-vendor {
     url = "https://github.com/google/benchmark.git";
     rev = "344117638c8ff7e239044fd0fa7085839fc03021";

--- a/distros/lyrical/rmw-connextdds-common/default.nix
+++ b/distros/lyrical/rmw-connextdds-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, fastcdr, rcpputils, rcutils, rmw, rmw-dds-common, rmw-security-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, rti-connext-dds-cmake-module, tracetools }:
 buildRosPackage {
   pname = "ros-lyrical-rmw-connextdds-common";
-  version = "1.2.7-r1";
+  version = "1.2.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/lyrical/rmw_connextdds_common/1.2.7-1.tar.gz";
-    name = "1.2.7-1.tar.gz";
-    sha256 = "9011dd6d162a2700b50a845822da9ce6201eac8c95fa6f48a6df54ee7e35322c";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/lyrical/rmw_connextdds_common/1.2.7-2.tar.gz";
+    name = "1.2.7-2.tar.gz";
+    sha256 = "1f6a7270e0ff7d37b00acd02020fa098e3e893394bd463514d65763ed4d49e46";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rmw-connextdds/default.nix
+++ b/distros/lyrical/rmw-connextdds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rmw-connextdds-common }:
 buildRosPackage {
   pname = "ros-lyrical-rmw-connextdds";
-  version = "1.2.7-r1";
+  version = "1.2.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/lyrical/rmw_connextdds/1.2.7-1.tar.gz";
-    name = "1.2.7-1.tar.gz";
-    sha256 = "1716807aedcd99bfbbfb90ce1383d6b8af0bd11476ec157c59f2b99ae8d6fb11";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/lyrical/rmw_connextdds/1.2.7-2.tar.gz";
+    name = "1.2.7-2.tar.gz";
+    sha256 = "22ac87f11f43d98c0318ea9c8b8e4b990fa91d05ebbbdc51c3abd956ffa32cd1";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ros-gz-bridge/default.nix
+++ b/distros/lyrical/ros-gz-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actuator-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, gps-msgs, gz-msgs-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, marine-acoustic-msgs, nav-msgs, pkg-config, rclcpp, rclcpp-components, ros-gz-interfaces, rosgraph-msgs, rosidl-pycommon, sensor-msgs, std-msgs, tf2-msgs, trajectory-msgs, vision-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-lyrical-ros-gz-bridge";
-  version = "3.0.8-r3";
+  version = "3.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/lyrical/ros_gz_bridge/3.0.8-3.tar.gz";
-    name = "3.0.8-3.tar.gz";
-    sha256 = "ea6f3e34e76d677fcba60951739eba4b0b27f63f112b50ad048dd895ba69267e";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/lyrical/ros_gz_bridge/3.0.9-1.tar.gz";
+    name = "3.0.9-1.tar.gz";
+    sha256 = "11f2aafd679695b1a6065ca1781b920214e2a88049d3197f91ddcd1d13bb3738";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ros-gz-image/default.nix
+++ b/distros/lyrical/ros-gz-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-msgs-vendor, gz-transport-vendor, image-transport, pkg-config, rclcpp, ros-gz-bridge, sensor-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-ros-gz-image";
-  version = "3.0.8-r3";
+  version = "3.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/lyrical/ros_gz_image/3.0.8-3.tar.gz";
-    name = "3.0.8-3.tar.gz";
-    sha256 = "71d26e1e5fe6a5c10c887f014934be2e979def3c7fad8375f16bd06ddb7eb7a6";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/lyrical/ros_gz_image/3.0.9-1.tar.gz";
+    name = "3.0.9-1.tar.gz";
+    sha256 = "7dc957e1013bd5dcd3c0d4586c0daaae17c0c07e1e1f20ae322abab58320dea5";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ros-gz-interfaces/default.nix
+++ b/distros/lyrical/ros-gz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-ros-gz-interfaces";
-  version = "3.0.8-r3";
+  version = "3.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/lyrical/ros_gz_interfaces/3.0.8-3.tar.gz";
-    name = "3.0.8-3.tar.gz";
-    sha256 = "81476ad215ce92af073237949da3e232c8581a4ddef08581716b7247113b3ffa";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/lyrical/ros_gz_interfaces/3.0.9-1.tar.gz";
+    name = "3.0.9-1.tar.gz";
+    sha256 = "ca4e02cc5d0f9186fc71d0b08d873727212de7576bd61547d5440171d2d6007f";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ros-gz-sim-demos/default.nix
+++ b/distros/lyrical/ros-gz-sim-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-sim-vendor, image-transport-plugins, marine-acoustic-msgs, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, rqt-image-view, rqt-plot, rqt-topic, rviz-imu-plugin, rviz2, sdformat-urdf, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-lyrical-ros-gz-sim-demos";
-  version = "3.0.8-r3";
+  version = "3.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/lyrical/ros_gz_sim_demos/3.0.8-3.tar.gz";
-    name = "3.0.8-3.tar.gz";
-    sha256 = "e8f8dc03c006fe270e9f7a9a48e4b58f5fb4ad5ae2881c4db4346faa211e5e98";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/lyrical/ros_gz_sim_demos/3.0.9-1.tar.gz";
+    name = "3.0.9-1.tar.gz";
+    sha256 = "4e3511cc461e55c103bd3517d6083715ee8d9ada55ac41c5ecf92835c8732816";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ros-gz-sim/default.nix
+++ b/distros/lyrical/ros-gz-sim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, cli11, geometry-msgs, gflags, gz-math-vendor, gz-msgs-vendor, gz-sim-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, pkg-config, rclcpp, rclcpp-action, rclcpp-components, rcpputils, ros-gz-bridge, ros-gz-interfaces, ros2pkg, simulation-interfaces, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-lyrical-ros-gz-sim";
-  version = "3.0.8-r3";
+  version = "3.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/lyrical/ros_gz_sim/3.0.8-3.tar.gz";
-    name = "3.0.8-3.tar.gz";
-    sha256 = "f018bcfed96792b6985b00f202849e2db8b04a7e2044721ca96e20a92c0e51b0";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/lyrical/ros_gz_sim/3.0.9-1.tar.gz";
+    name = "3.0.9-1.tar.gz";
+    sha256 = "bf41ac51de430de9035fa11002058c5b407ec3889b378abb120a85a06649f52e";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ros-gz/default.nix
+++ b/distros/lyrical/ros-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz-bridge, ros-gz-image, ros-gz-sim, ros-gz-sim-demos }:
 buildRosPackage {
   pname = "ros-lyrical-ros-gz";
-  version = "3.0.8-r3";
+  version = "3.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/lyrical/ros_gz/3.0.8-3.tar.gz";
-    name = "3.0.8-3.tar.gz";
-    sha256 = "9429efeaa0b0d3b44b32a94a1aaace71250427a97773020eab0d345bd9b81a68";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/lyrical/ros_gz/3.0.9-1.tar.gz";
+    name = "3.0.9-1.tar.gz";
+    sha256 = "a44b841b7fe7904da19f968a5b0412af899b596dd5ef1ad25dd6073819d2da57";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ros2-medkit-beacon-common/default.nix
+++ b/distros/lyrical/ros2-medkit-beacon-common/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nlohmann_json, rclcpp, ros2-medkit-cmake, ros2-medkit-gateway, ros2-medkit-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-ros2-medkit-beacon-common";
+  version = "0.5.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_beacon_common/0.5.0-3.tar.gz";
+    name = "0.5.0-3.tar.gz";
+    sha256 = "edecb201075cf5fa24145df4b9d7d41115338915f704054a3859e791888de770";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros2-medkit-cmake ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ nlohmann_json rclcpp ros2-medkit-gateway ros2-medkit-msgs ];
+  nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
+
+  meta = {
+    description = "Shared library for ros2_medkit beacon discovery plugins";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/ros2-medkit-cmake/default.nix
+++ b/distros/lyrical/ros2-medkit-cmake/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-lyrical-ros2-medkit-cmake";
+  version = "0.5.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_cmake/0.5.0-3.tar.gz";
+    name = "0.5.0-3.tar.gz";
+    sha256 = "4bb1348375f7f39c89f2a5d5c35bd8e9b16ac9ea601ad1414afa0e977b3af7ce";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Shared CMake modules for ros2_medkit packages (multi-distro compat, ccache, linting)";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/ros2-medkit-diagnostic-bridge/default.nix
+++ b/distros/lyrical/ros2-medkit-diagnostic-bridge/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch-testing-ament-cmake, launch-testing-ros, rclcpp, ros2-medkit-cmake, ros2-medkit-fault-manager, ros2-medkit-fault-reporter, ros2-medkit-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-ros2-medkit-diagnostic-bridge";
+  version = "0.5.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_diagnostic_bridge/0.5.0-3.tar.gz";
+    name = "0.5.0-3.tar.gz";
+    sha256 = "cf026d655ebc00549f2610ff02439d1ab7a0c0c976e0ff8699032cd5c709f28d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros2-medkit-cmake ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-clang-tidy ament-cmake-gtest ament-lint-auto ament-lint-common launch-testing-ament-cmake launch-testing-ros ros2-medkit-fault-manager ];
+  propagatedBuildInputs = [ diagnostic-msgs rclcpp ros2-medkit-fault-reporter ros2-medkit-msgs ];
+  nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
+
+  meta = {
+    description = "Bridge node converting ROS2 /diagnostics to FaultManager faults";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/ros2-medkit-fault-manager/default.nix
+++ b/distros/lyrical/ros2-medkit-fault-manager/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-testing-ament-cmake, launch-testing-ros, nlohmann_json, rclcpp, ros2-medkit-cmake, ros2-medkit-msgs, ros2-medkit-serialization, rosbag2-cpp, rosbag2-storage, rosbag2-storage-mcap, sensor-msgs, sqlite, std-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-ros2-medkit-fault-manager";
+  version = "0.5.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_fault_manager/0.5.0-3.tar.gz";
+    name = "0.5.0-3.tar.gz";
+    sha256 = "866501e960f7b92ea60fed43ed772b1f869bcd41699634289b9aa27b5329b3d8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros2-medkit-cmake ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-clang-tidy ament-cmake-gtest ament-lint-auto ament-lint-common launch-testing-ament-cmake launch-testing-ros sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ nlohmann_json rclcpp ros2-medkit-msgs ros2-medkit-serialization rosbag2-cpp rosbag2-storage rosbag2-storage-mcap sqlite ];
+  nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
+
+  meta = {
+    description = "Central fault manager node for ros2_medkit fault management system";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/ros2-medkit-fault-reporter/default.nix
+++ b/distros/lyrical/ros2-medkit-fault-reporter/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-testing-ament-cmake, launch-testing-ros, rclcpp, ros2-medkit-cmake, ros2-medkit-fault-manager, ros2-medkit-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-ros2-medkit-fault-reporter";
+  version = "0.5.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_fault_reporter/0.5.0-3.tar.gz";
+    name = "0.5.0-3.tar.gz";
+    sha256 = "5c0d2fd908eabbade989c3ed6c9ef77f852b19092f90a3cca71573bec1cb43a4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros2-medkit-cmake ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-clang-tidy ament-cmake-gtest ament-lint-auto ament-lint-common launch-testing-ament-cmake launch-testing-ros ros2-medkit-fault-manager ];
+  propagatedBuildInputs = [ rclcpp ros2-medkit-msgs ];
+  nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
+
+  meta = {
+    description = "Client library for easy fault reporting with local filtering";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/ros2-medkit-gateway/default.nix
+++ b/distros/lyrical/ros2-medkit-gateway/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, example-interfaces, httplib, nlohmann_json, openssl, rcl-interfaces, rclcpp, rclcpp-action, ros2-medkit-cmake, ros2-medkit-msgs, ros2-medkit-serialization, rosidl-parser, rosidl-runtime-py, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, sensor-msgs, sqlite, std-msgs, std-srvs, yaml-cpp-vendor }:
+buildRosPackage {
+  pname = "ros-lyrical-ros2-medkit-gateway";
+  version = "0.5.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_gateway/0.5.0-3.tar.gz";
+    name = "0.5.0-3.tar.gz";
+    sha256 = "e269a6055a4178b5d8f2ea882eb95764f11f9d426e1aa77500fb437b303a8d6f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros2-medkit-cmake ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-clang-tidy ament-cmake-gtest ament-lint-auto ament-lint-common example-interfaces rclcpp-action ];
+  propagatedBuildInputs = [ action-msgs ament-index-cpp httplib nlohmann_json openssl rcl-interfaces rclcpp ros2-medkit-msgs ros2-medkit-serialization rosidl-parser rosidl-runtime-py rosidl-typesupport-cpp rosidl-typesupport-introspection-cpp sensor-msgs sqlite std-msgs std-srvs yaml-cpp-vendor ];
+  nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
+
+  meta = {
+    description = "HTTP gateway for ros2_medkit diagnostics system";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/ros2-medkit-graph-provider/default.nix
+++ b/distros/lyrical/ros2-medkit-graph-provider/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, nlohmann_json, rclcpp, ros2-medkit-cmake, ros2-medkit-gateway, ros2-medkit-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-ros2-medkit-graph-provider";
+  version = "0.5.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_graph_provider/0.5.0-3.tar.gz";
+    name = "0.5.0-3.tar.gz";
+    sha256 = "a3ce6fc1973ee57417d998b8676dd45b42ee507600603ebd4e87af5db86483af";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros2-medkit-cmake ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ diagnostic-msgs nlohmann_json rclcpp ros2-medkit-gateway ros2-medkit-msgs ];
+  nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
+
+  meta = {
+    description = "Graph provider plugin for ros2_medkit gateway";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/ros2-medkit-integration-tests/default.nix
+++ b/distros/lyrical/ros2-medkit-integration-tests/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, diagnostic-msgs, example-interfaces, launch-ros, launch-testing, launch-testing-ament-cmake, python3Packages, rcl-interfaces, rclcpp, rclcpp-action, ros2-medkit-cmake, ros2-medkit-fault-manager, ros2-medkit-gateway, ros2-medkit-graph-provider, ros2-medkit-linux-introspection, ros2-medkit-msgs, ros2-medkit-param-beacon, ros2-medkit-topic-beacon, sensor-msgs, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-lyrical-ros2-medkit-integration-tests";
+  version = "0.5.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_integration_tests/0.5.0-3.tar.gz";
+    name = "0.5.0-3.tar.gz";
+    sha256 = "8327dc8aa0f7ee84fbd684b60a3d507988acd525695e925172e8334415284d9c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ros2-medkit-cmake ];
+  checkInputs = [ ament-index-python launch-ros launch-testing launch-testing-ament-cmake python3Packages.jsonschema python3Packages.requests ros2-medkit-fault-manager ros2-medkit-gateway ros2-medkit-graph-provider ros2-medkit-linux-introspection ros2-medkit-param-beacon ros2-medkit-topic-beacon ];
+  propagatedBuildInputs = [ diagnostic-msgs example-interfaces rcl-interfaces rclcpp rclcpp-action ros2-medkit-msgs sensor-msgs std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ros2-medkit-cmake ];
+
+  meta = {
+    description = "Integration tests and demo nodes for ros2_medkit";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/ros2-medkit-linux-introspection/default.nix
+++ b/distros/lyrical/ros2-medkit-linux-introspection/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, nlohmann_json, pkg-config, ros2-medkit-cmake, ros2-medkit-gateway, systemd }:
+buildRosPackage {
+  pname = "ros-lyrical-ros2-medkit-linux-introspection";
+  version = "0.5.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_linux_introspection/0.5.0-3.tar.gz";
+    name = "0.5.0-3.tar.gz";
+    sha256 = "c360d4388c0f4c7b0f1c07183ba8d8eb35d67e688fdfda6a6bcf8ddba8e8ccbe";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake pkg-config ros2-medkit-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ];
+  propagatedBuildInputs = [ nlohmann_json ros2-medkit-gateway systemd ];
+  nativeBuildInputs = [ ament-cmake pkg-config ros2-medkit-cmake ];
+
+  meta = {
+    description = "Linux introspection plugins for ros2_medkit gateway - procfs, systemd, and container";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/ros2-medkit-msgs/default.nix
+++ b/distros/lyrical/ros2-medkit-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-lyrical-ros2-medkit-msgs";
+  version = "0.5.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_msgs/0.5.0-3.tar.gz";
+    name = "0.5.0-3.tar.gz";
+    sha256 = "009e3c5deab91bfbc65933957964650ad974ad516fe7da3f14ea877c0ed5b4d3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces diagnostic-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "ROS 2 message and service definitions for ros2_medkit fault management";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/ros2-medkit-param-beacon/default.nix
+++ b/distros/lyrical/ros2-medkit-param-beacon/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-lint-auto, ament-lint-common, nlohmann_json, rclcpp, ros2-medkit-beacon-common, ros2-medkit-cmake, ros2-medkit-gateway }:
+buildRosPackage {
+  pname = "ros-lyrical-ros2-medkit-param-beacon";
+  version = "0.5.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_param_beacon/0.5.0-3.tar.gz";
+    name = "0.5.0-3.tar.gz";
+    sha256 = "89f5953095bfc346da30ff76411c736046022e56258ef4d678e629c915c99a4b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros2-medkit-cmake ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gmock ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ nlohmann_json rclcpp ros2-medkit-beacon-common ros2-medkit-gateway ];
+  nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
+
+  meta = {
+    description = "Parameter-based beacon discovery plugin for ros2_medkit gateway";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/ros2-medkit-serialization/default.nix
+++ b/distros/lyrical/ros2-medkit-serialization/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nlohmann_json, rclcpp, rcpputils, rcutils, ros2-medkit-cmake, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, sensor-msgs, std-msgs, std-srvs, test-msgs, yaml-cpp-vendor }:
+buildRosPackage {
+  pname = "ros-lyrical-ros2-medkit-serialization";
+  version = "0.5.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_serialization/0.5.0-3.tar.gz";
+    name = "0.5.0-3.tar.gz";
+    sha256 = "89f3f1d12638a0f80ec783f37919b23453283c99ff4093a26b06729ccac3d196";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros2-medkit-cmake ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-clang-tidy ament-cmake-gtest ament-lint-auto ament-lint-common geometry-msgs sensor-msgs std-msgs std-srvs test-msgs ];
+  propagatedBuildInputs = [ nlohmann_json rclcpp rcpputils rcutils rosidl-runtime-c rosidl-runtime-cpp rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp yaml-cpp-vendor ];
+  nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
+
+  meta = {
+    description = "Runtime JSON to ROS 2 message serialization library";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/ros2-medkit-sovd-service-interface/default.nix
+++ b/distros/lyrical/ros2-medkit-sovd-service-interface/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nlohmann_json, rclcpp, ros2-medkit-cmake, ros2-medkit-gateway, ros2-medkit-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-ros2-medkit-sovd-service-interface";
+  version = "0.5.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_sovd_service_interface/0.5.0-3.tar.gz";
+    name = "0.5.0-3.tar.gz";
+    sha256 = "42790648a13209ac81565af31f852c7ce605d577be04a07aba9bf00d361612e6";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros2-medkit-cmake ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ nlohmann_json rclcpp ros2-medkit-gateway ros2-medkit-msgs ];
+  nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
+
+  meta = {
+    description = "SOVD Service Interface plugin - exposes medkit entity tree and fault data via ROS 2 services";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/ros2-medkit-topic-beacon/default.nix
+++ b/distros/lyrical/ros2-medkit-topic-beacon/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, nlohmann_json, rclcpp, ros2-medkit-beacon-common, ros2-medkit-cmake, ros2-medkit-gateway, ros2-medkit-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-ros2-medkit-topic-beacon";
+  version = "0.5.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_topic_beacon/0.5.0-3.tar.gz";
+    name = "0.5.0-3.tar.gz";
+    sha256 = "65435d06789e741c60a72b9d3d42f95fbe209f39f6d9f0883aedd04bbd6d416a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros2-medkit-cmake ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ diagnostic-msgs nlohmann_json rclcpp ros2-medkit-beacon-common ros2-medkit-gateway ros2-medkit-msgs ];
+  nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
+
+  meta = {
+    description = "Topic-based beacon discovery plugin for ros2_medkit gateway";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/rosidl-adapter/default.nix
+++ b/distros/lyrical/rosidl-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-mypy, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3, python3Packages, rosidl-cli }:
 buildRosPackage {
   pname = "ros-lyrical-rosidl-adapter";
-  version = "5.2.0-r3";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_adapter/5.2.0-3.tar.gz";
-    name = "5.2.0-3.tar.gz";
-    sha256 = "09e0a967077ebb96f7c083309d218abc27fe2e135c5b9bd9cc874a88995f3500";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_adapter/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "c20987705808f01de5c51601659bd28c54c5513a65088443e76ff76b92b1229c";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosidl-buffer-backend-registry/default.nix
+++ b/distros/lyrical/rosidl-buffer-backend-registry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rmw, rosidl-buffer, rosidl-buffer-backend, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-lyrical-rosidl-buffer-backend-registry";
-  version = "5.2.0-r3";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_buffer_backend_registry/5.2.0-3.tar.gz";
-    name = "5.2.0-3.tar.gz";
-    sha256 = "72e61adebbe3e91647e0779f91bfcabe0121907e5b47733e27de3cc8e534f4d9";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_buffer_backend_registry/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "8a50243c0a0354b3e9bc04603bf408fd6fbc103836bca55b26cadf9e2b87dea7";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosidl-buffer-backend/default.nix
+++ b/distros/lyrical/rosidl-buffer-backend/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rmw }:
 buildRosPackage {
   pname = "ros-lyrical-rosidl-buffer-backend";
-  version = "5.2.0-r3";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_buffer_backend/5.2.0-3.tar.gz";
-    name = "5.2.0-3.tar.gz";
-    sha256 = "26e1ac5f43901a53a316dc01ca9f21e655494d40460ea699330b42a66ce94101";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_buffer_backend/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "74b38e3aaf6be1ce250d9a18db961d90b7e7da5c074fff24e0c42f60f809a5b9";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosidl-buffer-py/default.nix
+++ b/distros/lyrical/rosidl-buffer-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python3, python3Packages, rosidl-buffer }:
 buildRosPackage {
   pname = "ros-lyrical-rosidl-buffer-py";
-  version = "5.2.0-r3";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_buffer_py/5.2.0-3.tar.gz";
-    name = "5.2.0-3.tar.gz";
-    sha256 = "5c154479c1e29eec3e40e989d62a22223ed26f9ed427196f9b9d8f0e85aef91c";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_buffer_py/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "aef9a254f76682c43b7c75ca36f02570043baf03d557b891ae6d3cc3c7694ee4";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosidl-buffer/default.nix
+++ b/distros/lyrical/rosidl-buffer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-lyrical-rosidl-buffer";
-  version = "5.2.0-r3";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_buffer/5.2.0-3.tar.gz";
-    name = "5.2.0-3.tar.gz";
-    sha256 = "f46d2511bf84c39b8b3a1647107d7cde89c9467e3b26b429697a29ea5c3d41dd";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_buffer/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "cec7604e080e488234536770033914279ba432cc0101396000a19ba7fcf33519";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosidl-cli/default.nix
+++ b/distros/lyrical/rosidl-cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-lyrical-rosidl-cli";
-  version = "5.2.0-r3";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_cli/5.2.0-3.tar.gz";
-    name = "5.2.0-3.tar.gz";
-    sha256 = "c925e5b1bfc7f1ee68787a21ba5c112c9e85e712c46b8ff7d2d0c7844a223638";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_cli/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "9e95218eb46e1c1ecc5619f5cdbd72d528d4124df773abdf43b34ffcb8572a40";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/rosidl-cmake/default.nix
+++ b/distros/lyrical/rosidl-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python3Packages, rosidl-pycommon }:
 buildRosPackage {
   pname = "ros-lyrical-rosidl-cmake";
-  version = "5.2.0-r3";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_cmake/5.2.0-3.tar.gz";
-    name = "5.2.0-3.tar.gz";
-    sha256 = "e739e761d0c0be575cb3304191d58ae4ec27b71b5789d6eafb9cd20ada59ae14";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_cmake/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "b7a03b41fc7020d51bb426448e72f6db0c85d32de92c71a56a29d87321baf937";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosidl-generator-c/default.nix
+++ b/distros/lyrical/rosidl-generator-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-python, ament-cmake-ros-core, ament-index-python, ament-lint-auto, ament-lint-common, python3, rcutils, rosidl-cli, rosidl-cmake, rosidl-generator-type-description, rosidl-parser, rosidl-pycommon, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-lyrical-rosidl-generator-c";
-  version = "5.2.0-r3";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_generator_c/5.2.0-3.tar.gz";
-    name = "5.2.0-3.tar.gz";
-    sha256 = "ae0aee59ea4f56cdabf0a6bb0362cd91ed3fb646014d499033eefd8159e380b1";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_generator_c/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "edf03c5067ac5337472383d670a22cbaaa374735001033bcad122b34122ed61b";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosidl-generator-cpp/default.nix
+++ b/distros/lyrical/rosidl-generator-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-type-description, rosidl-parser, rosidl-pycommon, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-lyrical-rosidl-generator-cpp";
-  version = "5.2.0-r3";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_generator_cpp/5.2.0-3.tar.gz";
-    name = "5.2.0-3.tar.gz";
-    sha256 = "2130b494a2d82b20bc85c3691da4a60a26b86e16707d7db107b64c240c8d5f66";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_generator_cpp/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "12eff73d39a42f712f3d72e20f4b68590dc6b262722f4ba17c10705d709d3450";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosidl-generator-type-description/default.nix
+++ b/distros/lyrical/rosidl-generator-type-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros-core, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-parser }:
 buildRosPackage {
   pname = "ros-lyrical-rosidl-generator-type-description";
-  version = "5.2.0-r3";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_generator_type_description/5.2.0-3.tar.gz";
-    name = "5.2.0-3.tar.gz";
-    sha256 = "c6e22bc0f19eb721b8a2de7dbff441ac24d7eaddf91aeeacda5a733b8e4ba783";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_generator_type_description/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "f4e9c03e08505cb3c07cb52497c73bc281a6e27d26eebda9982a4b0d854838b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosidl-parser/default.nix
+++ b/distros/lyrical/rosidl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-mypy, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, rosidl-adapter }:
 buildRosPackage {
   pname = "ros-lyrical-rosidl-parser";
-  version = "5.2.0-r3";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_parser/5.2.0-3.tar.gz";
-    name = "5.2.0-3.tar.gz";
-    sha256 = "e9fe3dfda68519f3de5661d60d93935f4e2b3bb87f4c12e9754718840a4d4633";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_parser/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "8b4933ecada1541239add7487d4b0bac9c2007068551e84e0d1ed42d4a74faf1";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosidl-pycommon/default.nix
+++ b/distros/lyrical/rosidl-pycommon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, python3Packages, rosidl-parser }:
 buildRosPackage {
   pname = "ros-lyrical-rosidl-pycommon";
-  version = "5.2.0-r3";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_pycommon/5.2.0-3.tar.gz";
-    name = "5.2.0-3.tar.gz";
-    sha256 = "d610650ba39975046f7ca69d17251d0284d4522d10a963cafe425d550fb97681";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_pycommon/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "c747ce81066b1014116006291b72cd9b8024f3bff2cfbf8a29d26fb39bc39685";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/rosidl-runtime-c/default.nix
+++ b/distros/lyrical/rosidl-runtime-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros-core, ament-lint-auto, ament-lint-common, performance-test-fixture, rcutils, rosidl-buffer, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-lyrical-rosidl-runtime-c";
-  version = "5.2.0-r3";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_runtime_c/5.2.0-3.tar.gz";
-    name = "5.2.0-3.tar.gz";
-    sha256 = "5614784c2bd2705a2228411df0d3c1dad1a63df785f8d789cb6cc0a1389eb2f4";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_runtime_c/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "5b511fb39a1c08056daf83812cf4ee945b25e16c4bf92cc74c34abfd6ec7a8a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosidl-runtime-cpp/default.nix
+++ b/distros/lyrical/rosidl-runtime-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, performance-test-fixture, rosidl-buffer, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-lyrical-rosidl-runtime-cpp";
-  version = "5.2.0-r3";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_runtime_cpp/5.2.0-3.tar.gz";
-    name = "5.2.0-3.tar.gz";
-    sha256 = "be5c576a72bdc96d7facc874eb95ed7e1bf9e6200af5dbb2dab7b805ee39c0ea";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_runtime_cpp/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "91178034e43941f35a3733a14d3391a1c201d0be173f6b25df12779b340f59e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosidl-typesupport-interface/default.nix
+++ b/distros/lyrical/rosidl-typesupport-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-lyrical-rosidl-typesupport-interface";
-  version = "5.2.0-r3";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_typesupport_interface/5.2.0-3.tar.gz";
-    name = "5.2.0-3.tar.gz";
-    sha256 = "f4b133807d0e925d4ce9cfdfe295cd9909fffe7882af56f658a44b22c5bf1bf3";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_typesupport_interface/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "7e7fb72e65d87f1ce9bcb05c733cfbf567d679573c1f91893f0e11c5cd3d9d44";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosidl-typesupport-introspection-c/default.nix
+++ b/distros/lyrical/rosidl-typesupport-introspection-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros-core, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-buffer, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-lyrical-rosidl-typesupport-introspection-c";
-  version = "5.2.0-r3";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_typesupport_introspection_c/5.2.0-3.tar.gz";
-    name = "5.2.0-3.tar.gz";
-    sha256 = "52336695882d8462479a23d64fb68f0ed03dcc37c0a75e873629612d0efa3701";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_typesupport_introspection_c/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "0c28405ba1cdd280595e39473a1eeb63a3a47bffe9054f487796f39eaf3d7ece";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosidl-typesupport-introspection-cpp/default.nix
+++ b/distros/lyrical/rosidl-typesupport-introspection-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros-core, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-buffer, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidl-typesupport-introspection-c }:
 buildRosPackage {
   pname = "ros-lyrical-rosidl-typesupport-introspection-cpp";
-  version = "5.2.0-r3";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_typesupport_introspection_cpp/5.2.0-3.tar.gz";
-    name = "5.2.0-3.tar.gz";
-    sha256 = "0b64476d4b32a072a60cbcf4e97d83e6f91d2d3bd9c1b948599ba9219163643a";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/lyrical/rosidl_typesupport_introspection_cpp/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "1de63926a0839641d5a4d2ca0b9187864709b5f3365f70a78036343002fb71e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rqt-bag-plugins/default.nix
+++ b/distros/lyrical/rqt-bag-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, builtin-interfaces, geometry-msgs, python3Packages, rclpy, rosbag2, rqt-bag, rqt-gui, rqt-gui-py, rqt-plot, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-rqt-bag-plugins";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/lyrical/rqt_bag_plugins/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "74b9815bea9ca6f302e57b4ff44b287751539ec7874885f4d03d92bd71ea0aa5";
+    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/lyrical/rqt_bag_plugins/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "cd0eab7ff4e6554d285b547aeabdcd950680da4103775a3d4a907f4561f6682e";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/rqt-bag/default.nix
+++ b/distros/lyrical/rqt-bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, builtin-interfaces, python-qt-binding, python3Packages, rclpy, rosbag2-py, rosidl-runtime-py, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-lyrical-rqt-bag";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/lyrical/rqt_bag/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "468b365e3deba5155d120e8bb1616f819756e5e9b735767cc30cc6e580f8e1bf";
+    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/lyrical/rqt_bag/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "395244eaac5ded68d4468d4c362c76105007162f6d4c990be209797b569a4b81";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/rqt-reconfigure/default.nix
+++ b/distros/lyrical/rqt-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-xmllint, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-lyrical-rqt-reconfigure";
-  version = "1.8.4-r3";
+  version = "1.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/lyrical/rqt_reconfigure/1.8.4-3.tar.gz";
-    name = "1.8.4-3.tar.gz";
-    sha256 = "049783afab777463f37c89423686052267c6e38af84bf7bfbd075ce9a77cdff5";
+    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/lyrical/rqt_reconfigure/1.8.5-1.tar.gz";
+    name = "1.8.5-1.tar.gz";
+    sha256 = "0154fbbab906bc1b3af7979fb234727fb4a34312479ac9b922b12b409930ed70";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/rqt-tf-tree/default.nix
+++ b/distros/lyrical/rqt-tf-tree/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-dotgraph, rclpy, rqt-graph, rqt-gui, rqt-gui-py, tf2-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, python-qt-binding, python3Packages, qt-dotgraph, rclpy, rqt-graph, rqt-gui, rqt-gui-py, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-lyrical-rqt-tf-tree";
-  version = "1.0.6-r3";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_tf_tree-release/archive/release/lyrical/rqt_tf_tree/1.0.6-3.tar.gz";
-    name = "1.0.6-3.tar.gz";
-    sha256 = "42c9b8a020b4ece754eda44cf3d48adddd4d78386ebc8396542b3dab62ae7847";
+    url = "https://github.com/ros2-gbp/rqt_tf_tree-release/archive/release/lyrical/rqt_tf_tree/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "859e3ffb9e7fce51baf52b971b4854054a71d072315f698800f2f6ce4bd4786f";
   };
 
   buildType = "ament_python";
-  checkInputs = [ python3Packages.mock python3Packages.pytest ];
+  checkInputs = [ ament-flake8 ament-pep257 python3Packages.mock python3Packages.pytest ];
   propagatedBuildInputs = [ python-qt-binding qt-dotgraph rclpy rqt-graph rqt-gui rqt-gui-py tf2-msgs tf2-ros ];
 
   meta = {

--- a/distros/lyrical/rti-connext-dds-cmake-module/default.nix
+++ b/distros/lyrical/rti-connext-dds-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-lyrical-rti-connext-dds-cmake-module";
-  version = "1.2.7-r1";
+  version = "1.2.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/lyrical/rti_connext_dds_cmake_module/1.2.7-1.tar.gz";
-    name = "1.2.7-1.tar.gz";
-    sha256 = "efc8e10b362dd388c5ede86f242a44b6eb69fba565a0524c7438ef5824409a8b";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/lyrical/rti_connext_dds_cmake_module/1.2.7-2.tar.gz";
+    name = "1.2.7-2.tar.gz";
+    sha256 = "7c058231282089261fdac11c9d7fc4a15fcec556521f1fc9eeaa1a8c76bd320d";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/sound-play-msgs/default.nix
+++ b/distros/lyrical/sound-play-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-lyrical-sound-play-msgs";
+  version = "0.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/audio_common-release/archive/release/lyrical/sound_play_msgs/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "82aaa8395f760c117c1c055812d354b9b3c17697dc228d89ff144fa47a402156";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "Messages for transmitting sound via ROS with sound_play";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/sound-play/default.nix
+++ b/distros/lyrical/sound-play/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, _unresolved_festival, action-msgs, ament-cmake, ament-cmake-python, ament-index-python, boost, gst_all_1, launch-xml, python3Packages, rclpy, sound-play-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-sound-play";
+  version = "0.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/audio_common-release/archive/release/lyrical/sound_play/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "8de0b505fb3bdf45ed13f6fb07fd10e680bbf49dc75e07e76a22b5bdab653765";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python boost python3Packages.setuptools ];
+  propagatedBuildInputs = [ _unresolved_festival action-msgs ament-index-python gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good gst_all_1.gst-plugins-ugly gst_all_1.gstreamer launch-xml python3Packages.pygobject3 rclpy sound-play-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python python3Packages.setuptools ];
+
+  meta = {
+    description = "sound_play provides a ROS node that translates commands on a ROS topic (<tt>robotsound</tt>) into sounds. The node supports built-in sounds, playing OGG/WAV files, and doing speech synthesis via festival. C++ and Python bindings allow this node to be used without understanding the details of the message format, allowing faster development and resilience to message format changes.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/tensor-msgs/default.nix
+++ b/distros/lyrical/tensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-lyrical-tensor-msgs";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/lyrical/tensor_msgs/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "d94e08eb97808693d0d9bb5c684f947cedde3615e22a88f02d73e4446e97b436";
+    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/lyrical/tensor_msgs/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "a552261da8bc5728432ce12ca57c48adfc4bcc8af3486de440108acfa966ba92";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/torch-conversions/default.nix
+++ b/distros/lyrical/torch-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-testing-ament-cmake, libtorch-vendor, rclcpp, rclcpp-components, rcutils, rmw, rosidl-buffer, std-msgs, tensor-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-torch-conversions";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/lyrical/torch_conversions/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "0cfa5c633e187ab8140353c71c9f62b3b0e01cf5d1be6509ce6d32828f058fc3";
+    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/lyrical/torch_conversions/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "748f079ee35fc91c93e38c6b89f9d8ea6e8e22d009f9a5d45aa27d18b7cea70a";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/video-to-image-msg-publisher/default.nix
+++ b/distros/lyrical/video-to-image-msg-publisher/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-lint-auto, ament-lint-common, cv-bridge, opencv, rclcpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-video-to-image-msg-publisher";
+  version = "0.9.5-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/video_to_image_msg_publisher-release/archive/release/lyrical/video_to_image_msg_publisher/0.9.5-2.tar.gz";
+    name = "0.9.5-2.tar.gz";
+    sha256 = "e78aa47a121976e0856dec11121ff2162eb648bb24c8de3ab2471dc298044ab7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge opencv opencv.cxxdev rclcpp sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ];
+
+  meta = {
+    description = "A simple node that publishes sensor_msgs/Image messages from a specified video file";
+    license = with lib.licenses; [ gpl2 ];
+  };
+}

--- a/distros/rolling/agni-tf-tools/default.nix
+++ b/distros/rolling/agni-tf-tools/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, angles, boost, eigen, geometry-msgs, interactive-markers, pluginlib, rclcpp, rviz-common, rviz-default-plugins, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-agni-tf-tools";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/agni_tf_tools-release/archive/release/rolling/agni_tf_tools/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "2124c45dffb325df6aedfe994538283be214655670263fc359e73588bcb88715";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake eigen ];
+  propagatedBuildInputs = [ angles boost geometry-msgs interactive-markers pluginlib rclcpp rviz-common rviz-default-plugins std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "This package provides a gui program as well as a rviz plugin to publish static transforms.
+  Both support the transformation between various Euler angle representations.
+  The rviz plugin also allows to configure the transform with an interactive marker.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/ament-black/default.nix
+++ b/distros/rolling/ament-black/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-black";
-  version = "0.2.6-r2";
+  version = "0.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/rolling/ament_black/0.2.6-2.tar.gz";
-    name = "0.2.6-2.tar.gz";
-    sha256 = "1f2d242b36e0ebb48c653dac7f87534f2934bfe4ea35b2b25577b84b71b9d2e7";
+    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/rolling/ament_black/0.2.7-1.tar.gz";
+    name = "0.2.7-1.tar.gz";
+    sha256 = "822c38e985ec348084b28e7c61581b7b3d08129b761fe13a83a3769c0503aef8";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-cmake-black/default.nix
+++ b/distros/rolling/ament-cmake-black/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-black, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-black";
-  version = "0.2.6-r2";
+  version = "0.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/rolling/ament_cmake_black/0.2.6-2.tar.gz";
-    name = "0.2.6-2.tar.gz";
-    sha256 = "ef0dbd7abdc9525738da2d8ff7d596d118c423f800d89ddc6ff755856c4c3b66";
+    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/rolling/ament_cmake_black/0.2.7-1.tar.gz";
+    name = "0.2.7-1.tar.gz";
+    sha256 = "c3924eac852ec1e76ff1aaeef1837d4356bd8956c7e8fc7de15d42a566d169f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/audio-capture/default.nix
+++ b/distros/rolling/audio-capture/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, audio-common-msgs, boost, diagnostic-updater, gst_all_1, launch-xml, rclcpp, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-rolling-audio-capture";
+  version = "0.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/audio_common-release/archive/release/rolling/audio_capture/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "72e7cd526e55fd220602decc38bbc3ff311a4686e462a0a10b401418e81da354";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake boost ];
+  propagatedBuildInputs = [ audio-common-msgs diagnostic-updater gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good gst_all_1.gst-plugins-ugly gst_all_1.gstreamer launch-xml rclcpp rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Transports audio from a source to a destination. Audio sources can come
+      from a microphone or file. The destination can play the audio or save it
+      to an mp3 file.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/audio-common-msgs/default.nix
+++ b/distros/rolling/audio-common-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-audio-common-msgs";
+  version = "0.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/audio_common-release/archive/release/rolling/audio_common_msgs/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "ef265045b34a5edc96a614677f7f2d6784e32816dd79b9f41afb3d79ec804d8c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "Messages for transmitting audio via ROS";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/audio-common/default.nix
+++ b/distros/rolling/audio-common/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, audio-capture, audio-common-msgs, audio-play, sound-play, sound-play-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-audio-common";
+  version = "0.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/audio_common-release/archive/release/rolling/audio_common/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "77808304fe637e435692e4decf488239153c7c7dab3c8a9ae1bb7d453a4e4211";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ audio-capture audio-common-msgs audio-play sound-play sound-play-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Common code for working with audio in ROS";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/audio-play/default.nix
+++ b/distros/rolling/audio-play/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, audio-common-msgs, boost, gst_all_1, launch-xml, rclcpp, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-rolling-audio-play";
+  version = "0.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/audio_common-release/archive/release/rolling/audio_play/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "a4090e7cc51a75435b08369a3c7e8dc5246c64a0123445d448b3b02d0b9d0ea4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake boost ];
+  propagatedBuildInputs = [ audio-common-msgs gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good gst_all_1.gst-plugins-ugly gst_all_1.gstreamer launch-xml rclcpp rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Outputs audio to a speaker from a source node.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/automatika-embodied-agents/default.nix
+++ b/distros/rolling/automatika-embodied-agents/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, automatika-ros-sugar, builtin-interfaces, python3Packages, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-automatika-embodied-agents";
-  version = "0.7.1-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/automatika_embodied_agents-release/archive/release/rolling/automatika_embodied_agents/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "d8587b735c6a760a03ceba50411a974cba60c960b8b035887e81b6db730df4da";
+    url = "https://github.com/ros2-gbp/automatika_embodied_agents-release/archive/release/rolling/automatika_embodied_agents/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "997327b80801ef6d098ce361cf03e3f5c1e7027faafe8e1645d53f7221d88af1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/automatika-ros-sugar/default.nix
+++ b/distros/rolling/automatika-ros-sugar/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-index-python, ament-lint-auto, builtin-interfaces, geometry-msgs, launch, launch-testing, lifecycle-msgs, nav-msgs, python3Packages, rclcpp, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-automatika-ros-sugar";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/automatika_ros_sugar-release/archive/release/rolling/automatika_ros_sugar/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "a7bcef68130e784f830d1d63087b3936adb81084fffdd4d5ca70c4f5c04f4271";
+    url = "https://github.com/ros2-gbp/automatika_ros_sugar-release/archive/release/rolling/automatika_ros_sugar/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "19a68f3c6ba1d01317f0ed7a7d4433d1c463166f43afdc6f04b19cda52e09f79";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/camera-calibration-parsers/default.nix
+++ b/distros/rolling/camera-calibration-parsers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-camera-calibration-parsers";
-  version = "7.0.1-r1";
+  version = "7.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_calibration_parsers/7.0.1-1.tar.gz";
-    name = "7.0.1-1.tar.gz";
-    sha256 = "59d206091bc2d19e19589098bb6efcbc6e64151d24a2b4e59a61c6c68e572e58";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_calibration_parsers/7.0.2-1.tar.gz";
+    name = "7.0.2-1.tar.gz";
+    sha256 = "df68485c3e99f9262898a5f0814a9cb0e3981eed19a76320deab86eac73b8535";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/camera-info-manager-py/default.nix
+++ b/distros/rolling/camera-info-manager-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, python3Packages, rclpy, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-camera-info-manager-py";
-  version = "7.0.1-r1";
+  version = "7.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_info_manager_py/7.0.1-1.tar.gz";
-    name = "7.0.1-1.tar.gz";
-    sha256 = "767f37a9ca3d642d97ad26b4d3c75dd949522c7a6b2356e507f20b249486c6e5";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_info_manager_py/7.0.2-1.tar.gz";
+    name = "7.0.2-1.tar.gz";
+    sha256 = "27a49840b7faedd42c419849779c6437368d0a72c586c18f8e017483393a81b4";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/camera-info-manager/default.nix
+++ b/distros/rolling/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rclcpp-lifecycle, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-camera-info-manager";
-  version = "7.0.1-r1";
+  version = "7.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_info_manager/7.0.1-1.tar.gz";
-    name = "7.0.1-1.tar.gz";
-    sha256 = "dddcced439d29f1285763c5e00a20f4ef06841f97ef8061e71710bb567cad8d7";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_info_manager/7.0.2-1.tar.gz";
+    name = "7.0.2-1.tar.gz";
+    sha256 = "0a01792fb54705077419e84d1a4b1907d19f6d35b4e4ba23d064c060859c6cfc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/camera-ros/default.nix
+++ b/distros/rolling/camera-ros/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-pep257, ament-cmake-pyflakes, ament-cmake-xmllint, ament-index-python, ament-lint-auto, camera-info-manager, clang, cv-bridge, image-view, libcamera, rclcpp, rclcpp-components, ros2launch, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-pep257, ament-cmake-pyflakes, ament-cmake-xmllint, ament-index-python, ament-lint-auto, camera-info-manager, clang, cv-bridge, diagnostic-msgs, image-view, libcamera, rclcpp, rclcpp-components, ros2launch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-camera-ros";
-  version = "0.6.0-r2";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/camera_ros-release/archive/release/rolling/camera_ros/0.6.0-2.tar.gz";
-    name = "0.6.0-2.tar.gz";
-    sha256 = "dad6c26ff6633823ca64e496f045f6743beb6d83f7e5b97a55054337c81cb409";
+    url = "https://github.com/ros2-gbp/camera_ros-release/archive/release/rolling/camera_ros/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "fae4589af71a054b502e4d71cfbae171ccf7e4bf328402b691a067671bf5f9fe";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-mypy ament-cmake-pep257 ament-cmake-pyflakes ament-cmake-xmllint ament-lint-auto clang ];
-  propagatedBuildInputs = [ ament-index-python camera-info-manager cv-bridge image-view libcamera rclcpp rclcpp-components ros2launch sensor-msgs ];
+  propagatedBuildInputs = [ ament-index-python camera-info-manager cv-bridge diagnostic-msgs image-view libcamera rclcpp rclcpp-components ros2launch sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/crazyflie-examples/default.nix
+++ b/distros/rolling/crazyflie-examples/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, crazyflie-py, geometry-msgs, nav-msgs, python3Packages, rclpy, sensor-msgs, tf-transformations, tf2-ros }:
+buildRosPackage {
+  pname = "ros-rolling-crazyflie-examples";
+  version = "1.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/rolling/crazyflie_examples/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "2653d886af009355358d97fda732ba8500fa253b1ea91010c3dfed9987167484";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-pytest ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
+  propagatedBuildInputs = [ crazyflie-py geometry-msgs nav-msgs rclpy sensor-msgs tf-transformations tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "Examples for the Crazyswarm2 ROS stack";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/crazyflie-interfaces/default.nix
+++ b/distros/rolling/crazyflie-interfaces/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-rolling-crazyflie-interfaces";
+  version = "1.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/rolling/crazyflie_interfaces/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "8d48c5fa4e369f33fa21143384d66a07ac3bad75e6b6ff76a96c7c2e76f9d322";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-cmake-cppcheck ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "Interfaces for Crazyswarm2 package.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/crazyflie-py/default.nix
+++ b/distros/rolling/crazyflie-py/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, crazyflie-interfaces, python3Packages, rclpy }:
+buildRosPackage {
+  pname = "ros-rolling-crazyflie-py";
+  version = "1.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/rolling/crazyflie_py/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "cf334cac549947636766725c57bebca74a4b4869490377e4b5d0a235082ef0bf";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
+  propagatedBuildInputs = [ crazyflie-interfaces rclpy ];
+
+  meta = {
+    description = "Simple Python Interface for Crayzswarm2";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/crazyflie-server-py/default.nix
+++ b/distros/rolling/crazyflie-server-py/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, crazyflie-interfaces, geometry-msgs, motion-capture-tracking-interfaces, nav-msgs, python3Packages, rcl-interfaces, rclpy, sensor-msgs, std-msgs, std-srvs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-rolling-crazyflie-server-py";
+  version = "1.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/rolling/crazyflie_server_py/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "299a38c4c901d6e393ac763b51522b7587016a7acb647b17fde4220a01c59694";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-flake8 ament-pep257 python3Packages.pytest ];
+  propagatedBuildInputs = [ crazyflie-interfaces geometry-msgs motion-capture-tracking-interfaces nav-msgs rcl-interfaces rclpy sensor-msgs std-msgs std-srvs tf2-ros ];
+
+  meta = {
+    description = "Python Crazyflie server node for Crazyswarm2";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/crazyflie-sim/default.nix
+++ b/distros/rolling/crazyflie-sim/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, crazyflie-interfaces, python3Packages, rclpy }:
+buildRosPackage {
+  pname = "ros-rolling-crazyflie-sim";
+  version = "1.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/rolling/crazyflie_sim/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "1158436f813eba7e7b9afa1d7a6526d039ec7ba1d59292d6a9dfb70ff2c92a58";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-pytest ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
+  propagatedBuildInputs = [ crazyflie-interfaces rclpy ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "Simulator for the Crazyswarm2 ROS stack";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/crazyflie/default.nix
+++ b/distros/rolling/crazyflie/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, boost, crazyflie-interfaces, eigen, geometry-msgs, libusb1, motion-capture-tracking-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, std-srvs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-rolling-crazyflie";
+  version = "1.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/rolling/crazyflie/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "72bc776408173513f6b35a613c3e6c2d0598c1bebd18d1fd35b57906d79e2266";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ boost crazyflie-interfaces eigen geometry-msgs libusb1 motion-capture-tracking-interfaces nav-msgs rclcpp ros-environment sensor-msgs std-srvs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "ROS 2 Package for Bitcraze Crazyflie robots";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/cuda-buffer-backend-msgs/default.nix
+++ b/distros/rolling/cuda-buffer-backend-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-cuda-buffer-backend-msgs";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/rolling/cuda_buffer_backend_msgs/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "97748df74b5742055f1129d5b533a352122b2bb74711ab3c550e2a0986f91c70";
+    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/rolling/cuda_buffer_backend_msgs/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "7023a3950252db20eb279b40f881adac4caa8c55108fea1b527b5517da5605b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/cuda-buffer-backend/default.nix
+++ b/distros/rolling/cuda-buffer-backend/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cuda-buffer, cuda-buffer-backend-msgs, launch-ros, launch-testing, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-components, rcutils, rosidl-buffer-backend, rosidl-buffer-backend-registry, rosidl-runtime-cpp, rosidl-typesupport-cpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-cuda-buffer-backend";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/rolling/cuda_buffer_backend/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "f24403e3cc17f52872340c7fd8aace1cc8c6ac8ee740b42229f9a3d5d15a8aa8";
+    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/rolling/cuda_buffer_backend/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "0b2366a309b719c926144e6f9665ab2bcd13851cba97cd8a0aea2df3ece04d99";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/cuda-buffer/default.nix
+++ b/distros/rolling/cuda-buffer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cuda-buffer-backend-msgs, cudaPackages, rcutils, rmw, rosidl-buffer }:
 buildRosPackage {
   pname = "ros-rolling-cuda-buffer";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/rolling/cuda_buffer/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "5e1a4549566804dfa83dbc96c99a17b17eb096b513cf64f5a08c37cefba0682a";
+    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/rolling/cuda_buffer/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "99b3bc96b4b3597036a3341779211df979f5675c20237bf3d32f1619fff14d38";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/eigenpy/default.nix
+++ b/distros/rolling/eigenpy/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
+{ lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, jrl-cmakemodules, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-eigenpy";
-  version = "3.12.0-r2";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/rolling/eigenpy/3.12.0-2.tar.gz";
-    name = "3.12.0-2.tar.gz";
-    sha256 = "19ae0eaa26d83ff85c4e90e08b9e635579ef9d5a98573833183015461c576eb9";
+    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/rolling/eigenpy/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "623c2950b6fc0c8d1438293588a10a6a6d4fcff154e54e51c9b09470c295995c";
   };
 
   buildType = "cmake";
-  buildInputs = [ cmake doxygen git ];
+  buildInputs = [ cmake doxygen git jrl-cmakemodules ];
   propagatedBuildInputs = [ boost eigen python3 python3Packages.numpy python3Packages.scipy ];
   nativeBuildInputs = [ cmake ];
 
   meta = {
     description = "Bindings between Numpy and Eigen using Boost.Python";
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ "BSD-2-Clause" ];
   };
 }

--- a/distros/rolling/generate-parameter-library-py/default.nix
+++ b/distros/rolling/generate-parameter-library-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-generate-parameter-library-py";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library_py/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "f6021533b5675f9bc74419641a248369ab8b23af4bf061d29e96bc91ad348db2";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library_py/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "9acbe3858dbe3c31944f8816b5d13beb87428d1843dc57b415b7e43ce313ed69";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/generate-parameter-library/default.nix
+++ b/distros/rolling/generate-parameter-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, fmt, generate-parameter-library-py, rclcpp, rclcpp-lifecycle, rclpy, rsl, tcb-span, tl-expected-nixpkgs }:
 buildRosPackage {
   pname = "ros-rolling-generate-parameter-library";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "c12d8c0f27c3c48834d58888b9661ef5ebe1556fcd37bfbf13f3ff08229a3ca1";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "d1d18edbb26ebfc2c234f37a7c9a178169e8abb514ddb677f31b664075178647";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -24,6 +24,8 @@ self: super: {
 
  admittance-controller = self.callPackage ./admittance-controller {};
 
+ agni-tf-tools = self.callPackage ./agni-tf-tools {};
+
  ament-acceleration = self.callPackage ./ament-acceleration {};
 
  ament-black = self.callPackage ./ament-black {};
@@ -193,6 +195,14 @@ self: super: {
  async-web-server-cpp = self.callPackage ./async-web-server-cpp {};
 
  at-sonde-ros-driver = self.callPackage ./at-sonde-ros-driver {};
+
+ audio-capture = self.callPackage ./audio-capture {};
+
+ audio-common = self.callPackage ./audio-common {};
+
+ audio-common-msgs = self.callPackage ./audio-common-msgs {};
+
+ audio-play = self.callPackage ./audio-play {};
 
  auto-apms-behavior-tree = self.callPackage ./auto-apms-behavior-tree {};
 
@@ -431,6 +441,18 @@ self: super: {
  cras-msgs = self.callPackage ./cras-msgs {};
 
  cras-topic-tools = self.callPackage ./cras-topic-tools {};
+
+ crazyflie = self.callPackage ./crazyflie {};
+
+ crazyflie-examples = self.callPackage ./crazyflie-examples {};
+
+ crazyflie-interfaces = self.callPackage ./crazyflie-interfaces {};
+
+ crazyflie-py = self.callPackage ./crazyflie-py {};
+
+ crazyflie-server-py = self.callPackage ./crazyflie-server-py {};
+
+ crazyflie-sim = self.callPackage ./crazyflie-sim {};
 
  crocoddyl = self.callPackage ./crocoddyl {};
 
@@ -1294,6 +1316,8 @@ self: super: {
 
  mola-input-rawlog = self.callPackage ./mola-input-rawlog {};
 
+ mola-input-rosbag1 = self.callPackage ./mola-input-rosbag1 {};
+
  mola-input-rosbag2 = self.callPackage ./mola-input-rosbag2 {};
 
  mola-input-video = self.callPackage ./mola-input-video {};
@@ -1450,9 +1474,51 @@ self: super: {
 
  mrpt-apps = self.callPackage ./mrpt-apps {};
 
+ mrpt-apps-cli = self.callPackage ./mrpt-apps-cli {};
+
+ mrpt-apps-gui = self.callPackage ./mrpt-apps-gui {};
+
+ mrpt-bayes = self.callPackage ./mrpt-bayes {};
+
+ mrpt-common = self.callPackage ./mrpt-common {};
+
+ mrpt-comms = self.callPackage ./mrpt-comms {};
+
+ mrpt-config = self.callPackage ./mrpt-config {};
+
+ mrpt-containers = self.callPackage ./mrpt-containers {};
+
+ mrpt-core = self.callPackage ./mrpt-core {};
+
+ mrpt-data = self.callPackage ./mrpt-data {};
+
+ mrpt-examples-cpp = self.callPackage ./mrpt-examples-cpp {};
+
+ mrpt-expr = self.callPackage ./mrpt-expr {};
+
  mrpt-generic-sensor = self.callPackage ./mrpt-generic-sensor {};
 
+ mrpt-graphs = self.callPackage ./mrpt-graphs {};
+
+ mrpt-graphslam = self.callPackage ./mrpt-graphslam {};
+
+ mrpt-gui = self.callPackage ./mrpt-gui {};
+
+ mrpt-hwdrivers = self.callPackage ./mrpt-hwdrivers {};
+
+ mrpt-img = self.callPackage ./mrpt-img {};
+
+ mrpt-imgui = self.callPackage ./mrpt-imgui {};
+
+ mrpt-io = self.callPackage ./mrpt-io {};
+
+ mrpt-kinematics = self.callPackage ./mrpt-kinematics {};
+
  mrpt-libapps = self.callPackage ./mrpt-libapps {};
+
+ mrpt-libapps-cli = self.callPackage ./mrpt-libapps-cli {};
+
+ mrpt-libapps-gui = self.callPackage ./mrpt-libapps-gui {};
 
  mrpt-libbase = self.callPackage ./mrpt-libbase {};
 
@@ -1480,13 +1546,23 @@ self: super: {
 
  mrpt-map-server = self.callPackage ./mrpt-map-server {};
 
+ mrpt-maps = self.callPackage ./mrpt-maps {};
+
+ mrpt-math = self.callPackage ./mrpt-math {};
+
  mrpt-msgs = self.callPackage ./mrpt-msgs {};
 
  mrpt-msgs-bridge = self.callPackage ./mrpt-msgs-bridge {};
 
+ mrpt-nav = self.callPackage ./mrpt-nav {};
+
  mrpt-nav-interfaces = self.callPackage ./mrpt-nav-interfaces {};
 
  mrpt-navigation = self.callPackage ./mrpt-navigation {};
+
+ mrpt-obs = self.callPackage ./mrpt-obs {};
+
+ mrpt-opengl = self.callPackage ./mrpt-opengl {};
 
  mrpt-path-planning = self.callPackage ./mrpt-path-planning {};
 
@@ -1494,7 +1570,13 @@ self: super: {
 
  mrpt-pointcloud-pipeline = self.callPackage ./mrpt-pointcloud-pipeline {};
 
+ mrpt-poses = self.callPackage ./mrpt-poses {};
+
+ mrpt-random = self.callPackage ./mrpt-random {};
+
  mrpt-reactivenav2d = self.callPackage ./mrpt-reactivenav2d {};
+
+ mrpt-rtti = self.callPackage ./mrpt-rtti {};
 
  mrpt-sensor-bumblebee-stereo = self.callPackage ./mrpt-sensor-bumblebee-stereo {};
 
@@ -1508,9 +1590,23 @@ self: super: {
 
  mrpt-sensors = self.callPackage ./mrpt-sensors {};
 
+ mrpt-serialization = self.callPackage ./mrpt-serialization {};
+
+ mrpt-slam = self.callPackage ./mrpt-slam {};
+
+ mrpt-system = self.callPackage ./mrpt-system {};
+
+ mrpt-tfest = self.callPackage ./mrpt-tfest {};
+
+ mrpt-topography = self.callPackage ./mrpt-topography {};
+
  mrpt-tps-astar-planner = self.callPackage ./mrpt-tps-astar-planner {};
 
  mrpt-tutorials = self.callPackage ./mrpt-tutorials {};
+
+ mrpt-typemeta = self.callPackage ./mrpt-typemeta {};
+
+ mrpt-viz = self.callPackage ./mrpt-viz {};
 
  mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
 
@@ -1529,6 +1625,8 @@ self: super: {
  mvsim = self.callPackage ./mvsim {};
 
  nanoeigenpy = self.callPackage ./nanoeigenpy {};
+
+ nanoflann = self.callPackage ./nanoflann {};
 
  nao-button-sim = self.callPackage ./nao-button-sim {};
 
@@ -2276,6 +2374,8 @@ self: super: {
 
  rosbag2rawlog = self.callPackage ./rosbag2rawlog {};
 
+ rosbag-timing-inspector = self.callPackage ./rosbag-timing-inspector {};
+
  rosbridge-library = self.callPackage ./rosbridge-library {};
 
  rosbridge-msgs = self.callPackage ./rosbridge-msgs {};
@@ -2579,6 +2679,10 @@ self: super: {
  sol-vendor = self.callPackage ./sol-vendor {};
 
  sophus = self.callPackage ./sophus {};
+
+ sound-play = self.callPackage ./sound-play {};
+
+ sound-play-msgs = self.callPackage ./sound-play-msgs {};
 
  spacenav = self.callPackage ./spacenav {};
 
@@ -2909,6 +3013,8 @@ self: super: {
  velodyne-msgs = self.callPackage ./velodyne-msgs {};
 
  velodyne-pointcloud = self.callPackage ./velodyne-pointcloud {};
+
+ video-to-image-msg-publisher = self.callPackage ./video-to-image-msg-publisher {};
 
  vision-msgs = self.callPackage ./vision-msgs {};
 

--- a/distros/rolling/geometric-shapes/default.nix
+++ b/distros/rolling/geometric-shapes/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, assimp, boost, console-bridge-vendor, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometry-msgs, octomap, pkg-config, qhull, random-numbers, rclcpp, resource-retriever, rosidl-default-generators, rosidl-default-runtime, shape-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, assimp, boost, console-bridge-vendor, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometry-msgs, pkg-config, qhull, random-numbers, rclcpp, resource-retriever, rosidl-default-generators, rosidl-default-runtime, shape-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-geometric-shapes";
-  version = "2.3.3-r2";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometric_shapes-release/archive/release/rolling/geometric_shapes/2.3.3-2.tar.gz";
-    name = "2.3.3-2.tar.gz";
-    sha256 = "b599fa94fb261435dc85b6d7bbd5c9025021eb062612a39c3e4c8cf1d124f960";
+    url = "https://github.com/ros2-gbp/geometric_shapes-release/archive/release/rolling/geometric_shapes/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "683fef7ae2d500bad44be3526c6f73c2465af7a4ad2928bb41521b8bc8bd7695";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake pkg-config rosidl-default-generators ];
   checkInputs = [ ament-cmake-copyright ament-cmake-gtest ament-lint-auto ament-lint-cmake ];
-  propagatedBuildInputs = [ assimp boost console-bridge-vendor eigen eigen-stl-containers eigen3-cmake-module fcl geometry-msgs octomap qhull random-numbers rclcpp resource-retriever rosidl-default-runtime shape-msgs visualization-msgs ];
+  propagatedBuildInputs = [ assimp boost console-bridge-vendor eigen eigen-stl-containers eigen3-cmake-module fcl geometry-msgs qhull random-numbers rclcpp resource-retriever rosidl-default-runtime shape-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module rosidl-default-generators ];
 
   meta = {

--- a/distros/rolling/gz-cmake-vendor/default.nix
+++ b/distros/rolling/gz-cmake-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, pkg-config }:
 buildRosPackage {
   pname = "ros-rolling-gz-cmake-vendor";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_cmake_vendor-release/archive/release/rolling/gz_cmake_vendor/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "188b7470d787f38680881409d5ffdc9fbc8a7db653821891975f1b26feaea850";
+    url = "https://github.com/ros2-gbp/gz_cmake_vendor-release/archive/release/rolling/gz_cmake_vendor/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "24667ba5133d40a681e548fbb0a76e6161696c390ffa1cc6d1a50000df542008";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake pkg-config ];
 
   meta = {
-    description = "Vendor package for: gz-cmake 5.1.0
+    description = "Vendor package for: gz-cmake 5.1.1
 
     Gazebo CMake : CMake Modules for Gazebo Projects";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-cmake-vendor/vendored-source.json
+++ b/distros/rolling/gz-cmake-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_cmake_vendor": {
     "url": "https://github.com/gazebosim/gz-cmake.git",
-    "rev": "gz-cmake5_5.1.0",
-    "hash": "sha256-o7JI3K1VuM1MKG0Wq0QUtyRI8cfBnHsW2mFuoapEQW8="
+    "rev": "gz-cmake5_5.1.1",
+    "hash": "sha256-bp3qaLuE/0sf6u4ZVOGsuJVkuEm2IS0zB0vHMVE0g/g="
   }
 }

--- a/distros/rolling/gz-physics-vendor/default.nix
+++ b/distros/rolling/gz-physics-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, bullet, cmake, eigen, gbenchmark, gz-cmake-vendor, gz-common-vendor, gz-dartsim-vendor, gz-math-vendor, gz-plugin-vendor, gz-utils-vendor, sdformat-vendor }:
 buildRosPackage {
   pname = "ros-rolling-gz-physics-vendor";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_physics_vendor-release/archive/release/rolling/gz_physics_vendor/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "d6440c5cc6b399d37c474021234ae10172206649019c4058ed08023edffa509c";
+    url = "https://github.com/ros2-gbp/gz_physics_vendor-release/archive/release/rolling/gz_physics_vendor/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "120c8eb009bbed0987740a94368dce1f37647281ed1373bfc505536eae362cd3";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-physics 9.1.0
+    description = "Vendor package for: gz-physics 9.3.0
 
     Gazebo Physics : Physics classes and functions for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-physics-vendor/vendored-source.json
+++ b/distros/rolling/gz-physics-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_physics_vendor": {
     "url": "https://github.com/gazebosim/gz-physics.git",
-    "rev": "gz-physics9_9.1.0",
-    "hash": "sha256-9JM/vtDOOfwpmc4cu1XEE0FSgaYBaLAD7dCvqI7MuMY="
+    "rev": "gz-physics9_9.3.0",
+    "hash": "sha256-HUydNVfOX/nWi0a29CcFlM2dCt9hqfsafJR61WkBPIw="
   }
 }

--- a/distros/rolling/image-common/default.nix
+++ b/distros/rolling/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-rolling-image-common";
-  version = "7.0.1-r1";
+  version = "7.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_common/7.0.1-1.tar.gz";
-    name = "7.0.1-1.tar.gz";
-    sha256 = "f3c914df899ec04d1a7ba2c1c49219ebbc1c1271c86c863e0beeedbaa4fa9f42";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_common/7.0.2-1.tar.gz";
+    name = "7.0.2-1.tar.gz";
+    sha256 = "3acdf89f64176605cd9cd34fde346741371d2269a91c96829bfe8dc23cf8a0c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-transport-py/default.nix
+++ b/distros/rolling/image-transport-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, image-transport, python3, python3Packages, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-image-transport-py";
-  version = "7.0.1-r1";
+  version = "7.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_transport_py/7.0.1-1.tar.gz";
-    name = "7.0.1-1.tar.gz";
-    sha256 = "abe36b357eb67473ddebba05b98740ac65b819406f25986fcf64eb7df60c6af7";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_transport_py/7.0.2-1.tar.gz";
+    name = "7.0.2-1.tar.gz";
+    sha256 = "910f5449c2fae68d243934f259ee4a2318f1dc4bbae71457bd753c1af6b744d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-transport/default.nix
+++ b/distros/rolling/image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-rolling-image-transport";
-  version = "7.0.1-r1";
+  version = "7.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_transport/7.0.1-1.tar.gz";
-    name = "7.0.1-1.tar.gz";
-    sha256 = "4c027f49db68bd2c0e3879f08388769230edf68a71adb05edc7e496acfd71f1c";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_transport/7.0.2-1.tar.gz";
+    name = "7.0.2-1.tar.gz";
+    sha256 = "41d2d2f07d8d88a9e454dd6b359d1a6016a97c616a97c146cd2640380eb8700e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/kompass-interfaces/default.nix
+++ b/distros/rolling/kompass-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-kompass-interfaces";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kompass-release/archive/release/rolling/kompass_interfaces/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "93aba809ad808b56ca61d4839dc89f9c586b5bbb1199a57a56da3cb4b5af411c";
+    url = "https://github.com/ros2-gbp/kompass-release/archive/release/rolling/kompass_interfaces/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "1746b6bb87887f7bca831b49aa5a524f19515c81134af922c109873784e1e12c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/kompass/default.nix
+++ b/distros/rolling/kompass/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, automatika-ros-sugar, kompass-interfaces, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-kompass";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kompass-release/archive/release/rolling/kompass/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "027fe8760b226104c8bec645d73ec56db4a939358f68fdb07e3c0b870db24beb";
+    url = "https://github.com/ros2-gbp/kompass-release/archive/release/rolling/kompass/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "b5d5b200fdc22b2e2f986fd9c7d3133d3df8532e5e31f825995654dcfa601687";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/libtorch-vendor/default.nix
+++ b/distros/rolling/libtorch-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-libtorch-vendor";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/rolling/libtorch_vendor/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "ccc56928fed6cfa585d70a2417a5003f364e757e23d5be75e99384a3053de637";
+    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/rolling/libtorch_vendor/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "368ba3d17d28dbf55fe11ddc5dc696a3b13a5b62fbe6998d6543005e18eddb5a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mavlink/default.nix
+++ b/distros/rolling/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mavlink";
-  version = "2026.3.3-r2";
+  version = "2026.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/rolling/mavlink/2026.3.3-2.tar.gz";
-    name = "2026.3.3-2.tar.gz";
-    sha256 = "20a3d9936b2c52f492aa1994f8f40f5e4d0348361cbdc66a695e24d66ad3440b";
+    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/rolling/mavlink/2026.6.6-1.tar.gz";
+    name = "2026.6.6-1.tar.gz";
+    sha256 = "bb11acb0ae6904df269949515f6f13b5a5b4798e4276673a0aedaeba62715c45";
   };
 
   buildType = "cmake";

--- a/distros/rolling/microstrain-inertial-description/default.nix
+++ b/distros/rolling/microstrain-inertial-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, xacro }:
 buildRosPackage {
   pname = "ros-rolling-microstrain-inertial-description";
-  version = "4.8.0-r2";
+  version = "4.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_description/4.8.0-2.tar.gz";
-    name = "4.8.0-2.tar.gz";
-    sha256 = "cf07e2a00920d44eb9d605b3dff4d6aa971bdfe1f5a6d1a57827eb03099e8656";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_description/4.9.0-1.tar.gz";
+    name = "4.9.0-1.tar.gz";
+    sha256 = "1bc683fd5c51474fe924926962fb625650b9053d3a82b38413607b4de99fa73e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/microstrain-inertial-driver/default.nix
+++ b/distros/rolling/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-target-dependencies, ament-cpplint, diagnostic-aggregator, diagnostic-updater, eigen, geographiclib, geometry-msgs, git, lifecycle-msgs, microstrain-inertial-msgs, nav-msgs, nmea-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, rtcm-msgs, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-microstrain-inertial-driver";
-  version = "4.8.0-r2";
+  version = "4.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_driver/4.8.0-2.tar.gz";
-    name = "4.8.0-2.tar.gz";
-    sha256 = "fe5228480786370d742c13c6c17dfad7f1e717a9de8a6ea17095806778a56e24";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_driver/4.9.0-1.tar.gz";
+    name = "4.9.0-1.tar.gz";
+    sha256 = "6c26af4be760ae597a0128c612699170378ba9d855751f21bd3337c2333ad7e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/microstrain-inertial-examples/default.nix
+++ b/distros/rolling/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-driver, rviz-imu-plugin, rviz2, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-microstrain-inertial-examples";
-  version = "4.8.0-r2";
+  version = "4.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_examples/4.8.0-2.tar.gz";
-    name = "4.8.0-2.tar.gz";
-    sha256 = "459b13003e246b9d4cd893f1bc8b1b8b52213aa7bf2078af066a47b05fc9aa87";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_examples/4.9.0-1.tar.gz";
+    name = "4.9.0-1.tar.gz";
+    sha256 = "0cff7f2c83f0e925f65cb63108842efc656b94835522979506e23a1d021210a8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/microstrain-inertial-msgs/default.nix
+++ b/distros/rolling/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-microstrain-inertial-msgs";
-  version = "4.8.0-r2";
+  version = "4.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_msgs/4.8.0-2.tar.gz";
-    name = "4.8.0-2.tar.gz";
-    sha256 = "7dfd62fe9702b712b5015b854e34e81f69477f3db2f757f8c5f325c6ae56650f";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_msgs/4.9.0-1.tar.gz";
+    name = "4.9.0-1.tar.gz";
+    sha256 = "d246b2f4188f82800bbc21cea48710f76d0c13e2de63c4ef8a162237dfab9928";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/microstrain-inertial-rqt/default.nix
+++ b/distros/rolling/microstrain-inertial-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, microstrain-inertial-msgs, nav-msgs, rclpy, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-microstrain-inertial-rqt";
-  version = "4.8.0-r2";
+  version = "4.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_rqt/4.8.0-2.tar.gz";
-    name = "4.8.0-2.tar.gz";
-    sha256 = "b574291d88eb7a4caf23ebfcfa3d4ff608b5ed068b39fb1f68b7ccce315a3ee2";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_rqt/4.9.0-1.tar.gz";
+    name = "4.9.0-1.tar.gz";
+    sha256 = "4ea1e88de4490ccdf6fbc7ab7ca375faf0951725736de243bc14e940ee0d7bec";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/mola-input-rosbag1/default.nix
+++ b/distros/rolling/mola-input-rosbag1/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, bzip2, cmake, geometry-msgs, lz4, mola-common, mola-kernel, mrpt-libmaps, mrpt-libobs, opencv, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-rolling-mola-input-rosbag1";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_input_rosbag1-release/archive/release/rolling/mola_input_rosbag1/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "c4f03212ba22c9b8360a246b327c76c8509e11bde550b5ebadc1ab3046341ff5";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ boost bzip2 geometry-msgs lz4 mola-common mola-kernel mrpt-libmaps mrpt-libobs opencv opencv.cxxdev tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "MOLA DataSource from ROS1 bag files that does not need a ROS1 installation";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/rolling/mrpt-apps-cli/default.nix
+++ b/distros/rolling/mrpt-apps-cli/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, mrpt-libapps-cli }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-apps-cli";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_apps_cli/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "1a8c814673e11bec28f6f885cbaa021d6adcff3c345def501c45af68d14df5b1";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mrpt-common mrpt-libapps-cli ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "MRPT command line applications";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-apps-gui/default.nix
+++ b/distros/rolling/mrpt-apps-gui/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, mrpt-common, mrpt-graphslam, mrpt-kinematics, mrpt-libapps-gui, mrpt-nav }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-apps-gui";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_apps_gui/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "e2b8e1c4c6a56cfb91df94d35eae4c2ac40dce192e09fb07156d4c79e6bd5964";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen ];
+  propagatedBuildInputs = [ mrpt-common mrpt-graphslam mrpt-kinematics mrpt-libapps-gui mrpt-nav ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "MRPT graphical user interface applications";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-bayes/default.nix
+++ b/distros/rolling/mrpt-bayes/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, mrpt-common, mrpt-config, mrpt-math, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-bayes";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_bayes/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "8bdd3311a2caae422251071e1283a3c60dc30fabd02893d6aa28f3ee3f4a5e44";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-common mrpt-config mrpt-math ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_bayes";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-common/default.nix
+++ b/distros/rolling/mrpt-common/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, gtest }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-common";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_common/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "f29805ba7cd5c79da153f334d2ef300d3a43969ef26bcf8b980577ea016b813d";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  checkInputs = [ gtest ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Common CMake scripts to all MRPT modules";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-comms/default.nix
+++ b/distros/rolling/mrpt-comms/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, mrpt-io, mrpt-poses, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-comms";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_comms/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "fab7adbc10c48341ae21e55a086b2e84dbd30f0989e3ae6607a0c3394bd0d323";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake python3 python3Packages.pybind11 ];
+  checkInputs = [ mrpt-poses ];
+  propagatedBuildInputs = [ mrpt-common mrpt-io ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_comms";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-config/default.nix
+++ b/distros/rolling/mrpt-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, mrpt-expr, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-config";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_config/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "597d19e286dc36e41c51af1b7ba035c2a51ed0c2bc580369c67c83d70e6b92ec";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-common mrpt-expr ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_config";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-containers/default.nix
+++ b/distros/rolling/mrpt-containers/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, mrpt-core, mrpt-typemeta, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-containers";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_containers/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "5a3ebb0efa6c2643c11cd965c4f267f712699080e653f722438a7b223e415ede";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-common mrpt-core mrpt-typemeta ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_containers";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-core/default.nix
+++ b/distros/rolling/mrpt-core/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-core";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_core/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "8ae9ddc9666f8dcb13a1a8a93ce1748a3d2796df67bc6ed680ca78d3940b0c56";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-common ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_core";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-data/default.nix
+++ b/distros/rolling/mrpt-data/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-data";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_data/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "802f2b7981f08af7b580af2b321bc79be754801fa3fecfee133bbdc9c676ac0e";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "MRPT shared data files: test datasets and example config files";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-examples-cpp/default.nix
+++ b/distros/rolling/mrpt-examples-cpp/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, glfw3, mrpt-common, mrpt-data, mrpt-graphslam, mrpt-gui, mrpt-imgui, mrpt-libapps-cli, mrpt-libapps-gui, mrpt-nav }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-examples-cpp";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_examples_cpp/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "1f8edfe6ded202b3ff4ac4333761e6d146f604332fec8b120389e21ccdb50fdb";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake glfw3 ];
+  propagatedBuildInputs = [ mrpt-common mrpt-data mrpt-graphslam mrpt-gui mrpt-imgui mrpt-libapps-cli mrpt-libapps-gui mrpt-nav ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "C++ examples demonstrating MRPT functionality";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-expr/default.nix
+++ b/distros/rolling/mrpt-expr/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, mrpt-system, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-expr";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_expr/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "71a635fce48fdda9a5d341c5ce4ee6ec77854f2b390184e580f2d8be0115a1c5";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-common mrpt-system ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_expr";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-graphs/default.nix
+++ b/distros/rolling/mrpt-graphs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, mrpt-common, mrpt-io, mrpt-poses, mrpt-viz, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-graphs";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_graphs/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "eba674ca7be88f8495a44baf02b7965b097863f43756776035ab6224eb1df4a1";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen python3 python3Packages.pybind11 ];
+  checkInputs = [ python3Packages.numpy ];
+  propagatedBuildInputs = [ mrpt-common mrpt-io mrpt-poses mrpt-viz ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_graphs";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-graphslam/default.nix
+++ b/distros/rolling/mrpt-graphslam/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, mrpt-gui, mrpt-slam }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-graphslam";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_graphslam/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "cc44bd482ede1e7606c8ab598e36fe3712dc3407b586d356a54ebdb30e1e7dcd";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen ];
+  propagatedBuildInputs = [ mrpt-gui mrpt-slam ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_graphslam";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-gui/default.nix
+++ b/distros/rolling/mrpt-gui/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, glfw3, libGL, libGLU, libxrandr, libxxf86vm, mrpt-opengl, python3, python3Packages, qt5, wxGTK32 }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-gui";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_gui/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "767d1a79878925c4e8cc31e690888feb241b3434208477729c29c9ed81bef0c9";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake libGL libGLU libxrandr libxxf86vm python3 python3Packages.pybind11 qt5.qtbase wxGTK32 ];
+  propagatedBuildInputs = [ eigen glfw3 mrpt-opengl ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_gui";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-hwdrivers/default.nix
+++ b/distros/rolling/mrpt-hwdrivers/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-comms, mrpt-maps, mrpt-viz }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-hwdrivers";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_hwdrivers/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "acf28b5bef5d3fbe7a8a3143808862522a1de65bfefe0b9aca73327f5d0987f9";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mrpt-comms mrpt-maps mrpt-viz ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_hwdrivers";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-img/default.nix
+++ b/distros/rolling/mrpt-img/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, glfw3, mrpt-common, mrpt-config, mrpt-io, mrpt-math, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-img";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_img/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "9cc4bda5aac46bfb9e9582173d1d2229cf4d36f4ca32ebb198785d3f8e4de3f2";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen glfw3 python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-common mrpt-config mrpt-io mrpt-math ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_img";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-imgui/default.nix
+++ b/distros/rolling/mrpt-imgui/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-opengl }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-imgui";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_imgui/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "a528ab5985ada9c0c2a51bbd18e3f56ec31dd8b82860b237c6981c98500d6c26";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mrpt-opengl ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_imgui, wrapping rendering objects as a Dear ImGUI component";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-io/default.nix
+++ b/distros/rolling/mrpt-io/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, mrpt-system, python3, python3Packages, zstd }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-io";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_io/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "2195e2d40e5d7df3edce7b79dfb0a9c0dbedd79b315f63bf6cb508d6371f1bd4";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake python3 python3Packages.pybind11 zstd ];
+  propagatedBuildInputs = [ mrpt-common mrpt-system ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_io";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-kinematics/default.nix
+++ b/distros/rolling/mrpt-kinematics/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, mrpt-viz, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-kinematics";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_kinematics/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "56bbc1cdb0138f2228ad9ccc93b297d67733b85f60ac7d53ddcaf38fe890100a";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake python3 python3Packages.pybind11 ];
+  checkInputs = [ python3Packages.numpy ];
+  propagatedBuildInputs = [ mrpt-common mrpt-viz ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_kinematics";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-libapps-cli/default.nix
+++ b/distros/rolling/mrpt-libapps-cli/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cli11, cmake, mrpt-hwdrivers, mrpt-slam, mrpt-topography }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-libapps-cli";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_libapps_cli/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "adda60cd72970638e4d20f3aef8888e50feb1ce2c4bb701a64af1ccb3ab9e3cb";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ cli11 mrpt-hwdrivers mrpt-slam mrpt-topography ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_libapps_cli";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-libapps-gui/default.nix
+++ b/distros/rolling/mrpt-libapps-gui/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, mrpt-gui, mrpt-libapps-cli, wxGTK32 }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-libapps-gui";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_libapps_gui/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "4758c0d3734a9ed07b6264c1d9d46fd5580e8562253bf012b4ad81b2cfc9b0bf";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen wxGTK32 ];
+  propagatedBuildInputs = [ mrpt-gui mrpt-libapps-cli ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_libapps_gui";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-maps/default.nix
+++ b/distros/rolling/mrpt-maps/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, mrpt-graphs, mrpt-obs, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-maps";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_maps/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "9773fc0829c8071470e9182f1c35bc190aba6ec4b35a7bc56dbfd71fde7e72e5";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-graphs mrpt-obs ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_maps";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-math/default.nix
+++ b/distros/rolling/mrpt-math/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, mrpt-common, mrpt-io, mrpt-random, mrpt-serialization, mrpt-system, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-math";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_math/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "6040594796e8df779a2271e409ab417c0c1ddefc82ccf2f76aa993ce53eab2ee";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen python3 python3Packages.pybind11 ];
+  checkInputs = [ mrpt-io ];
+  propagatedBuildInputs = [ mrpt-common mrpt-random mrpt-serialization mrpt-system ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_math";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-nav/default.nix
+++ b/distros/rolling/mrpt-nav/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, mrpt-kinematics, mrpt-maps, mrpt-viz }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-nav";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_nav/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "116959c918a0b0cb97277400c0a54b563a92b49ec2034399dfed48f4996e567b";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen ];
+  propagatedBuildInputs = [ mrpt-kinematics mrpt-maps mrpt-viz ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_nav";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-obs/default.nix
+++ b/distros/rolling/mrpt-obs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, mrpt-common, mrpt-tfest, mrpt-viz, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-obs";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_obs/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "62e9dd3d41841c9018063415d6e2843bc6a23b91770c02317ef56d61615dba1a";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-common mrpt-tfest mrpt-viz ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_obs";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-opengl/default.nix
+++ b/distros/rolling/mrpt-opengl/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, libGL, libGLU, mrpt-img, mrpt-poses, mrpt-viz }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-opengl";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_opengl/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "9ac53c976dac270d72eb9f1495dcaa65349f12c41ae80729fcff7e3705de25fb";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen libGL libGLU ];
+  propagatedBuildInputs = [ mrpt-img mrpt-poses mrpt-viz ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_opengl";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-poses/default.nix
+++ b/distros/rolling/mrpt-poses/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, mrpt-bayes, mrpt-common, mrpt-io, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-poses";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_poses/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "584919c5d084ea8fd19673e696ae48695665c61f44a0c1fd3c6afa37067ea651";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen python3 python3Packages.pybind11 ];
+  checkInputs = [ mrpt-io ];
+  propagatedBuildInputs = [ mrpt-bayes mrpt-common ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_poses";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-random/default.nix
+++ b/distros/rolling/mrpt-random/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-random";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_random/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "750dda9e58dd4a7c011b632a0e39f4607545e30252e16b10b3da68499147907c";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-common ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_random";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-rtti/default.nix
+++ b/distros/rolling/mrpt-rtti/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, mrpt-core, mrpt-typemeta, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-rtti";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_rtti/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "52bd1f54d5c5f4d4878eb2659a399f37685d41a69f98011fb746a3be2ca7722c";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-common mrpt-core mrpt-typemeta ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_rtti";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-serialization/default.nix
+++ b/distros/rolling/mrpt-serialization/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, mrpt-rtti, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-serialization";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_serialization/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "c4360e69e9cd140d9245bc3055ed6514c014714a64c0a0fce80f3e8d2eedbe7c";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-common mrpt-rtti ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_serialization";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-slam/default.nix
+++ b/distros/rolling/mrpt-slam/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, mrpt-maps, mrpt-topography, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-slam";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_slam/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "e8e7b6911e56369f546f5135aa7d3152474b2c237fab6550922fd8f1b990ea45";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen python3 python3Packages.pybind11 ];
+  checkInputs = [ python3Packages.numpy ];
+  propagatedBuildInputs = [ mrpt-maps mrpt-topography ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_slam";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-system/default.nix
+++ b/distros/rolling/mrpt-system/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, mrpt-containers, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-system";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_system/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "60d5879d8640da6cca660bc492840ada827c85a84e5ef227a9d00cbbb252bd9a";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-common mrpt-containers ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_system";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-tfest/default.nix
+++ b/distros/rolling/mrpt-tfest/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, mrpt-common, mrpt-poses, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-tfest";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_tfest/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "5eef416130c0992f45202fba02cb2f58bb5791c5ee7038decf1a68101e832bb6";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake eigen python3 python3Packages.pybind11 ];
+  checkInputs = [ python3Packages.numpy ];
+  propagatedBuildInputs = [ mrpt-common mrpt-poses ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_tfest";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-topography/default.nix
+++ b/distros/rolling/mrpt-topography/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common, mrpt-math, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-topography";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_topography/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "76b772f86c04b0f0a5d07bc515d909c15bd51d7f7b8432138a7c3a969ead87db";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake python3 python3Packages.pybind11 ];
+  checkInputs = [ python3Packages.numpy ];
+  propagatedBuildInputs = [ mrpt-common mrpt-math ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_topography";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-typemeta/default.nix
+++ b/distros/rolling/mrpt-typemeta/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt-common }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-typemeta";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_typemeta/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "a9a37a1a7a963e82997fc065898583a29d4debffeea6ff0503a0acd2e440ee8e";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mrpt-common ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_typemeta";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-viz/default.nix
+++ b/distros/rolling/mrpt-viz/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, cmake, eigen, mrpt-common, mrpt-img, mrpt-poses, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-viz";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt3-release/archive/release/rolling/mrpt_viz/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "24006c10813ebc8dd88069f57559f80f3a0e18693100862146021fe9b8557de6";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ assimp cmake eigen python3 python3Packages.pybind11 ];
+  propagatedBuildInputs = [ mrpt-common mrpt-img mrpt-poses ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "The MRPT C++ library mrpt_viz";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/nanoflann/default.nix
+++ b/distros/rolling/nanoflann/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, gtest }:
+buildRosPackage {
+  pname = "ros-rolling-nanoflann";
+  version = "1.10.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/nanoflann-release/archive/release/rolling/nanoflann/1.10.1-1.tar.gz";
+    name = "1.10.1-1.tar.gz";
+    sha256 = "9311df8936f840c26e49932fc75973dc2ad6206dc4cc319d270092cb4946310c";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  checkInputs = [ gtest ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "nanoflann: a C++11 header-only library for Nearest Neighbor (NN) search
+    with KD-trees, optimized for point clouds and Eigen matrices.";
+    license = with lib.licenses; [ "BSD-2-Clause" ];
+  };
+}

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -434,6 +434,13 @@ in {
     buildInputs = buildInputs ++ [ self.zlib ];
   });
 
+  mrpt-opengl = rosSuper.mrpt-opengl.overrideAttrs ({
+    propagatedBuildInputs ? [], ...
+  }: {
+    # TODO: Remove after https://github.com/MRPT/mrpt/pull/1368 is merged and released
+    propagatedBuildInputs = propagatedBuildInputs ++ [ self.libGL ];
+  });
+
   mrpt-viz = rosSuper.mrpt-viz.overrideAttrs ({
     buildInputs ? [], nativeBuildInputs ? [], ...
   }: {

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -412,6 +412,13 @@ in {
     buildInputs = buildInputs ++ [ self.libfyaml ];
   });
 
+  mrpt-io = rosSuper.mrpt-io.overrideAttrs ({
+    buildInputs ? [], ...
+  }: {
+    # Don't use built-in zlib
+    buildInputs = buildInputs ++ [ self.zlib ];
+  });
+
   mrt-cmake-modules = rosSuper.mrt-cmake-modules.overrideAttrs ({
     patches ? [], ...
   }: {

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -404,6 +404,14 @@ in {
     '';
   });
 
+  mrpt-containers = rosSuper.mrpt-containers.overrideAttrs ({
+    buildInputs ? [], nativeBuildInputs ? [], ...
+  }: {
+    # Don't use vendored libfyaml
+    nativeBuildInputs = nativeBuildInputs ++ [ self.pkg-config ];
+    buildInputs = buildInputs ++ [ self.libfyaml ];
+  });
+
   mrt-cmake-modules = rosSuper.mrt-cmake-modules.overrideAttrs ({
     patches ? [], ...
   }: {

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -419,6 +419,14 @@ in {
     buildInputs = buildInputs ++ [ self.zlib ];
   });
 
+  mrpt-viz = rosSuper.mrpt-viz.overrideAttrs ({
+    buildInputs ? [], nativeBuildInputs ? [], ...
+  }: {
+    # Don't use vendored assimp
+    nativeBuildInputs = nativeBuildInputs ++ [ self.pkg-config ];
+    buildInputs = buildInputs ++ [ self.assimp ];
+  });
+
   mrt-cmake-modules = rosSuper.mrt-cmake-modules.overrideAttrs ({
     patches ? [], ...
   }: {

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -412,6 +412,13 @@ in {
     buildInputs = buildInputs ++ [ self.libfyaml ];
   });
 
+  mrpt-maps = rosSuper.mrpt-maps.overrideAttrs ({
+    buildInputs ? [], ...
+  }: {
+    # Don't use vendored octomap
+    buildInputs = buildInputs ++ [ self.octomap ];
+  });
+
   mrpt-io = rosSuper.mrpt-io.overrideAttrs ({
     buildInputs ? [], ...
   }: {

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -109,17 +109,6 @@ in {
 
   gazebo = self.gazebo_11;
 
-  geometric-shapes = rosSuper.geometric-shapes.overrideAttrs({
-      postPatch ? "", ...
-  }: {
-      # Remove workaround for Ubuntu-specific dependency hell issue
-      postPatch = postPatch + ''
-        substituteInPlace CMakeLists.txt --replace-fail \
-          'find_package(octomap 1.9.7...<1.10.0 REQUIRED)' \
-          'find_package(octomap REQUIRED)'
-      '';
-  });
-
   google-benchmark-vendor = lib.patchExternalProjectGit rosSuper.google-benchmark-vendor {
     url = "https://github.com/google/benchmark.git";
     rev = "344117638c8ff7e239044fd0fa7085839fc03021";

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -610,6 +610,19 @@ in {
     ];
   });
 
+  rviz-imu-plugin = rosSuper.rviz-imu-plugin.overrideAttrs ({
+    patches ? [], ...
+  }: {
+    patches = patches ++ [
+      # https://github.com/CCNYRoboticsLab/imu_tools/pull/233
+      (self.fetchpatch2 {
+        url = "https://github.com/CCNYRoboticsLab/imu_tools/commit/af3bf747b23abf23e034e6a0395eabd871f89448.patch?full_index=1";
+        hash = "sha256-9GaDJ0SDjCEd1Mh24Zr7iZldC8JEp4P/ybchyAFbRf4=";
+        stripLen = 1;
+      })
+    ];
+  });
+
   rviz-ogre-vendor = lib.patchAmentVendorGit rosSuper.rviz-ogre-vendor {
     tarSourceArgs.hook = let
       version = "1.79";

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -412,6 +412,14 @@ in {
     buildInputs = buildInputs ++ [ self.libfyaml ];
   });
 
+  mrpt-gui = rosSuper.mrpt-gui.overrideAttrs ({
+    buildInputs ? [], nativeBuildInputs ? [], ...
+  }: {
+    # Add dependencies for vendored nanogui
+    nativeBuildInputs = nativeBuildInputs ++ [ self.pkg-config ];
+    buildInputs = buildInputs ++ [ self.wayland-scanner ];
+  });
+
   mrpt-maps = rosSuper.mrpt-maps.overrideAttrs ({
     buildInputs ? [], ...
   }: {

--- a/distros/rolling/rmw-connextdds-common/default.nix
+++ b/distros/rolling/rmw-connextdds-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, fastcdr, rcpputils, rcutils, rmw, rmw-dds-common, rmw-security-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, rti-connext-dds-cmake-module, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-connextdds-common";
-  version = "1.3.0-r1";
+  version = "1.3.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds_common/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "8d07720911528a62bd484c3af2f494e49cb53488522fb678ae264650dd392adc";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds_common/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "41896eb32f71ae40972dfc034ee2747de36d90d4d1a871b2574a73dc39339928";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-connextdds/default.nix
+++ b/distros/rolling/rmw-connextdds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rmw-connextdds-common }:
 buildRosPackage {
   pname = "ros-rolling-rmw-connextdds";
-  version = "1.3.0-r1";
+  version = "1.3.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "781cfe9736c9b5f9b9521817c9566b7d802443d35df2b59a45ef51e5d9967153";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "f1cf13778bf6536ddd9400aee2c73da13cee7f77faec703a1d60215e646a3a53";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-bridge/default.nix
+++ b/distros/rolling/ros-gz-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actuator-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, gps-msgs, gz-msgs-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, marine-acoustic-msgs, nav-msgs, pkg-config, rclcpp, rclcpp-components, ros-gz-interfaces, rosgraph-msgs, rosidl-pycommon, sensor-msgs, std-msgs, tf2-msgs, trajectory-msgs, vision-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-bridge";
-  version = "3.0.8-r2";
+  version = "4.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_bridge/3.0.8-2.tar.gz";
-    name = "3.0.8-2.tar.gz";
-    sha256 = "992761cb96320a1c6ff9c3289472f3b75c4900101cfa7650316bd2897a7d061a";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_bridge/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "c21dc1afb125251434fdc4d00bdc8023dfc9ca655c4f1abb5f75fba90b831cc5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-image/default.nix
+++ b/distros/rolling/ros-gz-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-msgs-vendor, gz-transport-vendor, image-transport, pkg-config, rclcpp, ros-gz-bridge, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-image";
-  version = "3.0.8-r2";
+  version = "4.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_image/3.0.8-2.tar.gz";
-    name = "3.0.8-2.tar.gz";
-    sha256 = "0599209b5083eaf2fb87c6a2e750d697240e79f69f58db28f7db46e68e4da32f";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_image/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "78d8c94ea530d77a3a8409dd8f70f01ed071d8c8139dc1f3188858b985416331";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-interfaces/default.nix
+++ b/distros/rolling/ros-gz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-interfaces";
-  version = "3.0.8-r2";
+  version = "4.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_interfaces/3.0.8-2.tar.gz";
-    name = "3.0.8-2.tar.gz";
-    sha256 = "cc174278083240c6649fb7f7e95e36b233192e42f5bc6bba2139d63034f369f9";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_interfaces/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "b922957927001a544d433cd4b0e8ef476af86244d23b7b7832075f927f5f09e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-sim-demos/default.nix
+++ b/distros/rolling/ros-gz-sim-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-sim-vendor, image-transport-plugins, marine-acoustic-msgs, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, rqt-image-view, rqt-plot, rqt-topic, rviz-imu-plugin, rviz2, sdformat-urdf, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-sim-demos";
-  version = "3.0.8-r2";
+  version = "4.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim_demos/3.0.8-2.tar.gz";
-    name = "3.0.8-2.tar.gz";
-    sha256 = "2b939c7a2e95eb49ad4fe4ca4b1945d609fc6c4c0a9e0a2f7b84771212ac8a41";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim_demos/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "3623ef4131d186712b85f44aab3da658d5dfad9b9036df8195c4941af9f99edb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-sim/default.nix
+++ b/distros/rolling/ros-gz-sim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, cli11, geometry-msgs, gflags, gz-math-vendor, gz-msgs-vendor, gz-sim-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, pkg-config, rclcpp, rclcpp-action, rclcpp-components, rcpputils, ros-gz-bridge, ros-gz-interfaces, ros2pkg, simulation-interfaces, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-sim";
-  version = "3.0.8-r2";
+  version = "4.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim/3.0.8-2.tar.gz";
-    name = "3.0.8-2.tar.gz";
-    sha256 = "2747dc24b2dc77c11bf0a492b129796aa034a2a49537627f5db606a77138323e";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "ef2b913b431ed6606da992229b76204e7299e932423733db4b0753f65a6d1312";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz/default.nix
+++ b/distros/rolling/ros-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz-bridge, ros-gz-image, ros-gz-sim, ros-gz-sim-demos }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz";
-  version = "3.0.8-r2";
+  version = "4.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz/3.0.8-2.tar.gz";
-    name = "3.0.8-2.tar.gz";
-    sha256 = "86ed81fb21965fbb7878b43ecf3cd9162c030ab285ee1f4087e9565645475f7e";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "1becd0e4dc8c4cdd7db5fb5ad7b72fc15812dc8c2df6131892edadcb338511fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag-timing-inspector/default.nix
+++ b/distros/rolling/rosbag-timing-inspector/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, glfw3, libGL, libGLU, rosbag2-cpp, rosbag2-storage }:
+buildRosPackage {
+  pname = "ros-rolling-rosbag-timing-inspector";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbag_timing_inspector-release/archive/release/rolling/rosbag_timing_inspector/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "fc81aac954c258e01d7e6c3b6b6ea324407a74dadf9d72bfb35074f5e40ce036";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake glfw3 libGL libGLU ];
+  propagatedBuildInputs = [ rosbag2-cpp rosbag2-storage ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "GUI tool to visualize and analyze message timing from ROS2 bags (mcap or db3).";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/rosidl-adapter/default.nix
+++ b/distros/rolling/rosidl-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-mypy, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3, python3Packages, rosidl-cli }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-adapter";
-  version = "5.3.0-r1";
+  version = "5.3.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_adapter/5.3.0-1.tar.gz";
-    name = "5.3.0-1.tar.gz";
-    sha256 = "ed4f9eeb3eaeb898ddd7d9e8d6066020bcb93a8e221577109a7d7ea1fe95f8d5";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_adapter/5.3.1-2.tar.gz";
+    name = "5.3.1-2.tar.gz";
+    sha256 = "ef990d9cff136595c9e130b8022346275b064a228acc4196bbcd1ac26496b84b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-buffer-backend-registry/default.nix
+++ b/distros/rolling/rosidl-buffer-backend-registry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rmw, rosidl-buffer, rosidl-buffer-backend, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-buffer-backend-registry";
-  version = "5.3.0-r1";
+  version = "5.3.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_buffer_backend_registry/5.3.0-1.tar.gz";
-    name = "5.3.0-1.tar.gz";
-    sha256 = "dd4dba17ffafa2e23bbb4a64bf5b18d13cb6c5d7100f7933b4509102867fc13c";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_buffer_backend_registry/5.3.1-2.tar.gz";
+    name = "5.3.1-2.tar.gz";
+    sha256 = "6e4524a587fb4eb1c17699f0a6a5d8f239a25c0d99afee62b50f46aad2a94123";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-buffer-backend/default.nix
+++ b/distros/rolling/rosidl-buffer-backend/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rmw }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-buffer-backend";
-  version = "5.3.0-r1";
+  version = "5.3.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_buffer_backend/5.3.0-1.tar.gz";
-    name = "5.3.0-1.tar.gz";
-    sha256 = "a4ecae1f6e1e4ac791f42f51a451596918b2cfbb0d27843e6ff43f353d55eb43";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_buffer_backend/5.3.1-2.tar.gz";
+    name = "5.3.1-2.tar.gz";
+    sha256 = "2e2a68e6228a2d28353b0f7a55ccc537625c627b7f9eb6d94659c5ed58d4f9e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-buffer-py/default.nix
+++ b/distros/rolling/rosidl-buffer-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python3, python3Packages, rosidl-buffer }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-buffer-py";
-  version = "5.3.0-r1";
+  version = "5.3.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_buffer_py/5.3.0-1.tar.gz";
-    name = "5.3.0-1.tar.gz";
-    sha256 = "c874faa59e8420e7d986fd969f65765f5fa2246afda588d4b041da58121bb702";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_buffer_py/5.3.1-2.tar.gz";
+    name = "5.3.1-2.tar.gz";
+    sha256 = "895e68d655a57379c663d69d21f65417df747e34a1a2523551f7e65b8215e039";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-buffer/default.nix
+++ b/distros/rolling/rosidl-buffer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-buffer";
-  version = "5.3.0-r1";
+  version = "5.3.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_buffer/5.3.0-1.tar.gz";
-    name = "5.3.0-1.tar.gz";
-    sha256 = "b6e8828db30cfe43dd039626642002bdfa72d3978846c580c81dfc6974234fa6";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_buffer/5.3.1-2.tar.gz";
+    name = "5.3.1-2.tar.gz";
+    sha256 = "ff1b9fb133a76ac485d9fe7031ec231118900fcb611d8995e63737059c45a622";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-cli/default.nix
+++ b/distros/rolling/rosidl-cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-cli";
-  version = "5.3.0-r1";
+  version = "5.3.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cli/5.3.0-1.tar.gz";
-    name = "5.3.0-1.tar.gz";
-    sha256 = "f61d6571eead155487813b361f7b3bb490419468695c2735795dcf23016a3827";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cli/5.3.1-2.tar.gz";
+    name = "5.3.1-2.tar.gz";
+    sha256 = "697a8c51cfc298465d765157c318d6304a4f51e5b5736437c08acf054b148fb0";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosidl-cmake/default.nix
+++ b/distros/rolling/rosidl-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python3Packages, rosidl-pycommon }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-cmake";
-  version = "5.3.0-r1";
+  version = "5.3.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cmake/5.3.0-1.tar.gz";
-    name = "5.3.0-1.tar.gz";
-    sha256 = "df93fabbf45920f6b95200c78cac15b7763fadc8b97241bf1191fae0a7f7cc49";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cmake/5.3.1-2.tar.gz";
+    name = "5.3.1-2.tar.gz";
+    sha256 = "c4133ea18caa18300a1aab1302fbef80a2b53a560f58b3e46a8f4545959d8e20";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-c/default.nix
+++ b/distros/rolling/rosidl-generator-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-python, ament-cmake-ros-core, ament-index-python, ament-lint-auto, ament-lint-common, python3, rcutils, rosidl-cli, rosidl-cmake, rosidl-generator-type-description, rosidl-parser, rosidl-pycommon, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-c";
-  version = "5.3.0-r1";
+  version = "5.3.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_c/5.3.0-1.tar.gz";
-    name = "5.3.0-1.tar.gz";
-    sha256 = "03b9f1df6ce90949dd31e0ce0d16c9e93a82fce8bb21e89e1e006bd37f0b7a5a";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_c/5.3.1-2.tar.gz";
+    name = "5.3.1-2.tar.gz";
+    sha256 = "b15e96e55e96c1b9f6a58d2a68e36c79fd70bcec783350712cc500dc454c8353";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-cpp/default.nix
+++ b/distros/rolling/rosidl-generator-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-type-description, rosidl-parser, rosidl-pycommon, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-cpp";
-  version = "5.3.0-r1";
+  version = "5.3.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_cpp/5.3.0-1.tar.gz";
-    name = "5.3.0-1.tar.gz";
-    sha256 = "cfdf9506504eca27996f62bc457473aafdd944066e33453eb79edf6af7393b01";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_cpp/5.3.1-2.tar.gz";
+    name = "5.3.1-2.tar.gz";
+    sha256 = "75261fad260e36ee10105276de5be5d61d5fe93d05cf3973dfd75af5368f8f8b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-type-description/default.nix
+++ b/distros/rolling/rosidl-generator-type-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros-core, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-type-description";
-  version = "5.3.0-r1";
+  version = "5.3.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_type_description/5.3.0-1.tar.gz";
-    name = "5.3.0-1.tar.gz";
-    sha256 = "a2829774f346a3662eac93a0b9737f76f180958b5365feff895e715410cb3b8c";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_type_description/5.3.1-2.tar.gz";
+    name = "5.3.1-2.tar.gz";
+    sha256 = "70ceec2173383198deee7ab2085ceaf0f741b73f3a4f6293d8ebbd5c7115ba0c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-parser/default.nix
+++ b/distros/rolling/rosidl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-mypy, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, rosidl-adapter }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-parser";
-  version = "5.3.0-r1";
+  version = "5.3.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_parser/5.3.0-1.tar.gz";
-    name = "5.3.0-1.tar.gz";
-    sha256 = "ef0b53b004b15de4d3928a8086e1cb4628892e82176534488a12e5c913f483eb";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_parser/5.3.1-2.tar.gz";
+    name = "5.3.1-2.tar.gz";
+    sha256 = "c13f37a8b2696c256834f9978f104f7192202705e0695b5131a5d77bff70b017";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-pycommon/default.nix
+++ b/distros/rolling/rosidl-pycommon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, python3Packages, rosidl-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-pycommon";
-  version = "5.3.0-r1";
+  version = "5.3.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_pycommon/5.3.0-1.tar.gz";
-    name = "5.3.0-1.tar.gz";
-    sha256 = "68ec10dc2923e8facb7f0395707a013a222b77e30c046b6bc5b47e43ff68e8dd";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_pycommon/5.3.1-2.tar.gz";
+    name = "5.3.1-2.tar.gz";
+    sha256 = "f7b490cab95533ea4181d2a9f961a509ff39cf166f321da43f115871113e6b30";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosidl-runtime-c/default.nix
+++ b/distros/rolling/rosidl-runtime-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros-core, ament-lint-auto, ament-lint-common, performance-test-fixture, rcutils, rosidl-buffer, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-runtime-c";
-  version = "5.3.0-r1";
+  version = "5.3.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_c/5.3.0-1.tar.gz";
-    name = "5.3.0-1.tar.gz";
-    sha256 = "4ba042fce0d08526a12016eef371ff2261b05455a4031ca11ef31a69114c5557";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_c/5.3.1-2.tar.gz";
+    name = "5.3.1-2.tar.gz";
+    sha256 = "a2f9955b48386b9cfff862da9e28cd6a8b68aa35b68afa6ed882c9f907a53f60";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-runtime-cpp/default.nix
+++ b/distros/rolling/rosidl-runtime-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, performance-test-fixture, rosidl-buffer, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-runtime-cpp";
-  version = "5.3.0-r1";
+  version = "5.3.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_cpp/5.3.0-1.tar.gz";
-    name = "5.3.0-1.tar.gz";
-    sha256 = "2df9c3555b02b16f27cd1cfb115dd954ecaab54c7ff58896379f22273cf5c02b";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_cpp/5.3.1-2.tar.gz";
+    name = "5.3.1-2.tar.gz";
+    sha256 = "e5d59a3a7f327b40209ab51f6de72e34dffedcb76d0b8daad2aadb0c8fe12f6c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-interface/default.nix
+++ b/distros/rolling/rosidl-typesupport-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-interface";
-  version = "5.3.0-r1";
+  version = "5.3.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_interface/5.3.0-1.tar.gz";
-    name = "5.3.0-1.tar.gz";
-    sha256 = "dfdd73b54b4ca69eeb07239a7f5629aeb784c245d7ac13ee69697655c16af2ee";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_interface/5.3.1-2.tar.gz";
+    name = "5.3.1-2.tar.gz";
+    sha256 = "286ec4ff98ad371706a62332908ede18b4442f607121831445d137a2646aa0cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-introspection-c/default.nix
+++ b/distros/rolling/rosidl-typesupport-introspection-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros-core, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-buffer, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-introspection-c";
-  version = "5.3.0-r1";
+  version = "5.3.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_c/5.3.0-1.tar.gz";
-    name = "5.3.0-1.tar.gz";
-    sha256 = "b640d5c6a0ff8b425f3ab98e3ee7efee4a7c88add4a2fa057b1583599cff0bd4";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_c/5.3.1-2.tar.gz";
+    name = "5.3.1-2.tar.gz";
+    sha256 = "5adaff8bef4c5160d7200a29e36b751586b691592e2f229b7bf1b91f119968d2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-introspection-cpp/default.nix
+++ b/distros/rolling/rosidl-typesupport-introspection-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros-core, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-buffer, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidl-typesupport-introspection-c }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-introspection-cpp";
-  version = "5.3.0-r1";
+  version = "5.3.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_cpp/5.3.0-1.tar.gz";
-    name = "5.3.0-1.tar.gz";
-    sha256 = "f8dabe36f8d1f9136c378e3b2436319ccdeb523a917fe68d937537951a3fc40b";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_cpp/5.3.1-2.tar.gz";
+    name = "5.3.1-2.tar.gz";
+    sha256 = "8aae8dab2df5baa71449c00ae633a806477ce1b31045fd009a7a4f44aab7c0b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-bag-plugins/default.nix
+++ b/distros/rolling/rqt-bag-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, builtin-interfaces, geometry-msgs, python3Packages, rclpy, rosbag2, rqt-bag, rqt-gui, rqt-gui-py, rqt-plot, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-bag-plugins";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/rolling/rqt_bag_plugins/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "80658ecd12e86ec0e3f21f86ee415e70265af26b83541b047034055e9018a068";
+    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/rolling/rqt_bag_plugins/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "b4797632b7c2fb20405899f552385f2de7771665e7890c2244655bad2ed94e7a";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-bag/default.nix
+++ b/distros/rolling/rqt-bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, builtin-interfaces, python-qt-binding, python3Packages, rclpy, rosbag2-py, rosidl-runtime-py, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-bag";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/rolling/rqt_bag/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "9422f99412e37840230602421d1bb63c29fa93dca4287b7aa4893a5086e9b6c5";
+    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/rolling/rqt_bag/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "0b640c55a7ca1b2bc4ea1340b2a3dee5c2e660fd25e88a7b8a3d4692e9fcb635";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-reconfigure/default.nix
+++ b/distros/rolling/rqt-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-xmllint, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-rolling-rqt-reconfigure";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/rolling/rqt_reconfigure/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "870f8cc8b0749e57e5c1700ce3d77a8fca0c9b2f3a06bddd862aa1d3bbe15d80";
+    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/rolling/rqt_reconfigure/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "9074d2a93e0e1e1530c4f2e92d22315c4ce3c0be1780ec5fcaf310ed08df12f5";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-tf-tree/default.nix
+++ b/distros/rolling/rqt-tf-tree/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-dotgraph, rclpy, rqt-graph, rqt-gui, rqt-gui-py, tf2-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, python-qt-binding, python3Packages, qt-dotgraph, rclpy, rqt-graph, rqt-gui, rqt-gui-py, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rqt-tf-tree";
-  version = "1.0.6-r2";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_tf_tree-release/archive/release/rolling/rqt_tf_tree/1.0.6-2.tar.gz";
-    name = "1.0.6-2.tar.gz";
-    sha256 = "d29e93639838c060deb2855965baa8cf2e31fcfa65b46d8904841fd3ffec1c14";
+    url = "https://github.com/ros2-gbp/rqt_tf_tree-release/archive/release/rolling/rqt_tf_tree/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "e88c5345aaf9b039561e8daa00cc9d7428602ff819269eee7742e06e3c7e9f95";
   };
 
   buildType = "ament_python";
-  checkInputs = [ python3Packages.mock python3Packages.pytest ];
+  checkInputs = [ ament-flake8 ament-pep257 python3Packages.mock python3Packages.pytest ];
   propagatedBuildInputs = [ python-qt-binding qt-dotgraph rclpy rqt-graph rqt-gui rqt-gui-py tf2-msgs tf2-ros ];
 
   meta = {

--- a/distros/rolling/rti-connext-dds-cmake-module/default.nix
+++ b/distros/rolling/rti-connext-dds-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rti-connext-dds-cmake-module";
-  version = "1.3.0-r1";
+  version = "1.3.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rti_connext_dds_cmake_module/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "8352ff38e6109e6166e9933a033b643db44174de19811d4d4964a8e5622fcede";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rti_connext_dds_cmake_module/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "c3eaff532d935c0131625e00c7e75c8ac02cbbeafccb09a6199ec492db3869d9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-common/default.nix
+++ b/distros/rolling/rviz-common/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, message-filters, pluginlib, qt6, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml-2, urdf, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, message-filters, pluginlib, qt6, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml-2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-common";
-  version = "16.0.0-r1";
+  version = "16.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/16.0.0-1.tar.gz";
-    name = "16.0.0-1.tar.gz";
-    sha256 = "a40ee1279d812c548749eeacb4e02bfbf84fa764ec76eace0bc138fab9e6e23d";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/16.0.1-1.tar.gz";
+    name = "16.0.1-1.tar.gz";
+    sha256 = "53a40ccb934a03c3d3012b97431703fe6bbbefeebdadabea0597a68de10c8e8f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs message-filters pluginlib qt6.qtbase qt6.qtsvg rclcpp resource-retriever rviz-ogre-vendor rviz-rendering sensor-msgs std-msgs std-srvs tf2 tf2-ros tinyxml-2 urdf yaml-cpp-vendor ];
+  propagatedBuildInputs = [ geometry-msgs message-filters pluginlib qt6.qtbase qt6.qtsvg rclcpp resource-retriever rviz-ogre-vendor rviz-rendering sensor-msgs std-msgs std-srvs tf2 tf2-ros tinyxml-2 yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/rviz-default-plugins/default.nix
+++ b/distros/rolling/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, gz-math-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt6, rclcpp, resource-retriever, resource-retriever-service-plugin, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz-default-plugins";
-  version = "16.0.0-r1";
+  version = "16.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/16.0.0-1.tar.gz";
-    name = "16.0.0-1.tar.gz";
-    sha256 = "d15cf0322967bf6c29384edf3274d9f933869b354faeacb64d7e096a559a7118";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/16.0.1-1.tar.gz";
+    name = "16.0.1-1.tar.gz";
+    sha256 = "e3721578fe0e9fedb3e62148d8f60a468be7f3bc74afc4a401acd8703a765e17";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-ogre-vendor/default.nix
+++ b/distros/rolling/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, glew, libGL, libGLU, libx11, libxaw, libxrandr }:
 buildRosPackage {
   pname = "ros-rolling-rviz-ogre-vendor";
-  version = "16.0.0-r1";
+  version = "16.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/16.0.0-1.tar.gz";
-    name = "16.0.0-1.tar.gz";
-    sha256 = "09cf63f48ff0e40ac59cb211382a83b062eb1ef5e0d750d6501535cb47d6a4a4";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/16.0.1-1.tar.gz";
+    name = "16.0.1-1.tar.gz";
+    sha256 = "1ea4001ec4e54293b870d4a127f73e065a9e731d15e5ca77ccc77fcf4e3686cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering-tests/default.nix
+++ b/distros/rolling/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, qt6, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering-tests";
-  version = "16.0.0-r1";
+  version = "16.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/16.0.0-1.tar.gz";
-    name = "16.0.0-1.tar.gz";
-    sha256 = "db31465450e67bfacd95183fa54a685a73f2a0b7815e96ff5fda6817d44efc01";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/16.0.1-1.tar.gz";
+    name = "16.0.1-1.tar.gz";
+    sha256 = "7baa7481c0f948fb275c23adaa77b810f4af9b7ab57f80f1da3dd848e80f723b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering/default.nix
+++ b/distros/rolling/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, assimp, eigen, eigen3-cmake-module, qt6, resource-retriever, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering";
-  version = "16.0.0-r1";
+  version = "16.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/16.0.0-1.tar.gz";
-    name = "16.0.0-1.tar.gz";
-    sha256 = "f25e834208ba8a1abea3361cf4e0f16f84b0091548513a11f77b999572a9f86a";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/16.0.1-1.tar.gz";
+    name = "16.0.1-1.tar.gz";
+    sha256 = "e7df8ef344d5ae42ca9a9aaf14fad7597fca108200f34df84b495685350e858d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-visual-testing-framework/default.nix
+++ b/distros/rolling/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, qt6, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rviz-visual-testing-framework";
-  version = "16.0.0-r1";
+  version = "16.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/16.0.0-1.tar.gz";
-    name = "16.0.0-1.tar.gz";
-    sha256 = "f6512d18ef7a5c0ec5b1a5c888f86fea84420cb8dec876fc6554061a70038ed5";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/16.0.1-1.tar.gz";
+    name = "16.0.1-1.tar.gz";
+    sha256 = "ad3a40fa138f9536358b672928503c64a0d085699f9650e186436e049a6445e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz2/default.nix
+++ b/distros/rolling/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, python3, python3Packages, qt6, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz2";
-  version = "16.0.0-r1";
+  version = "16.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/16.0.0-1.tar.gz";
-    name = "16.0.0-1.tar.gz";
-    sha256 = "a1b94f258cd74a606ff83da1e55fa99d6baaca116ca4de5f87bb67cc0834de97";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/16.0.1-1.tar.gz";
+    name = "16.0.1-1.tar.gz";
+    sha256 = "a200a6c701602c013e6f945186e8a30ab71b789aa62bf7872818fbfffcd28c88";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sound-play-msgs/default.nix
+++ b/distros/rolling/sound-play-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-rolling-sound-play-msgs";
+  version = "0.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/audio_common-release/archive/release/rolling/sound_play_msgs/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "227e5df820913436a9cfe0cdaf667febbe93fbd89d4c3df1cda7d3dc6fdded78";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "Messages for transmitting sound via ROS with sound_play";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/sound-play/default.nix
+++ b/distros/rolling/sound-play/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, _unresolved_festival, action-msgs, ament-cmake, ament-cmake-python, ament-index-python, boost, gst_all_1, launch-xml, python3Packages, rclpy, sound-play-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-sound-play";
+  version = "0.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/audio_common-release/archive/release/rolling/sound_play/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "4a102379e1f60885b5f39be8fed26e4a1d388d946f45221d692e377e09a14bbc";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python boost python3Packages.setuptools ];
+  propagatedBuildInputs = [ _unresolved_festival action-msgs ament-index-python gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good gst_all_1.gst-plugins-ugly gst_all_1.gstreamer launch-xml python3Packages.pygobject3 rclpy sound-play-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python python3Packages.setuptools ];
+
+  meta = {
+    description = "sound_play provides a ROS node that translates commands on a ROS topic (<tt>robotsound</tt>) into sounds. The node supports built-in sounds, playing OGG/WAV files, and doing speech synthesis via festival. C++ and Python bindings allow this node to be used without understanding the details of the message format, allowing faster development and resilience to message format changes.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/tensor-msgs/default.nix
+++ b/distros/rolling/tensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-tensor-msgs";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/rolling/tensor_msgs/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "b36a6019de9e0f40bfa311f3549cdb3f857e077e1cbf72d8ab46c6adc132d570";
+    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/rolling/tensor_msgs/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "3c2d594a37d149da857c787e819fdc0e2c0b4aeb175b09aef68913a8a31f657d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/torch-conversions/default.nix
+++ b/distros/rolling/torch-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-testing-ament-cmake, libtorch-vendor, rclcpp, rclcpp-components, rcutils, rmw, rosidl-buffer, std-msgs, tensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-torch-conversions";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/rolling/torch_conversions/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "3d6a24c7771aa14d9c55995f97a5f85d5c1ae32ddfbf6aebe91c20670f7a16b4";
+    url = "https://github.com/ros2-gbp/rosidl_buffer_backends-release/archive/release/rolling/torch_conversions/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "260dcceb7ffcc7f0e18bea31d133d73377c5d9c62f0dea9500c39db789eadc49";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/video-to-image-msg-publisher/default.nix
+++ b/distros/rolling/video-to-image-msg-publisher/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-lint-auto, ament-lint-common, cv-bridge, opencv, rclcpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-video-to-image-msg-publisher";
+  version = "0.9.5-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/video_to_image_msg_publisher-release/archive/release/rolling/video_to_image_msg_publisher/0.9.5-2.tar.gz";
+    name = "0.9.5-2.tar.gz";
+    sha256 = "df31ec925c8612b6c609e286e8b0d1530d8baec5f3af12747054cb3e06c04641";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge opencv opencv.cxxdev rclcpp sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ];
+
+  meta = {
+    description = "A simple node that publishes sensor_msgs/Image messages from a specified video file";
+    license = with lib.licenses; [ gpl2 ];
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
     "rosdistro": {
       "flake": false,
       "locked": {
-        "lastModified": 1780665549,
-        "narHash": "sha256-QzobMKNpcpS4uWETzPxXkt0F66Sji15N+xsK1JcEWDU=",
+        "lastModified": 1781238695,
+        "narHash": "sha256-Sk8KQa9ryFrkdGGZ64sNdqoVqiGmC+IAAi3qzE7zn8s=",
         "owner": "ros",
         "repo": "rosdistro",
-        "rev": "bcec45c05427f0ad6860cb323695995d8cb1e4bd",
+        "rev": "a0e7ccc6f866a081acc0656d9cd03cda7acc6853",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'kilted', 'lyrical', 'rolling'] from nix-ros-overlay commit 6b50f3bf17071bae315e8948c93ee737c87809a2.
This pull request was generated by running the following command:

```
superflore-gen-nix --dry-run --output-repository-path . --all --tar-archive-dir /home/runner/.ros/tar --upstream-branch develop
```

Changes:
========
Humble Changes:
---------------
* *agni-tf-tools 1.0.0-r1*
* *audio-capture 0.4.0-r2*
* *audio-common 0.4.0-r2*
* *audio-common-msgs 0.4.0-r2*
* *audio-play 0.4.0-r2*
* *automatika-embodied-agents 0.7.1-r1 --> 0.7.4-r1*
* *automatika-ros-sugar 0.7.0-r1 --> 0.7.1-r1*
* *camera-ros 0.6.0-r1 --> 0.7.0-r1*
* *crazyflie 1.0.3-r1 --> 1.0.4-r1*
* *crazyflie-examples 1.0.3-r1 --> 1.0.4-r1*
* *crazyflie-interfaces 1.0.3-r1 --> 1.0.4-r1*
* *crazyflie-py 1.0.3-r1 --> 1.0.4-r1*
* *crazyflie-server-py 1.0.4-r1*
* *crazyflie-sim 1.0.3-r1 --> 1.0.4-r1*
* *depthai-bridge-v3 3.2.1-r1 --> 3.3.0-r1*
* *depthai-descriptions-v3 3.2.1-r1 --> 3.3.0-r1*
* *depthai-examples-v3 3.2.1-r1 --> 3.3.0-r1*
* *depthai-filters-v3 3.2.1-r1 --> 3.3.0-r1*
* *depthai-ros-driver-v3 3.2.1-r1 --> 3.3.0-r1*
* *depthai-ros-msgs-v3 3.2.1-r1 --> 3.3.0-r1*
* *depthai-ros-v3 3.2.1-r1 --> 3.3.0-r1*
* *depthai-v3 3.6.1-r2 --> 3.7.1-r1*
* *eigenpy 3.12.0-r1 --> 3.13.0-r1*
* *generate-parameter-library 0.7.3-r1 --> 0.7.4-r1*
* *generate-parameter-library-py 0.7.3-r1 --> 0.7.4-r1*
* *geometric-shapes 2.3.2-r1 --> 2.3.4-r1*
* *kompass 0.5.0-r1 --> 0.6.0-r1*
* *kompass-interfaces 0.5.0-r1 --> 0.6.0-r1*
* *linear-feedback-controller 4.0.1-r1*
* *mavlink 2026.3.3-r1 --> 2026.6.6-r1*
* *microstrain-inertial-description 4.8.0-r1 --> 4.9.0-r1*
* *microstrain-inertial-driver 4.8.0-r1 --> 4.9.0-r1*
* *microstrain-inertial-examples 4.8.0-r1 --> 4.9.0-r1*
* *microstrain-inertial-msgs 4.8.0-r1 --> 4.9.0-r1*
* *microstrain-inertial-rqt 4.8.0-r1 --> 4.9.0-r1*
* *mola-input-rosbag1 0.2.0-r1*
* *mrpt-apps-cli 3.0.2-r1*
* *mrpt-apps-gui 3.0.2-r1*
* *mrpt-bayes 3.0.2-r1*
* *mrpt-common 3.0.2-r1*
* *mrpt-comms 3.0.2-r1*
* *mrpt-config 3.0.2-r1*
* *mrpt-containers 3.0.2-r1*
* *mrpt-core 3.0.2-r1*
* *mrpt-data 3.0.2-r1*
* *mrpt-examples-cpp 3.0.2-r1*
* *mrpt-expr 3.0.2-r1*
* *mrpt-graphs 3.0.2-r1*
* *mrpt-graphslam 3.0.2-r1*
* *mrpt-gui 3.0.2-r1*
* *mrpt-hwdrivers 3.0.2-r1*
* *mrpt-img 3.0.2-r1*
* *mrpt-imgui 3.0.2-r1*
* *mrpt-io 3.0.2-r1*
* *mrpt-kinematics 3.0.2-r1*
* *mrpt-libapps-cli 3.0.2-r1*
* *mrpt-libapps-gui 3.0.2-r1*
* *mrpt-maps 3.0.2-r1*
* *mrpt-math 3.0.2-r1*
* *mrpt-nav 3.0.2-r1*
* *mrpt-obs 3.0.2-r1*
* *mrpt-opengl 3.0.2-r1*
* *mrpt-poses 3.0.2-r1*
* *mrpt-random 3.0.2-r1*
* *mrpt-rtti 3.0.2-r1*
* *mrpt-serialization 3.0.2-r1*
* *mrpt-slam 3.0.2-r1*
* *mrpt-system 3.0.2-r1*
* *mrpt-tfest 3.0.2-r1*
* *mrpt-topography 3.0.2-r1*
* *mrpt-typemeta 3.0.2-r1*
* *mrpt-viz 3.0.2-r1*
* *nanoflann 1.10.1-r1*
* *orbbec-camera 2.7.6-r1 --> 2.8.6-r1*
* *orbbec-camera-msgs 2.7.6-r1 --> 2.8.6-r1*
* *orbbec-description 2.7.6-r1 --> 2.8.6-r1*
* *parameter-traits 0.7.3-r1 --> 0.7.4-r1*
* *ros-gz 0.244.24-r1 --> 0.244.25-r1*
* *ros-gz-bridge 0.244.24-r1 --> 0.244.25-r1*
* *ros-gz-image 0.244.24-r1 --> 0.244.25-r1*
* *ros-gz-interfaces 0.244.24-r1 --> 0.244.25-r1*
* *ros-gz-sim 0.244.24-r1 --> 0.244.25-r1*
* *ros-gz-sim-demos 0.244.24-r1 --> 0.244.25-r1*
* *ros-ign 0.244.24-r1 --> 0.244.25-r1*
* *ros-ign-bridge 0.244.24-r1 --> 0.244.25-r1*
* *ros-ign-gazebo 0.244.24-r1 --> 0.244.25-r1*
* *ros-ign-gazebo-demos 0.244.24-r1 --> 0.244.25-r1*
* *ros-ign-image 0.244.24-r1 --> 0.244.25-r1*
* *ros-ign-interfaces 0.244.24-r1 --> 0.244.25-r1*
* *ros2-medkit-beacon-common 0.4.0-r1 --> 0.5.0-r2*
* *ros2-medkit-cmake 0.4.0-r1 --> 0.5.0-r2*
* *ros2-medkit-diagnostic-bridge 0.4.0-r1 --> 0.5.0-r2*
* *ros2-medkit-fault-manager 0.4.0-r1 --> 0.5.0-r2*
* *ros2-medkit-fault-reporter 0.4.0-r1 --> 0.5.0-r2*
* *ros2-medkit-gateway 0.4.0-r1 --> 0.5.0-r2*
* *ros2-medkit-graph-provider 0.4.0-r1 --> 0.5.0-r2*
* *ros2-medkit-integration-tests 0.4.0-r1 --> 0.5.0-r2*
* *ros2-medkit-linux-introspection 0.4.0-r1 --> 0.5.0-r2*
* *ros2-medkit-msgs 0.4.0-r1 --> 0.5.0-r2*
* *ros2-medkit-param-beacon 0.4.0-r1 --> 0.5.0-r2*
* *ros2-medkit-serialization 0.4.0-r1 --> 0.5.0-r2*
* *ros2-medkit-sovd-service-interface 0.5.0-r2*
* *ros2-medkit-topic-beacon 0.4.0-r1 --> 0.5.0-r2*
* *rosbag-timing-inspector 1.0.0-r1*
* *rqt-tf-tree 1.0.6-r1 --> 1.1.0-r1*
* *scan-2d-merger 2.0.0-r3*
* *sound-play 0.4.0-r2*
* *sound-play-msgs 0.4.0-r2*
* *tcb-span 1.3.1-r1 --> 1.3.2-r1*
* *tl-expected 1.3.1-r1 --> 1.3.2-r1*
* *video-to-image-msg-publisher 0.9.5-r8*

Jazzy Changes:
--------------
* *actionlib-msgs 5.3.7-r1 --> 5.3.8-r1*
* *behaviortree-cpp-v3 3.8.6-r3 --> 3.8.8-r1*
* *common-interfaces 5.3.7-r1 --> 5.3.8-r1*
* *diagnostic-msgs 5.3.7-r1 --> 5.3.8-r1*
* *geometric-shapes 2.3.2-r1 --> 2.3.4-r1*
* *geometry-msgs 5.3.7-r1 --> 5.3.8-r1*
* *message-filters 4.11.15-r1 --> 4.11.16-r1*
* *nav-msgs 5.3.7-r1 --> 5.3.8-r1*
* *rcl 9.2.10-r1 --> 9.2.11-r1*
* *rcl-action 9.2.10-r1 --> 9.2.11-r1*
* *rcl-lifecycle 9.2.10-r1 --> 9.2.11-r1*
* *rcl-yaml-param-parser 9.2.10-r1 --> 9.2.11-r1*
* *rclcpp 28.1.19-r1 --> 28.1.21-r1*
* *rclcpp-action 28.1.19-r1 --> 28.1.21-r1*
* *rclcpp-components 28.1.19-r1 --> 28.1.21-r1*
* *rclcpp-lifecycle 28.1.19-r1 --> 28.1.21-r1*
* *rosidl-adapter 4.6.8-r1 --> 4.6.9-r1*
* *rosidl-cli 4.6.8-r1 --> 4.6.9-r1*
* *rosidl-cmake 4.6.8-r1 --> 4.6.9-r1*
* *rosidl-generator-c 4.6.8-r1 --> 4.6.9-r1*
* *rosidl-generator-cpp 4.6.8-r1 --> 4.6.9-r1*
* *rosidl-generator-type-description 4.6.8-r1 --> 4.6.9-r1*
* *rosidl-parser 4.6.8-r1 --> 4.6.9-r1*
* *rosidl-pycommon 4.6.8-r1 --> 4.6.9-r1*
* *rosidl-runtime-c 4.6.8-r1 --> 4.6.9-r1*
* *rosidl-runtime-cpp 4.6.8-r1 --> 4.6.9-r1*
* *rosidl-typesupport-interface 4.6.8-r1 --> 4.6.9-r1*
* *rosidl-typesupport-introspection-c 4.6.8-r1 --> 4.6.9-r1*
* *rosidl-typesupport-introspection-cpp 4.6.8-r1 --> 4.6.9-r1*
* *rviz-assimp-vendor 14.1.21-r1 --> 14.1.22-r1*
* *rviz-common 14.1.21-r1 --> 14.1.22-r1*
* *rviz-default-plugins 14.1.21-r1 --> 14.1.22-r1*
* *rviz-ogre-vendor 14.1.21-r1 --> 14.1.22-r1*
* *rviz-rendering 14.1.21-r1 --> 14.1.22-r1*
* *rviz-rendering-tests 14.1.21-r1 --> 14.1.22-r1*
* *rviz-visual-testing-framework 14.1.21-r1 --> 14.1.22-r1*
* *rviz2 14.1.21-r1 --> 14.1.22-r1*
* *sensor-msgs 5.3.7-r1 --> 5.3.8-r1*
* *sensor-msgs-py 5.3.7-r1 --> 5.3.8-r1*
* *shape-msgs 5.3.7-r1 --> 5.3.8-r1*
* *std-msgs 5.3.7-r1 --> 5.3.8-r1*
* *std-srvs 5.3.7-r1 --> 5.3.8-r1*
* *stereo-msgs 5.3.7-r1 --> 5.3.8-r1*
* *trajectory-msgs 5.3.7-r1 --> 5.3.8-r1*
* *visualization-msgs 5.3.7-r1 --> 5.3.8-r1*

Kilted Changes:
---------------
* *audio-capture 0.4.0-r2*
* *audio-common 0.4.0-r2*
* *audio-common-msgs 0.4.0-r2*
* *audio-play 0.4.0-r2*
* *automatika-embodied-agents 0.7.1-r1 --> 0.7.4-r1*
* *automatika-ros-sugar 0.7.0-r1 --> 0.7.1-r1*
* *depthai 3.6.1-r2 --> 3.7.1-r3*
* *depthai-bridge 3.2.1-r1 --> 3.3.0-r1*
* *depthai-descriptions 3.2.1-r1 --> 3.3.0-r1*
* *depthai-examples 3.2.1-r1 --> 3.3.0-r1*
* *depthai-filters 3.2.1-r1 --> 3.3.0-r1*
* *depthai-ros 3.2.1-r1 --> 3.3.0-r1*
* *depthai-ros-driver 3.2.1-r1 --> 3.3.0-r1*
* *depthai-ros-msgs 3.2.1-r1 --> 3.3.0-r1*
* *eigenpy 3.12.0-r1 --> 3.13.0-r1*
* *generate-parameter-library 0.7.3-r1 --> 0.7.4-r1*
* *generate-parameter-library-py 0.7.3-r1 --> 0.7.4-r1*
* *kompass 0.5.0-r1 --> 0.6.0-r1*
* *kompass-interfaces 0.5.0-r1 --> 0.6.0-r1*
* *linear-feedback-controller 4.0.1-r1*
* *mavlink 2026.3.3-r1 --> 2026.6.6-r1*
* *microstrain-inertial-description 4.8.0-r1 --> 4.9.0-r1*
* *microstrain-inertial-driver 4.8.0-r1 --> 4.9.0-r1*
* *microstrain-inertial-examples 4.8.0-r1 --> 4.9.0-r1*
* *microstrain-inertial-msgs 4.8.0-r1 --> 4.9.0-r1*
* *microstrain-inertial-rqt 4.8.0-r1 --> 4.9.0-r1*
* *mola-input-rosbag1 0.2.0-r1*
* *nanoflann 1.10.1-r1*
* *parameter-traits 0.7.3-r1 --> 0.7.4-r1*
* *ros-gz 2.1.16-r1 --> 2.1.17-r1*
* *ros-gz-bridge 2.1.16-r1 --> 2.1.17-r1*
* *ros-gz-image 2.1.16-r1 --> 2.1.17-r1*
* *ros-gz-interfaces 2.1.16-r1 --> 2.1.17-r1*
* *ros-gz-sim 2.1.16-r1 --> 2.1.17-r1*
* *ros-gz-sim-demos 2.1.16-r1 --> 2.1.17-r1*
* *rosbag-timing-inspector 1.0.0-r1*
* *rqt-tf-tree 1.0.6-r2 --> 1.1.0-r1*
* *sound-play 0.4.0-r2*
* *sound-play-msgs 0.4.0-r2*
* *tcb-span 1.3.1-r1 --> 1.3.2-r1*
* *tl-expected 1.3.1-r1 --> 1.3.2-r1*
* *video-to-image-msg-publisher 0.9.5-r1*

Lyrical Changes:
----------------
* *agni-tf-tools 1.0.0-r1*
* *ament-black 0.2.6-r3 --> 0.2.7-r1*
* *ament-cmake-black 0.2.6-r3 --> 0.2.7-r1*
* *audio-capture 0.4.0-r2*
* *audio-common 0.4.0-r2*
* *audio-common-msgs 0.4.0-r2*
* *audio-play 0.4.0-r2*
* *automatika-ros-sugar 0.6.1-r3 --> 0.7.1-r1*
* *camera-calibration-parsers 6.4.9-r1 --> 6.4.10-r1*
* *camera-info-manager 6.4.9-r1 --> 6.4.10-r1*
* *camera-info-manager-py 6.4.9-r1 --> 6.4.10-r1*
* *camera-ros 0.6.0-r3 --> 0.7.0-r1*
* *crazyflie 1.0.4-r1*
* *crazyflie-examples 1.0.4-r1*
* *crazyflie-interfaces 1.0.4-r1*
* *crazyflie-py 1.0.4-r1*
* *crazyflie-server-py 1.0.4-r1*
* *crazyflie-sim 1.0.4-r1*
* *cuda-buffer 0.1.1-r1 --> 0.1.2-r1*
* *cuda-buffer-backend 0.1.1-r1 --> 0.1.2-r1*
* *cuda-buffer-backend-msgs 0.1.1-r1 --> 0.1.2-r1*
* *dataspeed-can 2.0.7-r1*
* *dataspeed-can-msg-filters 2.0.7-r1*
* *dataspeed-can-msgs 2.0.7-r1*
* *dataspeed-can-tools 2.0.7-r1*
* *dataspeed-can-usb 2.0.7-r1*
* *eigenpy 3.12.0-r3 --> 3.13.0-r1*
* *generate-parameter-library 1.1.0-r1 --> 1.2.0-r1*
* *generate-parameter-library-py 1.1.0-r1 --> 1.2.0-r1*
* *geometric-shapes 2.3.3-r3 --> 2.3.4-r1*
* *gz-cmake-vendor 0.4.4-r3 --> 0.4.5-r1*
* *gz-physics-vendor 0.4.3-r3 --> 0.4.4-r1*
* *gz-sim-vendor 0.4.4-r3 --> 0.4.5-r1*
* *image-common 6.4.9-r1 --> 6.4.10-r1*
* *image-transport 6.4.9-r1 --> 6.4.10-r1*
* *image-transport-py 6.4.9-r1 --> 6.4.10-r1*
* *kompass 0.4.1-r3 --> 0.6.0-r1*
* *kompass-interfaces 0.4.1-r3 --> 0.6.0-r1*
* *libtorch-vendor 0.1.1-r1 --> 0.1.2-r1*
* *lusb 2.0.3-r1*
* *mavlink 2026.3.3-r3 --> 2026.6.6-r1*
* *mola-input-rosbag1 0.2.0-r1*
* *nanoflann 1.10.1-r1*
* *rmw-connextdds 1.2.7-r1 --> 1.2.7-r2*
* *rmw-connextdds-common 1.2.7-r1 --> 1.2.7-r2*
* *ros-gz 3.0.8-r3 --> 3.0.9-r1*
* *ros-gz-bridge 3.0.8-r3 --> 3.0.9-r1*
* *ros-gz-image 3.0.8-r3 --> 3.0.9-r1*
* *ros-gz-interfaces 3.0.8-r3 --> 3.0.9-r1*
* *ros-gz-sim 3.0.8-r3 --> 3.0.9-r1*
* *ros-gz-sim-demos 3.0.8-r3 --> 3.0.9-r1*
* *ros2-medkit-beacon-common 0.5.0-r3*
* *ros2-medkit-cmake 0.5.0-r3*
* *ros2-medkit-diagnostic-bridge 0.5.0-r3*
* *ros2-medkit-fault-manager 0.5.0-r3*
* *ros2-medkit-fault-reporter 0.5.0-r3*
* *ros2-medkit-gateway 0.5.0-r3*
* *ros2-medkit-graph-provider 0.5.0-r3*
* *ros2-medkit-integration-tests 0.5.0-r3*
* *ros2-medkit-linux-introspection 0.5.0-r3*
* *ros2-medkit-msgs 0.5.0-r3*
* *ros2-medkit-param-beacon 0.5.0-r3*
* *ros2-medkit-serialization 0.5.0-r3*
* *ros2-medkit-sovd-service-interface 0.5.0-r3*
* *ros2-medkit-topic-beacon 0.5.0-r3*
* *rosidl-adapter 5.2.0-r3 --> 5.2.1-r1*
* *rosidl-buffer 5.2.0-r3 --> 5.2.1-r1*
* *rosidl-buffer-backend 5.2.0-r3 --> 5.2.1-r1*
* *rosidl-buffer-backend-registry 5.2.0-r3 --> 5.2.1-r1*
* *rosidl-buffer-py 5.2.0-r3 --> 5.2.1-r1*
* *rosidl-cli 5.2.0-r3 --> 5.2.1-r1*
* *rosidl-cmake 5.2.0-r3 --> 5.2.1-r1*
* *rosidl-generator-c 5.2.0-r3 --> 5.2.1-r1*
* *rosidl-generator-cpp 5.2.0-r3 --> 5.2.1-r1*
* *rosidl-generator-type-description 5.2.0-r3 --> 5.2.1-r1*
* *rosidl-parser 5.2.0-r3 --> 5.2.1-r1*
* *rosidl-pycommon 5.2.0-r3 --> 5.2.1-r1*
* *rosidl-runtime-c 5.2.0-r3 --> 5.2.1-r1*
* *rosidl-runtime-cpp 5.2.0-r3 --> 5.2.1-r1*
* *rosidl-typesupport-interface 5.2.0-r3 --> 5.2.1-r1*
* *rosidl-typesupport-introspection-c 5.2.0-r3 --> 5.2.1-r1*
* *rosidl-typesupport-introspection-cpp 5.2.0-r3 --> 5.2.1-r1*
* *rqt-bag 2.2.3-r1 --> 2.2.4-r1*
* *rqt-bag-plugins 2.2.3-r1 --> 2.2.4-r1*
* *rqt-reconfigure 1.8.4-r3 --> 1.8.5-r1*
* *rqt-tf-tree 1.0.6-r3 --> 1.1.0-r1*
* *rti-connext-dds-cmake-module 1.2.7-r1 --> 1.2.7-r2*
* *sound-play 0.4.0-r2*
* *sound-play-msgs 0.4.0-r2*
* *tensor-msgs 0.1.1-r1 --> 0.1.2-r1*
* *torch-conversions 0.1.1-r1 --> 0.1.2-r1*
* *video-to-image-msg-publisher 0.9.5-r2*

Rolling Changes:
----------------
* *agni-tf-tools 1.0.0-r1*
* *ament-black 0.2.6-r2 --> 0.2.7-r1*
* *ament-cmake-black 0.2.6-r2 --> 0.2.7-r1*
* *audio-capture 0.4.0-r2*
* *audio-common 0.4.0-r2*
* *audio-common-msgs 0.4.0-r2*
* *audio-play 0.4.0-r2*
* *automatika-embodied-agents 0.7.1-r1 --> 0.7.4-r1*
* *automatika-ros-sugar 0.7.0-r1 --> 0.7.1-r1*
* *camera-calibration-parsers 7.0.1-r1 --> 7.0.2-r1*
* *camera-info-manager 7.0.1-r1 --> 7.0.2-r1*
* *camera-info-manager-py 7.0.1-r1 --> 7.0.2-r1*
* *camera-ros 0.6.0-r2 --> 0.7.0-r1*
* *crazyflie 1.0.4-r1*
* *crazyflie-examples 1.0.4-r1*
* *crazyflie-interfaces 1.0.4-r1*
* *crazyflie-py 1.0.4-r1*
* *crazyflie-server-py 1.0.4-r1*
* *crazyflie-sim 1.0.4-r1*
* *cuda-buffer 0.1.1-r1 --> 0.1.2-r1*
* *cuda-buffer-backend 0.1.1-r1 --> 0.1.2-r1*
* *cuda-buffer-backend-msgs 0.1.1-r1 --> 0.1.2-r1*
* *eigenpy 3.12.0-r2 --> 3.13.0-r1*
* *generate-parameter-library 1.1.0-r1 --> 1.2.0-r1*
* *generate-parameter-library-py 1.1.0-r1 --> 1.2.0-r1*
* *geometric-shapes 2.3.3-r2 --> 2.3.4-r1*
* *gz-cmake-vendor 0.5.0-r1 --> 0.5.1-r1*
* *gz-physics-vendor 0.5.0-r1 --> 0.5.1-r1*
* *image-common 7.0.1-r1 --> 7.0.2-r1*
* *image-transport 7.0.1-r1 --> 7.0.2-r1*
* *image-transport-py 7.0.1-r1 --> 7.0.2-r1*
* *kompass 0.5.0-r1 --> 0.6.0-r1*
* *kompass-interfaces 0.5.0-r1 --> 0.6.0-r1*
* *libtorch-vendor 0.1.1-r1 --> 0.1.2-r1*
* *mavlink 2026.3.3-r2 --> 2026.6.6-r1*
* *microstrain-inertial-description 4.8.0-r2 --> 4.9.0-r1*
* *microstrain-inertial-driver 4.8.0-r2 --> 4.9.0-r1*
* *microstrain-inertial-examples 4.8.0-r2 --> 4.9.0-r1*
* *microstrain-inertial-msgs 4.8.0-r2 --> 4.9.0-r1*
* *microstrain-inertial-rqt 4.8.0-r2 --> 4.9.0-r1*
* *mola-input-rosbag1 0.2.0-r1*
* *mrpt-apps-cli 3.0.2-r1*
* *mrpt-apps-gui 3.0.2-r1*
* *mrpt-bayes 3.0.2-r1*
* *mrpt-common 3.0.2-r1*
* *mrpt-comms 3.0.2-r1*
* *mrpt-config 3.0.2-r1*
* *mrpt-containers 3.0.2-r1*
* *mrpt-core 3.0.2-r1*
* *mrpt-data 3.0.2-r1*
* *mrpt-examples-cpp 3.0.2-r1*
* *mrpt-expr 3.0.2-r1*
* *mrpt-graphs 3.0.2-r1*
* *mrpt-graphslam 3.0.2-r1*
* *mrpt-gui 3.0.2-r1*
* *mrpt-hwdrivers 3.0.2-r1*
* *mrpt-img 3.0.2-r1*
* *mrpt-imgui 3.0.2-r1*
* *mrpt-io 3.0.2-r1*
* *mrpt-kinematics 3.0.2-r1*
* *mrpt-libapps-cli 3.0.2-r1*
* *mrpt-libapps-gui 3.0.2-r1*
* *mrpt-maps 3.0.2-r1*
* *mrpt-math 3.0.2-r1*
* *mrpt-nav 3.0.2-r1*
* *mrpt-obs 3.0.2-r1*
* *mrpt-opengl 3.0.2-r1*
* *mrpt-poses 3.0.2-r1*
* *mrpt-random 3.0.2-r1*
* *mrpt-rtti 3.0.2-r1*
* *mrpt-serialization 3.0.2-r1*
* *mrpt-slam 3.0.2-r1*
* *mrpt-system 3.0.2-r1*
* *mrpt-tfest 3.0.2-r1*
* *mrpt-topography 3.0.2-r1*
* *mrpt-typemeta 3.0.2-r1*
* *mrpt-viz 3.0.2-r1*
* *nanoflann 1.10.1-r1*
* *rmw-connextdds 1.3.0-r1 --> 1.3.0-r2*
* *rmw-connextdds-common 1.3.0-r1 --> 1.3.0-r2*
* *ros-gz 3.0.8-r2 --> 4.0.0-r1*
* *ros-gz-bridge 3.0.8-r2 --> 4.0.0-r1*
* *ros-gz-image 3.0.8-r2 --> 4.0.0-r1*
* *ros-gz-interfaces 3.0.8-r2 --> 4.0.0-r1*
* *ros-gz-sim 3.0.8-r2 --> 4.0.0-r1*
* *ros-gz-sim-demos 3.0.8-r2 --> 4.0.0-r1*
* *rosbag-timing-inspector 1.0.0-r1*
* *rosidl-adapter 5.3.0-r1 --> 5.3.1-r2*
* *rosidl-buffer 5.3.0-r1 --> 5.3.1-r2*
* *rosidl-buffer-backend 5.3.0-r1 --> 5.3.1-r2*
* *rosidl-buffer-backend-registry 5.3.0-r1 --> 5.3.1-r2*
* *rosidl-buffer-py 5.3.0-r1 --> 5.3.1-r2*
* *rosidl-cli 5.3.0-r1 --> 5.3.1-r2*
* *rosidl-cmake 5.3.0-r1 --> 5.3.1-r2*
* *rosidl-generator-c 5.3.0-r1 --> 5.3.1-r2*
* *rosidl-generator-cpp 5.3.0-r1 --> 5.3.1-r2*
* *rosidl-generator-type-description 5.3.0-r1 --> 5.3.1-r2*
* *rosidl-parser 5.3.0-r1 --> 5.3.1-r2*
* *rosidl-pycommon 5.3.0-r1 --> 5.3.1-r2*
* *rosidl-runtime-c 5.3.0-r1 --> 5.3.1-r2*
* *rosidl-runtime-cpp 5.3.0-r1 --> 5.3.1-r2*
* *rosidl-typesupport-interface 5.3.0-r1 --> 5.3.1-r2*
* *rosidl-typesupport-introspection-c 5.3.0-r1 --> 5.3.1-r2*
* *rosidl-typesupport-introspection-cpp 5.3.0-r1 --> 5.3.1-r2*
* *rqt-bag 2.3.1-r1 --> 2.3.2-r1*
* *rqt-bag-plugins 2.3.1-r1 --> 2.3.2-r1*
* *rqt-reconfigure 2.0.0-r1 --> 2.0.1-r1*
* *rqt-tf-tree 1.0.6-r2 --> 1.1.0-r1*
* *rti-connext-dds-cmake-module 1.3.0-r1 --> 1.3.0-r2*
* *rviz-common 16.0.0-r1 --> 16.0.1-r1*
* *rviz-default-plugins 16.0.0-r1 --> 16.0.1-r1*
* *rviz-ogre-vendor 16.0.0-r1 --> 16.0.1-r1*
* *rviz-rendering 16.0.0-r1 --> 16.0.1-r1*
* *rviz-rendering-tests 16.0.0-r1 --> 16.0.1-r1*
* *rviz-visual-testing-framework 16.0.0-r1 --> 16.0.1-r1*
* *rviz2 16.0.0-r1 --> 16.0.1-r1*
* *sound-play 0.4.0-r2*
* *sound-play-msgs 0.4.0-r2*
* *tensor-msgs 0.1.1-r1 --> 0.1.2-r1*
* *torch-conversions 0.1.1-r1 --> 0.1.2-r1*
* *video-to-image-msg-publisher 0.9.5-r2*


No missing dependencies.