### PR TITLE
colcon*: Switch src from fetchPypi to fetchFromGitHub

### DIFF
--- a/pkgs/colcon/alias.nix
+++ b/pkgs/colcon/alias.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   setuptools,
   wheel,
   colcon-core,
@@ -28,9 +28,11 @@ buildPythonPackage rec {
   version = "0.1.1";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-DlUoQ4BgeO7YX2spAj+1SOJweDfYpIyQ+9aal+d9TQM=";
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = version;
+    hash = "sha256-CUoNzXMNbmueChGeE5mq9jUqFNgD7Q8u7kCQdfTlP/k=";
   };
 
   build-system = [

--- a/pkgs/colcon/argcomplete.nix
+++ b/pkgs/colcon/argcomplete.nix
@@ -1,12 +1,14 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, argcomplete, setuptools }:
+{ lib, buildPythonPackage, fetchFromGitHub, colcon-core, argcomplete, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-argcomplete";
   version = "0.3.3";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-PnCjK30WuBanxyGCvbIN+YX/wBZ47Jxn1EZZgUphmH0=";
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = version;
+    hash = "sha256-A6ia9OVZa+DwChVwCmkjvDtUloiFQyqtmhlaApbD7iI=";
   };
 
   pyproject = true;

--- a/pkgs/colcon/bash.nix
+++ b/pkgs/colcon/bash.nix
@@ -1,12 +1,14 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, setuptools }:
+{ lib, buildPythonPackage, fetchFromGitHub, colcon-core, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-bash";
   version = "0.5.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-KaIjpmgo4Yqtm421CH9xFOOIYBgwCRgwyhewla2iy6w=";
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = version;
+    hash = "sha256-rdUo+aLnCkQBPwBVosPYhVZqBPXeJCKKWAv+0mQBJ8Q=";
   };
 
   pyproject = true;

--- a/pkgs/colcon/cargo.nix
+++ b/pkgs/colcon/cargo.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, catkin-pkg, colcon-cmake
+{ lib, buildPythonPackage, fetchFromGitHub, catkin-pkg, colcon-cmake
 , colcon-core, colcon-pkg-config, colcon-python-setup-py, colcon-recursive-crawl
 , colcon-library-path, toml, setuptools }:
 
