### PR TITLE
Add Dependabot configuration for updating nixpkgs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: "nix"
+    directory: "/"  # Location of flake.nix
+    allow:
+      - dependency-name: "nixpkgs"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
To ensure that we use reasonably recent nixpkgs, configure Dependabot to create nixpkgs update PR every month.

For this to work, "Dependabot version updates" have to be enabled in [repository settings](https://github.com/lopsided98/nix-ros-overlay/settings/security_analysis). @lopsided98 Can you please enable it?

An example PR generated by Dependabot with this configuration can be seen [here](https://github.com/wentasah/nix-ros-overlay/pull/55).