### PR TITLE
Add festival-stub

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -25,6 +25,11 @@ self: super: with self.lib; {
     colcon-zsh
   ];
 
+  # Festival is not available in nixpkgs, but packages in audio_common
+  # (which depend on festoval) are useful even without it. This
+  # placeholder allows building these packages.
+  festival-stub = null;
+
   gz-cmake_2 = self.callPackage ./gazebo/gz-cmake/2.nix { };
   gz-cmake_3 = self.callPackage ./gazebo/gz-cmake/3.nix { };
 


### PR DESCRIPTION
Festival is an old speech synthesis package, which is not available in nixpkgs. There were [some attempts to package it][1], but it seems to be complicated. The soud_play package, which is being ported to ROS 2, depends on it, but only via exec_depend and is still useful without festival. The only place, where festival is needed is [here][2].

Therefore, to have at least some sound_play functionality available, we add null festival-stub, which is is referenced in rosdep and allows building the relevant packages. If somebody uses the festival functionality, they'll see the [error message][2] at runtime.

[1]: https://github.com/NixOS/nixpkgs/blob/50338ea4bce54b50d184d68d8fb2885e45053f81/pkgs/development/python-modules/phonemizer/default.nix#L52
[2]: https://github.com/ros-drivers/audio_common/blob/db2770b0ad703c474039914937974c764dc94351/sound_play/scripts/soundplay_node.py#L376-L386