@@ -6,10 +6,11 @@ buildPythonPackage rec {
   pname = "colcon-cargo";
   version = "0.2.0";
 
-  src = fetchPypi {
-    inherit version;
-    pname = "colcon_cargo";
-    hash = "sha256-E66G45eqB0056PrS3V4+QpfMvYHVe3E3vQgtFkb8eKA=";
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = version;
+    hash = "sha256-jhc5mN4jnLk2zLj01sBm63acrku/FIexnIWCQ6GKDKA=";
   };
 
   pyproject = true;

--- a/pkgs/colcon/clean.nix
+++ b/pkgs/colcon/clean.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, scantree, setuptools }:
+{ lib, buildPythonPackage, fetchFromGitHub, colcon-core, scantree, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-clean";
@@ -7,9 +7,11 @@ buildPythonPackage rec {
   pyproject = true;
   build-system = [ setuptools ];
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-8rvyck24SxIhhP9AKiR7h1jY9pLJ8yulOAH2nabc61Q=";
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = version;
+    hash = "sha256-7lleFIYhA0s9zG4g2A95bnS8sutPykV8EF2ndSt2KsE=";
   };
 
   # Fix for https://github.com/colcon/colcon-clean/pull/46 is

--- a/pkgs/colcon/cmake.nix
+++ b/pkgs/colcon/cmake.nix
@@ -1,13 +1,15 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, colcon-library-path
+{ lib, buildPythonPackage, fetchFromGitHub, colcon-core, colcon-library-path
 , colcon-test-result, cmake, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-cmake";
   version = "0.2.29";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-8cChTiUw07c4+NBlnCfVnioKA9/vYB5hNpu1CD6/H2k=";
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = version;
+    hash = "sha256-v91UREVifYnwbMcM819B5CsXl8FbAH61Ydzu0vXBPX8=";
   };
 
   pyproject = true;

--- a/pkgs/colcon/core.nix
+++ b/pkgs/colcon/core.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, buildPythonApplication, buildPythonPackage, makeWrapper, fetchPypi
+{ lib, stdenv, buildPythonApplication, buildPythonPackage, makeWrapper, fetchFromGitHub
 , python, distlib, empy_3, pytest, pytest-cov, pytest-repeat
 , pytest-rerunfailures, setuptools, pytestCheckHook, flake8, flake8-blind-except
 , flake8-docstrings, flake8-import-order, pep8-naming, pylint
@@ -30,9 +30,11 @@ let
     pname = "colcon-core";
     version = "0.20.1";
 
-    src = fetchPypi {
-      inherit pname version;
-      hash = "sha256-YHgIs1x50woOH2/BfxJf9WUf0EjPVuKtMPczo5TooW0=";
+    src = fetchFromGitHub {
+      owner = "colcon";
+      repo = pname;
+      tag = version;
+      hash = "sha256-FV/G2FcnBgr7mUY/Jr+bVAdEfhHL9qAnpc92hpTfy7Y=";
     };
 
     pyproject = true;

--- a/pkgs/colcon/defaults.nix
+++ b/pkgs/colcon/defaults.nix
@@ -1,12 +1,14 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, pyyaml, setuptools }:
+{ lib, buildPythonPackage, fetchFromGitHub, colcon-core, pyyaml, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-defaults";
   version = "0.2.9";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-sPPMkAYmkGpGrp7lNB94sjeQjflXKhDlfQ8EHZRriOM=";
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = version;
+    hash = "sha256-Nb6D9jpbCvUnCNgRLBgWQFybNx0hyWVLSKj6gmTWjVs=";
   };
 
   pyproject = true;

--- a/pkgs/colcon/devtools.nix
+++ b/pkgs/colcon/devtools.nix
@@ -1,12 +1,14 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, setuptools }:
+{ lib, buildPythonPackage, fetchFromGitHub, colcon-core, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-devtools";
   version = "0.3.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-NK44d/YM4E9QrL8Rzq22YObq696Dfm2LA1q5+4yjbgU=";
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = version;
+    hash = "sha256-QBkShQ58QHhYtlKtYaj9/Zs8KMy/Cw55lJHM16uNoxI=";
   };
 
   pyproject = true;

--- a/pkgs/colcon/library-path.nix
+++ b/pkgs/colcon/library-path.nix
@@ -1,12 +1,14 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, setuptools }:
+{ lib, buildPythonPackage, fetchFromGitHub, colcon-core, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-library-path";
   version = "0.2.1";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1qp94i5czv7zmp9aqf6z1b9zpznyg91zdzs53dvq4mmb3a8zr242";
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = version;
+    hash = "sha256-/Zb8F/WcwpFMeJNLaf69ozXX8f+9gb+WXBda+nc/7MM=";
   };
 
   pyproject = true;

--- a/pkgs/colcon/meson.nix
+++ b/pkgs/colcon/meson.nix
@@ -1,13 +1,14 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, colcon-library-path, meson, setuptools }:
+{ lib, buildPythonPackage, fetchFromGitHub, colcon-core, colcon-library-path, meson, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-meson";
   version = "0.5.0";
 
-  src = fetchPypi {
-    inherit version;
-    pname = "colcon_meson"; # https://github.com/colcon/colcon-meson/issues/19
-    hash = "sha256-MgrMpSth0R+9AdUVoQr8y1unciIClvBn42FhEAitrX8=";
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = version;
+    hash = "sha256-VLCyKmPceY99cKMH/Ctotskl26Q3t7/qA4XOS7QBnBg=";
   };
 
   pyproject = true;

--- a/pkgs/colcon/metadata.nix
+++ b/pkgs/colcon/metadata.nix
@@ -1,12 +1,14 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, pyyaml, setuptools }:
+{ lib, buildPythonPackage, fetchFromGitHub, colcon-core, pyyaml, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-metadata";
   version = "0.2.5";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1j0yjzdin19dzsb25g73nszld7jlr3dg1i499nf22a8fw4678z0k";
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = version;
+    hash = "sha256-CCyhtTsSjaeY/OKO8F1zYpk8yA4HlUoXVTVkyYEpVU8=";
   };
 
   pyproject = true;

--- a/pkgs/colcon/mixin.nix
+++ b/pkgs/colcon/mixin.nix
@@ -1,12 +1,14 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, pyyaml, setuptools }:
+{ lib, buildPythonPackage, fetchFromGitHub, colcon-core, pyyaml, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-mixin";
   version = "0.2.3";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-4MNJz3sHCWEohm7BD6UI41QA2yCP7LvrhqVKsaHUnuk=";
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = version;
+    hash = "sha256-XQpRDBTtrFOOlCRXKVImUtwrwirO0ELWifUpfQuyrrY=";
   };
 
   pyproject = true;

