### PR TITLE
fix: mavlink: removed unused and broken python future dependency

### DIFF
--- a/distros/humble/mavlink/default.nix
+++ b/distros/humble/mavlink/default.nix
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  buildInputs = [ ament-cmake cmake python3 python3Packages.future python3Packages.lxml ros-environment ];
+  buildInputs = [ ament-cmake cmake python3 python3Packages.lxml ros-environment ];
   nativeBuildInputs = [ ament-cmake cmake ros-environment ];
 
   meta = {

--- a/distros/jazzy/mavlink/default.nix
+++ b/distros/jazzy/mavlink/default.nix
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  buildInputs = [ ament-cmake cmake python3 python3Packages.future python3Packages.lxml ros-environment ];
+  buildInputs = [ ament-cmake cmake python3 python3Packages.lxml ros-environment ];
   nativeBuildInputs = [ ament-cmake cmake ros-environment ];
 
   meta = {

--- a/distros/kilted/mavlink/default.nix
+++ b/distros/kilted/mavlink/default.nix
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  buildInputs = [ ament-cmake cmake python3 python3Packages.future python3Packages.lxml ros-environment ];
+  buildInputs = [ ament-cmake cmake python3 python3Packages.lxml ros-environment ];
   nativeBuildInputs = [ ament-cmake cmake ros-environment ];
 
   meta = {

--- a/distros/lyrical/mavlink/default.nix
+++ b/distros/lyrical/mavlink/default.nix
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  buildInputs = [ ament-cmake cmake python3 python3Packages.future python3Packages.lxml ros-environment ];
+  buildInputs = [ ament-cmake cmake python3 python3Packages.lxml ros-environment ];
   nativeBuildInputs = [ ament-cmake cmake ros-environment ];
 
   meta = {

--- a/distros/rolling/mavlink/default.nix
+++ b/distros/rolling/mavlink/default.nix
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  buildInputs = [ ament-cmake cmake python3 python3Packages.future python3Packages.lxml ros-environment ];
+  buildInputs = [ ament-cmake cmake python3 python3Packages.lxml ros-environment ];
   nativeBuildInputs = [ ament-cmake cmake ros-environment ];
 
   meta = {


### PR DESCRIPTION
Hey, guided by @wentasah, I have removed the unnecessary dependency on `python3Packages.future`, which was making the build fail in the last couple of weeks. The change does not seem to cause problems downstream.

**Tested:** I have compiled _mavlink_ successfully for all distros.