--- a/pkgs/colcon/notification.nix
+++ b/pkgs/colcon/notification.nix
@@ -1,13 +1,14 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, notify2, setuptools }:
+{ lib, buildPythonPackage, fetchFromGitHub, colcon-core, notify2, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-notification";
   version = "0.3.1";
 
-  src = fetchPypi {
-    inherit version;
-    pname = "colcon_notification";
-    hash = "sha256-z/1iAk2PWn90KwwZGkTJZ6R5+TbdsSk0q9acDPYk4TY=";
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = version;
+    hash = "sha256-gKi5xl2ln+6CCwynUzh+WI87A4KHcrwbjkLJ6LmOoxk=";
   };
 
   pyproject = true;

--- a/pkgs/colcon/output.nix
+++ b/pkgs/colcon/output.nix
@@ -1,13 +1,14 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, setuptools }:
+{ lib, buildPythonPackage, fetchFromGitHub, colcon-core, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-output";
   version = "0.2.14";
 
-  src = fetchPypi {
-    inherit version;
-    pname = "colcon_output";
-    hash = "sha256-IetY7i/i33bhIbpI6wIsYFi/JMvW1mtDP709+w+YLEc=";
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = version;
+    hash = "sha256-Zt8ZG2SZAgS1iXMnu3b2dSoP9IzrwLwMUXVSJWqRV9w=";
   };
 
   pyproject = true;

--- a/pkgs/colcon/package-information.nix
+++ b/pkgs/colcon/package-information.nix
@@ -1,13 +1,14 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, setuptools }:
+{ lib, buildPythonPackage, fetchFromGitHub, colcon-core, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-package-information";
   version = "0.4.1";
 
-  src = fetchPypi {
-    inherit version;
-    pname = "colcon_package_information";
-    hash = "sha256-TgFDzAKIKAtf11rafHX2l4V9aU/0imjab8wXi2/7JyY=";
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = version;
+    hash = "sha256-1l2c1f0Ppp7EqOtIdaTFpwY74J6OLTg2gK7bbeYmZ5Y=";
   };
 
   pyproject = true;

--- a/pkgs/colcon/package-selection.nix
+++ b/pkgs/colcon/package-selection.nix
@@ -1,12 +1,14 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, setuptools }:
+{ lib, buildPythonPackage, fetchFromGitHub, colcon-core, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-package-selection";
   version = "0.2.10";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1nq327rycxf9710ml7k9ivd1jrnaxyk6k7sydp76kb676vc96i29";
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = version;
+    hash = "sha256-27Kk1l/Zvc18d4EfFPdUR/yeCS9fU1VJuHglyjPwnh0=";
   };
 
   pyproject = true;

--- a/pkgs/colcon/parallel-executor.nix
+++ b/pkgs/colcon/parallel-executor.nix
@@ -1,12 +1,14 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, setuptools }:
+{ lib, buildPythonPackage, fetchFromGitHub, colcon-core, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-parallel-executor";
   version = "0.4.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-UwlL4kAQo7vCUD3Ck544tcm/oPKXfFiWk3d6CTPsRF0=";
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = version;
+    hash = "sha256-JjpVhBpkVNFOsTnY8vEqIre4Hzwg+eDYwrR2iaIC5TA=";
   };
 
   pyproject = true;

--- a/pkgs/colcon/pkg-config.nix
+++ b/pkgs/colcon/pkg-config.nix
@@ -1,12 +1,14 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, setuptools }:
+{ lib, buildPythonPackage, fetchFromGitHub, colcon-core, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-pkg-config";
   version = "0.1.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "18xzqs78bv1w3881091wbwqsvkii79bhr5r3gfx3140m6z84dz41";
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = version;
+    hash = "sha256-CCtRZ4hBfF+StTsr9tV+mGCqGhHk7GQ0JWIV4ZaCtN8=";
   };
 
   pyproject = true;

--- a/pkgs/colcon/python-setup-py.nix
+++ b/pkgs/colcon/python-setup-py.nix
@@ -1,12 +1,14 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, setuptools }:
+{ lib, buildPythonPackage, fetchFromGitHub, colcon-core, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-python-setup-py";
   version = "0.2.9";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-TYurLgW6M04p7uNxX73kkCgTQu2OAA4lITDlxRkVODo=";
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = version;
+    hash = "sha256-N+OL0rSoWwZZioMV9JRvrQHdahE3fY7kKjfflUiRVL8=";
   };
 
   pyproject = true;

--- a/pkgs/colcon/recursive-crawl.nix
+++ b/pkgs/colcon/recursive-crawl.nix
@@ -1,12 +1,14 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, setuptools }:
+{ lib, buildPythonPackage, fetchFromGitHub, colcon-core, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-recursive-crawl";
   version = "0.2.3";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-/KX2GSFNIDBtqvAS+ROZ1NO2BTZLEh5d+AOZQyxVxgM=";
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = version;
+    hash = "sha256-zmmEelMjsIbXy5LchZMtr2+x+Ne2c2PhexLjbkZJmm8=";
   };
 
   pyproject = true;

--- a/pkgs/colcon/rerun.nix
+++ b/pkgs/colcon/rerun.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   setuptools,
   wheel,
   colcon-core,
@@ -28,9 +28,11 @@ buildPythonPackage rec {
   version = "0.1.1";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-2cHdt/eSyQKVAPE2w+E1YzCkMeu0/oIEe4ObUIFWs30=";
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = version;
+    hash = "sha256-Wg4VFcvvmN2PitI6axk6M5ZiNsQvGQ/isVR3CQn2B9g=";
   };
 
   build-system = [

--- a/pkgs/colcon/ros-cargo.nix
+++ b/pkgs/colcon/ros-cargo.nix
@@ -1,14 +1,15 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, colcon-library-path
+{ lib, buildPythonPackage, fetchFromGitHub, colcon-core, colcon-library-path
 , colcon-cargo, colcon-ros, setuptools, cargo-ament-build }:
 
 buildPythonPackage rec {
   pname = "colcon-ros-cargo";
   version = "0.2.0";
 
-  src = fetchPypi {
-    pname = "colcon_ros_cargo";
-    inherit version;
-    hash = "sha256-70taCMJRPSq2CPvO5aqudsc8RN0l194vLbT1UZWXfU8=";
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = "v${version}";
+    hash = "sha256-79HsQk5F+Vkx3GafdX08YBQLrBv4dxBmWtdexDDqGbU=";
   };
 
   pyproject = true;

--- a/pkgs/colcon/ros.nix
+++ b/pkgs/colcon/ros.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, catkin-pkg, colcon-cmake, colcon-core
+{ lib, buildPythonPackage, fetchFromGitHub, catkin-pkg, colcon-cmake, colcon-core
 , colcon-pkg-config, colcon-python-setup-py
 , colcon-recursive-crawl, setuptools }:
 
@@ -6,9 +6,11 @@ buildPythonPackage rec {
   pname = "colcon-ros";
   version = "0.5.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-eafon2+mNvfk/USoi3hg+x2pnVHwunvPC5tiShpXg2U=";
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = version;
+    hash = "sha256-BsGCgFGxOIAGTP4A8bulakMoeUj+Ki6sPIpTQ4L7LSo=";
   };
 
   pyproject = true;

--- a/pkgs/colcon/test-result.nix
+++ b/pkgs/colcon/test-result.nix
@@ -1,12 +1,14 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, setuptools }:
+{ lib, buildPythonPackage, fetchFromGitHub, colcon-core, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-test-result";
   version = "0.3.8";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1lvfqd3yfqnbjc3hgpc6ikphs5823r7s1rr1ywfrzpavd9qjalma";
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = version;
+    hash = "sha256-4t2jGJlwm8ZQkOG+Q2KyZ9Qnhhy5PAHcxxo7lkqSDRA=";
   };
 
   pyproject = true;

--- a/pkgs/colcon/zsh.nix
+++ b/pkgs/colcon/zsh.nix
@@ -1,12 +1,14 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, setuptools }:
+{ lib, buildPythonPackage, fetchFromGitHub, colcon-core, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-zsh";
   version = "0.5.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-7/91xD3asmSYU1KeQc7jbg+DttTIZMBzY1PQ3s54M0o=";
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = version;
+    hash = "sha256-8aXmPxYFeqcLUNO4+md2lyk2/SnVu21HPBRZGrB/HHM=";
   };
 
   pyproject = true;


### PR DESCRIPTION
PyPI recently changed the names of package tarballs to use underscores instead of dashes. This is problematic, because we need to add the `pname` attribute to `fetchPypi` calls, but only after the package releases a new version. We cannot see new versions easily, because automated updates by `maintainers/scripts/update-colcon.sh` without added `pname` fail. To avoid this and have reliable updates, we just fetch the sources directly from GitHub. Many packages in nixpkgs did the same and this is the recommended practice now (see https://github.com/NixOS/nixpkgs/pull/405714).