### PR TITLE
rosdistro sync, Fri Jun 26 17:11:29 2026

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -176,6 +176,13 @@ let
       '';
     });
 
+    onnxruntime-vendor = rosSuper.onnxruntime-vendor.overrideAttrs ({
+      cmakeFlags ? [], propagatedBuildInputs ? [], ...
+    }: {
+      cmakeFlags = cmakeFlags ++ [ "-DAMENT_VENDOR_POLICY=NEVER_VENDOR" ];
+      propagatedBuildInputs = propagatedBuildInputs ++ [ self.onnxruntime ];
+    });
+
     osqp-vendor = pipe rosSuper.osqp-vendor [
       (pkg: pkg.overrideAttrs ({
         preInstall ? "", postPatch ? "", ...

--- a/distros/humble/autoware-cmake/default.nix
+++ b/distros/humble/autoware-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, autoware-lint-common, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-autoware-cmake";
-  version = "1.2.0-r3";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/humble/autoware_cmake/1.2.0-3.tar.gz";
-    name = "1.2.0-3.tar.gz";
-    sha256 = "1bf0e8eb98423ee87e80a59ec757ba461c605563787a967cf648028bad53774a";
+    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/humble/autoware_cmake/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "0cad2abd5624a0a7fc168fe28b8aa9d31d5a0f1cfc04f34c5e01dffefbd039c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-lint-common/default.nix
+++ b/distros/humble/autoware-lint-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-cppcheck, ament-cmake-export-dependencies, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-humble-autoware-lint-common";
-  version = "1.2.0-r3";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/humble/autoware_lint_common/1.2.0-3.tar.gz";
-    name = "1.2.0-3.tar.gz";
-    sha256 = "48b8c4838cd267bc93b86885adb1fd75843fdf5341bc2cce6c2a7bfec7f24272";
+    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/humble/autoware_lint_common/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "86574bbd9743513818d83965b9728d725a0f600c2a32b82f8a8399932c64de0a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/callback-isolated-executor/default.nix
+++ b/distros/humble/callback-isolated-executor/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cie-config-msgs, cie-thread-configurator, rclcpp, rclcpp-components, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-callback-isolated-executor";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/callback_isolated_executor-release/archive/release/humble/callback_isolated_executor/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "9c383dff9d5f4eb6ea116f530dda6fbcb2eb572becbf4a56ad23653ca96186f1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cie-config-msgs cie-thread-configurator rclcpp rclcpp-components std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Component container and executor assigning a dedicated thread to each callback group.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/cie-config-msgs/default.nix
+++ b/distros/humble/cie-config-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-humble-cie-config-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/callback_isolated_executor-release/archive/release/humble/cie_config_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "8bd44f501f166e39455cc55855aac410d120820e6cc1f6f3f461d3a6c704db6c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS messages for interaction between cie_thread_configurator and callback_isolated_executor.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/cie-sample-application/default.nix
+++ b/distros/humble/cie-sample-application/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, callback-isolated-executor, cie-thread-configurator, rclcpp, rclcpp-components, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-cie-sample-application";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/callback_isolated_executor-release/archive/release/humble/cie_sample_application/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "ff8af992f139c17a1f86ccbb2fa6af6bbb7cb8dcf3c603681ccbfe0f74de3c36";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ callback-isolated-executor cie-thread-configurator rclcpp rclcpp-components std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Sample application to demonstrate the use of cie_thread_configurator and callback_isolated_executor.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/cie-thread-configurator/default.nix
+++ b/distros/humble/cie-thread-configurator/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cie-config-msgs, rclcpp, yaml-cpp }:
+buildRosPackage {
+  pname = "ros-humble-cie-thread-configurator";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/callback_isolated_executor-release/archive/release/humble/cie_thread_configurator/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "d19a3b3a1006df03900a6c06d9f7be17c37f00fe4b5a1112838efd4ef7124e5a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cie-config-msgs rclcpp yaml-cpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A dedicated node that configures the scheduling attributes of each thread in callback_isolated_executor.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/clearpath-config-live/default.nix
+++ b/distros/humble/clearpath-config-live/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, clearpath-generator-common, python3Packages, rclpy, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-config-live";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_config_live/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "4c134969dcb2d435918025dcaaee90a36d14a8a0b8c76159d2bf4e98beaec221";
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_config_live/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "6471b108b3e7b4eee6b0102360990cf6157e01dfb0d7d9a0ceb008916dc5f39f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-desktop/default.nix
+++ b/distros/humble/clearpath-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-config-live, clearpath-platform-msgs, clearpath-viz }:
 buildRosPackage {
   pname = "ros-humble-clearpath-desktop";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_desktop/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "223bfaf366f87ab2f9ad20c5ae440e2f99f2f64fff25f10452f22f3ce65460a4";
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_desktop/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "52abe1a3933f58dae1ae3fba6f7fb17d4f3785043979e503509a77e8ae67b88d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-viz/default.nix
+++ b/distros/humble/clearpath-viz/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, clearpath-platform-description, joint-state-publisher-gui, rqt-robot-monitor, rviz2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, clearpath-description, joint-state-publisher-gui, nav2-rviz-plugins, rqt-robot-monitor, rviz2 }:
 buildRosPackage {
   pname = "ros-humble-clearpath-viz";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_viz/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "cd4fe57142eb16e903c4d65d93b36f482a24e652d1ec64b1cdb0b2567067fdee";
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_viz/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "88e8dcb9e266a60ac7c99277dcb13352ee9e9fbcb682730b23c988c38614b2b0";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ clearpath-platform-description joint-state-publisher-gui rqt-robot-monitor rviz2 ];
+  propagatedBuildInputs = [ clearpath-description joint-state-publisher-gui nav2-rviz-plugins rqt-robot-monitor rviz2 ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/clips-vendor/default.nix
+++ b/distros/humble/clips-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, unzip }:
 buildRosPackage {
   pname = "ros-humble-clips-vendor";
-  version = "6.4.3-r1";
+  version = "6.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/clips_vendor-release/archive/release/humble/clips_vendor/6.4.3-1.tar.gz";
-    name = "6.4.3-1.tar.gz";
-    sha256 = "ea286aa8f7e64d9f17f14710c68523d527cf7d82bc8a266ecebf2b745dd20888";
+    url = "https://github.com/ros2-gbp/clips_vendor-release/archive/release/humble/clips_vendor/6.4.4-1.tar.gz";
+    name = "6.4.4-1.tar.gz";
+    sha256 = "c080df67910cb9a49cbc20a31e8c51dae40a347639b0d65bc6d9dee32da896b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clips-vendor/vendored-source.json
+++ b/distros/humble/clips-vendor/vendored-source.json
@@ -1,6 +1,6 @@
 {
   "clips_vendor": {
-    "url": "https://raw.githubusercontent.com/carologistics/clips_vendor/r925/clipsrules-code-r925.zip",
-    "sha256": "08macis5ai6y6azzbp5mhyk30sx3qx3903wsbry9agfabgd2yviw"
+    "url": "https://raw.githubusercontent.com/carologistics/clips_vendor/r974/clipsrules-code-r974.zip",
+    "sha256": "0yg9gfqmql6fmw4qrzfm968nb10lnfxzlpish2xyscibax6gg97p"
   }
 }

--- a/distros/humble/compass-msgs/default.nix
+++ b/distros/humble/compass-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-compass-msgs";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/compass_msgs/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "a2d79916e6480a2ea54ecd34a87517e67ad9c571c6b42057dce1b24d3097a88d";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/compass_msgs/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "1c8ab4bccf09329e87abea14d8611106fe28c3978bd6bccef28e9f203b1de5f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/fkie-message-filters/default.nix
+++ b/distros/humble/fkie-message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, image-transport, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-fkie-message-filters";
-  version = "3.3.1-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fkie_message_filters-release/archive/release/humble/fkie_message_filters/3.3.1-1.tar.gz";
-    name = "3.3.1-1.tar.gz";
-    sha256 = "6a51ea0791a2ad6b7fbf2461ba9876a730d6db881daf761799d52c52fee7e0f2";
+    url = "https://github.com/ros2-gbp/fkie_message_filters-release/archive/release/humble/fkie_message_filters/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "e3fc4c9e4859fe20e6de5a81086c2fd2c25e9fdb64a910eb67694703c3a757bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/foxglove-bridge/default.nix
+++ b/distros/humble/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, geometry-msgs, nlohmann_json, rcl-interfaces, rclcpp, rclcpp-components, rcpputils, rcutils, resource-retriever, ros-environment, rosgraph-msgs, rosidl-typesupport-introspection-cpp, rosx-introspection, sensor-msgs, std-msgs, std-srvs, websocketpp }:
 buildRosPackage {
   pname = "ros-humble-foxglove-bridge";
-  version = "3.4.1-r1";
+  version = "3.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_bridge/3.4.1-1.tar.gz";
-    name = "3.4.1-1.tar.gz";
-    sha256 = "ac202de6f865054105be4a96e5833c80b8a95dbb311b90d2330e52467d43f6ab";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_bridge/3.4.2-1.tar.gz";
+    name = "3.4.2-1.tar.gz";
+    sha256 = "736941640f0f643eb9259a9fd246df6beaeb83ee5720c31f88c0ada6c22c9403";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/foxglove-msgs/default.nix
+++ b/distros/humble/foxglove-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-foxglove-msgs";
-  version = "3.4.1-r1";
+  version = "3.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_msgs/3.4.1-1.tar.gz";
-    name = "3.4.1-1.tar.gz";
-    sha256 = "7e6a7cae3b1f8102089b544dea32247a249e839afb732a469fed52177264eb4b";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_msgs/3.4.2-1.tar.gz";
+    name = "3.4.2-1.tar.gz";
+    sha256 = "f1d9f57c43a2f196a9ea8416585b9d576151abdd47452888be0da8e7adffee18";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/fusioncore-core/default.nix
+++ b/distros/humble/fusioncore-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module }:
 buildRosPackage {
   pname = "ros-humble-fusioncore-core";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/fusioncore_core/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "3ff23045f13c00dc56c5d51b64f088c368299f26a60343604180469cddf4fa7a";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/fusioncore_core/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "080e7dd0f2a2002fff83f92341cbd23e038be34ac0a94ca839155b6cac2fd3bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/fusioncore-datasets/default.nix
+++ b/distros/humble/fusioncore-datasets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fusioncore-ros, geometry-msgs, nav-msgs, rclpy, robot-localization, rosgraph-msgs, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-fusioncore-datasets";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/fusioncore_datasets/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "8a30b22d51d5c47bcaafd6759b14bb6c44a8158fce76d2a6c744b02e4c4b9571";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/fusioncore_datasets/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "2e09b0444c9a1f5e7db326ea50f2281df1bcb7d229655ad75639f5ff9ac85527";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/fusioncore-gazebo/default.nix
+++ b/distros/humble/fusioncore-gazebo/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, fusioncore-ros, nav-msgs, rclpy, robot-state-publisher, sensor-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, fusioncore-ros, geometry-msgs, nav-msgs, rclpy, robot-localization, robot-state-publisher, ros-gz-bridge, ros-gz-sim, rviz2, sensor-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-fusioncore-gazebo";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/fusioncore_gazebo/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "ee06dc3beff5387f6ff936dc8f84c5623d953164cfd77c86b1c8c7e7f850c341";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/fusioncore_gazebo/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "705b11e33d04dd18f44fcc773b94331ef37838944d823527dc9840e8193fb4d8";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ fusioncore-ros nav-msgs rclpy robot-state-publisher sensor-msgs tf2-ros ];
+  propagatedBuildInputs = [ fusioncore-ros geometry-msgs nav-msgs rclpy robot-localization robot-state-publisher ros-gz-bridge ros-gz-sim rviz2 sensor-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "Gazebo simulation world for FusionCore integration testing";
+    description = "Gazebo simulation world for FusionCore integration testing and demo recording";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/humble/fusioncore-ros/default.nix
+++ b/distros/humble/fusioncore-ros/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, compass-msgs, diagnostic-msgs, eigen3-cmake-module, fusioncore-core, geographic-msgs, geometry-msgs, gps-msgs, nav-msgs, proj, rclcpp, rclcpp-lifecycle, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, compass-msgs, diagnostic-msgs, eigen3-cmake-module, fusioncore-core, geographic-msgs, geometry-msgs, gps-msgs, lifecycle-msgs, nav-msgs, proj, rclcpp, rclcpp-lifecycle, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-fusioncore-ros";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/fusioncore_ros/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "b2e76fffe72edf971ac339ebb090fd164da1950a05e509304968daeb2ec4e192";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/fusioncore_ros/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "c7d6e5b8aee971139f708b36696ca1ec0cd4655ea13a567b18a16ccac4297ac6";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake rosidl-default-generators ];
-  propagatedBuildInputs = [ compass-msgs diagnostic-msgs eigen3-cmake-module fusioncore-core geographic-msgs geometry-msgs gps-msgs nav-msgs proj rclcpp rclcpp-lifecycle rosidl-default-runtime sensor-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
-  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+  buildInputs = [ ament-cmake-auto rosidl-default-generators ];
+  propagatedBuildInputs = [ compass-msgs diagnostic-msgs eigen3-cmake-module fusioncore-core geographic-msgs geometry-msgs gps-msgs lifecycle-msgs nav-msgs proj rclcpp rclcpp-lifecycle rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake-auto rosidl-default-generators ];
 
   meta = {
     description = "ROS 2 UKF sensor fusion for IMU, wheel encoders, GPS, and visual SLAM pose. 23-state filter with ECEF-native GPS handling, online gyro/accel/encoder bias estimation, adaptive noise covariance, chi-squared outlier rejection on every sensor, and map reinitialization recovery for GPS-denied operation. Drop-in robot_localization alternative. Benchmarked on 12 full-length NCLT sequences: wins 10 of 12 vs robot_localization EKF.";

--- a/distros/humble/fusioncore-ublox/default.nix
+++ b/distros/humble/fusioncore-ublox/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, nav-msgs, rclcpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-fusioncore-ublox";
+  version = "0.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/humble/fusioncore_ublox/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "e3277aecd09dd9bd81bfbb35d810836bc2aa16d5503fa1e073fc68817d6a776d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ nav-msgs rclcpp std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Bridge nodes for u-blox GPS receivers: converts raw NavPVT Doppler velocity to nav_msgs/Odometry for FusionCore (gnss.velocity_topic). Optional companion to fusioncore_ros; not required to build or run FusionCore.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -638,6 +638,8 @@ self: super: {
 
  builtin-interfaces = self.callPackage ./builtin-interfaces {};
 
+ callback-isolated-executor = self.callPackage ./callback-isolated-executor {};
+
  camera-aravis2 = self.callPackage ./camera-aravis2 {};
 
  camera-aravis2-msgs = self.callPackage ./camera-aravis2-msgs {};
@@ -697,6 +699,12 @@ self: super: {
  catch-ros2 = self.callPackage ./catch-ros2 {};
 
  chomp-motion-planner = self.callPackage ./chomp-motion-planner {};
+
+ cie-config-msgs = self.callPackage ./cie-config-msgs {};
+
+ cie-sample-application = self.callPackage ./cie-sample-application {};
+
+ cie-thread-configurator = self.callPackage ./cie-thread-configurator {};
 
  class-loader = self.callPackage ./class-loader {};
 
@@ -1408,6 +1416,8 @@ self: super: {
 
  fusioncore-ros = self.callPackage ./fusioncore-ros {};
 
+ fusioncore-ublox = self.callPackage ./fusioncore-ublox {};
+
  game-controller-spl = self.callPackage ./game-controller-spl {};
 
  game-controller-spl-interfaces = self.callPackage ./game-controller-spl-interfaces {};
@@ -2040,6 +2050,8 @@ self: super: {
 
  mimick-vendor = self.callPackage ./mimick-vendor {};
 
+ mobile-robot-simulator = self.callPackage ./mobile-robot-simulator {};
+
  mobileye-560-660-msgs = self.callPackage ./mobileye-560-660-msgs {};
 
  mocap4r2-control = self.callPackage ./mocap4r2-control {};
@@ -2662,6 +2674,8 @@ self: super: {
 
  ompl = self.callPackage ./ompl {};
 
+ onnxruntime-vendor = self.callPackage ./onnxruntime-vendor {};
+
  open3d-conversions = self.callPackage ./open3d-conversions {};
 
  open-manipulator = self.callPackage ./open-manipulator {};
@@ -2752,6 +2766,8 @@ self: super: {
 
  pal-pro-gripper-description = self.callPackage ./pal-pro-gripper-description {};
 
+ pal-pro-gripper-simulation = self.callPackage ./pal-pro-gripper-simulation {};
+
  pal-pro-gripper-wrapper = self.callPackage ./pal-pro-gripper-wrapper {};
 
  pal-robotiq-controller-configuration = self.callPackage ./pal-robotiq-controller-configuration {};
@@ -2771,6 +2787,8 @@ self: super: {
  pal-sea-arm-gazebo = self.callPackage ./pal-sea-arm-gazebo {};
 
  pal-sea-arm-moveit-config = self.callPackage ./pal-sea-arm-moveit-config {};
+
+ pal-sea-arm-mujoco = self.callPackage ./pal-sea-arm-mujoco {};
 
  pal-sea-arm-simulation = self.callPackage ./pal-sea-arm-simulation {};
 
@@ -2953,6 +2971,8 @@ self: super: {
  position-controllers = self.callPackage ./position-controllers {};
 
  proto2ros = self.callPackage ./proto2ros {};
+
+ protobuf-comm = self.callPackage ./protobuf-comm {};
 
  proxsuite = self.callPackage ./proxsuite {};
 
@@ -3338,6 +3358,8 @@ self: super: {
 
  ros2-fmt-logger = self.callPackage ./ros2-fmt-logger {};
 
+ ros2-medkit-action-status-bridge = self.callPackage ./ros2-medkit-action-status-bridge {};
+
  ros2-medkit-beacon-common = self.callPackage ./ros2-medkit-beacon-common {};
 
  ros2-medkit-cmake = self.callPackage ./ros2-medkit-cmake {};
@@ -3355,6 +3377,8 @@ self: super: {
  ros2-medkit-integration-tests = self.callPackage ./ros2-medkit-integration-tests {};
 
  ros2-medkit-linux-introspection = self.callPackage ./ros2-medkit-linux-introspection {};
+
+ ros2-medkit-log-bridge = self.callPackage ./ros2-medkit-log-bridge {};
 
  ros2-medkit-msgs = self.callPackage ./ros2-medkit-msgs {};
 
@@ -3661,6 +3685,8 @@ self: super: {
  rtabmap = self.callPackage ./rtabmap {};
 
  rtabmap-conversions = self.callPackage ./rtabmap-conversions {};
+
+ rtabmap-costmap-plugins = self.callPackage ./rtabmap-costmap-plugins {};
 
  rtabmap-demos = self.callPackage ./rtabmap-demos {};
 
@@ -4061,6 +4087,8 @@ self: super: {
  tiago-pro-laser-sensors = self.callPackage ./tiago-pro-laser-sensors {};
 
  tiago-pro-moveit-config = self.callPackage ./tiago-pro-moveit-config {};
+
+ tiago-pro-mujoco = self.callPackage ./tiago-pro-mujoco {};
 
  tiago-pro-navigation = self.callPackage ./tiago-pro-navigation {};
 

--- a/distros/humble/launch-pal/default.nix
+++ b/distros/humble/launch-pal/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-launch-pal";
-  version = "0.20.1-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_pal-release/archive/release/humble/launch_pal/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "0accbd0ce9f1f1ec5a77551aa83bb1d1f602fa339e362aa96d814c52858584c6";
+    url = "https://github.com/ros2-gbp/launch_pal-release/archive/release/humble/launch_pal/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "aabbc2fae95ba5eb398d007c436f0cd2e00a05ccf2e8a323a1689511ef984021";
   };
 
   buildType = "ament_python";

--- a/distros/humble/mobile-robot-simulator/default.nix
+++ b/distros/humble/mobile-robot-simulator/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, rclcpp, rosgraph-msgs, sensor-msgs, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-mobile-robot-simulator";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/nobleo/mobile_robot_simulator-release/archive/release/humble/mobile_robot_simulator/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "0144744f5e98c8bc12eef88aa313d3513b581cbfd5c604590fedf052233853a2";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ geometry-msgs nav-msgs rclcpp rosgraph-msgs sensor-msgs tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The mobile_robot_simulator package";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/nao-meshes/default.nix
+++ b/distros/humble/nao-meshes/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, openjdk }:
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-nao-meshes";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-naoqi/nao_meshes-release/archive/release/humble/nao_meshes/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "cc148ff3d80ce2e61f6ae47112a61890f8d2943197ce53d3878faaca57a369ab";
+    url = "https://github.com/ros-naoqi/nao_meshes-release/archive/release/humble/nao_meshes/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "eadf5f7cd2cca494d5bc87ac3dddb9a1887df881f3a7b01fd9b66d4ceec37290";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake openjdk ];
+  buildInputs = [ ament-cmake ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/naoqi-bridge-msgs/default.nix
+++ b/distros/humble/naoqi-bridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-naoqi-bridge-msgs";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-naoqi/naoqi_bridge_msgs2-release/archive/release/humble/naoqi_bridge_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "1c19aec33f2a15fd41455e3a81ece62c34ad8ade6b79af32fdc8072c9e0e07fa";
+    url = "https://github.com/ros-naoqi/naoqi_bridge_msgs2-release/archive/release/humble/naoqi_bridge_msgs/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "43e141ee2421b281ded73d9b11ae8a48bbf2a7eb0b09aaa931d76a76bf6d0aa4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/naoqi-driver/default.nix
+++ b/distros/humble/naoqi-driver/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, boost, cv-bridge, diagnostic-msgs, diagnostic-updater, geometry-msgs, image-transport, kdl-parser, naoqi-bridge-msgs, naoqi-libqi, naoqi-libqicore, rclcpp, rclcpp-action, robot-state-publisher, rosidl-default-generators, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, boost, cv-bridge, diagnostic-msgs, diagnostic-updater, geometry-msgs, image-transport, kdl-parser, naoqi-bridge-msgs, naoqi-libqi, naoqi-libqicore, rclcpp, rclcpp-action, robot-state-publisher, rosidl-default-generators, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-naoqi-driver";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-naoqi/naoqi_driver2-release/archive/release/humble/naoqi_driver/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "5cef270b3dab4c86abdf8c77f8d4c28fdf1eed89fb1f07926d65b53aa2252421";
+    url = "https://github.com/ros-naoqi/naoqi_driver2-release/archive/release/humble/naoqi_driver/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "9b9913f1bb13cab7be5b57fda261cdba88dfb5f3bfb556ac9d1cc098351f28f0";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake diagnostic-msgs diagnostic-updater geometry-msgs rosidl-default-generators sensor-msgs tf2-geometry-msgs tf2-msgs ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ action-msgs boost cv-bridge image-transport kdl-parser naoqi-bridge-msgs naoqi-libqi naoqi-libqicore rclcpp rclcpp-action robot-state-publisher tf2-ros ];
+  propagatedBuildInputs = [ action-msgs ament-index-cpp boost cv-bridge image-transport kdl-parser naoqi-bridge-msgs naoqi-libqi naoqi-libqicore rclcpp rclcpp-action robot-state-publisher tf2-ros ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/humble/naoqi-libqi/default.nix
+++ b/distros/humble/naoqi-libqi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, openssl }:
 buildRosPackage {
   pname = "ros-humble-naoqi-libqi";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-naoqi/libqi-release/archive/release/humble/naoqi_libqi/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "0d3e8e26b36fa564c0459c630b1ea3c14921fbbfe6304919748fd0f472400a16";
+    url = "https://github.com/ros-naoqi/libqi-release/archive/release/humble/naoqi_libqi/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "ae98ca8d97c6c228612838ca4248453264d425c8576b23b007313a9b26cd1315";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/naoqi-libqicore/default.nix
+++ b/distros/humble/naoqi-libqicore/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, naoqi-libqi }:
 buildRosPackage {
   pname = "ros-humble-naoqi-libqicore";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-naoqi/libqicore-release/archive/release/humble/naoqi_libqicore/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "f830abbbf5fccffc292cdbb19d5393bc1d129f03df5cf5bb7af414e8af005fde";
+    url = "https://github.com/ros-naoqi/libqicore-release/archive/release/humble/naoqi_libqicore/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "702a2a7f38f824d2673d43519474988de25b6f12e4d9aa2c384cc6d1590b8e7a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ntrip-client-node/default.nix
+++ b/distros/humble/ntrip-client-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, curl, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ntrip-client-node";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ntrip_client_node/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "243929b094ff69ffd00ae71f63172fd118b20d2a3b8aa1656a3327e14cbdfd96";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ntrip_client_node/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "e91d51884c4e8acf64941d02eaf6810d4ffc1d3f2b3cdd8e65b4b6f14e590449";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-2dnav/default.nix
+++ b/distros/humble/omni-base-2dnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-index-python, ament-lint-auto, ament-lint-common, diagnostic-aggregator, launch-pal, pal-maps, ros2launch }:
 buildRosPackage {
   pname = "ros-humble-omni-base-2dnav";
-  version = "2.22.0-r1";
+  version = "2.22.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/omni_base_navigation-release/archive/release/humble/omni_base_2dnav/2.22.0-1.tar.gz";
-    name = "2.22.0-1.tar.gz";
-    sha256 = "38a21b1dd51215c43b870e8281dd05f5da12f80da17c18b07f1e43cd7a42edec";
+    url = "https://github.com/ros2-gbp/omni_base_navigation-release/archive/release/humble/omni_base_2dnav/2.22.1-1.tar.gz";
+    name = "2.22.1-1.tar.gz";
+    sha256 = "03c9f840fe87a51d4154e9a1a30a847ad25f095aef718ff356393d23c9ac5068";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-bringup/default.nix
+++ b/distros/humble/omni-base-bringup/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-index-python, ament-lint-auto, ament-lint-common, diagnostic-aggregator, joy-linux, joy-teleop, launch-pal, omni-base-controller-configuration, omni-base-description, robot-state-publisher, twist-mux }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-index-python, ament-lint-auto, ament-lint-common, diagnostic-aggregator, joy, joy-teleop, launch-pal, omni-base-controller-configuration, omni-base-description, robot-state-publisher, twist-mux }:
 buildRosPackage {
   pname = "ros-humble-omni-base-bringup";
-  version = "2.15.1-r1";
+  version = "2.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/omni_base_robot-release/archive/release/humble/omni_base_bringup/2.15.1-1.tar.gz";
-    name = "2.15.1-1.tar.gz";
-    sha256 = "2d30aeb78fc9dbfe3117875f9c76ef5b3c6a0559604de7fac45df65b43e42a1c";
+    url = "https://github.com/ros2-gbp/omni_base_robot-release/archive/release/humble/omni_base_bringup/2.17.0-1.tar.gz";
+    name = "2.17.0-1.tar.gz";
+    sha256 = "68a64271d0ff421960186de7e13179a5fac2b64aa9d93ace7a0cfb90e9cea83b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python diagnostic-aggregator joy-linux joy-teleop launch-pal omni-base-controller-configuration omni-base-description robot-state-publisher twist-mux ];
+  propagatedBuildInputs = [ ament-index-python diagnostic-aggregator joy joy-teleop launch-pal omni-base-controller-configuration omni-base-description robot-state-publisher twist-mux ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/omni-base-controller-configuration/default.nix
+++ b/distros/humble/omni-base-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, joint-state-broadcaster, ros2controlcli, topic-tools }:
 buildRosPackage {
   pname = "ros-humble-omni-base-controller-configuration";
-  version = "2.15.1-r1";
+  version = "2.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/omni_base_robot-release/archive/release/humble/omni_base_controller_configuration/2.15.1-1.tar.gz";
-    name = "2.15.1-1.tar.gz";
-    sha256 = "3991f79176d731d4396bf12167e9340dc06e24d03b0339d06110941e750289da";
+    url = "https://github.com/ros2-gbp/omni_base_robot-release/archive/release/humble/omni_base_controller_configuration/2.17.0-1.tar.gz";
+    name = "2.17.0-1.tar.gz";
+    sha256 = "cdad61f937a8bd63800e2af5ac0774f7e9d3a07cdbeaaf6c766bc41bb59ad4c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-description/default.nix
+++ b/distros/humble/omni-base-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, gazebo-planar-move-plugin, joint-state-publisher-gui, launch, launch-pal, launch-param-builder, launch-ros, launch-testing-ament-cmake, pal-urdf-utils, realsense2-description, rviz2, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-omni-base-description";
-  version = "2.15.1-r1";
+  version = "2.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/omni_base_robot-release/archive/release/humble/omni_base_description/2.15.1-1.tar.gz";
-    name = "2.15.1-1.tar.gz";
-    sha256 = "80d7995dc5f5eb25a9481285dec9f10b3e471c3fb807eed337df1af51ee777a3";
+    url = "https://github.com/ros2-gbp/omni_base_robot-release/archive/release/humble/omni_base_description/2.17.0-1.tar.gz";
+    name = "2.17.0-1.tar.gz";
+    sha256 = "1f971354438f68c179e33635e96780a4843fe2f7c0ee9ce76f828093a945be9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-gazebo/default.nix
+++ b/distros/humble/omni-base-gazebo/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, gazebo-ros2-control, launch-pal, nav2-bringup, omni-base-2dnav, omni-base-bringup, omni-base-description, omni-base-laser-sensors, omni-base-rgbd-sensors, pal-gazebo-plugins, pal-gazebo-worlds, pal-maps, pal-urdf-utils, ros2launch }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, gazebo-ros2-control, launch-pal, nav2-bringup, omni-base-2dnav, omni-base-bringup, omni-base-description, omni-base-laser-sensors, omni-base-rgbd-sensors, pal-gazebo-plugins, pal-gazebo-worlds, pal-maps, pal-urdf-utils, ros-gz-bridge, ros-gz-sim, ros2launch }:
 buildRosPackage {
   pname = "ros-humble-omni-base-gazebo";
-  version = "2.11.1-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/omni_base_simulation-release/archive/release/humble/omni_base_gazebo/2.11.1-1.tar.gz";
-    name = "2.11.1-1.tar.gz";
-    sha256 = "b8bc8235dde51e19c3b3607aa3c64b8b513b37ae8418c37d0d5ecc23f5a5157d";
+    url = "https://github.com/ros2-gbp/omni_base_simulation-release/archive/release/humble/omni_base_gazebo/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "42f33c8317827f317ba1af30a3f10a0d12fd2450a75a68bc19005aa89f605694";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ gazebo-plugins gazebo-ros gazebo-ros2-control launch-pal nav2-bringup omni-base-2dnav omni-base-bringup omni-base-description omni-base-laser-sensors omni-base-rgbd-sensors pal-gazebo-plugins pal-gazebo-worlds pal-maps pal-urdf-utils ros2launch ];
+  propagatedBuildInputs = [ gazebo-plugins gazebo-ros gazebo-ros2-control launch-pal nav2-bringup omni-base-2dnav omni-base-bringup omni-base-description omni-base-laser-sensors omni-base-rgbd-sensors pal-gazebo-plugins pal-gazebo-worlds pal-maps pal-urdf-utils ros-gz-bridge ros-gz-sim ros2launch ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/omni-base-laser-sensors/default.nix
+++ b/distros/humble/omni-base-laser-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-index-python, ament-lint-auto, ament-lint-common, diagnostic-aggregator }:
 buildRosPackage {
   pname = "ros-humble-omni-base-laser-sensors";
-  version = "2.22.0-r1";
+  version = "2.22.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/omni_base_navigation-release/archive/release/humble/omni_base_laser_sensors/2.22.0-1.tar.gz";
-    name = "2.22.0-1.tar.gz";
-    sha256 = "63bbd464df949ad79d0b1b368e6368777428f76e4f6b51062dccf54275322b0f";
+    url = "https://github.com/ros2-gbp/omni_base_navigation-release/archive/release/humble/omni_base_laser_sensors/2.22.1-1.tar.gz";
+    name = "2.22.1-1.tar.gz";
+    sha256 = "01687d91b66a1899f89dd1631b3307d32492dcc6b83e8e113930384020678eb2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-navigation/default.nix
+++ b/distros/humble/omni-base-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, omni-base-2dnav, omni-base-laser-sensors }:
 buildRosPackage {
   pname = "ros-humble-omni-base-navigation";
-  version = "2.22.0-r1";
+  version = "2.22.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/omni_base_navigation-release/archive/release/humble/omni_base_navigation/2.22.0-1.tar.gz";
-    name = "2.22.0-1.tar.gz";
-    sha256 = "d72331a3c98cbfeaa68178622f6752a3079bec96a7a420d77d40bb970fa7950c";
+    url = "https://github.com/ros2-gbp/omni_base_navigation-release/archive/release/humble/omni_base_navigation/2.22.1-1.tar.gz";
+    name = "2.22.1-1.tar.gz";
+    sha256 = "30b95ec175d5a0606a2e2acfdd8567a2c0291f91f90b7b907a373c196e4df56c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-rgbd-sensors/default.nix
+++ b/distros/humble/omni-base-rgbd-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-index-python, ament-lint-auto, ament-lint-common, diagnostic-updater }:
 buildRosPackage {
   pname = "ros-humble-omni-base-rgbd-sensors";
-  version = "2.22.0-r1";
+  version = "2.22.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/omni_base_navigation-release/archive/release/humble/omni_base_rgbd_sensors/2.22.0-1.tar.gz";
-    name = "2.22.0-1.tar.gz";
-    sha256 = "7f3634246fbb2815b089558bdbda3df2845a166d459aeb57086850e740091b37";
+    url = "https://github.com/ros2-gbp/omni_base_navigation-release/archive/release/humble/omni_base_rgbd_sensors/2.22.1-1.tar.gz";
+    name = "2.22.1-1.tar.gz";
+    sha256 = "5cb5fd6234b28b27316f8c7bd01e68317461c2469b48252437542e4dcbd93208";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-robot/default.nix
+++ b/distros/humble/omni-base-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, omni-base-bringup, omni-base-controller-configuration, omni-base-description }:
 buildRosPackage {
   pname = "ros-humble-omni-base-robot";
-  version = "2.15.1-r1";
+  version = "2.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/omni_base_robot-release/archive/release/humble/omni_base_robot/2.15.1-1.tar.gz";
-    name = "2.15.1-1.tar.gz";
-    sha256 = "11c602e78bd96cca04ca4ca03c7cf5e5a9d04f42a6165f2a4caad063612d9c68";
+    url = "https://github.com/ros2-gbp/omni_base_robot-release/archive/release/humble/omni_base_robot/2.17.0-1.tar.gz";
+    name = "2.17.0-1.tar.gz";
+    sha256 = "06c47ab57ccedd39add0aa00c9b2d668beba48b8cdf76a3ac380298e2310505c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-simulation/default.nix
+++ b/distros/humble/omni-base-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, omni-base-gazebo }:
 buildRosPackage {
   pname = "ros-humble-omni-base-simulation";
-  version = "2.11.1-r1";
+  version = "2.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/omni_base_simulation-release/archive/release/humble/omni_base_simulation/2.11.1-1.tar.gz";
-    name = "2.11.1-1.tar.gz";
-    sha256 = "d6cf7a10d8c7709ccad9d81e4f1d3071ac367e12685428d13a8fc75f03ed2c67";
+    url = "https://github.com/ros2-gbp/omni_base_simulation-release/archive/release/humble/omni_base_simulation/2.14.1-1.tar.gz";
+    name = "2.14.1-1.tar.gz";
+    sha256 = "b28486c6a18f10da3ffeb838fad658901afe3fd33aa0d4b49a8f4f77ab7a09d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/onnxruntime-vendor/default.nix
+++ b/distros/humble/onnxruntime-vendor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, git, pkg-config }:
+buildRosPackage {
+  pname = "ros-humble-onnxruntime-vendor";
+  version = "0.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/onnxruntime_vendor-release/archive/release/humble/onnxruntime_vendor/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "42a3c4c973336a2a53470b15981de97b7e072afc8fcfd19794e5e1335c1f609b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-vendor-package git pkg-config ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package git ];
+
+  meta = {
+    description = "Vendor package for ONNX Runtime 1.24.3";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -144,6 +144,22 @@ in with lib; {
     '';
   });
 
+  autoware-perception-rviz-plugin = rosSuper.autoware-perception-rviz-plugin.overrideAttrs ({
+    postPatch ? "", ...
+  }: {
+    # Define the tinyxml2::tinyxml2 imported target before autoware_package()
+    # transitively pulls in tinyxml2_vendor. Its tinyxml2_vendor-extras.cmake
+    # otherwise tries to reconstruct the target from the empty TINYXML2_LIBRARY
+    # variable (tinyxml-2 in nixpkgs ships a CMake config providing the target
+    # instead) and aborts with "Unable to extract the library file path".
+    postPatch = postPatch + ''
+      substituteInPlace CMakeLists.txt --replace-fail \
+        "autoware_package()" \
+        "find_package(tinyxml2 REQUIRED)
+      autoware_package()"
+    '';
+  });
+
   autoware-pose-initializer = rosSuper.autoware-pose-initializer.overrideAttrs ({
     postPatch ? "", ...
   }: {

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -124,8 +124,16 @@ in with lib; {
   });
 
   autoware-ndt-scan-matcher = rosSuper.autoware-ndt-scan-matcher.overrideAttrs ({
-    postPatch ? "", ...
+    patches ? [], postPatch ? "", ...
   }: {
+    patches = patches ++ [
+      # fix(ndt_scan_matcher): explicitly include omp.h (#1166)
+      (self.fetchpatch2 {
+        url = "https://github.com/autowarefoundation/autoware_core/commit/801be9de40889d564ce3164a4b4f4eecd76b826f.patch?full_index=1";
+        hash = "sha256-zYuYJwXOym2RQbjuzrKOoMuMm85qYy6hXglqopT1CTE=";
+        stripLen = 2;
+      })
+    ];
     # fix "fatal error: pcl/filters/boost.h: No such file or directory"
     # pcl/filters/boost.h was removed in newer PCL versions
     postPatch = postPatch + ''

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -303,14 +303,14 @@ in with lib; {
       # https://github.com/foxglove/foxglove-sdk/blob/main/ros/src/foxglove_bridge/CMakeLists.txt.
       # If the version doesn't match, cmake fails with "Hash mismatch"
       # and we can fix it here.
-      FOXGLOVE_SDK_VERSION = "0.25.1";
+      FOXGLOVE_SDK_VERSION = "0.25.3";
       systemToPlatform = {
         "x86_64-linux" = "x86_64-unknown-linux-gnu";
         "aarch64-linux" = "aarch64-unknown-linux-gnu";
       };
       systemToHash = {
-        "x86_64-linux" = "sha256-C500jfOo6Y0sLO4jYMyfUug7s0RQRN69dx0bRtw1i+Q=";
-        "aarch64-linux" = "sha256-xw41x48ON/O6jQJRzTHzU7sQsf0QYgDcbF9AntTfGRg=";
+        "x86_64-linux" = "sha256-1ItT8ULp2RpJe95jwDCwEg83a+VppDFd7MA02gGeWqc=";
+        "aarch64-linux" = "sha256-wiI9yymwU0sxzJ7RpR/sk4Y8EC3loKH6dJ9w8hFw/Nk=";
       };
       FOXGLOVE_SDK_PLATFORM = systemToPlatform.${self.system};
       sdk = self.fetchurl {

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -1430,15 +1430,6 @@ in with lib; {
     '';
   });
 
-  warehouse-ros-sqlite = rosSuper.warehouse-ros-sqlite.overrideAttrs ({
-    postPatch ? "", ...
-  }: {
-    # https://github.com/moveit/warehouse_ros_sqlite/pull/61
-    postPatch = postPatch + ''
-      substituteInPlace CMakeLists.txt --replace-fail " system" ""
-    '';
-  });
-
   web-video-server = rosSuper.web-video-server.overrideAttrs ({
     postPatch ? "", ...
   }: {

--- a/distros/humble/pal-gazebo-worlds/default.nix
+++ b/distros/humble/pal-gazebo-worlds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-lint-auto, ament-lint-common, launch-pal }:
 buildRosPackage {
   pname = "ros-humble-pal-gazebo-worlds";
-  version = "4.14.0-r1";
+  version = "4.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_gazebo_worlds-release/archive/release/humble/pal_gazebo_worlds/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "793995909ccd88f0fd39ff37d1fd99677546979cc660f45d1140d2eed30b2320";
+    url = "https://github.com/ros2-gbp/pal_gazebo_worlds-release/archive/release/humble/pal_gazebo_worlds/4.15.1-1.tar.gz";
+    name = "4.15.1-1.tar.gz";
+    sha256 = "aff68ed007165e6f75fec7423f1bfb2414da2aa9b560e6a051c329e40721b106";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-gripper-controller-configuration/default.nix
+++ b/distros/humble/pal-gripper-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, joint-trajectory-controller, position-controllers }:
 buildRosPackage {
   pname = "ros-humble-pal-gripper-controller-configuration";
-  version = "3.6.5-r1";
+  version = "3.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_gripper-release/archive/release/humble/pal_gripper_controller_configuration/3.6.5-1.tar.gz";
-    name = "3.6.5-1.tar.gz";
-    sha256 = "cc540414f9ab74afa34eb98799a5f8b2f42df7f5b79a288ede36d02bdfbd2c5b";
+    url = "https://github.com/ros2-gbp/pal_gripper-release/archive/release/humble/pal_gripper_controller_configuration/3.6.6-1.tar.gz";
+    name = "3.6.6-1.tar.gz";
+    sha256 = "850571565947c5c935e2d2e6e753ebf23db57570d98fc519466b18995f50314f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-gripper-description/default.nix
+++ b/distros/humble/pal-gripper-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, pal-urdf-utils, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-pal-gripper-description";
-  version = "3.6.5-r1";
+  version = "3.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_gripper-release/archive/release/humble/pal_gripper_description/3.6.5-1.tar.gz";
-    name = "3.6.5-1.tar.gz";
-    sha256 = "a86d12d87c17f237620455c962b43b7f2c396c714e2dccd0e2ab92cbc114114b";
+    url = "https://github.com/ros2-gbp/pal_gripper-release/archive/release/humble/pal_gripper_description/3.6.6-1.tar.gz";
+    name = "3.6.6-1.tar.gz";
+    sha256 = "a0982412a8787495cbc4ebdbc860cef546a5505e3cf7d6b5ebb62afc65b11e82";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-gripper-simulation/default.nix
+++ b/distros/humble/pal-gripper-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, pal-gazebo-worlds, pal-gripper-controller-configuration, pal-gripper-description, pal-urdf-utils, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-humble-pal-gripper-simulation";
-  version = "3.6.5-r1";
+  version = "3.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_gripper-release/archive/release/humble/pal_gripper_simulation/3.6.5-1.tar.gz";
-    name = "3.6.5-1.tar.gz";
-    sha256 = "63ec2a3f6a2642c7ab3affdab5f14c2821903539591e092b5bbb60ffcf022d7c";
+    url = "https://github.com/ros2-gbp/pal_gripper-release/archive/release/humble/pal_gripper_simulation/3.6.6-1.tar.gz";
+    name = "3.6.6-1.tar.gz";
+    sha256 = "4805b4678e3c91df23f722a82e10f08af683504922d72542370b30f55d608d5a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-gripper/default.nix
+++ b/distros/humble/pal-gripper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pal-gripper-controller-configuration, pal-gripper-description }:
 buildRosPackage {
   pname = "ros-humble-pal-gripper";
-  version = "3.6.5-r1";
+  version = "3.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_gripper-release/archive/release/humble/pal_gripper/3.6.5-1.tar.gz";
-    name = "3.6.5-1.tar.gz";
-    sha256 = "e7006b8a1a2e0cd59d7e3ae107a7dd133fdc8e09ddbe8e4ee23b448690af24f8";
+    url = "https://github.com/ros2-gbp/pal_gripper-release/archive/release/humble/pal_gripper/3.6.6-1.tar.gz";
+    name = "3.6.6-1.tar.gz";
+    sha256 = "387bd2a93c4ec7254a049e13614a4ba83e1b015259a48618508161fe36abcc90";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-maps/default.nix
+++ b/distros/humble/pal-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto }:
 buildRosPackage {
   pname = "ros-humble-pal-maps";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_maps-release/archive/release/humble/pal_maps/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "35437800bb8350bdc2d5fc0ebbc9c9769db59182cb40e86d8b090f0e15032b0e";
+    url = "https://github.com/ros2-gbp/pal_maps-release/archive/release/humble/pal_maps/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "d2b2b245bf3b27e36227b14a711f2e2c06f161ab2044341424d33beac02f74e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-pro-gripper-bringup/default.nix
+++ b/distros/humble/pal-pro-gripper-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, joint-state-broadcaster, joint-trajectory-controller, pal-pro-gripper-controller-configuration, pal-pro-gripper-description }:
 buildRosPackage {
   pname = "ros-humble-pal-pro-gripper-bringup";
-  version = "1.11.3-r1";
+  version = "1.12.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_pro_gripper-release/archive/release/humble/pal_pro_gripper_bringup/1.11.3-1.tar.gz";
-    name = "1.11.3-1.tar.gz";
-    sha256 = "fc691ba2ea88d6e15acce82fbebd40eb0f54d868fb672ea561d4793cf8128c2c";
+    url = "https://github.com/ros2-gbp/pal_pro_gripper-release/archive/release/humble/pal_pro_gripper_bringup/1.12.5-1.tar.gz";
+    name = "1.12.5-1.tar.gz";
+    sha256 = "ced08d1d3eac4cac531839e65adf03dd7777759415dc792816908826d2f9acae";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-pro-gripper-controller-configuration/default.nix
+++ b/distros/humble/pal-pro-gripper-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, joint-state-broadcaster, joint-trajectory-controller, launch, launch-pal, launch-ros, pal-pro-gripper-wrapper }:
 buildRosPackage {
   pname = "ros-humble-pal-pro-gripper-controller-configuration";
-  version = "1.11.3-r1";
+  version = "1.12.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_pro_gripper-release/archive/release/humble/pal_pro_gripper_controller_configuration/1.11.3-1.tar.gz";
-    name = "1.11.3-1.tar.gz";
-    sha256 = "f873192bbafe1976aeaaeda430b61f9ad52abe96a6e2615161859f6be7922610";
+    url = "https://github.com/ros2-gbp/pal_pro_gripper-release/archive/release/humble/pal_pro_gripper_controller_configuration/1.12.5-1.tar.gz";
+    name = "1.12.5-1.tar.gz";
+    sha256 = "9ab5c649bde1e27f8bcf346741c792d1f87503fd1927efbb573082b762bd2905";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-pro-gripper-description/default.nix
+++ b/distros/humble/pal-pro-gripper-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, pal-urdf-utils, xacro }:
 buildRosPackage {
   pname = "ros-humble-pal-pro-gripper-description";
-  version = "1.11.3-r1";
+  version = "1.12.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_pro_gripper-release/archive/release/humble/pal_pro_gripper_description/1.11.3-1.tar.gz";
-    name = "1.11.3-1.tar.gz";
-    sha256 = "3565e7736309eb77fb1b59e8dda1cd217151b9454cad06fd2bd65580c3e359fc";
+    url = "https://github.com/ros2-gbp/pal_pro_gripper-release/archive/release/humble/pal_pro_gripper_description/1.12.5-1.tar.gz";
+    name = "1.12.5-1.tar.gz";
+    sha256 = "0851bf0a601a3aa3c6636b660d6596ac847b5b1822493150a222023804d933fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-pro-gripper-simulation/default.nix
+++ b/distros/humble/pal-pro-gripper-simulation/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, launch-pal, pal-gazebo-worlds, pal-pro-gripper-controller-configuration, pal-pro-gripper-description }:
+buildRosPackage {
+  pname = "ros-humble-pal-pro-gripper-simulation";
+  version = "1.12.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/pal_pro_gripper-release/archive/release/humble/pal_pro_gripper_simulation/1.12.5-1.tar.gz";
+    name = "1.12.5-1.tar.gz";
+    sha256 = "99efdfba2f50f1b29d51a5dc6b15c32d7dc343dd42f3ce238430dc4e8f850151";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ launch-pal pal-gazebo-worlds pal-pro-gripper-controller-configuration pal-pro-gripper-description ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = "The pal_pro_gripper_simulation package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/pal-pro-gripper-wrapper/default.nix
+++ b/distros/humble/pal-pro-gripper-wrapper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-copyright, ament-flake8, ament-lint-auto, ament-lint-common, ament-pep257, python3Packages, rclpy, sensor-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-pal-pro-gripper-wrapper";
-  version = "1.11.3-r1";
+  version = "1.12.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_pro_gripper-release/archive/release/humble/pal_pro_gripper_wrapper/1.11.3-1.tar.gz";
-    name = "1.11.3-1.tar.gz";
-    sha256 = "218bfbb02d3c41a94776650435f9a134b65aab96feddd97732a4fecda4afbad7";
+    url = "https://github.com/ros2-gbp/pal_pro_gripper-release/archive/release/humble/pal_pro_gripper_wrapper/1.12.5-1.tar.gz";
+    name = "1.12.5-1.tar.gz";
+    sha256 = "d7446b56631905528241bc4ae3fbb022ea33da5ac1c32cc46495f5fa0393ed70";
   };
 
   buildType = "ament_python";

--- a/distros/humble/pal-pro-gripper/default.nix
+++ b/distros/humble/pal-pro-gripper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pal-pro-gripper-controller-configuration, pal-pro-gripper-description }:
 buildRosPackage {
   pname = "ros-humble-pal-pro-gripper";
-  version = "1.11.3-r1";
+  version = "1.12.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_pro_gripper-release/archive/release/humble/pal_pro_gripper/1.11.3-1.tar.gz";
-    name = "1.11.3-1.tar.gz";
-    sha256 = "7331a4e029d6994f6fc94eb4b17b23bfa206568ed61d8065d140747d5dc5098e";
+    url = "https://github.com/ros2-gbp/pal_pro_gripper-release/archive/release/humble/pal_pro_gripper/1.12.5-1.tar.gz";
+    name = "1.12.5-1.tar.gz";
+    sha256 = "707870db49af9c7e52fe7ecc66a7354c22d3739241f664f6b6423af749cc213a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-robotiq-controller-configuration/default.nix
+++ b/distros/humble/pal-robotiq-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, joint-trajectory-controller, position-controllers }:
 buildRosPackage {
   pname = "ros-humble-pal-robotiq-controller-configuration";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_robotiq_gripper-release/archive/release/humble/pal_robotiq_controller_configuration/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "b911b8b0efebd0d3b49779928303fa8a55be9c7e30c1db172ce0d26f6c343aa2";
+    url = "https://github.com/ros2-gbp/pal_robotiq_gripper-release/archive/release/humble/pal_robotiq_controller_configuration/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "42db4235b6d2af5b2d2a0de2002de706a21325051ac4c132b9d078be9aa203a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-robotiq-description/default.nix
+++ b/distros/humble/pal-robotiq-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, xacro }:
 buildRosPackage {
   pname = "ros-humble-pal-robotiq-description";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_robotiq_gripper-release/archive/release/humble/pal_robotiq_description/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "2d93c2253e4d0f019761b5caea45ff70b7ac8476e08f24b9d5b242e7a862fd8c";
+    url = "https://github.com/ros2-gbp/pal_robotiq_gripper-release/archive/release/humble/pal_robotiq_description/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "fb6f6424fd4a350b6eb6a73347f4b0caa206bc45ead1bee8c4baa0c941130647";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-robotiq-gripper/default.nix
+++ b/distros/humble/pal-robotiq-gripper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, pal-robotiq-controller-configuration, pal-robotiq-description, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-pal-robotiq-gripper";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_robotiq_gripper-release/archive/release/humble/pal_robotiq_gripper/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "375b6c4bd92ef0be10cc221475ec9602a00c89b042b8774e6fdb8ea24f17d37a";
+    url = "https://github.com/ros2-gbp/pal_robotiq_gripper-release/archive/release/humble/pal_robotiq_gripper/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "643dd9ab86c4a32679ed3960e9f46c547edf5da8ba93e97ddf6bbbb490e3088d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-sea-arm-bringup/default.nix
+++ b/distros/humble/pal-sea-arm-bringup/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, joint-state-broadcaster, joint-trajectory-controller, joy, joy-teleop, launch-pal, pal-sea-arm-controller-configuration, pal-sea-arm-description, play-motion2, play-motion2-cli }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, joint-state-broadcaster, joint-trajectory-controller, joy, joy-teleop, launch-pal, pal-sea-arm-controller-configuration, pal-sea-arm-description, play-motion2, play-motion2-cli, play-motion2-msgs }:
 buildRosPackage {
   pname = "ros-humble-pal-sea-arm-bringup";
-  version = "1.23.2-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_sea_arm-release/archive/release/humble/pal_sea_arm_bringup/1.23.2-1.tar.gz";
-    name = "1.23.2-1.tar.gz";
-    sha256 = "672f2a6857d87f5f9bbfe67f2aca3a1844467061afbbab036443e18a8f330c0a";
+    url = "https://github.com/ros2-gbp/pal_sea_arm-release/archive/release/humble/pal_sea_arm_bringup/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "03b1f5bd78dcc8fecd40445f438fe96211d2f0484e330700dc3e88f81139df6e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ joint-state-broadcaster joint-trajectory-controller joy joy-teleop launch-pal pal-sea-arm-controller-configuration pal-sea-arm-description play-motion2 play-motion2-cli ];
+  propagatedBuildInputs = [ joint-state-broadcaster joint-trajectory-controller joy joy-teleop launch-pal pal-sea-arm-controller-configuration pal-sea-arm-description play-motion2 play-motion2-cli play-motion2-msgs ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/pal-sea-arm-controller-configuration/default.nix
+++ b/distros/humble/pal-sea-arm-controller-configuration/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, joint-trajectory-controller, launch, launch-pal, pal-pro-gripper-controller-configuration }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, joint-trajectory-controller, launch, launch-pal, pal-pro-gripper-controller-configuration, ros2controlcli }:
 buildRosPackage {
   pname = "ros-humble-pal-sea-arm-controller-configuration";
-  version = "1.23.2-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_sea_arm-release/archive/release/humble/pal_sea_arm_controller_configuration/1.23.2-1.tar.gz";
-    name = "1.23.2-1.tar.gz";
-    sha256 = "80ee3d870c2b75f5e3a89f812b1f45412a88d8759553f1964621cfdddc8b8f73";
+    url = "https://github.com/ros2-gbp/pal_sea_arm-release/archive/release/humble/pal_sea_arm_controller_configuration/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "714bb4fb6f696f5790c2d7a1f8036aca7888cfbc9e7f9e596ccdab5b89d3c84f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ controller-manager joint-trajectory-controller launch launch-pal pal-pro-gripper-controller-configuration ];
+  propagatedBuildInputs = [ controller-manager joint-trajectory-controller launch launch-pal pal-pro-gripper-controller-configuration ros2controlcli ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/pal-sea-arm-description/default.nix
+++ b/distros/humble/pal-sea-arm-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, joint-state-publisher-gui, launch, launch-pal, launch-param-builder, launch-ros, launch-testing-ament-cmake, pal-pro-gripper-description, pal-sea-arm-controller-configuration, pal-urdf-utils, robot-state-publisher, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-pal-sea-arm-description";
-  version = "1.23.2-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_sea_arm-release/archive/release/humble/pal_sea_arm_description/1.23.2-1.tar.gz";
-    name = "1.23.2-1.tar.gz";
-    sha256 = "2cefcefa10f97d7da98539ce484d39010d6a880d20a3ceb9ffb556a3767f3c54";
+    url = "https://github.com/ros2-gbp/pal_sea_arm-release/archive/release/humble/pal_sea_arm_description/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "313a2317d77ae83c82d6b4a019c1ffa0dd3c3fbe6620c15718402937329acdca";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-sea-arm-gazebo/default.nix
+++ b/distros/humble/pal-sea-arm-gazebo/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, gazebo-ros2-control, launch, launch-pal, launch-ros, pal-gazebo-plugins, pal-gazebo-worlds, pal-pro-gripper-description, pal-sea-arm-bringup, pal-sea-arm-description, pal-sea-arm-moveit-config, pal-urdf-utils }:
+{ lib, buildRosPackage, fetchurl, _unresolved_gz-sensors6, ament-cmake-auto, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, gazebo-ros2-control, gz-ros2-control, launch, launch-pal, launch-ros, pal-gazebo-plugins, pal-gazebo-worlds, pal-pro-gripper-description, pal-sea-arm-bringup, pal-sea-arm-description, pal-sea-arm-moveit-config, pal-urdf-utils, ros-gz-bridge }:
 buildRosPackage {
   pname = "ros-humble-pal-sea-arm-gazebo";
-  version = "1.0.4-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_sea_arm_simulation-release/archive/release/humble/pal_sea_arm_gazebo/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "0b47fb125683e6eb6ebd7167323fab8e29ce0c317888a59c8af3a0f9ec654c4d";
+    url = "https://github.com/ros2-gbp/pal_sea_arm_simulation-release/archive/release/humble/pal_sea_arm_gazebo/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "89d379d0bb0cbb0b26d0c8b69e7ef4f185ec0356c7b630c00af8dd2cd40cf701";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ gazebo-plugins gazebo-ros gazebo-ros2-control launch launch-pal launch-ros pal-gazebo-plugins pal-gazebo-worlds pal-pro-gripper-description pal-sea-arm-bringup pal-sea-arm-description pal-sea-arm-moveit-config pal-urdf-utils ];
+  propagatedBuildInputs = [ _unresolved_gz-sensors6 gazebo-plugins gazebo-ros gazebo-ros2-control gz-ros2-control launch launch-pal launch-ros pal-gazebo-plugins pal-gazebo-worlds pal-pro-gripper-description pal-sea-arm-bringup pal-sea-arm-description pal-sea-arm-moveit-config pal-urdf-utils ros-gz-bridge ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/pal-sea-arm-moveit-config/default.nix
+++ b/distros/humble/pal-sea-arm-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, launch-pal, moveit-configs-utils, moveit-kinematics, moveit-planners-chomp, moveit-planners-ompl, moveit-ros-control-interface, moveit-ros-move-group, moveit-ros-perception, moveit-ros-visualization, pal-sea-arm-description }:
 buildRosPackage {
   pname = "ros-humble-pal-sea-arm-moveit-config";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_sea_arm_moveit_config-release/archive/release/humble/pal_sea_arm_moveit_config/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "9d040eb2690675ba576d6c82ae5781595c997cd427df1eaf5deae043ec585f52";
+    url = "https://github.com/ros2-gbp/pal_sea_arm_moveit_config-release/archive/release/humble/pal_sea_arm_moveit_config/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "a3e200d677e9fb3af37b18923fafb40785d8d080e5bdc4dce79d40b513713ef4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-sea-arm-mujoco/default.nix
+++ b/distros/humble/pal-sea-arm-mujoco/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, launch, launch-pal, launch-ros, mujoco-ros2-control, pal-pro-gripper-description, pal-sea-arm-bringup, pal-sea-arm-description, pal-sea-arm-moveit-config, pal-urdf-utils }:
+buildRosPackage {
+  pname = "ros-humble-pal-sea-arm-mujoco";
+  version = "1.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/pal_sea_arm_simulation-release/archive/release/humble/pal_sea_arm_mujoco/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "fdfe84a3747c6b37e467ae821c9c8f33fc5c0f9b88af14025436d04ae90ebc20";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ launch launch-pal launch-ros mujoco-ros2-control pal-pro-gripper-description pal-sea-arm-bringup pal-sea-arm-description pal-sea-arm-moveit-config pal-urdf-utils ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = "The pal_sea_arm_mujoco package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/pal-sea-arm-simulation/default.nix
+++ b/distros/humble/pal-sea-arm-simulation/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, pal-sea-arm-gazebo }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, pal-sea-arm-gazebo, pal-sea-arm-mujoco }:
 buildRosPackage {
   pname = "ros-humble-pal-sea-arm-simulation";
-  version = "1.0.4-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_sea_arm_simulation-release/archive/release/humble/pal_sea_arm_simulation/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "cae0b2fdf6db77685a4018bf327c7693820558ec8ae1c5a4be79bfcd76ca867a";
+    url = "https://github.com/ros2-gbp/pal_sea_arm_simulation-release/archive/release/humble/pal_sea_arm_simulation/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "2e0fedd8e8a34732f184e0cd782dd3dcc3801dce480c1f9d9c15da858e323504";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ pal-sea-arm-gazebo ];
+  propagatedBuildInputs = [ pal-sea-arm-gazebo pal-sea-arm-mujoco ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/pal-sea-arm/default.nix
+++ b/distros/humble/pal-sea-arm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pal-sea-arm-bringup, pal-sea-arm-controller-configuration, pal-sea-arm-description }:
 buildRosPackage {
   pname = "ros-humble-pal-sea-arm";
-  version = "1.23.2-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_sea_arm-release/archive/release/humble/pal_sea_arm/1.23.2-1.tar.gz";
-    name = "1.23.2-1.tar.gz";
-    sha256 = "36d304134ac78d4743adcb0da036043a33ec6c5609169fb6a98644266d077116";
+    url = "https://github.com/ros2-gbp/pal_sea_arm-release/archive/release/humble/pal_sea_arm/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "ecb05d5f23a475b08308c805646acf3de6b952001bfbc8b060460371fac9f078";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-urdf-utils/default.nix
+++ b/distros/humble/pal-urdf-utils/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, realsense2-description, xacro }:
 buildRosPackage {
   pname = "ros-humble-pal-urdf-utils";
-  version = "2.3.3-r1";
+  version = "2.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_urdf_utils-release/archive/release/humble/pal_urdf_utils/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "49d8f24c7894413630398044b10a3256f40bdf20503b1d8b1626aca93bc2e5a1";
+    url = "https://github.com/ros2-gbp/pal_urdf_utils-release/archive/release/humble/pal_urdf_utils/2.9.1-1.tar.gz";
+    name = "2.9.1-1.tar.gz";
+    sha256 = "af57c6cb0ad8409b9fd0a9753639ac3e2531961502c3a1311e2345b77031a70b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ xacro ];
+  propagatedBuildInputs = [ realsense2-description xacro ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/pick-ik/default.nix
+++ b/distros/humble/pick-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, fmt, generate-parameter-library, moveit-core, moveit-resources-panda-moveit-config, pluginlib, range-v3, rclcpp, rsl, tf2-geometry-msgs, tf2-kdl, tl-expected }:
 buildRosPackage {
   pname = "ros-humble-pick-ik";
-  version = "1.1.1-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pick_ik-release/archive/release/humble/pick_ik/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "0f5ea00900ff101b170b97be3b8c93b0f16def7bf30613d2677a3a75adf4c3b3";
+    url = "https://github.com/ros2-gbp/pick_ik-release/archive/release/humble/pick_ik/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "0ba99243d3157af6baa2e64a67cd41c04fa10d31b0d7c0bc6a91010ae7121dcc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/play-motion2-cli/default.nix
+++ b/distros/humble/play-motion2-cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, play-motion2, python3Packages, rclpy, ros2cli }:
 buildRosPackage {
   pname = "ros-humble-play-motion2-cli";
-  version = "1.8.4-r1";
+  version = "1.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/play_motion2-release/archive/release/humble/play_motion2_cli/1.8.4-1.tar.gz";
-    name = "1.8.4-1.tar.gz";
-    sha256 = "e9b2c4356b415164d74f76422e1b010f630f555ecf3046a381fb3cd3b8dd0f75";
+    url = "https://github.com/ros2-gbp/play_motion2-release/archive/release/humble/play_motion2_cli/1.8.5-1.tar.gz";
+    name = "1.8.5-1.tar.gz";
+    sha256 = "c93c8788f08ec22e2ba5e4b43c5d9fd5096bcd5f849abef3abf9c135d09235a1";
   };
 
   buildType = "ament_python";

--- a/distros/humble/play-motion2-msgs/default.nix
+++ b/distros/humble/play-motion2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-play-motion2-msgs";
-  version = "1.8.4-r1";
+  version = "1.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/play_motion2-release/archive/release/humble/play_motion2_msgs/1.8.4-1.tar.gz";
-    name = "1.8.4-1.tar.gz";
-    sha256 = "2648e4a0f880182fea559ee080a98bcc2667c1b3db09447ee55404e2c52faa93";
+    url = "https://github.com/ros2-gbp/play_motion2-release/archive/release/humble/play_motion2_msgs/1.8.5-1.tar.gz";
+    name = "1.8.5-1.tar.gz";
+    sha256 = "1146c595914eaf72cc5921f3b6ddfaef2e016f8154f54eacd2b80167e5906144";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/play-motion2/default.nix
+++ b/distros/humble/play-motion2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-index-cpp, ament-lint-auto, ament-lint-common, backward-ros, control-msgs, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, lifecycle-msgs, moveit-ros-planning-interface, play-motion2-msgs, pluginlib, rclcpp, rclcpp-action, rclcpp-components, rclcpp-lifecycle, realtime-tools, robot-state-publisher, sensor-msgs, std-msgs, trajectory-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-play-motion2";
-  version = "1.8.4-r1";
+  version = "1.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/play_motion2-release/archive/release/humble/play_motion2/1.8.4-1.tar.gz";
-    name = "1.8.4-1.tar.gz";
-    sha256 = "9eeac7e4ddf384b3398b04d6cbc80d47ef8745f29556bba4a5f66b016b1bd6bc";
+    url = "https://github.com/ros2-gbp/play_motion2-release/archive/release/humble/play_motion2/1.8.5-1.tar.gz";
+    name = "1.8.5-1.tar.gz";
+    sha256 = "c0cd86f677022026315cfb5df08b4019ee253037bfb2a613d4dd80bec13a28cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-2dnav/default.nix
+++ b/distros/humble/pmb2-2dnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-index-python, ament-lint-auto, ament-lint-common, diagnostic-aggregator, launch-pal, pal-maps, ros2launch }:
 buildRosPackage {
   pname = "ros-humble-pmb2-2dnav";
-  version = "4.21.0-r1";
+  version = "4.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pmb2_navigation-release/archive/release/humble/pmb2_2dnav/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "eb521aec60721b0736df6bcc1e245fb86eb3e03be9c783146f4bee8cbcc2492d";
+    url = "https://github.com/ros2-gbp/pmb2_navigation-release/archive/release/humble/pmb2_2dnav/4.21.1-1.tar.gz";
+    name = "4.21.1-1.tar.gz";
+    sha256 = "ca1b22d72a7e58f3ce4cc9228df6f038aa0af879e313b78304d5537a792ae6ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-bringup/default.nix
+++ b/distros/humble/pmb2-bringup/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-index-python, ament-lint-auto, ament-lint-common, diagnostic-aggregator, geometry-msgs, joy-linux, joy-teleop, launch-pal, pmb2-controller-configuration, pmb2-description, robot-state-publisher, twist-mux, twist-mux-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-index-python, ament-lint-auto, ament-lint-common, diagnostic-aggregator, geometry-msgs, joy, joy-teleop, launch-pal, pmb2-controller-configuration, pmb2-description, robot-state-publisher, twist-mux, twist-mux-msgs }:
 buildRosPackage {
   pname = "ros-humble-pmb2-bringup";
-  version = "5.11.2-r1";
+  version = "5.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pmb2_robot-release/archive/release/humble/pmb2_bringup/5.11.2-1.tar.gz";
-    name = "5.11.2-1.tar.gz";
-    sha256 = "068765fc61a5ae962ee271ce9ccf0f3d15eb68aa25d90f7b77fba359a6083e47";
+    url = "https://github.com/ros2-gbp/pmb2_robot-release/archive/release/humble/pmb2_bringup/5.12.0-1.tar.gz";
+    name = "5.12.0-1.tar.gz";
+    sha256 = "015702bd42c962663629d6b707313b272d9d27dab0adc5435f825a4839da34b9";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python diagnostic-aggregator geometry-msgs joy-linux joy-teleop launch-pal pmb2-controller-configuration pmb2-description robot-state-publisher twist-mux twist-mux-msgs ];
+  propagatedBuildInputs = [ ament-index-python diagnostic-aggregator geometry-msgs joy joy-teleop launch-pal pmb2-controller-configuration pmb2-description robot-state-publisher twist-mux twist-mux-msgs ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/pmb2-controller-configuration/default.nix
+++ b/distros/humble/pmb2-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, diff-drive-controller, joint-state-broadcaster, launch, launch-pal, ros2controlcli }:
 buildRosPackage {
   pname = "ros-humble-pmb2-controller-configuration";
-  version = "5.11.2-r1";
+  version = "5.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pmb2_robot-release/archive/release/humble/pmb2_controller_configuration/5.11.2-1.tar.gz";
-    name = "5.11.2-1.tar.gz";
-    sha256 = "b3c2b86012c57108b28f393ae01511d91b3548e3c1931ce35dfdbbcc4e6232d5";
+    url = "https://github.com/ros2-gbp/pmb2_robot-release/archive/release/humble/pmb2_controller_configuration/5.12.0-1.tar.gz";
+    name = "5.12.0-1.tar.gz";
+    sha256 = "751f362dd9855be1780782bce99455a838fda83f61a8758eb66eb97afcc26548";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-description/default.nix
+++ b/distros/humble/pmb2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, joint-state-publisher-gui, launch, launch-pal, launch-param-builder, launch-ros, launch-testing-ament-cmake, pal-urdf-utils, realsense2-description, rviz2, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-pmb2-description";
-  version = "5.11.2-r1";
+  version = "5.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pmb2_robot-release/archive/release/humble/pmb2_description/5.11.2-1.tar.gz";
-    name = "5.11.2-1.tar.gz";
-    sha256 = "3f34e000c74962f3cf4af49d00364594326b8099d7db1da7b2c704c8f8cffc99";
+    url = "https://github.com/ros2-gbp/pmb2_robot-release/archive/release/humble/pmb2_description/5.12.0-1.tar.gz";
+    name = "5.12.0-1.tar.gz";
+    sha256 = "46312ad3c1280c3a92d9000b6da0bfc301720267eab086d6e19d1186338b7811";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-gazebo/default.nix
+++ b/distros/humble/pmb2-gazebo/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_gz-sensors6, ament-cmake-auto, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, gazebo-ros2-control, gz-ros2-control, launch-pal, nav2-bringup, pal-gazebo-plugins, pal-gazebo-worlds, pal-maps, pal-urdf-utils, pmb2-2dnav, pmb2-bringup, pmb2-description, pmb2-laser-sensors, pmb2-rgbd-sensors, ros-gz-bridge, ros2launch }:
+{ lib, buildRosPackage, fetchurl, _unresolved_gz-sensors6, ament-cmake-auto, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, gazebo-ros2-control, gz-ros2-control, launch-pal, nav2-bringup, pal-gazebo-plugins, pal-gazebo-worlds, pal-maps, pal-urdf-utils, pmb2-2dnav, pmb2-bringup, pmb2-description, pmb2-laser-sensors, pmb2-rgbd-sensors, ros-gz-bridge, ros-gz-sim, ros2launch }:
 buildRosPackage {
   pname = "ros-humble-pmb2-gazebo";
-  version = "4.11.1-r1";
+  version = "4.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pmb2_simulation-release/archive/release/humble/pmb2_gazebo/4.11.1-1.tar.gz";
-    name = "4.11.1-1.tar.gz";
-    sha256 = "277ec96e4c2edb7b7ff4fd09e2860013de574b052f4edf6a533193aa8da2d954";
+    url = "https://github.com/ros2-gbp/pmb2_simulation-release/archive/release/humble/pmb2_gazebo/4.12.1-1.tar.gz";
+    name = "4.12.1-1.tar.gz";
+    sha256 = "7e5cb55739741d4722099017cef8442bfefa99b806c2dc80c36fed896953afb6";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ _unresolved_gz-sensors6 gazebo-plugins gazebo-ros gazebo-ros2-control gz-ros2-control launch-pal nav2-bringup pal-gazebo-plugins pal-gazebo-worlds pal-maps pal-urdf-utils pmb2-2dnav pmb2-bringup pmb2-description pmb2-laser-sensors pmb2-rgbd-sensors ros-gz-bridge ros2launch ];
+  propagatedBuildInputs = [ _unresolved_gz-sensors6 gazebo-plugins gazebo-ros gazebo-ros2-control gz-ros2-control launch-pal nav2-bringup pal-gazebo-plugins pal-gazebo-worlds pal-maps pal-urdf-utils pmb2-2dnav pmb2-bringup pmb2-description pmb2-laser-sensors pmb2-rgbd-sensors ros-gz-bridge ros-gz-sim ros2launch ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/pmb2-laser-sensors/default.nix
+++ b/distros/humble/pmb2-laser-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-index-python, ament-lint-auto, ament-lint-common, diagnostic-aggregator }:
 buildRosPackage {
   pname = "ros-humble-pmb2-laser-sensors";
-  version = "4.21.0-r1";
+  version = "4.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pmb2_navigation-release/archive/release/humble/pmb2_laser_sensors/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "8209f31b26bbf48f1efe8d212481ccc2e86315b91aab2c8c0697bf5c32997461";
+    url = "https://github.com/ros2-gbp/pmb2_navigation-release/archive/release/humble/pmb2_laser_sensors/4.21.1-1.tar.gz";
+    name = "4.21.1-1.tar.gz";
+    sha256 = "65b0ccc1dbce370242053c2ea65a9fe6d703db8c9864389d274bf12a9335a17b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-navigation/default.nix
+++ b/distros/humble/pmb2-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, pmb2-2dnav, pmb2-laser-sensors }:
 buildRosPackage {
   pname = "ros-humble-pmb2-navigation";
-  version = "4.21.0-r1";
+  version = "4.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pmb2_navigation-release/archive/release/humble/pmb2_navigation/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "7144a6890c2bdfda1cc76e8df9efadb41117382be64e4486b82b74b243f788df";
+    url = "https://github.com/ros2-gbp/pmb2_navigation-release/archive/release/humble/pmb2_navigation/4.21.1-1.tar.gz";
+    name = "4.21.1-1.tar.gz";
+    sha256 = "d56ada6668789281d5d27b8f9fd6e77fbb0107071153d875c7ebd37aba21320a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-rgbd-sensors/default.nix
+++ b/distros/humble/pmb2-rgbd-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-index-python, ament-lint-auto, ament-lint-common, diagnostic-updater, launch-pal, rclcpp-components, rclpy, ros2launch }:
 buildRosPackage {
   pname = "ros-humble-pmb2-rgbd-sensors";
-  version = "4.21.0-r1";
+  version = "4.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pmb2_navigation-release/archive/release/humble/pmb2_rgbd_sensors/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "7bf7367538499ca8d66c5f5e59910d8b7f22eb4eb3dc8213634fa8e975b86f70";
+    url = "https://github.com/ros2-gbp/pmb2_navigation-release/archive/release/humble/pmb2_rgbd_sensors/4.21.1-1.tar.gz";
+    name = "4.21.1-1.tar.gz";
+    sha256 = "b2e8bc2a3478355c3341e898a078df31ae241613ac2443a85a82c5bbced8dcd5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-robot/default.nix
+++ b/distros/humble/pmb2-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pmb2-bringup, pmb2-controller-configuration, pmb2-description }:
 buildRosPackage {
   pname = "ros-humble-pmb2-robot";
-  version = "5.11.2-r1";
+  version = "5.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pmb2_robot-release/archive/release/humble/pmb2_robot/5.11.2-1.tar.gz";
-    name = "5.11.2-1.tar.gz";
-    sha256 = "8daab235b18f618fb76f3639874ae1ac8254f92f3a290dcc29ad8945b3e28f8a";
+    url = "https://github.com/ros2-gbp/pmb2_robot-release/archive/release/humble/pmb2_robot/5.12.0-1.tar.gz";
+    name = "5.12.0-1.tar.gz";
+    sha256 = "81994d800806d64a331356ba517c3688204c34e96a7f4b3830e3a9bac28bc6b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-simulation/default.nix
+++ b/distros/humble/pmb2-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pmb2-gazebo }:
 buildRosPackage {
   pname = "ros-humble-pmb2-simulation";
-  version = "4.11.1-r1";
+  version = "4.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pmb2_simulation-release/archive/release/humble/pmb2_simulation/4.11.1-1.tar.gz";
-    name = "4.11.1-1.tar.gz";
-    sha256 = "7c1e02261caefcc397467ebc8fcb4161e0c3b33564801e1558a956583b450ac0";
+    url = "https://github.com/ros2-gbp/pmb2_simulation-release/archive/release/humble/pmb2_simulation/4.12.1-1.tar.gz";
+    name = "4.12.1-1.tar.gz";
+    sha256 = "afdf674bd924131260353fe0ba9e58aee95aa9e69633ee09d17d1eaea4ddd047";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/protobuf-comm/default.nix
+++ b/distros/humble/protobuf-comm/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, cmake, openssl, protobuf, spdlog }:
+buildRosPackage {
+  pname = "ros-humble-protobuf-comm";
+  version = "0.9.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/protobuf_comm-release/archive/release/humble/protobuf_comm/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "01a9871d9b132c9a88f44bd39ddf700b70d55ed23af896ed730e81d774790940";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ boost openssl protobuf spdlog ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Wrapper for protobuf communication using c++";
+    license = with lib.licenses; [ "GPL-2.0-or-later" ];
+  };
+}

--- a/distros/humble/ros2-medkit-action-status-bridge/default.nix
+++ b/distros/humble/ros2-medkit-action-status-bridge/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-testing-ament-cmake, launch-testing-ros, rclcpp, ros2-medkit-cmake, ros2-medkit-fault-manager, ros2-medkit-fault-reporter, ros2-medkit-msgs }:
+buildRosPackage {
+  pname = "ros-humble-ros2-medkit-action-status-bridge";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_action_status_bridge/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "87018ac74e7109230a6f211be0d39f30c8f7798b1b6cbc82e1ccce5324f97fa4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros2-medkit-cmake ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-clang-tidy ament-cmake-gtest ament-lint-auto ament-lint-common launch-testing-ament-cmake launch-testing-ros ros2-medkit-fault-manager ];
+  propagatedBuildInputs = [ action-msgs rclcpp ros2-medkit-fault-reporter ros2-medkit-msgs ];
+  nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
+
+  meta = {
+    description = "Bridge node turning terminal ROS2 action goal states (aborted) into FaultManager faults";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/ros2-medkit-beacon-common/default.nix
+++ b/distros/humble/ros2-medkit-beacon-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nlohmann_json, rclcpp, ros2-medkit-cmake, ros2-medkit-gateway, ros2-medkit-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-beacon-common";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_beacon_common/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "1d8fd3d72aa417c9eaaf94d7341a7fcfbf1920e03b773b8d0782c43c9b03e064";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_beacon_common/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "daa35af2997d8ec287db3c4d08945fc90dec8dae8e9791dd6b7e082e7c07e554";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-medkit-cmake/default.nix
+++ b/distros/humble/ros2-medkit-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-cmake";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_cmake/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "019392dba11a638a92ce7c35c0872aff592fafa44c6a21a51363f9855264cce7";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_cmake/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "b2160cede9c13d86f5a5c50995e7ac0cedf04f00337884cf17e2fe3024960de6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-medkit-diagnostic-bridge/default.nix
+++ b/distros/humble/ros2-medkit-diagnostic-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch-testing-ament-cmake, launch-testing-ros, rclcpp, ros2-medkit-cmake, ros2-medkit-fault-manager, ros2-medkit-fault-reporter, ros2-medkit-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-diagnostic-bridge";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_diagnostic_bridge/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "5c2d64f3a30be7cf5038f3ae6c6d867cb54d0d9ce7fb04b435da32dc8ef176ad";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_diagnostic_bridge/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "5975be2dd7e22e102ac5c4ce0a6443f73d98b6d145233f197f844b884d45ad68";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-medkit-fault-manager/default.nix
+++ b/distros/humble/ros2-medkit-fault-manager/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-testing-ament-cmake, launch-testing-ros, nlohmann_json, rclcpp, ros2-medkit-cmake, ros2-medkit-msgs, ros2-medkit-serialization, rosbag2-cpp, rosbag2-storage, rosbag2-storage-mcap, sensor-msgs, sqlite, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, nlohmann_json, rclcpp, ros2-medkit-cmake, ros2-medkit-msgs, ros2-medkit-serialization, rosbag2-cpp, rosbag2-py, rosbag2-storage, rosbag2-storage-mcap, sensor-msgs, sqlite, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-fault-manager";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_fault_manager/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "120a8351c2653f563a2520a9a86fb8b6367b057de8309ed8ccd07a43348b2770";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_fault_manager/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "57b4e6ecfd614779192998419066effeb373993af6ddcd6f2e89410641837f6b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros2-medkit-cmake ];
-  checkInputs = [ ament-cmake-clang-format ament-cmake-clang-tidy ament-cmake-gtest ament-lint-auto ament-lint-common launch-testing-ament-cmake launch-testing-ros sensor-msgs std-msgs ];
-  propagatedBuildInputs = [ nlohmann_json rclcpp ros2-medkit-msgs ros2-medkit-serialization rosbag2-cpp rosbag2-storage rosbag2-storage-mcap sqlite ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-clang-tidy ament-cmake-gtest ament-lint-auto ament-lint-common launch-ros launch-testing-ament-cmake launch-testing-ros rosbag2-py rosbag2-storage-mcap sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ ament-index-python launch launch-ros nlohmann_json rclcpp ros2-medkit-msgs ros2-medkit-serialization rosbag2-cpp rosbag2-storage sqlite ];
   nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
 
   meta = {

--- a/distros/humble/ros2-medkit-fault-reporter/default.nix
+++ b/distros/humble/ros2-medkit-fault-reporter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-testing-ament-cmake, launch-testing-ros, rclcpp, ros2-medkit-cmake, ros2-medkit-fault-manager, ros2-medkit-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-fault-reporter";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_fault_reporter/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "a530517b9d5f2b01b69c234a2802db7cbae9f5eaa2478041da52e316446007c2";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_fault_reporter/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "b2dab469d1327e34a445ae5658d97818bb3e73e9a3eaa0089aab43d44229a87f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-medkit-gateway/default.nix
+++ b/distros/humble/ros2-medkit-gateway/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, example-interfaces, httplib, nlohmann_json, openssl, rcl-interfaces, rclcpp, rclcpp-action, ros2-medkit-cmake, ros2-medkit-msgs, ros2-medkit-serialization, rosidl-parser, rosidl-runtime-py, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, sensor-msgs, sqlite, std-msgs, std-srvs, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-index-cpp, ament-index-python, ament-lint-auto, ament-lint-common, example-interfaces, httplib, launch, launch-ros, lifecycle-msgs, nlohmann_json, openssl, rcl-interfaces, rclcpp, rclcpp-action, ros2-medkit-action-status-bridge, ros2-medkit-cmake, ros2-medkit-diagnostic-bridge, ros2-medkit-fault-manager, ros2-medkit-log-bridge, ros2-medkit-msgs, ros2-medkit-serialization, rosidl-parser, rosidl-runtime-py, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, sensor-msgs, sqlite, std-msgs, std-srvs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-gateway";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_gateway/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "f95a34a7f40fe7e685d10344033afd9ae1a574762a9ba4a4913c04e11d567704";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_gateway/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "e4f0964627db20046274faf160654ab725182ad05a69a014ba9a13a42711d06d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros2-medkit-cmake ];
   checkInputs = [ ament-cmake-clang-format ament-cmake-clang-tidy ament-cmake-gtest ament-lint-auto ament-lint-common example-interfaces rclcpp-action ];
-  propagatedBuildInputs = [ action-msgs ament-index-cpp httplib nlohmann_json openssl rcl-interfaces rclcpp ros2-medkit-msgs ros2-medkit-serialization rosidl-parser rosidl-runtime-py rosidl-typesupport-cpp rosidl-typesupport-introspection-cpp sensor-msgs sqlite std-msgs std-srvs yaml-cpp-vendor ];
+  propagatedBuildInputs = [ action-msgs ament-index-cpp ament-index-python httplib launch launch-ros lifecycle-msgs nlohmann_json openssl rcl-interfaces rclcpp ros2-medkit-action-status-bridge ros2-medkit-diagnostic-bridge ros2-medkit-fault-manager ros2-medkit-log-bridge ros2-medkit-msgs ros2-medkit-serialization rosidl-parser rosidl-runtime-py rosidl-typesupport-cpp rosidl-typesupport-introspection-cpp sensor-msgs sqlite std-msgs std-srvs yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
 
   meta = {

--- a/distros/humble/ros2-medkit-graph-provider/default.nix
+++ b/distros/humble/ros2-medkit-graph-provider/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, nlohmann_json, rclcpp, ros2-medkit-cmake, ros2-medkit-gateway, ros2-medkit-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-graph-provider";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_graph_provider/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "dcf126846ef8b714b8878572508a432f7d11db94a31e1346c573cd39d0a64bc3";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_graph_provider/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "bca983fe67b5c15aa2d3938b63206da492c6e29597196c82a991513f6b5c9199";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-medkit-integration-tests/default.nix
+++ b/distros/humble/ros2-medkit-integration-tests/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, diagnostic-msgs, example-interfaces, launch-ros, launch-testing, launch-testing-ament-cmake, python3Packages, rcl-interfaces, rclcpp, rclcpp-action, ros2-medkit-cmake, ros2-medkit-fault-manager, ros2-medkit-gateway, ros2-medkit-graph-provider, ros2-medkit-linux-introspection, ros2-medkit-msgs, ros2-medkit-param-beacon, ros2-medkit-topic-beacon, sensor-msgs, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, diagnostic-msgs, example-interfaces, launch-ros, launch-testing, launch-testing-ament-cmake, python3Packages, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2-medkit-cmake, ros2-medkit-fault-manager, ros2-medkit-gateway, ros2-medkit-graph-provider, ros2-medkit-linux-introspection, ros2-medkit-msgs, ros2-medkit-param-beacon, ros2-medkit-topic-beacon, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-integration-tests";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_integration_tests/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "2f34d651e2514e15097d55ecd01d30aa4886fb8efe98c5a2769a64757adc1040";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_integration_tests/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "5739e954b4f129928def95adad0243303ad06b23f4d62d1b078089e76ac30bb2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ros2-medkit-cmake ];
   checkInputs = [ ament-index-python launch-ros launch-testing launch-testing-ament-cmake python3Packages.jsonschema python3Packages.requests ros2-medkit-fault-manager ros2-medkit-gateway ros2-medkit-graph-provider ros2-medkit-linux-introspection ros2-medkit-param-beacon ros2-medkit-topic-beacon ];
-  propagatedBuildInputs = [ diagnostic-msgs example-interfaces rcl-interfaces rclcpp rclcpp-action ros2-medkit-msgs sensor-msgs std-msgs std-srvs ];
+  propagatedBuildInputs = [ diagnostic-msgs example-interfaces rcl-interfaces rclcpp rclcpp-action rclcpp-lifecycle ros2-medkit-msgs sensor-msgs std-msgs std-srvs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ros2-medkit-cmake ];
 
   meta = {

--- a/distros/humble/ros2-medkit-linux-introspection/default.nix
+++ b/distros/humble/ros2-medkit-linux-introspection/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, nlohmann_json, pkg-config, ros2-medkit-cmake, ros2-medkit-gateway, systemd }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-linux-introspection";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_linux_introspection/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "589f9175f372a7bf5b61eec9250fdb886ca8518ec4e3945d76448be8748196b9";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_linux_introspection/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "e410b6e2a45b225d3bf8b4d5123831769a9ff73aa84f9f1c5f50b4deb5d5ee4c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-medkit-log-bridge/default.nix
+++ b/distros/humble/ros2-medkit-log-bridge/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-testing-ament-cmake, launch-testing-ros, rcl-interfaces, rclcpp, ros2-medkit-cmake, ros2-medkit-fault-manager, ros2-medkit-fault-reporter, ros2-medkit-msgs }:
+buildRosPackage {
+  pname = "ros-humble-ros2-medkit-log-bridge";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_log_bridge/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "c7b1763a88bcfec80ce15d5d452ba979feabac22e6c89bd248acbb5db794497b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros2-medkit-cmake ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-clang-tidy ament-cmake-gtest ament-lint-auto ament-lint-common launch-testing-ament-cmake launch-testing-ros ros2-medkit-fault-manager ];
+  propagatedBuildInputs = [ rcl-interfaces rclcpp ros2-medkit-fault-reporter ros2-medkit-msgs ];
+  nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
+
+  meta = {
+    description = "Bridge node promoting ROS2 /rosout log entries to FaultManager faults";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/ros2-medkit-msgs/default.nix
+++ b/distros/humble/ros2-medkit-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-msgs";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_msgs/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "07542235f245ea6af0707195772193b72c4275720100b7c843554cf34ccd4f1b";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_msgs/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "ffef4d901bdee18487738738496fe12bad4d21041ad69ee84137051ae8826a22";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-medkit-param-beacon/default.nix
+++ b/distros/humble/ros2-medkit-param-beacon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-lint-auto, ament-lint-common, nlohmann_json, rclcpp, ros2-medkit-beacon-common, ros2-medkit-cmake, ros2-medkit-gateway }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-param-beacon";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_param_beacon/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "8fe18a032dd3efb3523e67f13edc134c3c3575b30b44ace41eefa636e27fd5bf";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_param_beacon/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "f59ed90e1577354dbe76365ae975c2c5a3144ab0ff92ae71de8eaa955b396898";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-medkit-serialization/default.nix
+++ b/distros/humble/ros2-medkit-serialization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nlohmann_json, rclcpp, rcpputils, rcutils, ros2-medkit-cmake, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, sensor-msgs, std-msgs, std-srvs, test-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-serialization";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_serialization/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "0e1061f920ff04dae014d66d006ef09bcebee8a6877bf946a3fb5a89b1eb9988";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_serialization/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "4ea5b7a286d81bb1e3c70993101a3ef8736d0ce22d7c43cf00f73707a66feb66";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-medkit-sovd-service-interface/default.nix
+++ b/distros/humble/ros2-medkit-sovd-service-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nlohmann_json, rclcpp, ros2-medkit-cmake, ros2-medkit-gateway, ros2-medkit-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-sovd-service-interface";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_sovd_service_interface/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "a30f8fc3cb57422355536eb4c40d7b516638988b38e7ae6016e592819f9c6b1a";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_sovd_service_interface/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "77503b0d8d3e4b0d94593b9677d90721c7f6f51022e217d713e24622b6730e63";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-medkit-topic-beacon/default.nix
+++ b/distros/humble/ros2-medkit-topic-beacon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, nlohmann_json, rclcpp, ros2-medkit-beacon-common, ros2-medkit-cmake, ros2-medkit-gateway, ros2-medkit-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-medkit-topic-beacon";
-  version = "0.5.0-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_topic_beacon/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "2e0a048ce3f8a51fb4aa11bd85ea7becd2c55cd22d05b0ed53273304e2a8620a";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/humble/ros2_medkit_topic_beacon/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "a78832a95641920aa8a17f957a2bb4600012cc164969cd5ed1281404c0833f26";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag-timing-inspector/default.nix
+++ b/distros/humble/rosbag-timing-inspector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, glfw3, libGL, libGLU, rosbag2-cpp, rosbag2-storage }:
 buildRosPackage {
   pname = "ros-humble-rosbag-timing-inspector";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag_timing_inspector-release/archive/release/humble/rosbag_timing_inspector/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "715684751cf28b41c0a719a26c2485f309e229bc4a8b5216fa00b0c5c3f2e156";
+    url = "https://github.com/ros2-gbp/rosbag_timing_inspector-release/archive/release/humble/rosbag_timing_inspector/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "2396dcc96e0740afba40f4d3acd3f02f1942de404ceacfc81d893a11f75411e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-conversions/default.nix
+++ b/distros/humble/rtabmap-conversions/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, geometry-msgs, image-geometry, laser-geometry, pcl-conversions, rclcpp, rclcpp-components, ros-environment, rtabmap, rtabmap-msgs, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, geometry-msgs, image-geometry, laser-geometry, pcl-conversions, rclcpp, rclcpp-components, ros-environment, rtabmap, rtabmap-msgs, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-conversions";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_conversions/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "f789c3e833df6874ee531f6819fe9363c465c3e43fa9425b8230ab27a44585bb";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_conversions/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "3aec91587a8e630f057a77ff11a22894209574dc62f7b2efd373d030d647cc12";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ cv-bridge geometry-msgs image-geometry laser-geometry pcl-conversions rclcpp rclcpp-components rtabmap rtabmap-msgs sensor-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs image-geometry laser-geometry pcl-conversions rclcpp rclcpp-components rtabmap rtabmap-msgs sensor-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/rtabmap-costmap-plugins/default.nix
+++ b/distros/humble/rtabmap-costmap-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, nav2-costmap-2d, pluginlib, rclcpp, ros-environment, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-humble-rtabmap-costmap-plugins";
+  version = "0.23.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_costmap_plugins/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "6e856e21254cc56f18a2cd816610abd847d173705234357479e7793a3c0c93fe";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ros-environment ];
+  propagatedBuildInputs = [ nav2-costmap-2d pluginlib rclcpp visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = "RTAB-Map's costmap plugins.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/rtabmap-demos/default.nix
+++ b/distros/humble/rtabmap-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-bringup, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-demos";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_demos/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "3b06eca7e43eebac201baf55553d04d9177e26e575aba532a4985d82bca29cb9";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_demos/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "3ec1f5206036f9dceb38a2bf7cf0afeffad102ab0a0429d4144e57c2c428cbb6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-examples/default.nix
+++ b/distros/humble/rtabmap-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, imu-filter-madgwick, realsense2-camera, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz, tf2-ros, velodyne }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-examples";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_examples/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "e374a321e899d3efc7b55b7a1581c5178e7166c3a27c11c4a9eb37fa1261d8b2";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_examples/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "beabfdea4c9cec6486c08bdd19e722a4fb38bf101810ea34deb73cf276bd1a56";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-launch/default.nix
+++ b/distros/humble/rtabmap-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rtabmap-msgs, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-launch";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_launch/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "fdba718f5101bda7f33af116f05600f222b6ddc1571c04b9efacac5d6aff1f17";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_launch/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "e9fed0a5f87468296aa87111fa0cdaf9a5afdaa25e43913ff5b8379565c1b020";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-msgs/default.nix
+++ b/distros/humble/rtabmap-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-msgs";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_msgs/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "d9d680aafaac4ca394fa40249c122f4a8235cf74ea754fd8081f0db5c1811f48";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_msgs/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "977098eee8edad0db9ee3769559ca66462e78cf10252d0bbfae41c53637bee22";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-odom/default.nix
+++ b/distros/humble/rtabmap-odom/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, image-geometry, laser-geometry, message-filters, nav-msgs, pcl-conversions, pcl-ros, pluginlib, rclcpp, rclcpp-components, ros-environment, rtabmap-conversions, rtabmap-msgs, rtabmap-sync, rtabmap-util, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-odom";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_odom/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "09df7f97023000432a1db5eb8246eabca1cad89290d66423effe19feccfe433f";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_odom/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "8148a06568d8d69fc49354f75ffd13d0b2bce1af10aefb68e5a63dd5a88496c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-python/default.nix
+++ b/distros/humble/rtabmap-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-python";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_python/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "772e1db3623170f1bdc2033d38d1d623d412737064864bab3d20de5f8e45c3a3";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_python/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "fa158e238d1bcfe3590ecbe1a4904ca1a8e5a9ca0b2333323f142c47da52520a";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rtabmap-ros/default.nix
+++ b/distros/humble/rtabmap-ros/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, rtabmap-conversions, rtabmap-demos, rtabmap-examples, rtabmap-launch, rtabmap-msgs, rtabmap-odom, rtabmap-python, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-sync, rtabmap-util, rtabmap-viz }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, rtabmap-conversions, rtabmap-costmap-plugins, rtabmap-demos, rtabmap-examples, rtabmap-launch, rtabmap-msgs, rtabmap-odom, rtabmap-python, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-sync, rtabmap-util, rtabmap-viz }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-ros";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_ros/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "d9700e9f648c3fac66ab9ca07c600c906eebe4166c22bcf92b6ab96d482e399a";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_ros/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "5203a81f62f85b973e4539cf198cbe768b2081c6557ed8d1610e8329303d4cf7";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ rtabmap-conversions rtabmap-demos rtabmap-examples rtabmap-launch rtabmap-msgs rtabmap-odom rtabmap-python rtabmap-rviz-plugins rtabmap-slam rtabmap-sync rtabmap-util rtabmap-viz ];
+  propagatedBuildInputs = [ rtabmap-conversions rtabmap-costmap-plugins rtabmap-demos rtabmap-examples rtabmap-launch rtabmap-msgs rtabmap-odom rtabmap-python rtabmap-rviz-plugins rtabmap-slam rtabmap-sync rtabmap-util rtabmap-viz ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/rtabmap-rviz-plugins/default.nix
+++ b/distros/humble/rtabmap-rviz-plugins/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, pcl-conversions, pluginlib, rclcpp, ros-environment, rtabmap-conversions, rtabmap-msgs, rviz-common, rviz-default-plugins, rviz-rendering, sensor-msgs, std-msgs, tf2 }:
+{ lib, buildRosPackage, fetchurl, _unresolved_qtbase5-private-dev, ament-cmake-ros, pcl-conversions, pluginlib, rclcpp, ros-environment, rtabmap-conversions, rtabmap-msgs, rviz-common, rviz-default-plugins, rviz-rendering, sensor-msgs, std-msgs, tf2 }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-rviz-plugins";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_rviz_plugins/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "d8ed11ce10bf570b39f8a1b30f74f60f09b77ec59e09ce58df29cb2afa275d5d";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_rviz_plugins/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "ebf34a0048e090f0861fa6c7f90eeec29a73a730ad3701212a89595169e48671";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ros-environment ];
+  buildInputs = [ _unresolved_qtbase5-private-dev ament-cmake-ros ros-environment ];
   propagatedBuildInputs = [ pcl-conversions pluginlib rclcpp rtabmap-conversions rtabmap-msgs rviz-common rviz-default-plugins rviz-rendering sensor-msgs std-msgs tf2 ];
   nativeBuildInputs = [ ament-cmake-ros ];
 

--- a/distros/humble/rtabmap-slam/default.nix
+++ b/distros/humble/rtabmap-slam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, apriltag-msgs, aruco-msgs, aruco-opencv-msgs, cv-bridge, geometry-msgs, nav-msgs, nav2-msgs, rclcpp, rclcpp-components, ros-environment, rtabmap-msgs, rtabmap-sync, rtabmap-util, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-slam";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_slam/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "7a7b214aaddbe66603e639ad0464902f4bd529ffe02ddbea071df7f9d897db08";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_slam/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "5627470dba41d8e6a286acf6dc02fe04d6f81ac0ce9fa8f1345738e760fd51c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-sync/default.nix
+++ b/distros/humble/rtabmap-sync/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, diagnostic-updater, image-transport, message-filters, nav-msgs, rclcpp, rclcpp-components, ros-environment, rtabmap-conversions, rtabmap-msgs, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-sync";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_sync/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "2b4283c702c7be2fb8a93760139d6b50d8b58ba3b537f2bbf0b55241cc6d6192";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_sync/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "c740ec097e5704cfc010fd6bc2263e82ed0bd2e407ff8c23930e99c28dd643d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-util/default.nix
+++ b/distros/humble/rtabmap-util/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, grid-map-ros, image-transport, laser-geometry, message-filters, nav-msgs, octomap-msgs, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, ros-environment, rtabmap-conversions, rtabmap-msgs, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, grid-map-ros, image-geometry, image-transport, laser-geometry, message-filters, nav-msgs, octomap-msgs, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, ros-environment, rtabmap-conversions, rtabmap-msgs, rtabmap-sync, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-util";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_util/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "31e9b59230c6daf3c635708f4b91ea037316ce51576f819bcceb15b3f0feabbd";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_util/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "2b679a10e6429fb5ba822fc7a3d12a16b6e008f1578abf78cde8e4d2b76dd660";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ cv-bridge grid-map-ros image-transport laser-geometry message-filters nav-msgs octomap-msgs pcl-conversions pcl-ros rclcpp rclcpp-components rtabmap-conversions rtabmap-msgs sensor-msgs std-msgs stereo-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ cv-bridge grid-map-ros image-geometry image-transport laser-geometry message-filters nav-msgs octomap-msgs pcl-conversions pcl-ros rclcpp rclcpp-components rtabmap-conversions rtabmap-msgs rtabmap-sync sensor-msgs std-msgs stereo-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/rtabmap-viz/default.nix
+++ b/distros/humble/rtabmap-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, geometry-msgs, nav-msgs, rclcpp, ros-environment, rtabmap-msgs, rtabmap-sync, std-msgs, std-srvs, tf2 }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-viz";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_viz/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "d85150778dc103fbb34b389d7870ac5e0d5e4ff0e297336aa419990188da63af";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_viz/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "987775c83d18b37c3ae55faab61b094e5b30ef2560e57d208c6800be99101059";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap/default.nix
+++ b/distros/humble/rtabmap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, gtsam, libg2o, libpointmatcher, octomap, pcl, proj, qt-gui-cpp, sqlite, zlib }:
 buildRosPackage {
   pname = "ros-humble-rtabmap";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rtabmap-release/archive/release/humble/rtabmap/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "50ff8d0be65ca7b6cab8e08a76c8dbda1d49e422b196a8250d34ee6ae8aaad85";
+    url = "https://github.com/ros2-gbp/rtabmap-release/archive/release/humble/rtabmap/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "a743fc03dfe93f6b033d649fa70455ca3425bb0c01f2abf49142ecb50ebc21cb";
   };
 
   buildType = "cmake";

--- a/distros/humble/septentrio-gnss-driver/default.nix
+++ b/distros/humble/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, gtest-vendor, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-septentrio-gnss-driver";
-  version = "1.4.6-r1";
+  version = "1.4.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/humble/septentrio_gnss_driver/1.4.6-1.tar.gz";
-    name = "1.4.6-1.tar.gz";
-    sha256 = "7c0b6a6f5c514554f71c62dd57d810b85ce69fbf81b129721fe44c6f062fa038";
+    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/humble/septentrio_gnss_driver/1.4.7-2.tar.gz";
+    name = "1.4.7-2.tar.gz";
+    sha256 = "677a2e456a0a2e72fcfbfdb1c439b0c13b5fdd17e215f2ab2eff30f105570701";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-pro-bringup/default.nix
+++ b/distros/humble/tiago-pro-bringup/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-index-python, ament-lint-auto, ament-lint-common, diagnostic-aggregator, joy-linux, joy-teleop, pal-pro-gripper-wrapper, play-motion2, play-motion2-cli, tiago-pro-controller-configuration, tiago-pro-head-bringup, twist-mux }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-index-python, ament-lint-auto, ament-lint-common, diagnostic-aggregator, joy, joy-teleop, pal-pro-gripper-wrapper, play-motion2, play-motion2-cli, tiago-pro-controller-configuration, tiago-pro-head-bringup, twist-mux }:
 buildRosPackage {
   pname = "ros-humble-tiago-pro-bringup";
-  version = "1.35.4-r1";
+  version = "2.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tiago_pro_robot-release/archive/release/humble/tiago_pro_bringup/1.35.4-1.tar.gz";
-    name = "1.35.4-1.tar.gz";
-    sha256 = "a29412bd15ae0349606314ad6e2d509fc5f837e800239fe36cce3209f493da16";
+    url = "https://github.com/ros2-gbp/tiago_pro_robot-release/archive/release/humble/tiago_pro_bringup/2.4.1-1.tar.gz";
+    name = "2.4.1-1.tar.gz";
+    sha256 = "903a8bc37118f87c75cf33e464ab0873c260ce36809f7a6c96d60b10b9bc696f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python diagnostic-aggregator joy-linux joy-teleop pal-pro-gripper-wrapper play-motion2 play-motion2-cli tiago-pro-controller-configuration tiago-pro-head-bringup twist-mux ];
+  propagatedBuildInputs = [ ament-index-python diagnostic-aggregator joy joy-teleop pal-pro-gripper-wrapper play-motion2 play-motion2-cli tiago-pro-controller-configuration tiago-pro-head-bringup twist-mux ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/tiago-pro-controller-configuration/default.nix
+++ b/distros/humble/tiago-pro-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, joint-state-broadcaster, joint-trajectory-controller, launch, launch-pal, omni-base-controller-configuration, pal-pro-gripper-controller-configuration, pal-sea-arm-controller-configuration, ros2controlcli, tiago-pro-head-controller-configuration }:
 buildRosPackage {
   pname = "ros-humble-tiago-pro-controller-configuration";
-  version = "1.35.4-r1";
+  version = "2.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tiago_pro_robot-release/archive/release/humble/tiago_pro_controller_configuration/1.35.4-1.tar.gz";
-    name = "1.35.4-1.tar.gz";
-    sha256 = "e692bab9c3ac11dba4e972b1ad917348fe4ddef835579e4505ebfac31a6c993f";
+    url = "https://github.com/ros2-gbp/tiago_pro_robot-release/archive/release/humble/tiago_pro_controller_configuration/2.4.1-1.tar.gz";
+    name = "2.4.1-1.tar.gz";
+    sha256 = "e5271b875fce2fe04c7118fdf8f21f261b16c94430c611d9a4d59b247c5ff8f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-pro-description/default.nix
+++ b/distros/humble/tiago-pro-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, launch-testing-ament-cmake, omni-base-description, pal-sea-arm-description, pal-urdf-utils, robot-state-publisher, tiago-pro-head-description, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-tiago-pro-description";
-  version = "1.35.4-r1";
+  version = "2.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tiago_pro_robot-release/archive/release/humble/tiago_pro_description/1.35.4-1.tar.gz";
-    name = "1.35.4-1.tar.gz";
-    sha256 = "7b1e4c0b1b126a9238236a0d4c632f4319895aa11651dfce3d91d393f960ff4f";
+    url = "https://github.com/ros2-gbp/tiago_pro_robot-release/archive/release/humble/tiago_pro_description/2.4.1-1.tar.gz";
+    name = "2.4.1-1.tar.gz";
+    sha256 = "aa2cb021c3ea2af609db32fba8924500381fae8503d1c631691332a32491bd12";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-pro-gazebo/default.nix
+++ b/distros/humble/tiago-pro-gazebo/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, gazebo-ros2-control, launch, launch-pal, launch-ros, omni-base-description, pal-gazebo-plugins, pal-gazebo-worlds, pal-maps, pal-pro-gripper-description, pal-urdf-utils, play-motion2-msgs, tiago-pro-2dnav, tiago-pro-bringup, tiago-pro-description, tiago-pro-head-description, tiago-pro-laser-sensors, tiago-pro-moveit-config, tiago-pro-rgbd-sensors }:
+{ lib, buildRosPackage, fetchurl, _unresolved_gz-sensors6, ament-cmake-auto, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, gazebo-ros2-control, gz-ros2-control, launch, launch-pal, launch-ros, nav2-bringup, omni-base-description, pal-gazebo-plugins, pal-gazebo-worlds, pal-maps, pal-pro-gripper-description, pal-urdf-utils, play-motion2-msgs, ros-gz-bridge, ros-gz-sim, tiago-pro-2dnav, tiago-pro-bringup, tiago-pro-description, tiago-pro-head-description, tiago-pro-laser-sensors, tiago-pro-moveit-config, tiago-pro-rgbd-sensors }:
 buildRosPackage {
   pname = "ros-humble-tiago-pro-gazebo";
-  version = "1.14.1-r1";
+  version = "1.17.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tiago_pro_simulation-release/archive/release/humble/tiago_pro_gazebo/1.14.1-1.tar.gz";
-    name = "1.14.1-1.tar.gz";
-    sha256 = "941f730ea91cdc60c2322ed8d28b4ac7119cf3676bf4ab73777dda409543701b";
+    url = "https://github.com/ros2-gbp/tiago_pro_simulation-release/archive/release/humble/tiago_pro_gazebo/1.17.1-1.tar.gz";
+    name = "1.17.1-1.tar.gz";
+    sha256 = "bf70ec0f6131b535eb1071c224aaee0a1faee6e819682602aa9bbe990dd7f0bd";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ gazebo-plugins gazebo-ros gazebo-ros2-control launch launch-pal launch-ros omni-base-description pal-gazebo-plugins pal-gazebo-worlds pal-maps pal-pro-gripper-description pal-urdf-utils play-motion2-msgs tiago-pro-2dnav tiago-pro-bringup tiago-pro-description tiago-pro-head-description tiago-pro-laser-sensors tiago-pro-moveit-config tiago-pro-rgbd-sensors ];
+  propagatedBuildInputs = [ _unresolved_gz-sensors6 gazebo-plugins gazebo-ros gazebo-ros2-control gz-ros2-control launch launch-pal launch-ros nav2-bringup omni-base-description pal-gazebo-plugins pal-gazebo-worlds pal-maps pal-pro-gripper-description pal-urdf-utils play-motion2-msgs ros-gz-bridge ros-gz-sim tiago-pro-2dnav tiago-pro-bringup tiago-pro-description tiago-pro-head-description tiago-pro-laser-sensors tiago-pro-moveit-config tiago-pro-rgbd-sensors ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/tiago-pro-head-bringup/default.nix
+++ b/distros/humble/tiago-pro-head-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, play-motion2, play-motion2-cli, tiago-pro-head-controller-configuration, tiago-pro-head-description }:
 buildRosPackage {
   pname = "ros-humble-tiago-pro-head-bringup";
-  version = "1.9.0-r1";
+  version = "1.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tiago_pro_head_robot-release/archive/release/humble/tiago_pro_head_bringup/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "440297ea974598b9521775692728fd09b7604035ed0c414cf783f17e2649bbd2";
+    url = "https://github.com/ros2-gbp/tiago_pro_head_robot-release/archive/release/humble/tiago_pro_head_bringup/1.12.0-1.tar.gz";
+    name = "1.12.0-1.tar.gz";
+    sha256 = "1d246da64f2b27ef414681175638b25b616a5493ecbbca04cb72404ca2794d19";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-pro-head-controller-configuration/default.nix
+++ b/distros/humble/tiago-pro-head-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, joint-state-broadcaster, joint-trajectory-controller, launch, launch-pal, ros2controlcli }:
 buildRosPackage {
   pname = "ros-humble-tiago-pro-head-controller-configuration";
-  version = "1.9.0-r1";
+  version = "1.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tiago_pro_head_robot-release/archive/release/humble/tiago_pro_head_controller_configuration/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "7293f92edf88aba80e4ab9e6c991b89ec2d0c28f993e459af670d0ee1a5e974a";
+    url = "https://github.com/ros2-gbp/tiago_pro_head_robot-release/archive/release/humble/tiago_pro_head_controller_configuration/1.12.0-1.tar.gz";
+    name = "1.12.0-1.tar.gz";
+    sha256 = "9af47d871a996c149f09545b90e3e52157ab045cbf42e14a17757d0403d0a256";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-pro-head-description/default.nix
+++ b/distros/humble/tiago-pro-head-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, launch-param-builder, launch-testing-ament-cmake, pal-urdf-utils, realsense2-description, robot-state-publisher, tiago-pro-head-controller-configuration, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-tiago-pro-head-description";
-  version = "1.9.0-r1";
+  version = "1.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tiago_pro_head_robot-release/archive/release/humble/tiago_pro_head_description/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "fe7854d50e0cb62520c8ff116229473c70b3cc99f7ab217ce9baf5fff1846c73";
+    url = "https://github.com/ros2-gbp/tiago_pro_head_robot-release/archive/release/humble/tiago_pro_head_description/1.12.0-1.tar.gz";
+    name = "1.12.0-1.tar.gz";
+    sha256 = "fdb279a21d84b0160747eb5c89e0cc9f0efe5a36c360746593f33844b113b48e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-pro-head-robot/default.nix
+++ b/distros/humble/tiago-pro-head-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tiago-pro-head-bringup, tiago-pro-head-controller-configuration, tiago-pro-head-description }:
 buildRosPackage {
   pname = "ros-humble-tiago-pro-head-robot";
-  version = "1.9.0-r1";
+  version = "1.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tiago_pro_head_robot-release/archive/release/humble/tiago_pro_head_robot/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "fbad6771c51b8bf8ee10b41411a8a8fdc54b97066c53e5edd3fa8499c511dc20";
+    url = "https://github.com/ros2-gbp/tiago_pro_head_robot-release/archive/release/humble/tiago_pro_head_robot/1.12.0-1.tar.gz";
+    name = "1.12.0-1.tar.gz";
+    sha256 = "9d8427b66c5948914411311cf79adb1acd75a65a178e72f20a6445d9d85fe5a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-pro-moveit-config/default.nix
+++ b/distros/humble/tiago-pro-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, launch-pal, moveit-configs-utils, moveit-kinematics, moveit-planners-chomp, moveit-planners-ompl, moveit-ros-control-interface, moveit-ros-move-group, moveit-ros-perception, moveit-ros-visualization, moveit-task-constructor-capabilities, pal-sea-arm-moveit-config, tiago-pro-description }:
 buildRosPackage {
   pname = "ros-humble-tiago-pro-moveit-config";
-  version = "1.4.1-r1";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tiago_pro_moveit_config-release/archive/release/humble/tiago_pro_moveit_config/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "3dd1b1e83bd80dcad7683ec03d9b457ec5f18ddb493729c46aa15c1906ccb36d";
+    url = "https://github.com/ros2-gbp/tiago_pro_moveit_config-release/archive/release/humble/tiago_pro_moveit_config/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "5088f292915da7122de63366d7fe4a67eb5ea3fba3a98c8747ddfbc34fb9fa25";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-pro-mujoco/default.nix
+++ b/distros/humble/tiago-pro-mujoco/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, launch, launch-pal, launch-ros, mujoco-ros2-control, omni-base-description, pal-pro-gripper-description, pal-urdf-utils, play-motion2-msgs, tiago-pro-bringup, tiago-pro-description, tiago-pro-head-description, tiago-pro-laser-sensors, tiago-pro-moveit-config }:
+buildRosPackage {
+  pname = "ros-humble-tiago-pro-mujoco";
+  version = "1.17.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/tiago_pro_simulation-release/archive/release/humble/tiago_pro_mujoco/1.17.1-1.tar.gz";
+    name = "1.17.1-1.tar.gz";
+    sha256 = "6bd30ed062c7c75b10ffaae6e2831cb3d39d8e920ff5cabf28010f697372c4c7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ launch launch-pal launch-ros mujoco-ros2-control omni-base-description pal-pro-gripper-description pal-urdf-utils play-motion2-msgs tiago-pro-bringup tiago-pro-description tiago-pro-head-description tiago-pro-laser-sensors tiago-pro-moveit-config ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = "The tiago_pro_mujoco package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/tiago-pro-robot/default.nix
+++ b/distros/humble/tiago-pro-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tiago-pro-bringup, tiago-pro-controller-configuration, tiago-pro-description }:
 buildRosPackage {
   pname = "ros-humble-tiago-pro-robot";
-  version = "1.35.4-r1";
+  version = "2.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tiago_pro_robot-release/archive/release/humble/tiago_pro_robot/1.35.4-1.tar.gz";
-    name = "1.35.4-1.tar.gz";
-    sha256 = "1964d0a4ec103713a490dc26f9edcce9fdc4c8e46a8b2c8a3f688950d1e5c526";
+    url = "https://github.com/ros2-gbp/tiago_pro_robot-release/archive/release/humble/tiago_pro_robot/2.4.1-1.tar.gz";
+    name = "2.4.1-1.tar.gz";
+    sha256 = "bb2a92e4879ee2b3ec9ec00fade5081b6e1ec4f3a3ba3264c9cece4e68095111";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-pro-simulation/default.nix
+++ b/distros/humble/tiago-pro-simulation/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, tiago-pro-gazebo }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, tiago-pro-gazebo, tiago-pro-mujoco }:
 buildRosPackage {
   pname = "ros-humble-tiago-pro-simulation";
-  version = "1.14.1-r1";
+  version = "1.17.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tiago_pro_simulation-release/archive/release/humble/tiago_pro_simulation/1.14.1-1.tar.gz";
-    name = "1.14.1-1.tar.gz";
-    sha256 = "257dd0cac92c2ad24d0b15cf6d2346f11cfba3f7cfb70e15d247c1c355e9ad20";
+    url = "https://github.com/ros2-gbp/tiago_pro_simulation-release/archive/release/humble/tiago_pro_simulation/1.17.1-1.tar.gz";
+    name = "1.17.1-1.tar.gz";
+    sha256 = "d4d856da4bf3b4694d968c9aacb9bf594c6c8a237864a0f55baa0af3c871e2d5";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ tiago-pro-gazebo ];
+  propagatedBuildInputs = [ tiago-pro-gazebo tiago-pro-mujoco ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/ublox-dgnss-node/default.nix
+++ b/distros/humble/ublox-dgnss-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-index-cpp, ament-lint-auto, ament-lint-common, libusb1, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-humble-ublox-dgnss-node";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_dgnss_node/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "c31c9628270653ba8a65a2a58297cdc9ae0ef601ffc0c44e205223ab2fcf1ffb";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_dgnss_node/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "c1ffa4de41a54f90e898b7d64d5c995e980656f497785ee6caf9ad3a82c29132";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ublox-dgnss/default.nix
+++ b/distros/humble/ublox-dgnss/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ntrip-client-node, ublox-dgnss-node, ublox-nav-sat-fix-hp-node, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-humble-ublox-dgnss";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_dgnss/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "3bf9b72b25c3d8b8d0a7adf3d24c23b0f9f455cca46731c26093db16eb07a54b";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_dgnss/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "bf59a29c73a5f8aa1c5e619fc970ca94c0b2e3383b2d742206780179503e572d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ublox-nav-sat-fix-hp-node/default.nix
+++ b/distros/humble/ublox-nav-sat-fix-hp-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-humble-ublox-nav-sat-fix-hp-node";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_nav_sat_fix_hp_node/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "15eb155e35538b0274d6b7304c9a1d84b533f976b4a02e578ddf8688b7ca7704";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_nav_sat_fix_hp_node/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "a46ba64b763661844f1ee90f6780dcf2ad6c6fa4a0141d2ef8fd8e4ee5c17ead";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ublox-ubx-interfaces/default.nix
+++ b/distros/humble/ublox-ubx-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-humble-ublox-ubx-interfaces";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_ubx_interfaces/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "444e62b9fd1bc4461e3a605dc119ae1ba382132709f0153c305793e67e73adac";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_ubx_interfaces/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "bfad645dd4c3201b7317dc8ed5b0dd576a329fba511e0a924105ecd3f4d67639";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ublox-ubx-msgs/default.nix
+++ b/distros/humble/ublox-ubx-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ublox-ubx-msgs";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_ubx_msgs/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "5267c885656892ef6be2ce4d45b9fc98ac248ce66aca873e9ae8a54339bbd174";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_ubx_msgs/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "cfacc7efe028c244c297b9c92efbca033a10058490a9cd29d75139fdd98c285c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-bringup/default.nix
+++ b/distros/humble/ur-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, force-torque-sensor-broadcaster, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, position-controllers, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, ur-controllers, ur-description, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-bringup";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_bringup/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "2d21349366ec553e901b923bbbef9ed30b2656c9d8ae4608db996b77c47d6809";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_bringup/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "a4f1452644e24af63a2b55d209b4a8100f7e0ec45e8bc01f9a5dcbe39cbadb68";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-calibration/default.nix
+++ b/distros/humble/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-ur-calibration";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_calibration/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "cce30968fecfa273c29585027fcc4fb5e8f0bcfece42877b1822aae70985630d";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_calibration/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "747de7f8cd7a5c8dcde6c6cf258d37b3461098ce44fc55a69b7648dc246472fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-controllers/default.nix
+++ b/distros/humble/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, angles, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, trajectory-msgs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-humble-ur-controllers";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_controllers/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "ff6e8c372c836cc85d23b0ccf135226bd9c9f38d58e38ab5f50311055c35b13a";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_controllers/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "6b72b90a4e0c7e6421cb2222ea600edeed00843050389238311e5fe9043a47be";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-dashboard-msgs/default.nix
+++ b/distros/humble/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-ur-dashboard-msgs";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_dashboard_msgs/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "eb474fe922ca2c31d09da58fcfefb36aac93e59b7eb1d65532b616fcda935ddb";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_dashboard_msgs/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "aa8a5c531406d9d9b48420a74cb182a74c0f51d2fea8a974fba3077e1864e6c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-moveit-config/default.nix
+++ b/distros/humble/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, launch, launch-ros, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, rviz2, ur-description, urdf, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-moveit-config";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_moveit_config/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "ed68d5842d4ce4c8d757954cdf52dbab78ddba89ba22a809ac7c0cae495ae288";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_moveit_config/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "6df8a5518d76f815617b20ea7b656a97c5b0b1d27a322e1afbdd3bdd85eb2be9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-robot-driver/default.nix
+++ b/distros/humble/ur-robot-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, backward-ros, controller-manager, controller-manager-msgs, effort-controllers, force-torque-sensor-broadcaster, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, pluginlib, pose-broadcaster, position-controllers, rclcpp, rclcpp-lifecycle, rclpy, robot-state-publisher, ros2-controllers-test-nodes, ros2run, rviz2, socat, std-msgs, std-srvs, tf2-geometry-msgs, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-robot-driver";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_robot_driver/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "6479c8d28a9b4d8cbcb5719329a19ae949daadc8931e3e97adacb8dd36f7983d";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_robot_driver/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "343a0f8936740e852906781706a748f772a151779d270861c5dfb351704a1bf9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur/default.nix
+++ b/distros/humble/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-humble-ur";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "e2e28771b442e0a18a2e4131407b85c33be540fdfbca995ddad6745434a2b0fb";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "5699d151ad582eaa9a26fe81d2bceaedc2097a27192c001b86d2c2240e280aea";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/urdf-test/default.nix
+++ b/distros/humble/urdf-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, rclpy, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-humble-urdf-test";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/urdf_test-release/archive/release/humble/urdf_test/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "6718bfecf50b7d6d96e9646b3baf5be37664081b2b0504658c6214fad98cd31e";
+    url = "https://github.com/ros2-gbp/urdf_test-release/archive/release/humble/urdf_test/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "f161b4902182470d256f385a28bb431c301b1e6c0cd1703e879d2bf52f3203c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/warehouse-ros-sqlite/default.nix
+++ b/distros/humble/warehouse-ros-sqlite/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite3-vendor, warehouse-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite, warehouse-ros }:
 buildRosPackage {
   pname = "ros-humble-warehouse-ros-sqlite";
-  version = "1.0.5-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/humble/warehouse_ros_sqlite/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "7bed57e1126dbc539984fe5b369a97c78f9f037d0457fb16eb951d07b01ab7bc";
+    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/humble/warehouse_ros_sqlite/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "c87956600dbe7daccac64be231fa00f56ca9b7d157bccc02fb26416a07bdacd2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake boost ];
   checkInputs = [ ament-cmake-copyright ament-cmake-gtest ament-lint-auto ament-lint-common geometry-msgs ];
-  propagatedBuildInputs = [ class-loader rclcpp sqlite3-vendor warehouse-ros ];
+  propagatedBuildInputs = [ class-loader rclcpp sqlite warehouse-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/autoware-cmake/default.nix
+++ b/distros/jazzy/autoware-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, autoware-lint-common, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-cmake";
-  version = "1.2.0-r2";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/jazzy/autoware_cmake/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "053e212de97c018b1452c0edf9b808ac849d74a37e5ec4089b3f48809471df91";
+    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/jazzy/autoware_cmake/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "d628055158da252e5dcbffa9915ea13461549db7c95bcb0244543cf71298a29a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-lint-common/default.nix
+++ b/distros/jazzy/autoware-lint-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-cppcheck, ament-cmake-export-dependencies, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-lint-common";
-  version = "1.2.0-r2";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/jazzy/autoware_lint_common/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "e01f7fd33722504de3a475bc932d58e12a18301995877edf1c5dd025cd14aa95";
+    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/jazzy/autoware_lint_common/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "da23bee2e89ddb87742a7d97026456b29b51a493308523db7a8cf20bea09780a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/callback-isolated-executor/default.nix
+++ b/distros/jazzy/callback-isolated-executor/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cie-config-msgs, cie-thread-configurator, rclcpp, rclcpp-components, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-callback-isolated-executor";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/callback_isolated_executor-release/archive/release/jazzy/callback_isolated_executor/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "fc7dc1f8df8a3ac09c972a42030da514342ba4f23443e51e21f1eda5a606456f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cie-config-msgs cie-thread-configurator rclcpp rclcpp-components std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Component container and executor assigning a dedicated thread to each callback group.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/cie-config-msgs/default.nix
+++ b/distros/jazzy/cie-config-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-jazzy-cie-config-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/callback_isolated_executor-release/archive/release/jazzy/cie_config_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "9661be9cb585c2d078e6c4c96f4cea4ffe4524cc23f471f85981de9141c4c4eb";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS messages for interaction between cie_thread_configurator and callback_isolated_executor.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/cie-sample-application/default.nix
+++ b/distros/jazzy/cie-sample-application/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, callback-isolated-executor, cie-thread-configurator, rclcpp, rclcpp-components, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-cie-sample-application";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/callback_isolated_executor-release/archive/release/jazzy/cie_sample_application/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "52d9e5d9098066486898671b834a49133a5a7242d6f77c9f1c11eada4e2f3c2d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ callback-isolated-executor cie-thread-configurator rclcpp rclcpp-components std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Sample application to demonstrate the use of cie_thread_configurator and callback_isolated_executor.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/cie-thread-configurator/default.nix
+++ b/distros/jazzy/cie-thread-configurator/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cie-config-msgs, rclcpp, yaml-cpp }:
+buildRosPackage {
+  pname = "ros-jazzy-cie-thread-configurator";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/callback_isolated_executor-release/archive/release/jazzy/cie_thread_configurator/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "f0e59ef5c21e7f24af0922ed8030824f0baeb8cb04e65b4b4f56ad7c70955201";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cie-config-msgs rclcpp yaml-cpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A dedicated node that configures the scheduling attributes of each thread in callback_isolated_executor.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/clearpath-config-live/default.nix
+++ b/distros/jazzy/clearpath-config-live/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, clearpath-generator-common, python3Packages, rclpy, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-config-live";
-  version = "2.7.0-r2";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/jazzy/clearpath_config_live/2.7.0-2.tar.gz";
-    name = "2.7.0-2.tar.gz";
-    sha256 = "74999f49f7fb42a3c9bf5f47c3a30660fae55953f60183645894f278f9d9b334";
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/jazzy/clearpath_config_live/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "96fda94d55f7d1148925956bfc161aadadc5b376956dd45c26c333a90860586d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-desktop/default.nix
+++ b/distros/jazzy/clearpath-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-config-live, clearpath-offboard-sensors, clearpath-platform-msgs, clearpath-viz }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-desktop";
-  version = "2.7.0-r2";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/jazzy/clearpath_desktop/2.7.0-2.tar.gz";
-    name = "2.7.0-2.tar.gz";
-    sha256 = "ba4cbf41bdd6f3efb47fde3c9dde8ed262ad6b4fe5bb1fc916c3f00e9a169b4d";
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/jazzy/clearpath_desktop/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "dd3f57b1bfc4cb3ed9372c0ccd939d364a271399f512fdba97e301bad126300d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-offboard-sensors/default.nix
+++ b/distros/jazzy/clearpath-offboard-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, image-transport, image-transport-plugins, velodyne-pointcloud }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-offboard-sensors";
-  version = "2.7.0-r2";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/jazzy/clearpath_offboard_sensors/2.7.0-2.tar.gz";
-    name = "2.7.0-2.tar.gz";
-    sha256 = "498552bb31aac44e4229ce64f23d3a8671ea37de85c9fb3e910e45bf85a1068a";
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/jazzy/clearpath_offboard_sensors/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "25ac88ddfc090ed591851675b45c3022d14f6e03d9abdcb89db4c26aea6babed";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-viz/default.nix
+++ b/distros/jazzy/clearpath-viz/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, clearpath-platform-description, joint-state-publisher-gui, rqt-robot-monitor, rviz2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, clearpath-description, joint-state-publisher-gui, nav2-rviz-plugins, rqt-robot-monitor, rviz2 }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-viz";
-  version = "2.7.0-r2";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/jazzy/clearpath_viz/2.7.0-2.tar.gz";
-    name = "2.7.0-2.tar.gz";
-    sha256 = "e0b1e0898ddce38e8311a3b6a701950b9b46660cd8fba67d4adb61b5e6c1aa17";
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/jazzy/clearpath_viz/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "06a28e47e1d4318d49d5c7686f4db4a98220a7a0d9b02a972bc3db17862dea56";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ clearpath-platform-description joint-state-publisher-gui rqt-robot-monitor rviz2 ];
+  propagatedBuildInputs = [ clearpath-description joint-state-publisher-gui nav2-rviz-plugins rqt-robot-monitor rviz2 ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/clips-vendor/default.nix
+++ b/distros/jazzy/clips-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, unzip }:
 buildRosPackage {
   pname = "ros-jazzy-clips-vendor";
-  version = "6.4.3-r2";
+  version = "6.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/clips_vendor-release/archive/release/jazzy/clips_vendor/6.4.3-2.tar.gz";
-    name = "6.4.3-2.tar.gz";
-    sha256 = "0f3fe94af4f4137581c500d5d86dd4d580b7794ce494335c45ae0991d7b4b8b9";
+    url = "https://github.com/ros2-gbp/clips_vendor-release/archive/release/jazzy/clips_vendor/6.4.4-1.tar.gz";
+    name = "6.4.4-1.tar.gz";
+    sha256 = "a087beeed28751e68439e6196b2bcf34ccc554113585b277b37b134c9759aa57";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clips-vendor/vendored-source.json
+++ b/distros/jazzy/clips-vendor/vendored-source.json
@@ -1,6 +1,6 @@
 {
   "clips_vendor": {
-    "url": "https://raw.githubusercontent.com/carologistics/clips_vendor/r925/clipsrules-code-r925.zip",
-    "sha256": "08macis5ai6y6azzbp5mhyk30sx3qx3903wsbry9agfabgd2yviw"
+    "url": "https://raw.githubusercontent.com/carologistics/clips_vendor/r974/clipsrules-code-r974.zip",
+    "sha256": "0yg9gfqmql6fmw4qrzfm968nb10lnfxzlpish2xyscibax6gg97p"
   }
 }

--- a/distros/jazzy/compass-msgs/default.nix
+++ b/distros/jazzy/compass-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-compass-msgs";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/compass_msgs/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "a9e944293bd2b6f56c027d9065df63185a3d91f3a05f03774f6c45cd158f9df8";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/compass_msgs/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "b56b07d325256c697043fd02750c56b30215d425e3fefb496701595efb4868ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fkie-message-filters/default.nix
+++ b/distros/jazzy/fkie-message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, image-transport, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-fkie-message-filters";
-  version = "3.3.1-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fkie_message_filters-release/archive/release/jazzy/fkie_message_filters/3.3.1-1.tar.gz";
-    name = "3.3.1-1.tar.gz";
-    sha256 = "428f4cdaefffab8bbb801e16f85931dec2517515d60c119d3d3a8b0c5c31c341";
+    url = "https://github.com/ros2-gbp/fkie_message_filters-release/archive/release/jazzy/fkie_message_filters/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "e376d29f03e447215b0f5626ebb658a178aaafebbfa4f4d60275a8b3383ba1b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/foxglove-bridge/default.nix
+++ b/distros/jazzy/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, geometry-msgs, nlohmann_json, rcl-interfaces, rclcpp, rclcpp-components, rcpputils, rcutils, resource-retriever, ros-environment, rosgraph-msgs, rosidl-typesupport-introspection-cpp, rosx-introspection, sensor-msgs, std-msgs, std-srvs, websocketpp }:
 buildRosPackage {
   pname = "ros-jazzy-foxglove-bridge";
-  version = "3.4.1-r1";
+  version = "3.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/jazzy/foxglove_bridge/3.4.1-1.tar.gz";
-    name = "3.4.1-1.tar.gz";
-    sha256 = "c4fb781baba9a44f71ab17f163e2c224910928e07ed2a30d391069d986151f0e";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/jazzy/foxglove_bridge/3.4.2-1.tar.gz";
+    name = "3.4.2-1.tar.gz";
+    sha256 = "29ffeacb6fe77eef72be6ef93231024613255a22d84db55eac55628714718b96";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/foxglove-msgs/default.nix
+++ b/distros/jazzy/foxglove-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-foxglove-msgs";
-  version = "3.4.1-r1";
+  version = "3.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/jazzy/foxglove_msgs/3.4.1-1.tar.gz";
-    name = "3.4.1-1.tar.gz";
-    sha256 = "2e74856669e8f51ebefd6e383caa9327af014b0c38688288c2f66a488da27948";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/jazzy/foxglove_msgs/3.4.2-1.tar.gz";
+    name = "3.4.2-1.tar.gz";
+    sha256 = "359a502d8d088e999270181c09291956026b2d8b5e54852af11d24216029e6ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fusioncore-core/default.nix
+++ b/distros/jazzy/fusioncore-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module }:
 buildRosPackage {
   pname = "ros-jazzy-fusioncore-core";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/fusioncore_core/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "d0d323afba097ffba74acac8dfdaeec90550039be591b857574153eb08559513";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/fusioncore_core/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "4d9f8cff15932d537b21b533489fbee9f43e5f705ebb854c4426514990081491";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fusioncore-datasets/default.nix
+++ b/distros/jazzy/fusioncore-datasets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fusioncore-ros, geometry-msgs, nav-msgs, rclpy, robot-localization, rosgraph-msgs, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-fusioncore-datasets";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/fusioncore_datasets/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "5fe08bd72b9a613bfe0272276d4491e42902f4b227114b6ef571fc19fc5cac53";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/fusioncore_datasets/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "4911f652b487a082d449ff768b71d829deef11c9203e2e2c537a467a9b8adf19";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fusioncore-gazebo/default.nix
+++ b/distros/jazzy/fusioncore-gazebo/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, fusioncore-ros, nav-msgs, rclpy, robot-state-publisher, sensor-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, fusioncore-ros, geometry-msgs, nav-msgs, rclpy, robot-localization, robot-state-publisher, ros-gz-bridge, ros-gz-sim, rviz2, sensor-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-fusioncore-gazebo";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/fusioncore_gazebo/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "1ecfb02b613d97cb323fcd406f69581920824d2d3739acf5092d6a99b7ac8c71";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/fusioncore_gazebo/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "643fc3b2c63a90d73e187b2df83696c2d5a5dc0118f7952023c2f120f6f46d58";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ fusioncore-ros nav-msgs rclpy robot-state-publisher sensor-msgs tf2-ros ];
+  propagatedBuildInputs = [ fusioncore-ros geometry-msgs nav-msgs rclpy robot-localization robot-state-publisher ros-gz-bridge ros-gz-sim rviz2 sensor-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "Gazebo simulation world for FusionCore integration testing";
+    description = "Gazebo simulation world for FusionCore integration testing and demo recording";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/jazzy/fusioncore-ros/default.nix
+++ b/distros/jazzy/fusioncore-ros/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, compass-msgs, diagnostic-msgs, eigen3-cmake-module, fusioncore-core, geographic-msgs, geometry-msgs, gps-msgs, nav-msgs, proj, rclcpp, rclcpp-lifecycle, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, compass-msgs, diagnostic-msgs, eigen3-cmake-module, fusioncore-core, geographic-msgs, geometry-msgs, gps-msgs, lifecycle-msgs, nav-msgs, proj, rclcpp, rclcpp-lifecycle, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-fusioncore-ros";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/fusioncore_ros/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "4c1c04977f91189c8b163c8604d74a29cc468d0496ba915367de8d9f60c1b086";
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/fusioncore_ros/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "4434afb4b3084173ee225234ea87655e38177c529673ae5f60aa52ceed17c2f3";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake rosidl-default-generators ];
-  propagatedBuildInputs = [ compass-msgs diagnostic-msgs eigen3-cmake-module fusioncore-core geographic-msgs geometry-msgs gps-msgs nav-msgs proj rclcpp rclcpp-lifecycle rosidl-default-runtime sensor-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
-  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+  buildInputs = [ ament-cmake-auto rosidl-default-generators ];
+  propagatedBuildInputs = [ compass-msgs diagnostic-msgs eigen3-cmake-module fusioncore-core geographic-msgs geometry-msgs gps-msgs lifecycle-msgs nav-msgs proj rclcpp rclcpp-lifecycle rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake-auto rosidl-default-generators ];
 
   meta = {
     description = "ROS 2 UKF sensor fusion for IMU, wheel encoders, GPS, and visual SLAM pose. 23-state filter with ECEF-native GPS handling, online gyro/accel/encoder bias estimation, adaptive noise covariance, chi-squared outlier rejection on every sensor, and map reinitialization recovery for GPS-denied operation. Drop-in robot_localization alternative. Benchmarked on 12 full-length NCLT sequences: wins 10 of 12 vs robot_localization EKF.";

--- a/distros/jazzy/fusioncore-ublox/default.nix
+++ b/distros/jazzy/fusioncore-ublox/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, nav-msgs, rclcpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-fusioncore-ublox";
+  version = "0.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/manankharwar/fusioncore-release/archive/release/jazzy/fusioncore_ublox/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "5b785e9758df2758aed78c128f3926227c40d35619ccdab7f247650811ed1fc1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ nav-msgs rclcpp std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Bridge nodes for u-blox GPS receivers: converts raw NavPVT Doppler velocity to nav_msgs/Odometry for FusionCore (gnss.velocity_topic). Optional companion to fusioncore_ros; not required to build or run FusionCore.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -486,10 +486,6 @@ self: super: {
 
  azure-iot-sdk-c = self.callPackage ./azure-iot-sdk-c {};
 
- backward-global-planner = self.callPackage ./backward-global-planner {};
-
- backward-local-planner = self.callPackage ./backward-local-planner {};
-
  backward-ros = self.callPackage ./backward-ros {};
 
  bag2-to-image = self.callPackage ./bag2-to-image {};
@@ -543,6 +539,8 @@ self: super: {
  broll = self.callPackage ./broll {};
 
  builtin-interfaces = self.callPackage ./builtin-interfaces {};
+
+ callback-isolated-executor = self.callPackage ./callback-isolated-executor {};
 
  camera-aravis2 = self.callPackage ./camera-aravis2 {};
 
@@ -606,29 +604,11 @@ self: super: {
 
  chomp-motion-planner = self.callPackage ./chomp-motion-planner {};
 
- cl-foundation-pose = self.callPackage ./cl-foundation-pose {};
+ cie-config-msgs = self.callPackage ./cie-config-msgs {};
 
- cl-gcalcli = self.callPackage ./cl-gcalcli {};
+ cie-sample-application = self.callPackage ./cie-sample-application {};
 
- cl-generic-sensor = self.callPackage ./cl-generic-sensor {};
-
- cl-http = self.callPackage ./cl-http {};
-
- cl-keyboard = self.callPackage ./cl-keyboard {};
-
- cl-lifecycle-node = self.callPackage ./cl-lifecycle-node {};
-
- cl-mission-tracker = self.callPackage ./cl-mission-tracker {};
-
- cl-modbus-tcp-relay = self.callPackage ./cl-modbus-tcp-relay {};
-
- cl-moveit2z = self.callPackage ./cl-moveit2z {};
-
- cl-nav2z = self.callPackage ./cl-nav2z {};
-
- cl-px4-mr = self.callPackage ./cl-px4-mr {};
-
- cl-ros2-timer = self.callPackage ./cl-ros2-timer {};
+ cie-thread-configurator = self.callPackage ./cie-thread-configurator {};
 
  class-loader = self.callPackage ./class-loader {};
 
@@ -1126,10 +1106,6 @@ self: super: {
 
  effort-controllers = self.callPackage ./effort-controllers {};
 
- eg-conditional-generator = self.callPackage ./eg-conditional-generator {};
-
- eg-random-generator = self.callPackage ./eg-random-generator {};
-
  eigen3-cmake-module = self.callPackage ./eigen3-cmake-module {};
 
  eigen-stl-containers = self.callPackage ./eigen-stl-containers {};
@@ -1384,10 +1360,6 @@ self: super: {
 
  forward-command-controller = self.callPackage ./forward-command-controller {};
 
- forward-global-planner = self.callPackage ./forward-global-planner {};
-
- forward-local-planner = self.callPackage ./forward-local-planner {};
-
  four-wheel-steering-msgs = self.callPackage ./four-wheel-steering-msgs {};
 
  foxglove-bridge = self.callPackage ./foxglove-bridge {};
@@ -1437,6 +1409,8 @@ self: super: {
  fusioncore-gazebo = self.callPackage ./fusioncore-gazebo {};
 
  fusioncore-ros = self.callPackage ./fusioncore-ros {};
+
+ fusioncore-ublox = self.callPackage ./fusioncore-ublox {};
 
  game-controller-spl = self.callPackage ./game-controller-spl {};
 
@@ -1607,6 +1581,8 @@ self: super: {
  human-description = self.callPackage ./human-description {};
 
  husarion-components-description = self.callPackage ./husarion-components-description {};
+
+ husarion-gz-worlds = self.callPackage ./husarion-gz-worlds {};
 
  husarion-mecanum-drive-controller = self.callPackage ./husarion-mecanum-drive-controller {};
 
@@ -2382,9 +2358,15 @@ self: super: {
 
  nao-lola-sensor-msgs = self.callPackage ./nao-lola-sensor-msgs {};
 
+ nao-meshes = self.callPackage ./nao-meshes {};
+
  nao-sensor-msgs = self.callPackage ./nao-sensor-msgs {};
 
+ naoqi-bridge-msgs = self.callPackage ./naoqi-bridge-msgs {};
+
  naoqi-libqi = self.callPackage ./naoqi-libqi {};
+
+ naoqi-libqicore = self.callPackage ./naoqi-libqicore {};
 
  nav2-amcl = self.callPackage ./nav2-amcl {};
 
@@ -2457,8 +2439,6 @@ self: super: {
  nav2-voxel-grid = self.callPackage ./nav2-voxel-grid {};
 
  nav2-waypoint-follower = self.callPackage ./nav2-waypoint-follower {};
-
- nav2z-planners-common = self.callPackage ./nav2z-planners-common {};
 
  nav-2d-msgs = self.callPackage ./nav-2d-msgs {};
 
@@ -2628,6 +2608,8 @@ self: super: {
 
  ompl = self.callPackage ./ompl {};
 
+ onnxruntime-vendor = self.callPackage ./onnxruntime-vendor {};
+
  open-manipulator = self.callPackage ./open-manipulator {};
 
  open-manipulator-bringup = self.callPackage ./open-manipulator-bringup {};
@@ -2709,6 +2691,8 @@ self: super: {
  pendulum-control = self.callPackage ./pendulum-control {};
 
  pendulum-msgs = self.callPackage ./pendulum-msgs {};
+
+ pepper-meshes = self.callPackage ./pepper-meshes {};
 
  perception = self.callPackage ./perception {};
 
@@ -2859,8 +2843,6 @@ self: super: {
  proxsuite = self.callPackage ./proxsuite {};
 
  ptz-action-server-msgs = self.callPackage ./ptz-action-server-msgs {};
-
- pure-spinning-local-planner = self.callPackage ./pure-spinning-local-planner {};
 
  py-binding-tools = self.callPackage ./py-binding-tools {};
 
@@ -3232,6 +3214,8 @@ self: super: {
 
  ros2-fmt-logger = self.callPackage ./ros2-fmt-logger {};
 
+ ros2-medkit-action-status-bridge = self.callPackage ./ros2-medkit-action-status-bridge {};
+
  ros2-medkit-beacon-common = self.callPackage ./ros2-medkit-beacon-common {};
 
  ros2-medkit-cmake = self.callPackage ./ros2-medkit-cmake {};
@@ -3249,6 +3233,8 @@ self: super: {
  ros2-medkit-integration-tests = self.callPackage ./ros2-medkit-integration-tests {};
 
  ros2-medkit-linux-introspection = self.callPackage ./ros2-medkit-linux-introspection {};
+
+ ros2-medkit-log-bridge = self.callPackage ./ros2-medkit-log-bridge {};
 
  ros2-medkit-msgs = self.callPackage ./ros2-medkit-msgs {};
 
@@ -3419,6 +3405,8 @@ self: super: {
  rosbot-joy = self.callPackage ./rosbot-joy {};
 
  rosbot-localization = self.callPackage ./rosbot-localization {};
+
+ rosbot-mavlink-bridge = self.callPackage ./rosbot-mavlink-bridge {};
 
  rosbot-moveit = self.callPackage ./rosbot-moveit {};
 
@@ -3620,6 +3608,8 @@ self: super: {
 
  rtabmap-conversions = self.callPackage ./rtabmap-conversions {};
 
+ rtabmap-costmap-plugins = self.callPackage ./rtabmap-costmap-plugins {};
+
  rtabmap-demos = self.callPackage ./rtabmap-demos {};
 
  rtabmap-examples = self.callPackage ./rtabmap-examples {};
@@ -3774,56 +3764,6 @@ self: super: {
 
  slider-publisher = self.callPackage ./slider-publisher {};
 
- sm-advanced-recovery-1 = self.callPackage ./sm-advanced-recovery-1 {};
-
- sm-atomic = self.callPackage ./sm-atomic {};
-
- sm-atomic-http = self.callPackage ./sm-atomic-http {};
-
- sm-atomic-lifecycle = self.callPackage ./sm-atomic-lifecycle {};
-
- sm-atomic-mode-states = self.callPackage ./sm-atomic-mode-states {};
-
- sm-atomic-performance-trace-1 = self.callPackage ./sm-atomic-performance-trace-1 {};
-
- sm-atomic-subscribers-performance-test = self.callPackage ./sm-atomic-subscribers-performance-test {};
-
- sm-branching = self.callPackage ./sm-branching {};
-
- sm-cl-gcalcli-test-1 = self.callPackage ./sm-cl-gcalcli-test-1 {};
-
- sm-cl-keyboard-unit-test-1 = self.callPackage ./sm-cl-keyboard-unit-test-1 {};
-
- sm-cl-px4-mr-test-1 = self.callPackage ./sm-cl-px4-mr-test-1 {};
-
- sm-cl-px4-mr-test-2 = self.callPackage ./sm-cl-px4-mr-test-2 {};
-
- sm-cl-ros2-timer-unit-test-1 = self.callPackage ./sm-cl-ros2-timer-unit-test-1 {};
-
- sm-coretest-transition-speed-1 = self.callPackage ./sm-coretest-transition-speed-1 {};
-
- sm-data-sharing-1 = self.callPackage ./sm-data-sharing-1 {};
-
- sm-data-sharing-2 = self.callPackage ./sm-data-sharing-2 {};
-
- sm-modbus-tcp-relay-test-1 = self.callPackage ./sm-modbus-tcp-relay-test-1 {};
-
- sm-multi-stage-1 = self.callPackage ./sm-multi-stage-1 {};
-
- sm-multithread-test-1 = self.callPackage ./sm-multithread-test-1 {};
-
- sm-nav2-gazebo-test-1 = self.callPackage ./sm-nav2-gazebo-test-1 {};
-
- sm-pack-ml = self.callPackage ./sm-pack-ml {};
-
- sm-panda-cl-moveit2z-cb-inventory = self.callPackage ./sm-panda-cl-moveit2z-cb-inventory {};
-
- sm-panda-cl-moveit2z-cb-inventory-isaacsim = self.callPackage ./sm-panda-cl-moveit2z-cb-inventory-isaacsim {};
-
- sm-simple-action-client = self.callPackage ./sm-simple-action-client {};
-
- sm-three-some = self.callPackage ./sm-three-some {};
-
  smacc2 = self.callPackage ./smacc2 {};
 
  smacc2-msgs = self.callPackage ./smacc2-msgs {};
@@ -3879,12 +3819,6 @@ self: super: {
  splsm-7-conversion = self.callPackage ./splsm-7-conversion {};
 
  sqlite3-vendor = self.callPackage ./sqlite3-vendor {};
-
- sr-all-events-go = self.callPackage ./sr-all-events-go {};
-
- sr-conditional = self.callPackage ./sr-conditional {};
-
- sr-event-countdown = self.callPackage ./sr-event-countdown {};
 
  srdfdom = self.callPackage ./srdfdom {};
 
@@ -4249,8 +4183,6 @@ self: super: {
  udp-msgs = self.callPackage ./udp-msgs {};
 
  uncrustify-vendor = self.callPackage ./uncrustify-vendor {};
-
- undo-path-global-planner = self.callPackage ./undo-path-global-planner {};
 
  unique-identifier-msgs = self.callPackage ./unique-identifier-msgs {};
 

--- a/distros/jazzy/husarion-gz-worlds/default.nix
+++ b/distros/jazzy/husarion-gz-worlds/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch, launch-ros, ros-gz-sim }:
+buildRosPackage {
+  pname = "ros-jazzy-husarion-gz-worlds";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/husarion_gz_worlds-release/archive/release/jazzy/husarion_gz_worlds/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "87d7247b1616243de57dcb9b8871d5de649259549a92a296e4ae4d6b83d1074e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ launch launch-ros ros-gz-sim ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Package containing the gazebo worlds and model";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/mobile-robot-simulator/default.nix
+++ b/distros/jazzy/mobile-robot-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, rclcpp, rosgraph-msgs, sensor-msgs, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-mobile-robot-simulator";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/mobile_robot_simulator-release/archive/release/jazzy/mobile_robot_simulator/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "b0e77721646bd4bed7438a4c54c981c8b62fbc9c87ef0943c4434cfe65b13741";
+    url = "https://github.com/nobleo/mobile_robot_simulator-release/archive/release/jazzy/mobile_robot_simulator/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "7e58665e209f071915a529a2fc926bd9baef39466689c57ee75e870cb026041b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nao-meshes/default.nix
+++ b/distros/jazzy/nao-meshes/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-jazzy-nao-meshes";
+  version = "2.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-naoqi/nao_meshes-release/archive/release/jazzy/nao_meshes/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "2312811ef139a1e60e63da35bd0cf5e4137ee4c30d132a9d00412397b725d4b9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS2 Meshes for the NAO robot";
+    license = with lib.licenses; [ "CC-BY-NC-ND-4.0" ];
+  };
+}

--- a/distros/jazzy/naoqi-bridge-msgs/default.nix
+++ b/distros/jazzy/naoqi-bridge-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-naoqi-bridge-msgs";
+  version = "2.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-naoqi/naoqi_bridge_msgs2-release/archive/release/jazzy/naoqi_bridge_msgs/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "a42fb9ec4ca7321cc298ae8872f98ea6f648e41e9093977debbd767399a8b5b7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ action-msgs geometry-msgs nav-msgs rosidl-default-runtime sensor-msgs std-msgs trajectory-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The naoqi_bridge_msgs package provides custom messages for running Aldebaran's robots in ROS2.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/naoqi-libqicore/default.nix
+++ b/distros/jazzy/naoqi-libqicore/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, naoqi-libqi }:
+buildRosPackage {
+  pname = "ros-jazzy-naoqi-libqicore";
+  version = "3.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-naoqi/libqicore-release/archive/release/jazzy/naoqi_libqicore/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "fee0aea4678f77289cb14134b35b0fda409a942889c3c54f6b28cbf243a22642";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ naoqi-libqi ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Aldebaran's libqicore: a layer on top of libqi";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/onnxruntime-vendor/default.nix
+++ b/distros/jazzy/onnxruntime-vendor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, git, pkg-config }:
+buildRosPackage {
+  pname = "ros-jazzy-onnxruntime-vendor";
+  version = "0.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/onnxruntime_vendor-release/archive/release/jazzy/onnxruntime_vendor/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "3c1f6d288b885166709e4ac9a3396dc7b5bfbaff217f6628d06a84a9d4a68669";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-vendor-package git pkg-config ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package git ];
+
+  meta = {
+    description = "Vendor package for ONNX Runtime 1.24.3";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -304,14 +304,14 @@ in {
       # https://github.com/foxglove/foxglove-sdk/blob/main/ros/src/foxglove_bridge/CMakeLists.txt.
       # If the version doesn't match, cmake fails with "Hash mismatch"
       # and we can fix it here.
-      FOXGLOVE_SDK_VERSION = "0.25.1";
+      FOXGLOVE_SDK_VERSION = "0.25.3";
       systemToPlatform = {
         "x86_64-linux" = "x86_64-unknown-linux-gnu";
         "aarch64-linux" = "aarch64-unknown-linux-gnu";
       };
       systemToHash = {
-        "x86_64-linux" = "sha256-C500jfOo6Y0sLO4jYMyfUug7s0RQRN69dx0bRtw1i+Q=";
-        "aarch64-linux" = "sha256-xw41x48ON/O6jQJRzTHzU7sQsf0QYgDcbF9AntTfGRg=";
+        "x86_64-linux" = "sha256-1ItT8ULp2RpJe95jwDCwEg83a+VppDFd7MA02gGeWqc=";
+        "aarch64-linux" = "sha256-wiI9yymwU0sxzJ7RpR/sk4Y8EC3loKH6dJ9w8hFw/Nk=";
       };
       FOXGLOVE_SDK_PLATFORM = systemToPlatform.${self.system};
       sdk = self.fetchurl {

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -1315,15 +1315,6 @@ in {
     '';
   });
 
-  warehouse-ros-sqlite = rosSuper.warehouse-ros-sqlite.overrideAttrs ({
-    postPatch ? "", ...
-  }: {
-    # https://github.com/moveit/warehouse_ros_sqlite/pull/61
-    postPatch = postPatch + ''
-      substituteInPlace CMakeLists.txt --replace-fail " system" ""
-    '';
-  });
-
   web-video-server = rosSuper.web-video-server.overrideAttrs ({
     postPatch ? "", ...
   }: {

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -136,8 +136,16 @@ in {
   });
 
   autoware-ndt-scan-matcher = rosSuper.autoware-ndt-scan-matcher.overrideAttrs ({
-    postPatch ? "", ...
+    patches ? [], postPatch ? "", ...
   }: {
+    patches = patches ++ [
+      # fix(ndt_scan_matcher): explicitly include omp.h (#1166)
+      (self.fetchpatch2 {
+        url = "https://github.com/autowarefoundation/autoware_core/commit/801be9de40889d564ce3164a4b4f4eecd76b826f.patch?full_index=1";
+        hash = "sha256-zYuYJwXOym2RQbjuzrKOoMuMm85qYy6hXglqopT1CTE=";
+        stripLen = 2;
+      })
+    ];
     # fix "fatal error: pcl/filters/boost.h: No such file or directory"
     # pcl/filters/boost.h was removed in newer PCL versions
     postPatch = postPatch + ''

--- a/distros/jazzy/pepper-meshes/default.nix
+++ b/distros/jazzy/pepper-meshes/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-jazzy-pepper-meshes";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-naoqi/pepper_meshes2-release/archive/release/jazzy/pepper_meshes/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "f9441b80fee8b6ab25a2ab36964b9c393a0e888eb40c03c6203fae1e9915dc28";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Meshes for the Pepper robot, for ROS2";
+    license = with lib.licenses; [ "CC-BY-NC-ND-4.0" ];
+  };
+}

--- a/distros/jazzy/pick-ik/default.nix
+++ b/distros/jazzy/pick-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, fmt, generate-parameter-library, moveit-core, moveit-resources-panda-moveit-config, pluginlib, range-v3, rclcpp, rsl, tf2-geometry-msgs, tf2-kdl, tl-expected }:
 buildRosPackage {
   pname = "ros-jazzy-pick-ik";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pick_ik-release/archive/release/jazzy/pick_ik/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "d1a6ee0b589c081901d80045891aed9f4487bcea39e9b88c5e3fe5064583f34a";
+    url = "https://github.com/ros2-gbp/pick_ik-release/archive/release/jazzy/pick_ik/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "1367222cb61f6fc959dd1522ef66c8d36bf03e882971057f0bde8b5c43caefcf";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/protobuf-comm/default.nix
+++ b/distros/jazzy/protobuf-comm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, openssl, protobuf, spdlog }:
 buildRosPackage {
   pname = "ros-jazzy-protobuf-comm";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/protobuf_comm-release/archive/release/jazzy/protobuf_comm/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "4c247cf8725a276e7067ea05cf7790752b1a8b85ba0057280c26d8be26b8585c";
+    url = "https://github.com/ros2-gbp/protobuf_comm-release/archive/release/jazzy/protobuf_comm/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "f9ca4fd13424a2cafaff2d8519e716ede42794a7e122f6c18054b2b7a3796f17";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/ros2-medkit-action-status-bridge/default.nix
+++ b/distros/jazzy/ros2-medkit-action-status-bridge/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-testing-ament-cmake, launch-testing-ros, rclcpp, ros2-medkit-cmake, ros2-medkit-fault-manager, ros2-medkit-fault-reporter, ros2-medkit-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-ros2-medkit-action-status-bridge";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_action_status_bridge/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "b0f573c9db01dee044c1a569002e8d881cb244a7c8509d2187c9120e5336d923";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros2-medkit-cmake ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-clang-tidy ament-cmake-gtest ament-lint-auto ament-lint-common launch-testing-ament-cmake launch-testing-ros ros2-medkit-fault-manager ];
+  propagatedBuildInputs = [ action-msgs rclcpp ros2-medkit-fault-reporter ros2-medkit-msgs ];
+  nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
+
+  meta = {
+    description = "Bridge node turning terminal ROS2 action goal states (aborted) into FaultManager faults";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/ros2-medkit-beacon-common/default.nix
+++ b/distros/jazzy/ros2-medkit-beacon-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nlohmann_json, rclcpp, ros2-medkit-cmake, ros2-medkit-gateway, ros2-medkit-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-medkit-beacon-common";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_beacon_common/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "a46d94c2de4c9439a9cbe72bdd78e4ed2a038ea16ee1d367ea3497817c38fd11";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_beacon_common/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "f8f2d13658a5971067f9845ccebab03b846c7ecc5f9e9cf693f48d8817d8f702";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-medkit-cmake/default.nix
+++ b/distros/jazzy/ros2-medkit-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-medkit-cmake";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_cmake/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "efc19dd347a83a3b30e5d2aba56e1fd438ff1588d0b4858787d460d4906116a5";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_cmake/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "db7151a8b3516f801221cf2e9db24cbb72ae57be8c120fcb70daa288098a2e47";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-medkit-diagnostic-bridge/default.nix
+++ b/distros/jazzy/ros2-medkit-diagnostic-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch-testing-ament-cmake, launch-testing-ros, rclcpp, ros2-medkit-cmake, ros2-medkit-fault-manager, ros2-medkit-fault-reporter, ros2-medkit-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-medkit-diagnostic-bridge";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_diagnostic_bridge/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "72e21550085efe2cfac328ddf03d641632ec13ea88200979dbd6e2ae01eb5017";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_diagnostic_bridge/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "5e60297ae8530fe48cb0b0121af05b09add643f6011b8b4bf011db9819ff8d90";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-medkit-fault-manager/default.nix
+++ b/distros/jazzy/ros2-medkit-fault-manager/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-testing-ament-cmake, launch-testing-ros, nlohmann_json, rclcpp, ros2-medkit-cmake, ros2-medkit-msgs, ros2-medkit-serialization, rosbag2-cpp, rosbag2-storage, rosbag2-storage-mcap, sensor-msgs, sqlite, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, nlohmann_json, rclcpp, ros2-medkit-cmake, ros2-medkit-msgs, ros2-medkit-serialization, rosbag2-cpp, rosbag2-py, rosbag2-storage, rosbag2-storage-mcap, sensor-msgs, sqlite, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-medkit-fault-manager";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_fault_manager/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "2e25fbf483099eec77b4d4d14aac8e8bc38bd96f081205696b547e3b90ae3bd5";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_fault_manager/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "a5a86c66524931ad2f9aa5af55e33562f5c9bee159b8459ab84ae4f174636b80";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros2-medkit-cmake ];
-  checkInputs = [ ament-cmake-clang-format ament-cmake-clang-tidy ament-cmake-gtest ament-lint-auto ament-lint-common launch-testing-ament-cmake launch-testing-ros sensor-msgs std-msgs ];
-  propagatedBuildInputs = [ nlohmann_json rclcpp ros2-medkit-msgs ros2-medkit-serialization rosbag2-cpp rosbag2-storage rosbag2-storage-mcap sqlite ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-clang-tidy ament-cmake-gtest ament-lint-auto ament-lint-common launch-ros launch-testing-ament-cmake launch-testing-ros rosbag2-py rosbag2-storage-mcap sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ ament-index-python launch launch-ros nlohmann_json rclcpp ros2-medkit-msgs ros2-medkit-serialization rosbag2-cpp rosbag2-storage sqlite ];
   nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
 
   meta = {

--- a/distros/jazzy/ros2-medkit-fault-reporter/default.nix
+++ b/distros/jazzy/ros2-medkit-fault-reporter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-testing-ament-cmake, launch-testing-ros, rclcpp, ros2-medkit-cmake, ros2-medkit-fault-manager, ros2-medkit-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-medkit-fault-reporter";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_fault_reporter/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "715bf669654ac666003aca61b2f6fe07cb06ee3d1cb176b7576a4bb5344b6ee4";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_fault_reporter/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "75cec2b34c456bc3b62fef2b1eb2ec174533dc8c105d995b60c16a709a3c3c4a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-medkit-gateway/default.nix
+++ b/distros/jazzy/ros2-medkit-gateway/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, example-interfaces, httplib, nlohmann_json, openssl, rcl-interfaces, rclcpp, rclcpp-action, ros2-medkit-cmake, ros2-medkit-msgs, ros2-medkit-serialization, rosidl-parser, rosidl-runtime-py, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, sensor-msgs, sqlite, std-msgs, std-srvs, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-index-cpp, ament-index-python, ament-lint-auto, ament-lint-common, example-interfaces, httplib, launch, launch-ros, lifecycle-msgs, nlohmann_json, openssl, rcl-interfaces, rclcpp, rclcpp-action, ros2-medkit-action-status-bridge, ros2-medkit-cmake, ros2-medkit-diagnostic-bridge, ros2-medkit-fault-manager, ros2-medkit-log-bridge, ros2-medkit-msgs, ros2-medkit-serialization, rosidl-parser, rosidl-runtime-py, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, sensor-msgs, sqlite, std-msgs, std-srvs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-medkit-gateway";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_gateway/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "cd034c2a0aacdedf0f9bd5da6bc99bece1dc528e62234fb34676c161bf63f4fa";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_gateway/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "d9482b78a76c3247674e7d34e952bd785abba7ee7af23bc363bd8948a94bf543";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros2-medkit-cmake ];
   checkInputs = [ ament-cmake-clang-format ament-cmake-clang-tidy ament-cmake-gtest ament-lint-auto ament-lint-common example-interfaces rclcpp-action ];
-  propagatedBuildInputs = [ action-msgs ament-index-cpp httplib nlohmann_json openssl rcl-interfaces rclcpp ros2-medkit-msgs ros2-medkit-serialization rosidl-parser rosidl-runtime-py rosidl-typesupport-cpp rosidl-typesupport-introspection-cpp sensor-msgs sqlite std-msgs std-srvs yaml-cpp-vendor ];
+  propagatedBuildInputs = [ action-msgs ament-index-cpp ament-index-python httplib launch launch-ros lifecycle-msgs nlohmann_json openssl rcl-interfaces rclcpp ros2-medkit-action-status-bridge ros2-medkit-diagnostic-bridge ros2-medkit-fault-manager ros2-medkit-log-bridge ros2-medkit-msgs ros2-medkit-serialization rosidl-parser rosidl-runtime-py rosidl-typesupport-cpp rosidl-typesupport-introspection-cpp sensor-msgs sqlite std-msgs std-srvs yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
 
   meta = {

--- a/distros/jazzy/ros2-medkit-graph-provider/default.nix
+++ b/distros/jazzy/ros2-medkit-graph-provider/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, nlohmann_json, rclcpp, ros2-medkit-cmake, ros2-medkit-gateway, ros2-medkit-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-medkit-graph-provider";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_graph_provider/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "f6af1df8d509dbdd34a0f88dce06780f2a4e25413aa6202bd164350358d3b69e";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_graph_provider/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "cfbc0d0259ea3116ad5c3d18b474e4b265abcc26f84c22da752a4eb35671711e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-medkit-integration-tests/default.nix
+++ b/distros/jazzy/ros2-medkit-integration-tests/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, diagnostic-msgs, example-interfaces, launch-ros, launch-testing, launch-testing-ament-cmake, python3Packages, rcl-interfaces, rclcpp, rclcpp-action, ros2-medkit-cmake, ros2-medkit-fault-manager, ros2-medkit-gateway, ros2-medkit-graph-provider, ros2-medkit-linux-introspection, ros2-medkit-msgs, ros2-medkit-param-beacon, ros2-medkit-topic-beacon, sensor-msgs, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, diagnostic-msgs, example-interfaces, launch-ros, launch-testing, launch-testing-ament-cmake, python3Packages, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2-medkit-cmake, ros2-medkit-fault-manager, ros2-medkit-gateway, ros2-medkit-graph-provider, ros2-medkit-linux-introspection, ros2-medkit-msgs, ros2-medkit-param-beacon, ros2-medkit-topic-beacon, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-medkit-integration-tests";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_integration_tests/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "d3dee478c4493edf944d7c1fcb28ad35b8835f64788ff40bd8f1cc32037ddf6b";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_integration_tests/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "c13ce449c22a290c2b4aea0b684d8e1f3ff158e05eabf037203f47f41183de7c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ros2-medkit-cmake ];
   checkInputs = [ ament-index-python launch-ros launch-testing launch-testing-ament-cmake python3Packages.jsonschema python3Packages.requests ros2-medkit-fault-manager ros2-medkit-gateway ros2-medkit-graph-provider ros2-medkit-linux-introspection ros2-medkit-param-beacon ros2-medkit-topic-beacon ];
-  propagatedBuildInputs = [ diagnostic-msgs example-interfaces rcl-interfaces rclcpp rclcpp-action ros2-medkit-msgs sensor-msgs std-msgs std-srvs ];
+  propagatedBuildInputs = [ diagnostic-msgs example-interfaces rcl-interfaces rclcpp rclcpp-action rclcpp-lifecycle ros2-medkit-msgs sensor-msgs std-msgs std-srvs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ros2-medkit-cmake ];
 
   meta = {

--- a/distros/jazzy/ros2-medkit-linux-introspection/default.nix
+++ b/distros/jazzy/ros2-medkit-linux-introspection/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, nlohmann_json, pkg-config, ros2-medkit-cmake, ros2-medkit-gateway, systemd }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-medkit-linux-introspection";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_linux_introspection/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "b0a31d1305a7de655f968a0e659fccc7d599250691d57d20af9179ec5e3d9cda";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_linux_introspection/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "756e38e1ae102bf1d551e5811f1431b8d366cc8641598570aaefc351be8c6365";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-medkit-log-bridge/default.nix
+++ b/distros/jazzy/ros2-medkit-log-bridge/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-testing-ament-cmake, launch-testing-ros, rcl-interfaces, rclcpp, ros2-medkit-cmake, ros2-medkit-fault-manager, ros2-medkit-fault-reporter, ros2-medkit-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-ros2-medkit-log-bridge";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_log_bridge/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "80f02d2ca368793b12abf716f7e5f69c5735a32cc3caa1486a0b48525ef04f2b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros2-medkit-cmake ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-clang-tidy ament-cmake-gtest ament-lint-auto ament-lint-common launch-testing-ament-cmake launch-testing-ros ros2-medkit-fault-manager ];
+  propagatedBuildInputs = [ rcl-interfaces rclcpp ros2-medkit-fault-reporter ros2-medkit-msgs ];
+  nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
+
+  meta = {
+    description = "Bridge node promoting ROS2 /rosout log entries to FaultManager faults";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/ros2-medkit-msgs/default.nix
+++ b/distros/jazzy/ros2-medkit-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-medkit-msgs";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_msgs/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "59236c15595049eed2b42e747f4fd7ae1300dd2365e1cf2c23f6d362070766f4";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_msgs/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "8636b541b5727f75ebacc831c3f28728dee7db1a00cd39085a66c3851de3f665";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-medkit-param-beacon/default.nix
+++ b/distros/jazzy/ros2-medkit-param-beacon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-lint-auto, ament-lint-common, nlohmann_json, rclcpp, ros2-medkit-beacon-common, ros2-medkit-cmake, ros2-medkit-gateway }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-medkit-param-beacon";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_param_beacon/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "dee83fe9514a6ca411cdebec50ae0b7f0f4537f50793ba8272604468273225ea";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_param_beacon/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "9d9327eaabf5c64584bdbfb0e5d1fad7910847dac0de508af469ba8a7fd13ad6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-medkit-serialization/default.nix
+++ b/distros/jazzy/ros2-medkit-serialization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nlohmann_json, rclcpp, rcpputils, rcutils, ros2-medkit-cmake, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, sensor-msgs, std-msgs, std-srvs, test-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-medkit-serialization";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_serialization/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "7a4e0209def757c038e78b11c8a8b86c35bc4e8145d2d35566e945077c3cff61";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_serialization/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "c881db691760032def0987d14001340a89b578a8b61204f6f50eebcfea4648e8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-medkit-sovd-service-interface/default.nix
+++ b/distros/jazzy/ros2-medkit-sovd-service-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nlohmann_json, rclcpp, ros2-medkit-cmake, ros2-medkit-gateway, ros2-medkit-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-medkit-sovd-service-interface";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_sovd_service_interface/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "166e5402cd9442cc8f1bb4c810f1e2cd30c3fa893f69d00dedd9737157dead50";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_sovd_service_interface/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "080a990a0922d8f6a3ca20ddedb3e3dded47b969923ea283181b66eb1f6970d2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-medkit-topic-beacon/default.nix
+++ b/distros/jazzy/ros2-medkit-topic-beacon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, nlohmann_json, rclcpp, ros2-medkit-beacon-common, ros2-medkit-cmake, ros2-medkit-gateway, ros2-medkit-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-medkit-topic-beacon";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_topic_beacon/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "43c3f431f77622d1c60fa3904b91ee37aad6a500961a3637c3d0cdadcbff5d95";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/jazzy/ros2_medkit_topic_beacon/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "7dd9e4bcde167af11dde05eb55b169c0953a511ca5062abd9484f4e57ce565f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbag-timing-inspector/default.nix
+++ b/distros/jazzy/rosbag-timing-inspector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, glfw3, libGL, libGLU, rosbag2-cpp, rosbag2-storage }:
 buildRosPackage {
   pname = "ros-jazzy-rosbag-timing-inspector";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag_timing_inspector-release/archive/release/jazzy/rosbag_timing_inspector/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "eb0232ff6c8a06f1871af490a0e171910de6b794b46258f537c161d56071d272";
+    url = "https://github.com/ros2-gbp/rosbag_timing_inspector-release/archive/release/jazzy/rosbag_timing_inspector/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "db51490591ac7508e44b73395cbf7db569ab152e50bf23837568c154bab5637d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbot-mavlink-bridge/default.nix
+++ b/distros/jazzy/rosbot-mavlink-bridge/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rclcpp, sensor-msgs, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-jazzy-rosbot-mavlink-bridge";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/husarion/rosbot_mavlink_bridge-release/archive/release/jazzy/rosbot_mavlink_bridge/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "d54d7c97fd460faab09e611587bb9c64bcb6e0d7d76ef4f62c1c3c11b103c357";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ rclcpp sensor-msgs std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Bridge node that translates the firmware's MAVLink wire protocol into the
+    same ROS 2 API the micro-ROS agent currently exposes, so downstream
+    consumers (e.g. rosbot_ros) see byte-identical topics/services. Single
+    source tree builds for both jazzy and humble (see MAVLINK_MIGRATION.md
+    D24).";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/rtabmap-conversions/default.nix
+++ b/distros/jazzy/rtabmap-conversions/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, geometry-msgs, image-geometry, laser-geometry, pcl-conversions, rclcpp, rclcpp-components, ros-environment, rtabmap, rtabmap-msgs, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, geometry-msgs, image-geometry, laser-geometry, pcl-conversions, rclcpp, rclcpp-components, ros-environment, rtabmap, rtabmap-msgs, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-rtabmap-conversions";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_conversions/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "15d452718d973d9b8b5bbc15c94238d3065db489f9a6d47837cce7267ea58401";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_conversions/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "2058ad38748a65b0173f9718e55522ef0175657df91467bea4c8d5086adf872f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ cv-bridge geometry-msgs image-geometry laser-geometry pcl-conversions rclcpp rclcpp-components rtabmap rtabmap-msgs sensor-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs image-geometry laser-geometry pcl-conversions rclcpp rclcpp-components rtabmap rtabmap-msgs sensor-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/rtabmap-costmap-plugins/default.nix
+++ b/distros/jazzy/rtabmap-costmap-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, nav2-costmap-2d, pluginlib, rclcpp, ros-environment, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-rtabmap-costmap-plugins";
+  version = "0.23.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_costmap_plugins/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "3364ff403fbae693d459ce463f3d3c291d6e70915225ba6b8e6bcde3e5ff3d9f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ros-environment ];
+  propagatedBuildInputs = [ nav2-costmap-2d pluginlib rclcpp visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = "RTAB-Map's costmap plugins.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/rtabmap-demos/default.nix
+++ b/distros/jazzy/rtabmap-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz }:
 buildRosPackage {
   pname = "ros-jazzy-rtabmap-demos";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_demos/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "26e8a99e0e60fae2cae1619368e093dfeaa584f079e9b5db72332108b83eb5f9";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_demos/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "59b8f2a555b36fa5c29a0904642b286cc1e65861567c16654fba54a31dc17432";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rtabmap-examples/default.nix
+++ b/distros/jazzy/rtabmap-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, imu-filter-madgwick, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz, tf2-ros, velodyne }:
 buildRosPackage {
   pname = "ros-jazzy-rtabmap-examples";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_examples/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "0359cd8e2069add2164d64aab209fb48207398bca4a104ce445ae7d777d2cbd6";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_examples/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "bf7f408706775471e501a82508451b58c4a72963d7e7a5adb8f541193eff6cd5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rtabmap-launch/default.nix
+++ b/distros/jazzy/rtabmap-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rtabmap-msgs, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz }:
 buildRosPackage {
   pname = "ros-jazzy-rtabmap-launch";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_launch/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "8e63c977b98d6260fd2636e767b1c942545713a46cc4713ef62b3739769c0b5c";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_launch/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "fd3c52380dbe9508909e71b68403e5da0f8db12e90c470c4aa8235e327e46a44";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rtabmap-msgs/default.nix
+++ b/distros/jazzy/rtabmap-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-rtabmap-msgs";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_msgs/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "917ffc4047591bee881ac6ee764ac4dd912d2f350e40af8f7f7f9b027d624959";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_msgs/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "34d3eb024c683324877f373f8e737c2e0ebc7fed61b8b95fb6c94d9d11ad1466";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rtabmap-odom/default.nix
+++ b/distros/jazzy/rtabmap-odom/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, image-geometry, laser-geometry, message-filters, nav-msgs, pcl-conversions, pcl-ros, pluginlib, rclcpp, rclcpp-components, ros-environment, rtabmap-conversions, rtabmap-msgs, rtabmap-sync, rtabmap-util, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rtabmap-odom";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_odom/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "d51ceb0df363e0c27069aa2a0edfb90b2b16f1a9200e84d420031ffd4025a171";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_odom/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "f217b78e64f1977c7590ed68a6bad148a3161764ecaab86e500069fa94374d80";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rtabmap-python/default.nix
+++ b/distros/jazzy/rtabmap-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-rtabmap-python";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_python/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "977cbafca1d7f2d17c69a1d4da37ce084417fd5002745fd2b22e742f34caf291";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_python/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "2790ceddaf5752b1cde5222914c2efad4db565f617c8b7871e5db6cffba51ea7";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rtabmap-ros/default.nix
+++ b/distros/jazzy/rtabmap-ros/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, rtabmap-conversions, rtabmap-demos, rtabmap-examples, rtabmap-launch, rtabmap-msgs, rtabmap-odom, rtabmap-python, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-sync, rtabmap-util, rtabmap-viz }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, rtabmap-conversions, rtabmap-costmap-plugins, rtabmap-demos, rtabmap-examples, rtabmap-launch, rtabmap-msgs, rtabmap-odom, rtabmap-python, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-sync, rtabmap-util, rtabmap-viz }:
 buildRosPackage {
   pname = "ros-jazzy-rtabmap-ros";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_ros/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "6d93c99b0e07beca70fc26a1a0577c46acdabd2b4497c4f73619c830c4b70be1";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_ros/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "acd1b391a1d3a2dcf4c63b71d9bc91fdb6f49a2b9cfd7e90f425a7f1d7db2a42";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ rtabmap-conversions rtabmap-demos rtabmap-examples rtabmap-launch rtabmap-msgs rtabmap-odom rtabmap-python rtabmap-rviz-plugins rtabmap-slam rtabmap-sync rtabmap-util rtabmap-viz ];
+  propagatedBuildInputs = [ rtabmap-conversions rtabmap-costmap-plugins rtabmap-demos rtabmap-examples rtabmap-launch rtabmap-msgs rtabmap-odom rtabmap-python rtabmap-rviz-plugins rtabmap-slam rtabmap-sync rtabmap-util rtabmap-viz ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/rtabmap-rviz-plugins/default.nix
+++ b/distros/jazzy/rtabmap-rviz-plugins/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, pcl-conversions, pluginlib, rclcpp, ros-environment, rtabmap-conversions, rtabmap-msgs, rviz-common, rviz-default-plugins, rviz-rendering, sensor-msgs, std-msgs, tf2 }:
+{ lib, buildRosPackage, fetchurl, _unresolved_qtbase5-private-dev, ament-cmake-ros, pcl-conversions, pluginlib, rclcpp, ros-environment, rtabmap-conversions, rtabmap-msgs, rviz-common, rviz-default-plugins, rviz-rendering, sensor-msgs, std-msgs, tf2 }:
 buildRosPackage {
   pname = "ros-jazzy-rtabmap-rviz-plugins";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_rviz_plugins/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "fb5cec6e4dc4688d5a189e70eff918405a27b73a0bc8300bdc083aa244f0b1db";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_rviz_plugins/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "d7e7d9fcfb159732c40453c911f7515111f8b97fb292a03890ba328a1a8bce50";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ros-environment ];
+  buildInputs = [ _unresolved_qtbase5-private-dev ament-cmake-ros ros-environment ];
   propagatedBuildInputs = [ pcl-conversions pluginlib rclcpp rtabmap-conversions rtabmap-msgs rviz-common rviz-default-plugins rviz-rendering sensor-msgs std-msgs tf2 ];
   nativeBuildInputs = [ ament-cmake-ros ];
 

--- a/distros/jazzy/rtabmap-slam/default.nix
+++ b/distros/jazzy/rtabmap-slam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, apriltag-msgs, aruco-msgs, aruco-opencv-msgs, cv-bridge, geometry-msgs, nav-msgs, nav2-msgs, rclcpp, rclcpp-components, ros-environment, rtabmap-msgs, rtabmap-sync, rtabmap-util, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rtabmap-slam";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_slam/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "47222202950c61c6cb1f255ff5e2fbdeef6d0360f2b5a2b8d7b75de558074558";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_slam/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "6cb0ab06486db9586fc4aac1560c180d4443f17c29fff9f3d64995bcdb1cb9bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rtabmap-sync/default.nix
+++ b/distros/jazzy/rtabmap-sync/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, diagnostic-updater, image-transport, message-filters, nav-msgs, rclcpp, rclcpp-components, ros-environment, rtabmap-conversions, rtabmap-msgs, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rtabmap-sync";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_sync/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "83aa4e71d41db9dd362ada635a37f4a504b52a30edbc8564011b3d1284eabc28";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_sync/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "5ad0f88cd37f83552fe9b756342ebfe908c3432cae7c6b55494b2808310d71e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rtabmap-util/default.nix
+++ b/distros/jazzy/rtabmap-util/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, image-transport, laser-geometry, message-filters, nav-msgs, octomap-msgs, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, ros-environment, rtabmap-conversions, rtabmap-msgs, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, grid-map-ros, image-geometry, image-transport, laser-geometry, message-filters, nav-msgs, octomap-msgs, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, ros-environment, rtabmap-conversions, rtabmap-msgs, rtabmap-sync, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-rtabmap-util";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_util/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "6458be9a6bfa36d0645b7d52746cff5eb1781c50dadc97c1626cd3fd0c476791";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_util/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "450db973f3baf51ecf9511e939fcbc23b0e2c84c7a699d1a3e3fbc2776c0dbee";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ cv-bridge image-transport laser-geometry message-filters nav-msgs octomap-msgs pcl-conversions pcl-ros rclcpp rclcpp-components rtabmap-conversions rtabmap-msgs sensor-msgs std-msgs stereo-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ cv-bridge grid-map-ros image-geometry image-transport laser-geometry message-filters nav-msgs octomap-msgs pcl-conversions pcl-ros rclcpp rclcpp-components rtabmap-conversions rtabmap-msgs rtabmap-sync sensor-msgs std-msgs stereo-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/rtabmap-viz/default.nix
+++ b/distros/jazzy/rtabmap-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, geometry-msgs, nav-msgs, rclcpp, ros-environment, rtabmap-msgs, rtabmap-sync, std-msgs, std-srvs, tf2 }:
 buildRosPackage {
   pname = "ros-jazzy-rtabmap-viz";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_viz/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "18f1b3c3f29b9c13f2dd7a56b3c24bb40e712b7da00a7010f964ff9b582d4763";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/jazzy/rtabmap_viz/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "42e8dbd0db357f98961fe47dc0e471684f32e23920dd41fa91e54b38035e0172";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rtabmap/default.nix
+++ b/distros/jazzy/rtabmap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, gtsam, libg2o, libpointmatcher, octomap, onetbb, pcl, proj, qt-gui-cpp, sqlite, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-rtabmap";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rtabmap-release/archive/release/jazzy/rtabmap/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "8405dee57bc58105dc18c49b71e9e082d96bb7c5f2e785ddab0d82bff961c634";
+    url = "https://github.com/ros2-gbp/rtabmap-release/archive/release/jazzy/rtabmap/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "ce59d390e488ef1e26d04a4c7c3954b23686d154f723f1c38752044817d79b01";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/septentrio-gnss-driver/default.nix
+++ b/distros/jazzy/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, gtest-vendor, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-septentrio-gnss-driver";
-  version = "1.4.7-r2";
+  version = "1.4.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/jazzy/septentrio_gnss_driver/1.4.7-2.tar.gz";
-    name = "1.4.7-2.tar.gz";
-    sha256 = "f744dad19ae8f70ec47eb2ee1680137553f4d084147102c00fe4e7cb67656d81";
+    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/jazzy/septentrio_gnss_driver/1.4.7-3.tar.gz";
+    name = "1.4.7-3.tar.gz";
+    sha256 = "fdb0714829a0d25b89de1c1323b3ff9512a7552fe778dda7698e7789ff1dd63a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/warehouse-ros-sqlite/default.nix
+++ b/distros/jazzy/warehouse-ros-sqlite/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite3-vendor, warehouse-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite, warehouse-ros }:
 buildRosPackage {
   pname = "ros-jazzy-warehouse-ros-sqlite";
-  version = "1.0.5-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/jazzy/warehouse_ros_sqlite/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "d7fe29e8f986d1dd7d9d27aa850eb98a2046797e725e8af3bd21a1ea3a9a1e69";
+    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/jazzy/warehouse_ros_sqlite/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "47259eeded0a19240dd4bafd3569f05885a7aa12e37c54d8300a7889dbe134f6";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake boost ];
   checkInputs = [ ament-cmake-copyright ament-cmake-gtest ament-lint-auto ament-lint-common geometry-msgs ];
-  propagatedBuildInputs = [ class-loader rclcpp sqlite3-vendor warehouse-ros ];
+  propagatedBuildInputs = [ class-loader rclcpp sqlite warehouse-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/clips-vendor/default.nix
+++ b/distros/kilted/clips-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, unzip }:
 buildRosPackage {
   pname = "ros-kilted-clips-vendor";
-  version = "6.4.3-r1";
+  version = "6.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/clips_vendor-release/archive/release/kilted/clips_vendor/6.4.3-1.tar.gz";
-    name = "6.4.3-1.tar.gz";
-    sha256 = "9d0f65286c63e8eb68a73d0433e8319291e453874711e22c9d0fd4e2def929e3";
+    url = "https://github.com/ros2-gbp/clips_vendor-release/archive/release/kilted/clips_vendor/6.4.4-1.tar.gz";
+    name = "6.4.4-1.tar.gz";
+    sha256 = "e4b7d4f50a46de6e74b2d5953a0f265f452dc1a1f1cabf03a467e28efb370277";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/clips-vendor/vendored-source.json
+++ b/distros/kilted/clips-vendor/vendored-source.json
@@ -1,6 +1,6 @@
 {
   "clips_vendor": {
-    "url": "https://raw.githubusercontent.com/carologistics/clips_vendor/r925/clipsrules-code-r925.zip",
-    "sha256": "08macis5ai6y6azzbp5mhyk30sx3qx3903wsbry9agfabgd2yviw"
+    "url": "https://raw.githubusercontent.com/carologistics/clips_vendor/r974/clipsrules-code-r974.zip",
+    "sha256": "0yg9gfqmql6fmw4qrzfm968nb10lnfxzlpish2xyscibax6gg97p"
   }
 }

--- a/distros/kilted/fkie-message-filters/default.nix
+++ b/distros/kilted/fkie-message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, image-transport, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-fkie-message-filters";
-  version = "3.3.1-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fkie_message_filters-release/archive/release/kilted/fkie_message_filters/3.3.1-1.tar.gz";
-    name = "3.3.1-1.tar.gz";
-    sha256 = "9dedf9913594496fb61e4bff4a4b28888c1cf97477a7fdc90a9b99f2a11053c1";
+    url = "https://github.com/ros2-gbp/fkie_message_filters-release/archive/release/kilted/fkie_message_filters/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "00267c74c9ab6e651ebb91700d830cdd5b1db23eae651584ab1bae568431d285";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/foxglove-bridge/default.nix
+++ b/distros/kilted/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, geometry-msgs, nlohmann_json, rcl-interfaces, rclcpp, rclcpp-components, rcpputils, rcutils, resource-retriever, ros-environment, rosgraph-msgs, rosidl-typesupport-introspection-cpp, rosx-introspection, sensor-msgs, std-msgs, std-srvs, websocketpp }:
 buildRosPackage {
   pname = "ros-kilted-foxglove-bridge";
-  version = "3.4.1-r1";
+  version = "3.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/kilted/foxglove_bridge/3.4.1-1.tar.gz";
-    name = "3.4.1-1.tar.gz";
-    sha256 = "2c2c9ebfedeae7932b7d83a9884224a11bb8450f174a40eafe2b0419e4d9c294";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/kilted/foxglove_bridge/3.4.2-1.tar.gz";
+    name = "3.4.2-1.tar.gz";
+    sha256 = "cb8c96eb1cc80a3e24c45d0937815227df9a5aad53e73649844ffa9184900f4d";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/foxglove-msgs/default.nix
+++ b/distros/kilted/foxglove-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-kilted-foxglove-msgs";
-  version = "3.4.1-r1";
+  version = "3.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/kilted/foxglove_msgs/3.4.1-1.tar.gz";
-    name = "3.4.1-1.tar.gz";
-    sha256 = "097d6259f7eb1e6694fb6efca9049cced4b86d2c2e8c9bd501b58138ac66004d";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/kilted/foxglove_msgs/3.4.2-1.tar.gz";
+    name = "3.4.2-1.tar.gz";
+    sha256 = "8cfe8e95c2b3b433e7ae0e23cbf19497672ad93d517f37dcce17b67a9abe7473";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/generated.nix
+++ b/distros/kilted/generated.nix
@@ -1802,7 +1802,13 @@ self: super: {
 
  nao-lola-sensor-msgs = self.callPackage ./nao-lola-sensor-msgs {};
 
+ nao-meshes = self.callPackage ./nao-meshes {};
+
  nao-sensor-msgs = self.callPackage ./nao-sensor-msgs {};
+
+ naoqi-bridge-msgs = self.callPackage ./naoqi-bridge-msgs {};
+
+ naoqi-libqi = self.callPackage ./naoqi-libqi {};
 
  nav2-amcl = self.callPackage ./nav2-amcl {};
 
@@ -1956,6 +1962,8 @@ self: super: {
 
  ompl = self.callPackage ./ompl {};
 
+ onnxruntime-vendor = self.callPackage ./onnxruntime-vendor {};
+
  open-manipulator = self.callPackage ./open-manipulator {};
 
  open-manipulator-bringup = self.callPackage ./open-manipulator-bringup {};
@@ -2021,6 +2029,8 @@ self: super: {
  pendulum-control = self.callPackage ./pendulum-control {};
 
  pendulum-msgs = self.callPackage ./pendulum-msgs {};
+
+ pepper-meshes = self.callPackage ./pepper-meshes {};
 
  perception = self.callPackage ./perception {};
 
@@ -2831,6 +2841,8 @@ self: super: {
  rtabmap = self.callPackage ./rtabmap {};
 
  rtabmap-conversions = self.callPackage ./rtabmap-conversions {};
+
+ rtabmap-costmap-plugins = self.callPackage ./rtabmap-costmap-plugins {};
 
  rtabmap-demos = self.callPackage ./rtabmap-demos {};
 

--- a/distros/kilted/mobile-robot-simulator/default.nix
+++ b/distros/kilted/mobile-robot-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, rclcpp, rosgraph-msgs, sensor-msgs, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-mobile-robot-simulator";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/mobile_robot_simulator-release/archive/release/kilted/mobile_robot_simulator/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "73060089e2a9dc504d4b25108a6d592a15bfba575c33adf62402ea60e69d160c";
+    url = "https://github.com/nobleo/mobile_robot_simulator-release/archive/release/kilted/mobile_robot_simulator/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "3061a100ac54d0dd32fec5f72c76691d6a48b6a36bdc754fc7d905fe24e4a578";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/nao-meshes/default.nix
+++ b/distros/kilted/nao-meshes/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-kilted-nao-meshes";
+  version = "2.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-naoqi/nao_meshes-release/archive/release/kilted/nao_meshes/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "caebee25a3352a725277fb673f498d2d2993493c3f732c4f5347c0c6f8c935b7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS2 Meshes for the NAO robot";
+    license = with lib.licenses; [ "CC-BY-NC-ND-4.0" ];
+  };
+}

--- a/distros/kilted/naoqi-bridge-msgs/default.nix
+++ b/distros/kilted/naoqi-bridge-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-naoqi-bridge-msgs";
+  version = "2.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-naoqi/naoqi_bridge_msgs2-release/archive/release/kilted/naoqi_bridge_msgs/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "049ca1b958c9da29057b19c553e93b9c604549f432360802deb8b68b5d5582f3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ action-msgs geometry-msgs nav-msgs rosidl-default-runtime sensor-msgs std-msgs trajectory-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The naoqi_bridge_msgs package provides custom messages for running Aldebaran's robots in ROS2.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kilted/naoqi-libqi/default.nix
+++ b/distros/kilted/naoqi-libqi/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, openssl }:
+buildRosPackage {
+  pname = "ros-kilted-naoqi-libqi";
+  version = "3.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-naoqi/libqi-release/archive/release/kilted/naoqi_libqi/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "fa7ea785c0ba251c3add192ea1f7b9ebd254d9e654d32b9fe13fe75badbc3c1a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ boost openssl ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Aldebaran's libqi: a core library for NAOqiOS development";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/ntrip-client-node/default.nix
+++ b/distros/kilted/ntrip-client-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, curl, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ntrip-client-node";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/kilted/ntrip_client_node/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "9af7d6fe92cd4c0b2b0ccaaf9b7eea82a34d875072ba29be3583fa5c5b0d9934";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/kilted/ntrip_client_node/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "e22a55afe08ce7952810f6c3fd1f60864fa61743c20e1024cebb1e51adcb32ed";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/onnxruntime-vendor/default.nix
+++ b/distros/kilted/onnxruntime-vendor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, git, pkg-config }:
+buildRosPackage {
+  pname = "ros-kilted-onnxruntime-vendor";
+  version = "0.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/onnxruntime_vendor-release/archive/release/kilted/onnxruntime_vendor/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "39b9d54dff7ee43ea7a458ed302a89d686e2ddc4707e342e36a3f62bd3abd904";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-vendor-package git pkg-config ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package git ];
+
+  meta = {
+    description = "Vendor package for ONNX Runtime 1.24.3";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -97,14 +97,14 @@ in {
       # https://github.com/foxglove/foxglove-sdk/blob/main/ros/src/foxglove_bridge/CMakeLists.txt.
       # If the version doesn't match, cmake fails with "Hash mismatch"
       # and we can fix it here.
-      FOXGLOVE_SDK_VERSION = "0.25.1";
+      FOXGLOVE_SDK_VERSION = "0.25.3";
       systemToPlatform = {
         "x86_64-linux" = "x86_64-unknown-linux-gnu";
         "aarch64-linux" = "aarch64-unknown-linux-gnu";
       };
       systemToHash = {
-        "x86_64-linux" = "sha256-C500jfOo6Y0sLO4jYMyfUug7s0RQRN69dx0bRtw1i+Q=";
-        "aarch64-linux" = "sha256-xw41x48ON/O6jQJRzTHzU7sQsf0QYgDcbF9AntTfGRg=";
+        "x86_64-linux" = "sha256-1ItT8ULp2RpJe95jwDCwEg83a+VppDFd7MA02gGeWqc=";
+        "aarch64-linux" = "sha256-wiI9yymwU0sxzJ7RpR/sk4Y8EC3loKH6dJ9w8hFw/Nk=";
       };
       FOXGLOVE_SDK_PLATFORM = systemToPlatform.${self.system};
       sdk = self.fetchurl {

--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -1023,15 +1023,6 @@ in {
     '';
   });
 
-  warehouse-ros-sqlite = rosSuper.warehouse-ros-sqlite.overrideAttrs ({
-    postPatch ? "", ...
-  }: {
-    # https://github.com/moveit/warehouse_ros_sqlite/pull/61
-    postPatch = postPatch + ''
-      substituteInPlace CMakeLists.txt --replace-fail " system" ""
-    '';
-  });
-
   web-video-server = rosSuper.web-video-server.overrideAttrs ({
     postPatch ? "", ...
   }: {

--- a/distros/kilted/pepper-meshes/default.nix
+++ b/distros/kilted/pepper-meshes/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-kilted-pepper-meshes";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-naoqi/pepper_meshes2-release/archive/release/kilted/pepper_meshes/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "c28988291447e860764ae118393e4b5d99a74c5bb555046e5d404216277146bd";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Meshes for the Pepper robot, for ROS2";
+    license = with lib.licenses; [ "CC-BY-NC-ND-4.0" ];
+  };
+}

--- a/distros/kilted/pick-ik/default.nix
+++ b/distros/kilted/pick-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, fmt, generate-parameter-library, moveit-core, moveit-resources-panda-moveit-config, pluginlib, range-v3, rclcpp, rsl, tf2-geometry-msgs, tf2-kdl, tl-expected }:
 buildRosPackage {
   pname = "ros-kilted-pick-ik";
-  version = "1.1.1-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pick_ik-release/archive/release/kilted/pick_ik/1.1.1-2.tar.gz";
-    name = "1.1.1-2.tar.gz";
-    sha256 = "bce44793d6f7044e37b3a3462710a18ba267c8f0373176797fa0248d2025aac4";
+    url = "https://github.com/ros2-gbp/pick_ik-release/archive/release/kilted/pick_ik/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "cbaf8820c077c19cf3159ff850f44ae3ec8584c2fd69e522b403ce98b3cc066b";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/protobuf-comm/default.nix
+++ b/distros/kilted/protobuf-comm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, openssl, protobuf, spdlog }:
 buildRosPackage {
   pname = "ros-kilted-protobuf-comm";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/protobuf_comm-release/archive/release/kilted/protobuf_comm/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "30dd980197aa4055aec71461f5b290d85060b9f5cdda49cebc223ce32300aca8";
+    url = "https://github.com/ros2-gbp/protobuf_comm-release/archive/release/kilted/protobuf_comm/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "332dcb87a9e5d3c931413fbece16b300483a06f38948784faa62d20df731840b";
   };
 
   buildType = "cmake";

--- a/distros/kilted/rosbag-timing-inspector/default.nix
+++ b/distros/kilted/rosbag-timing-inspector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, glfw3, libGL, libGLU, rosbag2-cpp, rosbag2-storage }:
 buildRosPackage {
   pname = "ros-kilted-rosbag-timing-inspector";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag_timing_inspector-release/archive/release/kilted/rosbag_timing_inspector/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "df5e4e11fd5a3005f62f55f7f139deb034b5cdfcef38fc18e9702e981c0b3fd9";
+    url = "https://github.com/ros2-gbp/rosbag_timing_inspector-release/archive/release/kilted/rosbag_timing_inspector/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "3afd896f1d3beb1dc09314a2f13c4261653f6152747f2b9e603fa58fa12cc418";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rtabmap-conversions/default.nix
+++ b/distros/kilted/rtabmap-conversions/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, geometry-msgs, image-geometry, laser-geometry, pcl-conversions, rclcpp, rclcpp-components, ros-environment, rtabmap, rtabmap-msgs, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, geometry-msgs, image-geometry, laser-geometry, pcl-conversions, rclcpp, rclcpp-components, ros-environment, rtabmap, rtabmap-msgs, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-rtabmap-conversions";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_conversions/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "bf590889beb1f91da3fb1557d1d5c8a84c098e78c47fdf97ec0dcf1dadafe3d3";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_conversions/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "ab1df910644634a83f1e98d8d92a6e17af39a06ff227287b95065ae9f04bcbf3";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ cv-bridge geometry-msgs image-geometry laser-geometry pcl-conversions rclcpp rclcpp-components rtabmap rtabmap-msgs sensor-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs image-geometry laser-geometry pcl-conversions rclcpp rclcpp-components rtabmap rtabmap-msgs sensor-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/rtabmap-costmap-plugins/default.nix
+++ b/distros/kilted/rtabmap-costmap-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, nav2-costmap-2d, pluginlib, rclcpp, ros-environment, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-rtabmap-costmap-plugins";
+  version = "0.23.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_costmap_plugins/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "54d7bac62264fa5647af0fed07ef7d03499340037b47320bdd0181a689e34a2f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ros-environment ];
+  propagatedBuildInputs = [ nav2-costmap-2d pluginlib rclcpp visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = "RTAB-Map's costmap plugins.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/rtabmap-demos/default.nix
+++ b/distros/kilted/rtabmap-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-bringup, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz }:
 buildRosPackage {
   pname = "ros-kilted-rtabmap-demos";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_demos/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "af2e74efa672bfa27af754956a62fce5cd3370448b850472fcce64b79c56b626";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_demos/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "8b62e4c4a21e24662bb689473bd99c6d94c8debaeeeb2135043bbb3fce3f3a54";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rtabmap-examples/default.nix
+++ b/distros/kilted/rtabmap-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, imu-filter-madgwick, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz, tf2-ros, velodyne }:
 buildRosPackage {
   pname = "ros-kilted-rtabmap-examples";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_examples/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "26f86baba367d20f417c5b721fb9703daa038b3e1cc74162ecb2520e4f787326";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_examples/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "167b49d50ed72e66df7aba020f364a5eb208942c1a002f5182c996cd6d3e6ac8";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rtabmap-launch/default.nix
+++ b/distros/kilted/rtabmap-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rtabmap-msgs, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz }:
 buildRosPackage {
   pname = "ros-kilted-rtabmap-launch";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_launch/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "bbeecb525707b2819fa343bd99f22775074324ccb11de95dcbe3b8c3349cb5fc";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_launch/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "221c8c008f23e12e403e255474b909fe3129073469cb8d197a29e28f3f66cc0b";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rtabmap-msgs/default.nix
+++ b/distros/kilted/rtabmap-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kilted-rtabmap-msgs";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_msgs/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "8cab13047a24b74d3c3b4d1f1e0f5c08fe0b7ad16ba7fbff43e10274c69976e7";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_msgs/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "73fdbf7d94bfd91f350231b3b7ebd7b31c3075cf5e7c3a3921cb3beb2530b73b";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rtabmap-odom/default.nix
+++ b/distros/kilted/rtabmap-odom/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, image-geometry, laser-geometry, message-filters, nav-msgs, pcl-conversions, pcl-ros, pluginlib, rclcpp, rclcpp-components, ros-environment, rtabmap-conversions, rtabmap-msgs, rtabmap-sync, rtabmap-util, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-rtabmap-odom";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_odom/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "35e0397c45df65a39f46143dca2d2648b2ecd03d9ab7406c084845fc5f236d38";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_odom/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "d1129d7e257993063c5baaad1ed47f2c360936fb81423734dad36ecc38ef924c";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rtabmap-python/default.nix
+++ b/distros/kilted/rtabmap-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-kilted-rtabmap-python";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_python/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "2b3ce89cabd556d2bda87b13f26676a0518dd7c2d01eb8813eba3871d4b991ef";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_python/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "26177b8728704f989694c05f54e9f824774bcd0710646f15145b04c9347d7e3f";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/rtabmap-ros/default.nix
+++ b/distros/kilted/rtabmap-ros/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, rtabmap-conversions, rtabmap-demos, rtabmap-examples, rtabmap-launch, rtabmap-msgs, rtabmap-odom, rtabmap-python, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-sync, rtabmap-util, rtabmap-viz }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, rtabmap-conversions, rtabmap-costmap-plugins, rtabmap-demos, rtabmap-examples, rtabmap-launch, rtabmap-msgs, rtabmap-odom, rtabmap-python, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-sync, rtabmap-util, rtabmap-viz }:
 buildRosPackage {
   pname = "ros-kilted-rtabmap-ros";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_ros/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "092c624fd057ad77843a953e0a9d13a11e16b46c170f74d47f67a039b5b6993e";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_ros/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "472c1a892407c530009715b4cb050daf468709b6a071562ab567ab6bbb5ec90e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ rtabmap-conversions rtabmap-demos rtabmap-examples rtabmap-launch rtabmap-msgs rtabmap-odom rtabmap-python rtabmap-rviz-plugins rtabmap-slam rtabmap-sync rtabmap-util rtabmap-viz ];
+  propagatedBuildInputs = [ rtabmap-conversions rtabmap-costmap-plugins rtabmap-demos rtabmap-examples rtabmap-launch rtabmap-msgs rtabmap-odom rtabmap-python rtabmap-rviz-plugins rtabmap-slam rtabmap-sync rtabmap-util rtabmap-viz ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/rtabmap-rviz-plugins/default.nix
+++ b/distros/kilted/rtabmap-rviz-plugins/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, pcl-conversions, pluginlib, rclcpp, ros-environment, rtabmap-conversions, rtabmap-msgs, rviz-common, rviz-default-plugins, rviz-rendering, sensor-msgs, std-msgs, tf2 }:
+{ lib, buildRosPackage, fetchurl, _unresolved_qtbase5-private-dev, ament-cmake-ros, pcl-conversions, pluginlib, rclcpp, ros-environment, rtabmap-conversions, rtabmap-msgs, rviz-common, rviz-default-plugins, rviz-rendering, sensor-msgs, std-msgs, tf2 }:
 buildRosPackage {
   pname = "ros-kilted-rtabmap-rviz-plugins";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_rviz_plugins/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "819dfdc973f240859155d6caf4c1ab58c5a01ca247cacfa3e68e3c43115e2a33";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_rviz_plugins/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "b6556c4df9ba6eb119c27fb6aa710d422b1360dfc57819fffbc299b9882dce92";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ros-environment ];
+  buildInputs = [ _unresolved_qtbase5-private-dev ament-cmake-ros ros-environment ];
   propagatedBuildInputs = [ pcl-conversions pluginlib rclcpp rtabmap-conversions rtabmap-msgs rviz-common rviz-default-plugins rviz-rendering sensor-msgs std-msgs tf2 ];
   nativeBuildInputs = [ ament-cmake-ros ];
 

--- a/distros/kilted/rtabmap-slam/default.nix
+++ b/distros/kilted/rtabmap-slam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, apriltag-msgs, aruco-msgs, aruco-opencv-msgs, cv-bridge, geometry-msgs, nav-msgs, nav2-msgs, rclcpp, rclcpp-components, ros-environment, rtabmap-msgs, rtabmap-sync, rtabmap-util, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-rtabmap-slam";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_slam/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "1bb63ee406847baf5fe9fd8c4310ef59dc40fae291343d298e666906a81508c6";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_slam/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "3508c52172cdb9b2261674048f0c8a8c6d59baacfa60a1b26f82296574c7b3a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rtabmap-sync/default.nix
+++ b/distros/kilted/rtabmap-sync/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, diagnostic-updater, image-transport, message-filters, nav-msgs, rclcpp, rclcpp-components, ros-environment, rtabmap-conversions, rtabmap-msgs, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-rtabmap-sync";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_sync/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "ff568d5b93f418074a36624189ad09eefe10ddddbd608f2823893734aa18c1a0";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_sync/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "5205e922250ae7c16d2e4853ec348b59b566f1e7f41ea34114bb035f5ed03cdc";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rtabmap-util/default.nix
+++ b/distros/kilted/rtabmap-util/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, image-transport, laser-geometry, message-filters, nav-msgs, octomap-msgs, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, ros-environment, rtabmap-conversions, rtabmap-msgs, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, grid-map-ros, image-geometry, image-transport, laser-geometry, message-filters, nav-msgs, octomap-msgs, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, ros-environment, rtabmap-conversions, rtabmap-msgs, rtabmap-sync, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-rtabmap-util";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_util/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "720fe5df1c3f73f0ceace65910984aea467a769f79af9914a5894e6512fe5214";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_util/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "1d51a15b5e106098c49ee6ec6c35586b9c8253d0d37d218aaea425934193f745";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ cv-bridge image-transport laser-geometry message-filters nav-msgs octomap-msgs pcl-conversions pcl-ros rclcpp rclcpp-components rtabmap-conversions rtabmap-msgs sensor-msgs std-msgs stereo-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ cv-bridge grid-map-ros image-geometry image-transport laser-geometry message-filters nav-msgs octomap-msgs pcl-conversions pcl-ros rclcpp rclcpp-components rtabmap-conversions rtabmap-msgs rtabmap-sync sensor-msgs std-msgs stereo-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/rtabmap-viz/default.nix
+++ b/distros/kilted/rtabmap-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, geometry-msgs, nav-msgs, rclcpp, ros-environment, rtabmap-msgs, rtabmap-sync, std-msgs, std-srvs, tf2 }:
 buildRosPackage {
   pname = "ros-kilted-rtabmap-viz";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_viz/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "8049c9c0f699ee7701cf66c9266bfaeb57a5cc892cfe6faeeed99357f2bef8a2";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kilted/rtabmap_viz/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "59154f5cc2cd4513f7fe25331a90921141572df4ee73fb7d059d23ca8c2394e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rtabmap/default.nix
+++ b/distros/kilted/rtabmap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, gtsam, libg2o, libpointmatcher, octomap, pcl, proj, qt-gui-cpp, sqlite, zlib }:
 buildRosPackage {
   pname = "ros-kilted-rtabmap";
-  version = "0.22.1-r1";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rtabmap-release/archive/release/kilted/rtabmap/0.22.1-1.tar.gz";
-    name = "0.22.1-1.tar.gz";
-    sha256 = "552b9bbf3475fcebfb38e9be5ff449357fd13b8bd46f6d6d66da2530d5a9aedb";
+    url = "https://github.com/ros2-gbp/rtabmap-release/archive/release/kilted/rtabmap/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "25830441057b141376bb01ba642f315a279666798fbc5b5c85c2957ae4484bcf";
   };
 
   buildType = "cmake";

--- a/distros/kilted/septentrio-gnss-driver/default.nix
+++ b/distros/kilted/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, gtest-vendor, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-septentrio-gnss-driver";
-  version = "1.4.6-r1";
+  version = "1.4.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/kilted/septentrio_gnss_driver/1.4.6-1.tar.gz";
-    name = "1.4.6-1.tar.gz";
-    sha256 = "941be71fb465d4a8ca5976d08bf53e8959ce935273b061c875ca2f97b1e3dccd";
+    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/kilted/septentrio_gnss_driver/1.4.7-2.tar.gz";
+    name = "1.4.7-2.tar.gz";
+    sha256 = "601fe589983346e20a36a924d947e34f965a0fb75842578752b3da38c60f7539";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ublox-dgnss-node/default.nix
+++ b/distros/kilted/ublox-dgnss-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-index-cpp, ament-lint-auto, ament-lint-common, libusb1, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ublox-dgnss-node";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/kilted/ublox_dgnss_node/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "d662fe034fbd43b3542a782980b5384ae17cc8d5c5b8cd34e5a38917eebd27dd";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/kilted/ublox_dgnss_node/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "bbff9ef35ef354b5083c332413b394fe684d43e698be3e6b08a8a174c8daa2b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ublox-dgnss/default.nix
+++ b/distros/kilted/ublox-dgnss/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ntrip-client-node, ublox-dgnss-node, ublox-nav-sat-fix-hp-node, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ublox-dgnss";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/kilted/ublox_dgnss/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "0c3ad7eefc5b53a1a49a46cf56fd2e63e6064a6aec127efd0ffcc400505e04c6";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/kilted/ublox_dgnss/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "6fef73973c2eefa3d15e776e8854e19af9d551922746196aabeedc68cbdd0721";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ublox-nav-sat-fix-hp-node/default.nix
+++ b/distros/kilted/ublox-nav-sat-fix-hp-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ublox-nav-sat-fix-hp-node";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/kilted/ublox_nav_sat_fix_hp_node/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "816a250b640560ddbf74e1f8654197666bb1ac347bd74b472404b6ce3d59b2b8";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/kilted/ublox_nav_sat_fix_hp_node/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "a95fd3531601cc55717692401a671efcb2ba9fc2bf76beed31215b517da7c524";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ublox-ubx-interfaces/default.nix
+++ b/distros/kilted/ublox-ubx-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-kilted-ublox-ubx-interfaces";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/kilted/ublox_ubx_interfaces/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "b29042b6717bef4b598ffca3c3efa212e4a7836dff6e0f16a3d484840e942c06";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/kilted/ublox_ubx_interfaces/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "2ef277a04c76812c5a351eafe01c40b2e6e60bdb1a8f3c3172f51b51675f1980";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/ublox-ubx-msgs/default.nix
+++ b/distros/kilted/ublox-ubx-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-ublox-ubx-msgs";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/kilted/ublox_ubx_msgs/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "5c489c8904814dec64f177e4855473c569bb4a421d4304373f54025f00cfe122";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/kilted/ublox_ubx_msgs/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "bc5fdda818286fa4cc944814bb24aba51dd210948ed9b8e78f7d972675787fda";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/warehouse-ros-sqlite/default.nix
+++ b/distros/kilted/warehouse-ros-sqlite/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite3-vendor, warehouse-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite, warehouse-ros }:
 buildRosPackage {
   pname = "ros-kilted-warehouse-ros-sqlite";
-  version = "1.0.5-r2";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/kilted/warehouse_ros_sqlite/1.0.5-2.tar.gz";
-    name = "1.0.5-2.tar.gz";
-    sha256 = "8659a642d5e11241713c5013d7702fa599d27602e9f804d9da85fe62697647d4";
+    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/kilted/warehouse_ros_sqlite/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "aa674e87db0bad12b2ee8adb5fbf7f29c3a62882e55b00a3a44d80650942d020";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake boost ];
   checkInputs = [ ament-cmake-copyright ament-cmake-gtest ament-lint-auto ament-lint-common geometry-msgs ];
-  propagatedBuildInputs = [ class-loader rclcpp sqlite3-vendor warehouse-ros ];
+  propagatedBuildInputs = [ class-loader rclcpp sqlite warehouse-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/lyrical/aruco-opencv-msgs/default.nix
+++ b/distros/lyrical/aruco-opencv-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-lint-auto, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-aruco-opencv-msgs";
-  version = "6.1.2-r1";
+  version = "7.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aruco_opencv-release/archive/release/lyrical/aruco_opencv_msgs/6.1.2-1.tar.gz";
-    name = "6.1.2-1.tar.gz";
-    sha256 = "65cc2d0dbefd3696fa41ac244e9c0af17a55e4d87198acbf23dada222a1da64a";
+    url = "https://github.com/ros2-gbp/aruco_opencv-release/archive/release/lyrical/aruco_opencv_msgs/7.0.0-1.tar.gz";
+    name = "7.0.0-1.tar.gz";
+    sha256 = "1c2ff961324d1e4a06622d035dd616a40f56afc9ddcfe1687c4acb6dc512cce6";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/aruco-opencv/default.nix
+++ b/distros/lyrical/aruco-opencv/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, aruco-opencv-msgs, cv-bridge, image-transport, python3Packages, rclcpp, rclcpp-components, rclcpp-lifecycle, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-lyrical-aruco-opencv";
-  version = "6.1.2-r1";
+  version = "7.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aruco_opencv-release/archive/release/lyrical/aruco_opencv/6.1.2-1.tar.gz";
-    name = "6.1.2-1.tar.gz";
-    sha256 = "2d98d05b811ba3fe5377f11cf154843266c47b5e9d301e0ef3a3a90c7b1402bc";
+    url = "https://github.com/ros2-gbp/aruco_opencv-release/archive/release/lyrical/aruco_opencv/7.0.0-1.tar.gz";
+    name = "7.0.0-1.tar.gz";
+    sha256 = "64ac11afffb5acb574ea0e2b18062d4ae2c1d8f2207e94af5bb19398069d3495";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/automatika-embodied-agents/default.nix
+++ b/distros/lyrical/automatika-embodied-agents/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, automatika-ros-sugar, builtin-interfaces, python3Packages, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-automatika-embodied-agents";
-  version = "0.7.0-r3";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/automatika_embodied_agents-release/archive/release/lyrical/automatika_embodied_agents/0.7.0-3.tar.gz";
-    name = "0.7.0-3.tar.gz";
-    sha256 = "8ddca5ae5e9f090b5a55209f16f1c2e5a60dba46816a87a15681a5c2a0934118";
+    url = "https://github.com/ros2-gbp/automatika_embodied_agents-release/archive/release/lyrical/automatika_embodied_agents/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "35c87dadca9aa863d2961ee95ab1b28995f0d48a1eec2cd72bacffa93b6537c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/clips-vendor/default.nix
+++ b/distros/lyrical/clips-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, unzip }:
 buildRosPackage {
   pname = "ros-lyrical-clips-vendor";
-  version = "6.4.3-r3";
+  version = "6.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/clips_vendor-release/archive/release/lyrical/clips_vendor/6.4.3-3.tar.gz";
-    name = "6.4.3-3.tar.gz";
-    sha256 = "288a5dbed62d25bbf0db95c6f6562b6854c6e4850e359f1421399a4c7ea3a450";
+    url = "https://github.com/ros2-gbp/clips_vendor-release/archive/release/lyrical/clips_vendor/6.4.4-1.tar.gz";
+    name = "6.4.4-1.tar.gz";
+    sha256 = "1d2791619f8ba1f1824158d5c30164df5932b7d683603dd0e0dadd6826870192";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/clips-vendor/vendored-source.json
+++ b/distros/lyrical/clips-vendor/vendored-source.json
@@ -1,6 +1,6 @@
 {
   "clips_vendor": {
-    "url": "https://raw.githubusercontent.com/carologistics/clips_vendor/r925/clipsrules-code-r925.zip",
-    "sha256": "08macis5ai6y6azzbp5mhyk30sx3qx3903wsbry9agfabgd2yviw"
+    "url": "https://raw.githubusercontent.com/carologistics/clips_vendor/r974/clipsrules-code-r974.zip",
+    "sha256": "0yg9gfqmql6fmw4qrzfm968nb10lnfxzlpish2xyscibax6gg97p"
   }
 }

--- a/distros/lyrical/fkie-message-filters/default.nix
+++ b/distros/lyrical/fkie-message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, image-transport, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-lyrical-fkie-message-filters";
-  version = "3.3.1-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fkie_message_filters-release/archive/release/lyrical/fkie_message_filters/3.3.1-1.tar.gz";
-    name = "3.3.1-1.tar.gz";
-    sha256 = "655268cda49aaf95d5f7e14aba31a8a4b7cf14f328d72cf45e78859c2adbd585";
+    url = "https://github.com/ros2-gbp/fkie_message_filters-release/archive/release/lyrical/fkie_message_filters/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "0bee9e44d181d28d7cfe267ebfe4a48193f2b47f4c87d1df3523f999960e1aeb";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/foxglove-bridge/default.nix
+++ b/distros/lyrical/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, geometry-msgs, nlohmann_json, rcl-interfaces, rclcpp, rclcpp-components, rcpputils, rcutils, resource-retriever, ros-environment, rosgraph-msgs, rosidl-typesupport-introspection-cpp, rosx-introspection, sensor-msgs, std-msgs, std-srvs, websocketpp }:
 buildRosPackage {
   pname = "ros-lyrical-foxglove-bridge";
-  version = "3.4.1-r1";
+  version = "3.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/lyrical/foxglove_bridge/3.4.1-1.tar.gz";
-    name = "3.4.1-1.tar.gz";
-    sha256 = "273d46c1ec95cfd84ef28234d88e13278d205bec569bcbd6d12c229cfdc7a702";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/lyrical/foxglove_bridge/3.4.2-1.tar.gz";
+    name = "3.4.2-1.tar.gz";
+    sha256 = "4668f80182426c881ddc83423791d20295e71c795fcc0215566d68f08c59e4f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/foxglove-msgs/default.nix
+++ b/distros/lyrical/foxglove-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-lyrical-foxglove-msgs";
-  version = "3.4.1-r1";
+  version = "3.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/lyrical/foxglove_msgs/3.4.1-1.tar.gz";
-    name = "3.4.1-1.tar.gz";
-    sha256 = "4e2c49b9a3f3ed86ec8861a8862dd9828848414cd55c7fdcf4658cf6a141fd5f";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/lyrical/foxglove_msgs/3.4.2-1.tar.gz";
+    name = "3.4.2-1.tar.gz";
+    sha256 = "9b50a692ae3036055123c27c4a61da3da378317ce1a22f438dcf74d15f01465b";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/franka-inria-inverse-dynamics-solver/default.nix
+++ b/distros/lyrical/franka-inria-inverse-dynamics-solver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, eigen, inverse-dynamics-solver, pluginlib }:
+buildRosPackage {
+  pname = "ros-lyrical-franka-inria-inverse-dynamics-solver";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/inverse_dynamics_solver-release/archive/release/lyrical/franka_inria_inverse_dynamics_solver/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "7dd59246ad4b5657c8a3f5a1aabb2d6a9b9caf04c4a65ff4118f31271ac08882";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ eigen inverse-dynamics-solver pluginlib ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A C++ library implementing the inverse dynamics solver for the Franka Emika Panda (FER) real robot.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/generated.nix
+++ b/distros/lyrical/generated.nix
@@ -820,6 +820,8 @@ self: super: {
 
  foxglove-sdk-vendor = self.callPackage ./foxglove-sdk-vendor {};
 
+ franka-inria-inverse-dynamics-solver = self.callPackage ./franka-inria-inverse-dynamics-solver {};
+
  frequency-cam = self.callPackage ./frequency-cam {};
 
  fuse = self.callPackage ./fuse {};
@@ -958,6 +960,8 @@ self: super: {
 
  hebi-cpp-api = self.callPackage ./hebi-cpp-api {};
 
+ hitch-estimation-apriltag-array = self.callPackage ./hitch-estimation-apriltag-array {};
+
  hls-lfcd-lds-driver = self.callPackage ./hls-lfcd-lds-driver {};
 
  hri = self.callPackage ./hri {};
@@ -1024,6 +1028,8 @@ self: super: {
 
  intra-process-demo = self.callPackage ./intra-process-demo {};
 
+ inverse-dynamics-solver = self.callPackage ./inverse-dynamics-solver {};
+
  io-context = self.callPackage ./io-context {};
 
  irobot-create-msgs = self.callPackage ./irobot-create-msgs {};
@@ -1053,6 +1059,8 @@ self: super: {
  jrl-cmakemodules = self.callPackage ./jrl-cmakemodules {};
 
  kartech-linear-actuator-msgs = self.callPackage ./kartech-linear-actuator-msgs {};
+
+ kdl-inverse-dynamics-solver = self.callPackage ./kdl-inverse-dynamics-solver {};
 
  kdl-parser = self.callPackage ./kdl-parser {};
 
@@ -1301,6 +1309,8 @@ self: super: {
  microstrain-inertial-rqt = self.callPackage ./microstrain-inertial-rqt {};
 
  mimick-vendor = self.callPackage ./mimick-vendor {};
+
+ mobile-robot-simulator = self.callPackage ./mobile-robot-simulator {};
 
  mobileye-560-660-msgs = self.callPackage ./mobileye-560-660-msgs {};
 
@@ -1753,6 +1763,8 @@ self: super: {
  omni-wheel-drive-controller = self.callPackage ./omni-wheel-drive-controller {};
 
  ompl = self.callPackage ./ompl {};
+
+ onnxruntime-vendor = self.callPackage ./onnxruntime-vendor {};
 
  open3d-vendor = self.callPackage ./open3d-vendor {};
 
@@ -2264,6 +2276,8 @@ self: super: {
 
  ros2-fmt-logger = self.callPackage ./ros2-fmt-logger {};
 
+ ros2-medkit-action-status-bridge = self.callPackage ./ros2-medkit-action-status-bridge {};
+
  ros2-medkit-beacon-common = self.callPackage ./ros2-medkit-beacon-common {};
 
  ros2-medkit-cmake = self.callPackage ./ros2-medkit-cmake {};
@@ -2281,6 +2295,8 @@ self: super: {
  ros2-medkit-integration-tests = self.callPackage ./ros2-medkit-integration-tests {};
 
  ros2-medkit-linux-introspection = self.callPackage ./ros2-medkit-linux-introspection {};
+
+ ros2-medkit-log-bridge = self.callPackage ./ros2-medkit-log-bridge {};
 
  ros2-medkit-msgs = self.callPackage ./ros2-medkit-msgs {};
 
@@ -2429,6 +2445,8 @@ self: super: {
  rosbag2-transport = self.callPackage ./rosbag2-transport {};
 
  rosbag2rawlog = self.callPackage ./rosbag2rawlog {};
+
+ rosbag-timing-inspector = self.callPackage ./rosbag-timing-inspector {};
 
  rosbridge-library = self.callPackage ./rosbridge-library {};
 
@@ -2629,6 +2647,32 @@ self: super: {
  rt-usb-9axisimu-driver = self.callPackage ./rt-usb-9axisimu-driver {};
 
  rtabmap = self.callPackage ./rtabmap {};
+
+ rtabmap-conversions = self.callPackage ./rtabmap-conversions {};
+
+ rtabmap-demos = self.callPackage ./rtabmap-demos {};
+
+ rtabmap-examples = self.callPackage ./rtabmap-examples {};
+
+ rtabmap-launch = self.callPackage ./rtabmap-launch {};
+
+ rtabmap-msgs = self.callPackage ./rtabmap-msgs {};
+
+ rtabmap-odom = self.callPackage ./rtabmap-odom {};
+
+ rtabmap-python = self.callPackage ./rtabmap-python {};
+
+ rtabmap-ros = self.callPackage ./rtabmap-ros {};
+
+ rtabmap-rviz-plugins = self.callPackage ./rtabmap-rviz-plugins {};
+
+ rtabmap-slam = self.callPackage ./rtabmap-slam {};
+
+ rtabmap-sync = self.callPackage ./rtabmap-sync {};
+
+ rtabmap-util = self.callPackage ./rtabmap-util {};
+
+ rtabmap-viz = self.callPackage ./rtabmap-viz {};
 
  rtcm-msgs = self.callPackage ./rtcm-msgs {};
 
@@ -3023,6 +3067,8 @@ self: super: {
  unique-identifier-msgs = self.callPackage ./unique-identifier-msgs {};
 
  ur = self.callPackage ./ur {};
+
+ ur10-inverse-dynamics-solver = self.callPackage ./ur10-inverse-dynamics-solver {};
 
  ur-calibration = self.callPackage ./ur-calibration {};
 

--- a/distros/lyrical/hitch-estimation-apriltag-array/default.nix
+++ b/distros/lyrical/hitch-estimation-apriltag-array/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, apriltag-msgs, apriltag-ros, geometry-msgs, python3Packages, rclpy, sensor-msgs, tf-transformations, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-hitch-estimation-apriltag-array";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/li9i/hitch-estimation-apriltag-array-release/archive/release/lyrical/hitch_estimation_apriltag_array/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "2879f99ef93aca8fd5733646c7390ad28d1aeed0f8fcd23b8f5ce6e5c475e801";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ apriltag-msgs apriltag-ros geometry-msgs python3Packages.numpy rclpy sensor-msgs tf-transformations tf2-ros ];
+
+  meta = {
+    description = "A package that estimates the hitch joint state between a robot and a
+    trailer by optical recognition of an array of April tags mounted at the
+    front of the trailer by the rear camera of the robot";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/inverse-dynamics-solver/default.nix
+++ b/distros/lyrical/inverse-dynamics-solver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, eigen, pluginlib, python3Packages, rclcpp, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, sensor-msgs, urdf }:
+buildRosPackage {
+  pname = "ros-lyrical-inverse-dynamics-solver";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/inverse_dynamics_solver-release/archive/release/lyrical/inverse_dynamics_solver/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "106487a47451491ec5f7496195e47f5d80fe8f1f492b2976ad1c6ab654920cf1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ eigen pluginlib python3Packages.matplotlib python3Packages.numpy python3Packages.tabulate rclcpp rosbag2-cpp rosbag2-storage rosbag2-storage-default-plugins sensor-msgs urdf ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A library implementing an inverse dynamics solver for serial manipulators.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/kdl-inverse-dynamics-solver/default.nix
+++ b/distros/lyrical/kdl-inverse-dynamics-solver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, inverse-dynamics-solver, kdl-parser, orocos-kdl, pluginlib, rclcpp, ros-testing, ur-description }:
+buildRosPackage {
+  pname = "ros-lyrical-kdl-inverse-dynamics-solver";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/inverse_dynamics_solver-release/archive/release/lyrical/kdl_inverse_dynamics_solver/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "65ed1212c25b0e147c7c0c22485dc5391fd4282a47fa7a26c09645504db29737";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common rclcpp ros-testing ];
+  propagatedBuildInputs = [ inverse-dynamics-solver kdl-parser orocos-kdl pluginlib rclcpp ur-description ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A KDL-based library implementing an inverse dynamics solver for simulated robots.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/mavlink/default.nix
+++ b/distros/lyrical/mavlink/default.nix
@@ -5,16 +5,16 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-lyrical-mavlink";
-  version = "2026.6.6-r1";
+  version = "2026.6.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/lyrical/mavlink/2026.6.6-1.tar.gz";
-    name = "2026.6.6-1.tar.gz";
-    sha256 = "abffa69483a124366f703be994058b1f809749b8716aff013cad29eeac4129df";
+    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/lyrical/mavlink/2026.6.19-1.tar.gz";
+    name = "2026.6.19-1.tar.gz";
+    sha256 = "2a45c08c72a784ca232929c7efc165d6978c998ed21e088eb6d0d1276497d7e9";
   };
 
   buildType = "cmake";
-  buildInputs = [ ament-cmake cmake python3 python3Packages.future python3Packages.lxml ros-environment ];
+  buildInputs = [ ament-cmake cmake python3 python3Packages.lxml ros-environment ];
   nativeBuildInputs = [ ament-cmake cmake ros-environment ];
 
   meta = {

--- a/distros/lyrical/mobile-robot-simulator/default.nix
+++ b/distros/lyrical/mobile-robot-simulator/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, rclcpp, rosgraph-msgs, sensor-msgs, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-mobile-robot-simulator";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/nobleo/mobile_robot_simulator-release/archive/release/lyrical/mobile_robot_simulator/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "ab8abbf56ed2438f9b6f7df1e9642fa09bb10a6e4b893f4b262950b46709de43";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ geometry-msgs nav-msgs rclcpp rosgraph-msgs sensor-msgs tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The mobile_robot_simulator package";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/ntrip-client-node/default.nix
+++ b/distros/lyrical/ntrip-client-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, curl, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-ntrip-client-node";
-  version = "0.7.4-r3";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/lyrical/ntrip_client_node/0.7.4-3.tar.gz";
-    name = "0.7.4-3.tar.gz";
-    sha256 = "5337a9a39e79bac86a485c26b31556991b9165b54af79f5ee50eb84e51f710b4";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/lyrical/ntrip_client_node/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "e86c59618f436b57c2209f7a223391051df07cff3681accfb3b15e887bf4d7b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ompl/default.nix
+++ b/distros/lyrical/ompl/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, flann, pkg-config }:
+{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, flann, pkg-config, python3, yaml-cpp }:
 buildRosPackage {
   pname = "ros-lyrical-ompl";
-  version = "1.7.0-r4";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ompl-release/archive/release/lyrical/ompl/1.7.0-4.tar.gz";
-    name = "1.7.0-4.tar.gz";
-    sha256 = "912fbc1bd7fd9c5ad77fa79f4b22edc570dda58165352acd8dc1d9bba3bac022";
+    url = "https://github.com/ros2-gbp/ompl-release/archive/release/lyrical/ompl/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "03f2d59ff35bf0ce9e0f2abe6c4f5112bbbd622dfe1f353f976ad6675659bd3a";
   };
 
   buildType = "cmake";
-  buildInputs = [ cmake pkg-config ];
-  propagatedBuildInputs = [ boost eigen flann ];
-  nativeBuildInputs = [ cmake ];
+  buildInputs = [ cmake eigen pkg-config python3 ];
+  propagatedBuildInputs = [ boost flann yaml-cpp ];
+  nativeBuildInputs = [ cmake pkg-config ];
 
   meta = {
     description = "OMPL is a free sampling-based motion planning library.";

--- a/distros/lyrical/onnxruntime-vendor/default.nix
+++ b/distros/lyrical/onnxruntime-vendor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, git, pkg-config }:
+buildRosPackage {
+  pname = "ros-lyrical-onnxruntime-vendor";
+  version = "0.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/onnxruntime_vendor-release/archive/release/lyrical/onnxruntime_vendor/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "8d902208d7f077c1ce7dd32b36380e67e62e6478d12ee7a59246621d7b3bf6d5";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-vendor-package git pkg-config ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package git ];
+
+  meta = {
+    description = "Vendor package for ONNX Runtime 1.24.3";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -84,14 +84,14 @@ in {
       # https://github.com/foxglove/foxglove-sdk/blob/main/ros/src/foxglove_bridge/CMakeLists.txt.
       # If the version doesn't match, cmake fails with "Hash mismatch"
       # and we can fix it here.
-      FOXGLOVE_SDK_VERSION = "0.25.1";
+      FOXGLOVE_SDK_VERSION = "0.25.3";
       systemToPlatform = {
         "x86_64-linux" = "x86_64-unknown-linux-gnu";
         "aarch64-linux" = "aarch64-unknown-linux-gnu";
       };
       systemToHash = {
-        "x86_64-linux" = "sha256-C500jfOo6Y0sLO4jYMyfUug7s0RQRN69dx0bRtw1i+Q=";
-        "aarch64-linux" = "sha256-xw41x48ON/O6jQJRzTHzU7sQsf0QYgDcbF9AntTfGRg=";
+        "x86_64-linux" = "sha256-1ItT8ULp2RpJe95jwDCwEg83a+VppDFd7MA02gGeWqc=";
+        "aarch64-linux" = "sha256-wiI9yymwU0sxzJ7RpR/sk4Y8EC3loKH6dJ9w8hFw/Nk=";
       };
       FOXGLOVE_SDK_PLATFORM = systemToPlatform.${self.system};
       sdk = self.fetchurl {

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -504,18 +504,6 @@ in {
     '';
   });
 
-  ompl = rosSuper.ompl.overrideAttrs ({
-    patches ? [], ...
-  }: {
-    patches = patches ++ [
-      # https://github.com/ompl/ompl/pull/1306 merged
-      (self.fetchpatch2 {
-        url = "https://github.com/ompl/ompl/commit/44eaf82b6e9829d15317884f9b78ab24618c5f6f.patch?full_index=1";
-        hash = "sha256-SSC0Uk3ddHwRdv81cY7DRJS9uekYgr2Zv13Yk0bWl2M=";
-      })
-    ];
-  });
-
   pcl-conversions = rosSuper.pcl-conversions.overrideAttrs ({
     patches ? [], ...
   }: {

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -773,15 +773,6 @@ in {
     '';
   });
 
-  warehouse-ros-sqlite = rosSuper.warehouse-ros-sqlite.overrideAttrs ({
-    postPatch ? "", ...
-  }: {
-    # https://github.com/moveit/warehouse_ros_sqlite/pull/61
-    postPatch = postPatch + ''
-      substituteInPlace CMakeLists.txt --replace-fail " system" ""
-    '';
-  });
-
   webots-ros2-driver = rosSuper.webots-ros2-driver.overrideAttrs ({
     postPatch ? "", ...
   }: {

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -504,6 +504,19 @@ in {
     '';
   });
 
+  # Make the PCL derivation compatible with the rtabmap package. The
+  # nixpkgs rtabmap derivation (see below) builds against PCL with
+  # Qt6-enabled VTK (pcl.override { vtk = vtkWithQt6; }). As a result,
+  # its exported rtabmap::core target references the VTK::GUISupportQt
+  # target. Downstream packages that call find_package(RTABMap) must
+  # use the same PCL configuration; otherwise, the VTK::GUISupportQt
+  # target will be undefined, causing CMake to fail. To ensure all ROS
+  # packages resolve the PCL dependency consistently to a single
+  # version, override the PCL package from nixpkgs with a different
+  # version (see ../../pkgs/default.nix). For older ROS distributions,
+  # a similar override is used, but with Qt5 instead of Qt6.
+  pcl = self.pclWithQt6;
+
   pcl-conversions = rosSuper.pcl-conversions.overrideAttrs ({
     patches ? [], ...
   }: {

--- a/distros/lyrical/protobuf-comm/default.nix
+++ b/distros/lyrical/protobuf-comm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, openssl, protobuf, spdlog }:
 buildRosPackage {
   pname = "ros-lyrical-protobuf-comm";
-  version = "0.9.3-r3";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/protobuf_comm-release/archive/release/lyrical/protobuf_comm/0.9.3-3.tar.gz";
-    name = "0.9.3-3.tar.gz";
-    sha256 = "ab9c3c81651c50c473dbad7278a24964d4379fae86dc1aa305b9af3d97061459";
+    url = "https://github.com/ros2-gbp/protobuf_comm-release/archive/release/lyrical/protobuf_comm/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "524936abef4c55969a81cee1ad1929c8b6afdc9b8fbcb7ff7c21d1736bce3381";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/qt-dotgraph/default.nix
+++ b/distros/lyrical/qt-dotgraph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python-qt-binding, python3Packages }:
 buildRosPackage {
   pname = "ros-lyrical-qt-dotgraph";
-  version = "2.11.0-r1";
+  version = "2.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/lyrical/qt_dotgraph/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "63b45837281259fd7c3a7f731a56ec40544e9d86457d4d6353834ac7ada3a1b4";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/lyrical/qt_dotgraph/2.11.1-1.tar.gz";
+    name = "2.11.1-1.tar.gz";
+    sha256 = "e6ba81251596fa7bd4ad562138c02171a47592d44f3ac52db90327b9a8e87252";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/qt-gui-app/default.nix
+++ b/distros/lyrical/qt-gui-app/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, qt-gui }:
 buildRosPackage {
   pname = "ros-lyrical-qt-gui-app";
-  version = "2.11.0-r1";
+  version = "2.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/lyrical/qt_gui_app/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "0761a38195f96d4ab60cf7361648214b2d1aec8a2c775c93bc5235fd543d047e";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/lyrical/qt_gui_app/2.11.1-1.tar.gz";
+    name = "2.11.1-1.tar.gz";
+    sha256 = "918e5990bae03528be3285ed57a1fc310dba13ed2291d5b76005a1b1f306b6f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/qt-gui-core/default.nix
+++ b/distros/lyrical/qt-gui-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, qt-dotgraph, qt-gui, qt-gui-app, qt-gui-cpp, qt-gui-py-common }:
 buildRosPackage {
   pname = "ros-lyrical-qt-gui-core";
-  version = "2.11.0-r1";
+  version = "2.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/lyrical/qt_gui_core/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "0c7d273539c077f9f3632f8517c583e6abd15a1c348c59762dfe04798861394f";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/lyrical/qt_gui_core/2.11.1-1.tar.gz";
+    name = "2.11.1-1.tar.gz";
+    sha256 = "4a53e5c2ca00bc412aed56a6522e944217d83127413e8c8bf289bfc51337d9c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/qt-gui-cpp/default.nix
+++ b/distros/lyrical/qt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, pkg-config, pluginlib, python-qt-binding, qt-gui, qt6, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-lyrical-qt-gui-cpp";
-  version = "2.11.0-r1";
+  version = "2.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/lyrical/qt_gui_cpp/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "2d7a5adec0ddae610bf94645320b82bdd3831746a7e79772d62c97cd976650f4";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/lyrical/qt_gui_cpp/2.11.1-1.tar.gz";
+    name = "2.11.1-1.tar.gz";
+    sha256 = "a33157bb2b5d3ef3c6d2cdf6c58081fc3311defe79850cbed187871a72c5f676";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/qt-gui-py-common/default.nix
+++ b/distros/lyrical/qt-gui-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding }:
 buildRosPackage {
   pname = "ros-lyrical-qt-gui-py-common";
-  version = "2.11.0-r1";
+  version = "2.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/lyrical/qt_gui_py_common/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "8094ea80cbca28975b72ced347a271af0f8591378f9ba54343b7e7e43a0e0c85";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/lyrical/qt_gui_py_common/2.11.1-1.tar.gz";
+    name = "2.11.1-1.tar.gz";
+    sha256 = "1010486f3aed4a42c86eb7e4d7c9cc0a14dc4eef0b971d4069b4ddd482aa9025";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/qt-gui/default.nix
+++ b/distros/lyrical/qt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages, tango-icons-vendor }:
 buildRosPackage {
   pname = "ros-lyrical-qt-gui";
-  version = "2.11.0-r1";
+  version = "2.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/lyrical/qt_gui/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "5718542938f2babc337c2937e4143147080687e4ee7750449fe12cb2af4adb78";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/lyrical/qt_gui/2.11.1-1.tar.gz";
+    name = "2.11.1-1.tar.gz";
+    sha256 = "e78db40d3661d3fb7ff462018a319ee42b3941ec21648602bd57268166731342";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rmw-desert/default.nix
+++ b/distros/lyrical/rmw-desert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros-core, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-cmake, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-lyrical-rmw-desert";
-  version = "4.0.1-r4";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_desert-release/archive/release/lyrical/rmw_desert/4.0.1-4.tar.gz";
-    name = "4.0.1-4.tar.gz";
-    sha256 = "148236ce4645ab3d88538f18487dce2ea1eafe16a6d3f5784dd35b5aeee96ffd";
+    url = "https://github.com/ros2-gbp/rmw_desert-release/archive/release/lyrical/rmw_desert/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "1722c7d3e8ae1df174df0f773f4ba77bcd69be556d1e72cddf44530997b534c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ros2-medkit-action-status-bridge/default.nix
+++ b/distros/lyrical/ros2-medkit-action-status-bridge/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-testing-ament-cmake, launch-testing-ros, rclcpp, ros2-medkit-cmake, ros2-medkit-fault-manager, ros2-medkit-fault-reporter, ros2-medkit-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-ros2-medkit-action-status-bridge";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_action_status_bridge/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "e84f349eb5ad0231c9a19abcdb626203c2412bf7729960c2a02a4c500f24644f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros2-medkit-cmake ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-clang-tidy ament-cmake-gtest ament-lint-auto ament-lint-common launch-testing-ament-cmake launch-testing-ros ros2-medkit-fault-manager ];
+  propagatedBuildInputs = [ action-msgs rclcpp ros2-medkit-fault-reporter ros2-medkit-msgs ];
+  nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
+
+  meta = {
+    description = "Bridge node turning terminal ROS2 action goal states (aborted) into FaultManager faults";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/ros2-medkit-beacon-common/default.nix
+++ b/distros/lyrical/ros2-medkit-beacon-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nlohmann_json, rclcpp, ros2-medkit-cmake, ros2-medkit-gateway, ros2-medkit-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-ros2-medkit-beacon-common";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_beacon_common/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "edecb201075cf5fa24145df4b9d7d41115338915f704054a3859e791888de770";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_beacon_common/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "fa96763df999d2b68f3766a89e2741dabd7f7576a1bd45049afe7b3c76477f86";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ros2-medkit-cmake/default.nix
+++ b/distros/lyrical/ros2-medkit-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-lyrical-ros2-medkit-cmake";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_cmake/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "4bb1348375f7f39c89f2a5d5c35bd8e9b16ac9ea601ad1414afa0e977b3af7ce";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_cmake/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "816ff614853d2da57810999c997225217c0d530d723f635a107407ee2b4e9fdd";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ros2-medkit-diagnostic-bridge/default.nix
+++ b/distros/lyrical/ros2-medkit-diagnostic-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch-testing-ament-cmake, launch-testing-ros, rclcpp, ros2-medkit-cmake, ros2-medkit-fault-manager, ros2-medkit-fault-reporter, ros2-medkit-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-ros2-medkit-diagnostic-bridge";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_diagnostic_bridge/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "cf026d655ebc00549f2610ff02439d1ab7a0c0c976e0ff8699032cd5c709f28d";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_diagnostic_bridge/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "69254dc414fb1ac8c9b94e995c6a69f4cd08392481ec63ac868bb469ffdc7607";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ros2-medkit-fault-manager/default.nix
+++ b/distros/lyrical/ros2-medkit-fault-manager/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-testing-ament-cmake, launch-testing-ros, nlohmann_json, rclcpp, ros2-medkit-cmake, ros2-medkit-msgs, ros2-medkit-serialization, rosbag2-cpp, rosbag2-storage, rosbag2-storage-mcap, sensor-msgs, sqlite, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, nlohmann_json, rclcpp, ros2-medkit-cmake, ros2-medkit-msgs, ros2-medkit-serialization, rosbag2-cpp, rosbag2-py, rosbag2-storage, rosbag2-storage-mcap, sensor-msgs, sqlite, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-ros2-medkit-fault-manager";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_fault_manager/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "866501e960f7b92ea60fed43ed772b1f869bcd41699634289b9aa27b5329b3d8";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_fault_manager/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "0160b010c7bb98f7e535da5ccd22e1cf4ddd80c11be130a6c9548aabafcb3faa";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros2-medkit-cmake ];
-  checkInputs = [ ament-cmake-clang-format ament-cmake-clang-tidy ament-cmake-gtest ament-lint-auto ament-lint-common launch-testing-ament-cmake launch-testing-ros sensor-msgs std-msgs ];
-  propagatedBuildInputs = [ nlohmann_json rclcpp ros2-medkit-msgs ros2-medkit-serialization rosbag2-cpp rosbag2-storage rosbag2-storage-mcap sqlite ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-clang-tidy ament-cmake-gtest ament-lint-auto ament-lint-common launch-ros launch-testing-ament-cmake launch-testing-ros rosbag2-py rosbag2-storage-mcap sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ ament-index-python launch launch-ros nlohmann_json rclcpp ros2-medkit-msgs ros2-medkit-serialization rosbag2-cpp rosbag2-storage sqlite ];
   nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
 
   meta = {

--- a/distros/lyrical/ros2-medkit-fault-reporter/default.nix
+++ b/distros/lyrical/ros2-medkit-fault-reporter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-testing-ament-cmake, launch-testing-ros, rclcpp, ros2-medkit-cmake, ros2-medkit-fault-manager, ros2-medkit-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-ros2-medkit-fault-reporter";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_fault_reporter/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "5c0d2fd908eabbade989c3ed6c9ef77f852b19092f90a3cca71573bec1cb43a4";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_fault_reporter/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "ff292cc04e377eb0e9b62fc7e3863dce43beadd77d1e245e83ff99b414c40497";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ros2-medkit-gateway/default.nix
+++ b/distros/lyrical/ros2-medkit-gateway/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, example-interfaces, httplib, nlohmann_json, openssl, rcl-interfaces, rclcpp, rclcpp-action, ros2-medkit-cmake, ros2-medkit-msgs, ros2-medkit-serialization, rosidl-parser, rosidl-runtime-py, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, sensor-msgs, sqlite, std-msgs, std-srvs, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-index-cpp, ament-index-python, ament-lint-auto, ament-lint-common, example-interfaces, httplib, launch, launch-ros, lifecycle-msgs, nlohmann_json, openssl, rcl-interfaces, rclcpp, rclcpp-action, ros2-medkit-action-status-bridge, ros2-medkit-cmake, ros2-medkit-diagnostic-bridge, ros2-medkit-fault-manager, ros2-medkit-log-bridge, ros2-medkit-msgs, ros2-medkit-serialization, rosidl-parser, rosidl-runtime-py, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, sensor-msgs, sqlite, std-msgs, std-srvs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-lyrical-ros2-medkit-gateway";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_gateway/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "e269a6055a4178b5d8f2ea882eb95764f11f9d426e1aa77500fb437b303a8d6f";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_gateway/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "33c9d4c71585eabc555f0ca4278a6ce3a366c12c465a9f550f25d192d1dcedb4";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros2-medkit-cmake ];
   checkInputs = [ ament-cmake-clang-format ament-cmake-clang-tidy ament-cmake-gtest ament-lint-auto ament-lint-common example-interfaces rclcpp-action ];
-  propagatedBuildInputs = [ action-msgs ament-index-cpp httplib nlohmann_json openssl rcl-interfaces rclcpp ros2-medkit-msgs ros2-medkit-serialization rosidl-parser rosidl-runtime-py rosidl-typesupport-cpp rosidl-typesupport-introspection-cpp sensor-msgs sqlite std-msgs std-srvs yaml-cpp-vendor ];
+  propagatedBuildInputs = [ action-msgs ament-index-cpp ament-index-python httplib launch launch-ros lifecycle-msgs nlohmann_json openssl rcl-interfaces rclcpp ros2-medkit-action-status-bridge ros2-medkit-diagnostic-bridge ros2-medkit-fault-manager ros2-medkit-log-bridge ros2-medkit-msgs ros2-medkit-serialization rosidl-parser rosidl-runtime-py rosidl-typesupport-cpp rosidl-typesupport-introspection-cpp sensor-msgs sqlite std-msgs std-srvs yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
 
   meta = {

--- a/distros/lyrical/ros2-medkit-graph-provider/default.nix
+++ b/distros/lyrical/ros2-medkit-graph-provider/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, nlohmann_json, rclcpp, ros2-medkit-cmake, ros2-medkit-gateway, ros2-medkit-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-ros2-medkit-graph-provider";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_graph_provider/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "a3ce6fc1973ee57417d998b8676dd45b42ee507600603ebd4e87af5db86483af";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_graph_provider/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "cff8db855c4fef976fdad3cae276c9ac807d27075a18764928d34548d02d7b5e";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ros2-medkit-integration-tests/default.nix
+++ b/distros/lyrical/ros2-medkit-integration-tests/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, diagnostic-msgs, example-interfaces, launch-ros, launch-testing, launch-testing-ament-cmake, python3Packages, rcl-interfaces, rclcpp, rclcpp-action, ros2-medkit-cmake, ros2-medkit-fault-manager, ros2-medkit-gateway, ros2-medkit-graph-provider, ros2-medkit-linux-introspection, ros2-medkit-msgs, ros2-medkit-param-beacon, ros2-medkit-topic-beacon, sensor-msgs, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, diagnostic-msgs, example-interfaces, launch-ros, launch-testing, launch-testing-ament-cmake, python3Packages, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2-medkit-cmake, ros2-medkit-fault-manager, ros2-medkit-gateway, ros2-medkit-graph-provider, ros2-medkit-linux-introspection, ros2-medkit-msgs, ros2-medkit-param-beacon, ros2-medkit-topic-beacon, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-lyrical-ros2-medkit-integration-tests";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_integration_tests/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "8327dc8aa0f7ee84fbd684b60a3d507988acd525695e925172e8334415284d9c";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_integration_tests/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "a0214b81bf149f1dc1e263c305bf4e54626c8b7bfc585c37f8de99527132ad16";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ros2-medkit-cmake ];
   checkInputs = [ ament-index-python launch-ros launch-testing launch-testing-ament-cmake python3Packages.jsonschema python3Packages.requests ros2-medkit-fault-manager ros2-medkit-gateway ros2-medkit-graph-provider ros2-medkit-linux-introspection ros2-medkit-param-beacon ros2-medkit-topic-beacon ];
-  propagatedBuildInputs = [ diagnostic-msgs example-interfaces rcl-interfaces rclcpp rclcpp-action ros2-medkit-msgs sensor-msgs std-msgs std-srvs ];
+  propagatedBuildInputs = [ diagnostic-msgs example-interfaces rcl-interfaces rclcpp rclcpp-action rclcpp-lifecycle ros2-medkit-msgs sensor-msgs std-msgs std-srvs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ros2-medkit-cmake ];
 
   meta = {

--- a/distros/lyrical/ros2-medkit-linux-introspection/default.nix
+++ b/distros/lyrical/ros2-medkit-linux-introspection/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, nlohmann_json, pkg-config, ros2-medkit-cmake, ros2-medkit-gateway, systemd }:
 buildRosPackage {
   pname = "ros-lyrical-ros2-medkit-linux-introspection";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_linux_introspection/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "c360d4388c0f4c7b0f1c07183ba8d8eb35d67e688fdfda6a6bcf8ddba8e8ccbe";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_linux_introspection/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "7ced75ae3d026913e1a78b34ee368f431c8367b61ce8d70a36e5356e9e4a76d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ros2-medkit-log-bridge/default.nix
+++ b/distros/lyrical/ros2-medkit-log-bridge/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-testing-ament-cmake, launch-testing-ros, rcl-interfaces, rclcpp, ros2-medkit-cmake, ros2-medkit-fault-manager, ros2-medkit-fault-reporter, ros2-medkit-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-ros2-medkit-log-bridge";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_log_bridge/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "6a7c216c7076cc332ab6476db1456d51ed8f088f0e3ccd485363a671f72b4521";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros2-medkit-cmake ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-clang-tidy ament-cmake-gtest ament-lint-auto ament-lint-common launch-testing-ament-cmake launch-testing-ros ros2-medkit-fault-manager ];
+  propagatedBuildInputs = [ rcl-interfaces rclcpp ros2-medkit-fault-reporter ros2-medkit-msgs ];
+  nativeBuildInputs = [ ament-cmake ros2-medkit-cmake ];
+
+  meta = {
+    description = "Bridge node promoting ROS2 /rosout log entries to FaultManager faults";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/ros2-medkit-msgs/default.nix
+++ b/distros/lyrical/ros2-medkit-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-lyrical-ros2-medkit-msgs";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_msgs/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "009e3c5deab91bfbc65933957964650ad974ad516fe7da3f14ea877c0ed5b4d3";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_msgs/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "1757a043c1c2ecc3649e00c8f8d7525e3d1cc2025dcd451c88b7720092d963dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ros2-medkit-param-beacon/default.nix
+++ b/distros/lyrical/ros2-medkit-param-beacon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-lint-auto, ament-lint-common, nlohmann_json, rclcpp, ros2-medkit-beacon-common, ros2-medkit-cmake, ros2-medkit-gateway }:
 buildRosPackage {
   pname = "ros-lyrical-ros2-medkit-param-beacon";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_param_beacon/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "89f5953095bfc346da30ff76411c736046022e56258ef4d678e629c915c99a4b";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_param_beacon/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "df6a9a39428be70d5a444af282a7fb42d10ea248533d08b96fc0d5719262abae";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ros2-medkit-serialization/default.nix
+++ b/distros/lyrical/ros2-medkit-serialization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-clang-tidy, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nlohmann_json, rclcpp, rcpputils, rcutils, ros2-medkit-cmake, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, sensor-msgs, std-msgs, std-srvs, test-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-lyrical-ros2-medkit-serialization";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_serialization/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "89f3f1d12638a0f80ec783f37919b23453283c99ff4093a26b06729ccac3d196";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_serialization/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "fe5fb5736e6a715614802c330ea562238de67e5a1806b7b889a991ca72cf2dc8";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ros2-medkit-sovd-service-interface/default.nix
+++ b/distros/lyrical/ros2-medkit-sovd-service-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nlohmann_json, rclcpp, ros2-medkit-cmake, ros2-medkit-gateway, ros2-medkit-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-ros2-medkit-sovd-service-interface";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_sovd_service_interface/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "42790648a13209ac81565af31f852c7ce605d577be04a07aba9bf00d361612e6";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_sovd_service_interface/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "4ca6ee20c265cfcdc53530a5ee26bab6736dd83abcded58e6288bc0d1f85aca1";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ros2-medkit-topic-beacon/default.nix
+++ b/distros/lyrical/ros2-medkit-topic-beacon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, nlohmann_json, rclcpp, ros2-medkit-beacon-common, ros2-medkit-cmake, ros2-medkit-gateway, ros2-medkit-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-ros2-medkit-topic-beacon";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_topic_beacon/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "65435d06789e741c60a72b9d3d42f95fbe209f39f6d9f0883aedd04bbd6d416a";
+    url = "https://github.com/ros2-gbp/ros2_medkit-release/archive/release/lyrical/ros2_medkit_topic_beacon/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "8283c5239346dbb3e33e69b228d84e81fab2cac3b4dc4d2204853e8e014afdca";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rosbag-timing-inspector/default.nix
+++ b/distros/lyrical/rosbag-timing-inspector/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, glfw3, libGL, libGLU, rosbag2-cpp, rosbag2-storage }:
+buildRosPackage {
+  pname = "ros-lyrical-rosbag-timing-inspector";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbag_timing_inspector-release/archive/release/lyrical/rosbag_timing_inspector/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "05d18e9de8ea7646c2fea2164862c951124a7ff00a8670ea2012858781568fee";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake glfw3 libGL libGLU ];
+  propagatedBuildInputs = [ rosbag2-cpp rosbag2-storage ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "GUI tool to visualize and analyze message timing from ROS2 bags (mcap or db3).";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/lyrical/rqt-bag-plugins/default.nix
+++ b/distros/lyrical/rqt-bag-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, builtin-interfaces, geometry-msgs, python3Packages, rclpy, rosbag2, rqt-bag, rqt-gui, rqt-gui-py, rqt-plot, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-rqt-bag-plugins";
-  version = "2.2.4-r1";
+  version = "2.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/lyrical/rqt_bag_plugins/2.2.4-1.tar.gz";
-    name = "2.2.4-1.tar.gz";
-    sha256 = "cd0eab7ff4e6554d285b547aeabdcd950680da4103775a3d4a907f4561f6682e";
+    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/lyrical/rqt_bag_plugins/2.2.5-1.tar.gz";
+    name = "2.2.5-1.tar.gz";
+    sha256 = "4a7518c5afff875df1e7552e411a956d2703e624fdad7ffa1b7b099488cb7abb";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/rqt-bag/default.nix
+++ b/distros/lyrical/rqt-bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, builtin-interfaces, python-qt-binding, python3Packages, rclpy, rosbag2-py, rosidl-runtime-py, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-lyrical-rqt-bag";
-  version = "2.2.4-r1";
+  version = "2.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/lyrical/rqt_bag/2.2.4-1.tar.gz";
-    name = "2.2.4-1.tar.gz";
-    sha256 = "395244eaac5ded68d4468d4c362c76105007162f6d4c990be209797b569a4b81";
+    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/lyrical/rqt_bag/2.2.5-1.tar.gz";
+    name = "2.2.5-1.tar.gz";
+    sha256 = "fab9bc6faefee350ee26a7710b508d57daaef3b320cf640bb6af8fb0dcc917e9";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/rqt-gui-cpp/default.nix
+++ b/distros/lyrical/rqt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, qt-gui-cpp, qt6, rclcpp }:
 buildRosPackage {
   pname = "ros-lyrical-rqt-gui-cpp";
-  version = "1.10.5-r1";
+  version = "1.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/lyrical/rqt_gui_cpp/1.10.5-1.tar.gz";
-    name = "1.10.5-1.tar.gz";
-    sha256 = "66b1c6327dc6ae73a6db4c86f29013469b73e2759608b89d4e37985bb1997b9e";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/lyrical/rqt_gui_cpp/1.10.6-1.tar.gz";
+    name = "1.10.6-1.tar.gz";
+    sha256 = "c5317e725a833a762d9d99ec1014f42990c7af9cbf03490167c63473ef7ccafc";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rqt-gui-py/default.nix
+++ b/distros/lyrical/rqt-gui-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui }:
 buildRosPackage {
   pname = "ros-lyrical-rqt-gui-py";
-  version = "1.10.5-r1";
+  version = "1.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/lyrical/rqt_gui_py/1.10.5-1.tar.gz";
-    name = "1.10.5-1.tar.gz";
-    sha256 = "75f83367d60103e17f446d3fc83eb388c16ae0a6c4f93226901fc32adcc4218c";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/lyrical/rqt_gui_py/1.10.6-1.tar.gz";
+    name = "1.10.6-1.tar.gz";
+    sha256 = "e6b5ecedb8695bb536946934fb2f0df843b1c625034fd0b00367ac4a3210fd17";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/rqt-gui/default.nix
+++ b/distros/lyrical/rqt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, python-qt-binding, python3Packages, qt-gui, rclpy }:
 buildRosPackage {
   pname = "ros-lyrical-rqt-gui";
-  version = "1.10.5-r1";
+  version = "1.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/lyrical/rqt_gui/1.10.5-1.tar.gz";
-    name = "1.10.5-1.tar.gz";
-    sha256 = "59ce23e1f2474b0e27382823120d0a765c981b3acb9c594b79d41109c340ac17";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/lyrical/rqt_gui/1.10.6-1.tar.gz";
+    name = "1.10.6-1.tar.gz";
+    sha256 = "2591accabbe68694cd96a238b09d789cadfda0a847004321bc6cedc89bb4dce7";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/rqt-py-common/default.nix
+++ b/distros/lyrical/rqt-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, python-qt-binding, qt-gui, qt6, rclpy, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-lyrical-rqt-py-common";
-  version = "1.10.5-r1";
+  version = "1.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/lyrical/rqt_py_common/1.10.5-1.tar.gz";
-    name = "1.10.5-1.tar.gz";
-    sha256 = "068dedd97403480b891ff24d85442b7cac33868cbca96d363a9d8e2e11c4de3b";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/lyrical/rqt_py_common/1.10.6-1.tar.gz";
+    name = "1.10.6-1.tar.gz";
+    sha256 = "929a2d78fc153fc2bae2d696da86afe84821f2bfdf62066c320654e9e0cfc007";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rqt/default.nix
+++ b/distros/lyrical/rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages, rqt-gui, rqt-gui-cpp, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-lyrical-rqt";
-  version = "1.10.5-r1";
+  version = "1.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/lyrical/rqt/1.10.5-1.tar.gz";
-    name = "1.10.5-1.tar.gz";
-    sha256 = "1f239d9a0746c0a5acb149501f292c8eb8fe0e698083fd1d7ac7d63f1350720e";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/lyrical/rqt/1.10.6-1.tar.gz";
+    name = "1.10.6-1.tar.gz";
+    sha256 = "bc839be2521c5798d3a918114d6cb81827691e3be83a28cf84da40c8cd6b508d";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/rtabmap-conversions/default.nix
+++ b/distros/lyrical/rtabmap-conversions/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, geometry-msgs, image-geometry, laser-geometry, pcl-conversions, rclcpp, rclcpp-components, ros-environment, rtabmap, rtabmap-msgs, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-rtabmap-conversions";
+  version = "0.23.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/lyrical/rtabmap_conversions/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "f1166be56bacfd93ab4992b9d7d78d3c20f53175818ebeb7abb02bf408fcbcf7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs image-geometry laser-geometry pcl-conversions rclcpp rclcpp-components rtabmap rtabmap-msgs sensor-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "RTAB-Map's conversions package. This package can be used to convert rtabmap_msgs's msgs into RTAB-Map's library objects.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/rtabmap-demos/default.nix
+++ b/distros/lyrical/rtabmap-demos/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz }:
+buildRosPackage {
+  pname = "ros-lyrical-rtabmap-demos";
+  version = "0.23.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/lyrical/rtabmap_demos/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "e746d08da8f0f534d095a58a2f86ee7f9d1737994cfe149605d792faaee893bc";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ rtabmap-odom rtabmap-rviz-plugins rtabmap-slam rtabmap-util rtabmap-viz ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "RTAB-Map's demo launch files.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/rtabmap-examples/default.nix
+++ b/distros/lyrical/rtabmap-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, imu-filter-madgwick, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-rtabmap-examples";
+  version = "0.23.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/lyrical/rtabmap_examples/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "22bdad54cc6532ca2254715a06d8bb8697b7b667f0147bc4a3090dc4efe0f2a4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ imu-filter-madgwick rtabmap-odom rtabmap-rviz-plugins rtabmap-slam rtabmap-util rtabmap-viz tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "RTAB-Map's example launch files.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/rtabmap-launch/default.nix
+++ b/distros/lyrical/rtabmap-launch/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rtabmap-msgs, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz }:
+buildRosPackage {
+  pname = "ros-lyrical-rtabmap-launch";
+  version = "0.23.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/lyrical/rtabmap_launch/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "87816749f34f6dbd12e02c77e4775ccfc13803bfc9f7a90fad68f10e37042b3e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ rtabmap-msgs rtabmap-odom rtabmap-rviz-plugins rtabmap-slam rtabmap-util rtabmap-viz ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "RTAB-Map's main launch files.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/rtabmap-msgs/default.nix
+++ b/distros/lyrical/rtabmap-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-lyrical-rtabmap-msgs";
+  version = "0.23.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/lyrical/rtabmap_msgs/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "607ecb7b0294a756f323e3b50fc51f479dfe64a185aac94a19df8baa980b64cb";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime sensor-msgs std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "RTAB-Map's msgs package.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/rtabmap-odom/default.nix
+++ b/distros/lyrical/rtabmap-odom/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, image-geometry, laser-geometry, message-filters, nav-msgs, pcl-conversions, pcl-ros, pluginlib, rclcpp, rclcpp-components, ros-environment, rtabmap-conversions, rtabmap-msgs, rtabmap-sync, rtabmap-util, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-rtabmap-odom";
+  version = "0.23.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/lyrical/rtabmap_odom/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "2c1e8de795a6e3ddfc898578d4a0afc440bdfb7ee1212a7c165f7ec052eb26f4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ros-environment ];
+  propagatedBuildInputs = [ cv-bridge image-geometry laser-geometry message-filters nav-msgs pcl-conversions pcl-ros pluginlib rclcpp rclcpp-components rtabmap-conversions rtabmap-msgs rtabmap-sync rtabmap-util sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = "RTAB-Map's odometry package.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/rtabmap-python/default.nix
+++ b/distros/lyrical/rtabmap-python/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
+buildRosPackage {
+  pname = "ros-lyrical-rtabmap-python";
+  version = "0.23.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/lyrical/rtabmap_python/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "95cbbf8aefea795a5561f17ea1eea8e8c2721b5b7083e8c2bae36d68025e2a88";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
+
+  meta = {
+    description = "RTAB-Map's python package.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/rtabmap-ros/default.nix
+++ b/distros/lyrical/rtabmap-ros/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rtabmap-conversions, rtabmap-demos, rtabmap-examples, rtabmap-launch, rtabmap-msgs, rtabmap-odom, rtabmap-python, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-sync, rtabmap-util, rtabmap-viz }:
+buildRosPackage {
+  pname = "ros-lyrical-rtabmap-ros";
+  version = "0.23.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/lyrical/rtabmap_ros/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "51cfa246c997456a7a1e60a1013880fba9824eededeb274a3e0515de5a89c1c9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ rtabmap-conversions rtabmap-demos rtabmap-examples rtabmap-launch rtabmap-msgs rtabmap-odom rtabmap-python rtabmap-rviz-plugins rtabmap-slam rtabmap-sync rtabmap-util rtabmap-viz ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "RTAB-Map Stack";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/rtabmap-rviz-plugins/default.nix
+++ b/distros/lyrical/rtabmap-rviz-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, _unresolved_qtbase5-private-dev, ament-cmake-ros, pcl-conversions, pluginlib, rclcpp, ros-environment, rtabmap-conversions, rtabmap-msgs, rviz-common, rviz-default-plugins, rviz-rendering, sensor-msgs, std-msgs, tf2 }:
+buildRosPackage {
+  pname = "ros-lyrical-rtabmap-rviz-plugins";
+  version = "0.23.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/lyrical/rtabmap_rviz_plugins/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "d58e297f6e143f3757eeaf063c19189decfd1f7191dedeedc107b895b11450e2";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ _unresolved_qtbase5-private-dev ament-cmake-ros ros-environment ];
+  propagatedBuildInputs = [ pcl-conversions pluginlib rclcpp rtabmap-conversions rtabmap-msgs rviz-common rviz-default-plugins rviz-rendering sensor-msgs std-msgs tf2 ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = "RTAB-Map's rviz plugins.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/rtabmap-slam/default.nix
+++ b/distros/lyrical/rtabmap-slam/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, apriltag-msgs, aruco-msgs, aruco-opencv-msgs, cv-bridge, geometry-msgs, nav-msgs, rclcpp, rclcpp-components, ros-environment, rtabmap-msgs, rtabmap-sync, rtabmap-util, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-rtabmap-slam";
+  version = "0.23.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/lyrical/rtabmap_slam/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "17211447242705eddca7dab223e94071cd8c7c254e10897c963d98e1a2e2407f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ros-environment ];
+  propagatedBuildInputs = [ apriltag-msgs aruco-msgs aruco-opencv-msgs cv-bridge geometry-msgs nav-msgs rclcpp rclcpp-components rtabmap-msgs rtabmap-sync rtabmap-util sensor-msgs std-msgs std-srvs tf2 tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = "RTAB-Map's SLAM package.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/rtabmap-sync/default.nix
+++ b/distros/lyrical/rtabmap-sync/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, diagnostic-updater, image-transport, message-filters, nav-msgs, rclcpp, rclcpp-components, ros-environment, rtabmap-conversions, rtabmap-msgs, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-rtabmap-sync";
+  version = "0.23.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/lyrical/rtabmap_sync/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "47d247a56d83aea4f012b7cd0d11de2daad2be6ff0c92ee24a4fb875ec38377b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ros-environment ];
+  propagatedBuildInputs = [ cv-bridge diagnostic-updater image-transport message-filters nav-msgs rclcpp rclcpp-components rtabmap-conversions rtabmap-msgs sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = "RTAB-Map's synchronization package.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/rtabmap-util/default.nix
+++ b/distros/lyrical/rtabmap-util/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, image-geometry, image-transport, laser-geometry, message-filters, nav-msgs, octomap-msgs, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, ros-environment, rtabmap-conversions, rtabmap-msgs, rtabmap-sync, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-rtabmap-util";
+  version = "0.23.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/lyrical/rtabmap_util/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "a38646ba9a2d260470baa417572a7552f1abd248646c7d59f068840d706b7990";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment ];
+  propagatedBuildInputs = [ cv-bridge image-geometry image-transport laser-geometry message-filters nav-msgs octomap-msgs pcl-conversions pcl-ros rclcpp rclcpp-components rtabmap-conversions rtabmap-msgs rtabmap-sync sensor-msgs std-msgs stereo-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "RTAB-Map's various useful nodes and nodelets.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/rtabmap-viz/default.nix
+++ b/distros/lyrical/rtabmap-viz/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, geometry-msgs, nav-msgs, rclcpp, ros-environment, rtabmap-msgs, rtabmap-sync, std-msgs, std-srvs, tf2 }:
+buildRosPackage {
+  pname = "ros-lyrical-rtabmap-viz";
+  version = "0.23.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/lyrical/rtabmap_viz/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "0b268411c70866fda1548406aedbbdf071c107921a6aa2d32577da426dde6a3f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ros-environment ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs nav-msgs rclcpp rtabmap-msgs rtabmap-sync std-msgs std-srvs tf2 ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = "RTAB-Map's visualization package.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/rtabmap/default.nix
+++ b/distros/lyrical/rtabmap/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_libpointmatcher, cmake, cv-bridge, gtsam, libg2o, octomap, onetbb, pcl, proj, qt5, sqlite, zlib }:
+{ lib, buildRosPackage, fetchurl, cmake, cv-bridge, gtsam, libg2o, octomap, pcl, proj, qt-gui-cpp, sqlite, zlib }:
 buildRosPackage {
   pname = "ros-lyrical-rtabmap";
-  version = "0.22.1-r3";
+  version = "0.23.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rtabmap-release/archive/release/lyrical/rtabmap/0.22.1-3.tar.gz";
-    name = "0.22.1-3.tar.gz";
-    sha256 = "f3c226f2654d03ecd73ae46c4536f9da796de08950c6b0dd1b0168ba282682c1";
+    url = "https://github.com/ros2-gbp/rtabmap-release/archive/release/lyrical/rtabmap/0.23.7-1.tar.gz";
+    name = "0.23.7-1.tar.gz";
+    sha256 = "7420effcaedcf4d8ba5c5001d2626c2741a64e439b4549867c35d61cfd28b583";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake proj ];
-  propagatedBuildInputs = [ _unresolved_libpointmatcher cv-bridge gtsam libg2o octomap onetbb pcl qt5.qtbase sqlite zlib ];
+  propagatedBuildInputs = [ cv-bridge gtsam libg2o octomap pcl qt-gui-cpp sqlite zlib ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/lyrical/septentrio-gnss-driver/default.nix
+++ b/distros/lyrical/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, gtest-vendor, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-lyrical-septentrio-gnss-driver";
-  version = "1.4.6-r3";
+  version = "1.4.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/lyrical/septentrio_gnss_driver/1.4.6-3.tar.gz";
-    name = "1.4.6-3.tar.gz";
-    sha256 = "211f5eafafa2e621f3e5bff7a5a363ee4a98b4a2abbbe2aeaf3a951549e906dd";
+    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/lyrical/septentrio_gnss_driver/1.4.7-2.tar.gz";
+    name = "1.4.7-2.tar.gz";
+    sha256 = "c65b5ebb9d46ad5c6dd6ff53c781b4812e30778ff9668f236c2828145baa2846";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ublox-dgnss-node/default.nix
+++ b/distros/lyrical/ublox-dgnss-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-index-cpp, ament-lint-auto, ament-lint-common, libusb1, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-ublox-dgnss-node";
-  version = "0.7.4-r3";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/lyrical/ublox_dgnss_node/0.7.4-3.tar.gz";
-    name = "0.7.4-3.tar.gz";
-    sha256 = "56d70473515d4592b633e08dc110f6101b7363facf1d084e3b6d5d2121ef7ad4";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/lyrical/ublox_dgnss_node/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "dccf4d1ef1021843bea9cb73273c1d925b5bee76cde3fecda8fb2210f65f43e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ublox-dgnss/default.nix
+++ b/distros/lyrical/ublox-dgnss/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ntrip-client-node, ublox-dgnss-node, ublox-nav-sat-fix-hp-node, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-ublox-dgnss";
-  version = "0.7.4-r3";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/lyrical/ublox_dgnss/0.7.4-3.tar.gz";
-    name = "0.7.4-3.tar.gz";
-    sha256 = "6649e64b60ac85359b018168299a738b5a69cca430aac33344008b0dbe7e1372";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/lyrical/ublox_dgnss/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "0217b9a928aeb75b5eca9745645f3ca1d6914aad74ed3a6ca0d9f3ca1af2bcad";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ublox-nav-sat-fix-hp-node/default.nix
+++ b/distros/lyrical/ublox-nav-sat-fix-hp-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-ublox-nav-sat-fix-hp-node";
-  version = "0.7.4-r3";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/lyrical/ublox_nav_sat_fix_hp_node/0.7.4-3.tar.gz";
-    name = "0.7.4-3.tar.gz";
-    sha256 = "7d419061662a5b50f69e4487f2921f7a559da2676e10f675ca0e5169cf1535f4";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/lyrical/ublox_nav_sat_fix_hp_node/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "b8f6dc38e209f7005a64c952ee0bb3ef161210765b7e0dacbf4f060ebcbfdd20";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ublox-ubx-interfaces/default.nix
+++ b/distros/lyrical/ublox-ubx-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-lyrical-ublox-ubx-interfaces";
-  version = "0.7.4-r3";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/lyrical/ublox_ubx_interfaces/0.7.4-3.tar.gz";
-    name = "0.7.4-3.tar.gz";
-    sha256 = "9f873cbc846ac6f3abe039317f71e26e4fe2d37a3dee74ad6133b612d284c2f6";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/lyrical/ublox_ubx_interfaces/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "2a1ce855f111a31b75dbac573beca1d2328088eaf93d54410c4119e839322cdf";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ublox-ubx-msgs/default.nix
+++ b/distros/lyrical/ublox-ubx-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-ublox-ubx-msgs";
-  version = "0.7.4-r3";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/lyrical/ublox_ubx_msgs/0.7.4-3.tar.gz";
-    name = "0.7.4-3.tar.gz";
-    sha256 = "3ad7f65abffc2c511fa5a575f7c2fbca049cbd4e3c17b3eb0239a0f4c94ba91f";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/lyrical/ublox_ubx_msgs/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "95a38302d52f899cae0989473df502836332fbb692a237c5539f7af49f91db11";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/ur-client-library/default.nix
+++ b/distros/lyrical/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-lyrical-ur-client-library";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/lyrical/ur_client_library/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "66d012c11ecd4d394923b4390457babb74e6572405b721a5f7d1f224737770cd";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/lyrical/ur_client_library/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "f5ca9bbd946c19b04d45fd0c14c76a49d0d0978ad3a6e54c5ab84ebdc3c8b12a";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/ur10-inverse-dynamics-solver/default.nix
+++ b/distros/lyrical/ur10-inverse-dynamics-solver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, inverse-dynamics-solver, pluginlib, rclcpp, ros-testing, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, trajectory-msgs, ur-description }:
+buildRosPackage {
+  pname = "ros-lyrical-ur10-inverse-dynamics-solver";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/inverse_dynamics_solver-release/archive/release/lyrical/ur10_inverse_dynamics_solver/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "e674160270a0742fb8c8981f49a2c19afd4fd7d303fada670e27312ae27b073a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common rclcpp ros-testing rosbag2-cpp rosbag2-storage rosbag2-storage-default-plugins trajectory-msgs ];
+  propagatedBuildInputs = [ inverse-dynamics-solver pluginlib ur-description ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A C++ library implementing the inverse dynamics solver for the UR10 real robot.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/warehouse-ros-sqlite/default.nix
+++ b/distros/lyrical/warehouse-ros-sqlite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite, warehouse-ros }:
 buildRosPackage {
   pname = "ros-lyrical-warehouse-ros-sqlite";
-  version = "1.0.7-r3";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/lyrical/warehouse_ros_sqlite/1.0.7-3.tar.gz";
-    name = "1.0.7-3.tar.gz";
-    sha256 = "61cb892f60f640d9530e61263fe4551567a058c15fde639f98b5669964cc77e4";
+    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/lyrical/warehouse_ros_sqlite/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "55b9a60b17ff187835a4cd722396a1d733871269f724b255526c6a5b25b00b36";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/aruco-opencv-msgs/default.nix
+++ b/distros/rolling/aruco-opencv-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-lint-auto, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-aruco-opencv-msgs";
-  version = "6.1.2-r2";
+  version = "7.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aruco_opencv-release/archive/release/rolling/aruco_opencv_msgs/6.1.2-2.tar.gz";
-    name = "6.1.2-2.tar.gz";
-    sha256 = "098d581868f883678207e02423e9c423f21650280f994c4c16a75fd629513f3a";
+    url = "https://github.com/ros2-gbp/aruco_opencv-release/archive/release/rolling/aruco_opencv_msgs/7.0.0-1.tar.gz";
+    name = "7.0.0-1.tar.gz";
+    sha256 = "d5221b5bf31a54ec1798b3b8b717e8017ecdd27d78521a0d80856360040ae629";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/aruco-opencv/default.nix
+++ b/distros/rolling/aruco-opencv/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, aruco-opencv-msgs, cv-bridge, image-transport, python3Packages, rclcpp, rclcpp-components, rclcpp-lifecycle, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-aruco-opencv";
-  version = "6.1.2-r2";
+  version = "7.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aruco_opencv-release/archive/release/rolling/aruco_opencv/6.1.2-2.tar.gz";
-    name = "6.1.2-2.tar.gz";
-    sha256 = "bfde59ac10a54d507bfe19f7b001e8125b5ebe38fd6d8e242fc8ca9f63cf3ed5";
+    url = "https://github.com/ros2-gbp/aruco_opencv-release/archive/release/rolling/aruco_opencv/7.0.0-1.tar.gz";
+    name = "7.0.0-1.tar.gz";
+    sha256 = "4ea7d34c0235141c607d8f8efb123b2bb130bea4f2879980fbb00c1f68b2c537";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/autoware-cmake/default.nix
+++ b/distros/rolling/autoware-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, autoware-lint-common, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-autoware-cmake";
-  version = "1.2.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/rolling/autoware_cmake/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "2f8965f90afc133b01c067dbc8ad300e1e0755740b1a2272de0fdf551ba8b78c";
+    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/rolling/autoware_cmake/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "c77dee4c5008a395d6ee7670d7773fb54367d18c4f36e83a8a8bb1fece0db6f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/autoware-lint-common/default.nix
+++ b/distros/rolling/autoware-lint-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-cppcheck, ament-cmake-export-dependencies, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-rolling-autoware-lint-common";
-  version = "1.2.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/rolling/autoware_lint_common/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "18aea9b2640e0a9da52d99507c7018a4557701a05a90229115deb071b603a856";
+    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/rolling/autoware_lint_common/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "af02d51c21db9210612714ac26780301bab20c7df6384182c83e79893e5eebd9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/clips-vendor/default.nix
+++ b/distros/rolling/clips-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, unzip }:
 buildRosPackage {
   pname = "ros-rolling-clips-vendor";
-  version = "6.4.3-r2";
+  version = "6.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/clips_vendor-release/archive/release/rolling/clips_vendor/6.4.3-2.tar.gz";
-    name = "6.4.3-2.tar.gz";
-    sha256 = "9b937a8c0f5e482d1fdf188815badf23a634755328452fb946c4de8fd60fd53d";
+    url = "https://github.com/ros2-gbp/clips_vendor-release/archive/release/rolling/clips_vendor/6.4.4-1.tar.gz";
+    name = "6.4.4-1.tar.gz";
+    sha256 = "5736f0fae1b0c65c7dfba34490573910ee351207f15fcb21fecac53555f60828";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/clips-vendor/vendored-source.json
+++ b/distros/rolling/clips-vendor/vendored-source.json
@@ -1,6 +1,6 @@
 {
   "clips_vendor": {
-    "url": "https://raw.githubusercontent.com/carologistics/clips_vendor/r925/clipsrules-code-r925.zip",
-    "sha256": "08macis5ai6y6azzbp5mhyk30sx3qx3903wsbry9agfabgd2yviw"
+    "url": "https://raw.githubusercontent.com/carologistics/clips_vendor/r974/clipsrules-code-r974.zip",
+    "sha256": "0yg9gfqmql6fmw4qrzfm968nb10lnfxzlpish2xyscibax6gg97p"
   }
 }

--- a/distros/rolling/fkie-message-filters/default.nix
+++ b/distros/rolling/fkie-message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, image-transport, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-fkie-message-filters";
-  version = "3.3.1-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fkie_message_filters-release/archive/release/rolling/fkie_message_filters/3.3.1-1.tar.gz";
-    name = "3.3.1-1.tar.gz";
-    sha256 = "ae7f384d39ce1afa7b8a548b79d0ae04d4724775cfd4e1cd46c62a8ad60a216d";
+    url = "https://github.com/ros2-gbp/fkie_message_filters-release/archive/release/rolling/fkie_message_filters/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "c492e24a1430060b61c79e96625957bb0bd04cf26ea16161f4f85ee67b0139bd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/foxglove-bridge/default.nix
+++ b/distros/rolling/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, geometry-msgs, nlohmann_json, rcl-interfaces, rclcpp, rclcpp-components, rcpputils, rcutils, resource-retriever, ros-environment, rosgraph-msgs, rosidl-typesupport-introspection-cpp, rosx-introspection, sensor-msgs, std-msgs, std-srvs, websocketpp }:
 buildRosPackage {
   pname = "ros-rolling-foxglove-bridge";
-  version = "3.4.1-r1";
+  version = "3.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/3.4.1-1.tar.gz";
-    name = "3.4.1-1.tar.gz";
-    sha256 = "ecba8901b39de9dd302c1d6be80628b849cb12dc546062bfba5e6b2f22163d0c";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/3.4.2-1.tar.gz";
+    name = "3.4.2-1.tar.gz";
+    sha256 = "6780d06814aa822c2a4a04e309e5a56becfe96be947e277f3d6385294a1d7866";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/foxglove-msgs/default.nix
+++ b/distros/rolling/foxglove-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-foxglove-msgs";
-  version = "3.4.1-r1";
+  version = "3.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_msgs/3.4.1-1.tar.gz";
-    name = "3.4.1-1.tar.gz";
-    sha256 = "28feaf0f3d61531a82a33b0f0f0f9173c86cdbe54372ca6a036be3c99376934a";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_msgs/3.4.2-1.tar.gz";
+    name = "3.4.2-1.tar.gz";
+    sha256 = "9e234a6ee296b6c0b062cf56b629cc6b219149beb7250fc2c5f1b6f5af4c3754";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -1746,6 +1746,8 @@ self: super: {
 
  ompl = self.callPackage ./ompl {};
 
+ onnxruntime-vendor = self.callPackage ./onnxruntime-vendor {};
+
  open3d-vendor = self.callPackage ./open3d-vendor {};
 
  open-manipulator = self.callPackage ./open-manipulator {};

--- a/distros/rolling/librealsense2/default.nix
+++ b/distros/rolling/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, git, glfw3, libGL, libGLU, libusb1, libx11, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-rolling-librealsense2";
-  version = "2.57.7-r2";
+  version = "2.58.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/librealsense2-release/archive/release/rolling/librealsense2/2.57.7-2.tar.gz";
-    name = "2.57.7-2.tar.gz";
-    sha256 = "5994489f485b155766b4497fa8a074b78fa1ad6d33dba285522c293e776ffb25";
+    url = "https://github.com/ros2-gbp/librealsense2-release/archive/release/rolling/librealsense2/2.58.2-1.tar.gz";
+    name = "2.58.2-1.tar.gz";
+    sha256 = "734ee15ccb79dfc61f2b90b36866549cd9aa168f1391a4635151c10428c2b9a1";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mavlink/default.nix
+++ b/distros/rolling/mavlink/default.nix
@@ -5,16 +5,16 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mavlink";
-  version = "2026.6.6-r1";
+  version = "2026.6.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/rolling/mavlink/2026.6.6-1.tar.gz";
-    name = "2026.6.6-1.tar.gz";
-    sha256 = "bb11acb0ae6904df269949515f6f13b5a5b4798e4276673a0aedaeba62715c45";
+    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/rolling/mavlink/2026.6.19-1.tar.gz";
+    name = "2026.6.19-1.tar.gz";
+    sha256 = "67cc5062acef3b822c82ba2e4d100595d1a2f6e82f0a35ee028079e4f1cb487c";
   };
 
   buildType = "cmake";
-  buildInputs = [ ament-cmake cmake python3 python3Packages.future python3Packages.lxml ros-environment ];
+  buildInputs = [ ament-cmake cmake python3 python3Packages.lxml ros-environment ];
   nativeBuildInputs = [ ament-cmake cmake ros-environment ];
 
   meta = {

--- a/distros/rolling/ntrip-client-node/default.nix
+++ b/distros/rolling/ntrip-client-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, curl, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ntrip-client-node";
-  version = "0.7.4-r2";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ntrip_client_node/0.7.4-2.tar.gz";
-    name = "0.7.4-2.tar.gz";
-    sha256 = "9873b436c4a050b110e60d2657108411eaafc905f312823ee45d47b95b6fbc90";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ntrip_client_node/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "a8ef841e04bbd3651da5be723a611d6db61fe8e9b345bb004afde6aa22a042c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ompl/default.nix
+++ b/distros/rolling/ompl/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, flann, pkg-config }:
+{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, flann, pkg-config, python3, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-ompl";
-  version = "1.7.0-r3";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ompl-release/archive/release/rolling/ompl/1.7.0-3.tar.gz";
-    name = "1.7.0-3.tar.gz";
-    sha256 = "b8dabcb6e5ca2893e999e61ebb059f96f370e8e02f608d99e6e9e64eba44cac4";
+    url = "https://github.com/ros2-gbp/ompl-release/archive/release/rolling/ompl/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "53bbe0e7083e8561580de7d024e50fa31ecd2ba059173549b7d93fafcf36ae27";
   };
 
   buildType = "cmake";
-  buildInputs = [ cmake pkg-config ];
-  propagatedBuildInputs = [ boost eigen flann ];
-  nativeBuildInputs = [ cmake ];
+  buildInputs = [ cmake eigen pkg-config python3 ];
+  propagatedBuildInputs = [ boost flann yaml-cpp ];
+  nativeBuildInputs = [ cmake pkg-config ];
 
   meta = {
     description = "OMPL is a free sampling-based motion planning library.";

--- a/distros/rolling/onnxruntime-vendor/default.nix
+++ b/distros/rolling/onnxruntime-vendor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, git, pkg-config }:
+buildRosPackage {
+  pname = "ros-rolling-onnxruntime-vendor";
+  version = "0.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/onnxruntime_vendor-release/archive/release/rolling/onnxruntime_vendor/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "856e2b711b376d05a5faed49ab42b05829cd147544777375460d0e7e6acfed8d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-vendor-package git pkg-config ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package git ];
+
+  meta = {
+    description = "Vendor package for ONNX Runtime 1.24.3";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -84,14 +84,14 @@ in {
       # https://github.com/foxglove/foxglove-sdk/blob/main/ros/src/foxglove_bridge/CMakeLists.txt.
       # If the version doesn't match, cmake fails with "Hash mismatch"
       # and we can fix it here.
-      FOXGLOVE_SDK_VERSION = "0.25.1";
+      FOXGLOVE_SDK_VERSION = "0.25.3";
       systemToPlatform = {
         "x86_64-linux" = "x86_64-unknown-linux-gnu";
         "aarch64-linux" = "aarch64-unknown-linux-gnu";
       };
       systemToHash = {
-        "x86_64-linux" = "sha256-C500jfOo6Y0sLO4jYMyfUug7s0RQRN69dx0bRtw1i+Q=";
-        "aarch64-linux" = "sha256-xw41x48ON/O6jQJRzTHzU7sQsf0QYgDcbF9AntTfGRg=";
+        "x86_64-linux" = "sha256-1ItT8ULp2RpJe95jwDCwEg83a+VppDFd7MA02gGeWqc=";
+        "aarch64-linux" = "sha256-wiI9yymwU0sxzJ7RpR/sk4Y8EC3loKH6dJ9w8hFw/Nk=";
       };
       FOXGLOVE_SDK_PLATFORM = systemToPlatform.${self.system};
       sdk = self.fetchurl {

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -769,15 +769,6 @@ in {
     '';
   });
 
-  warehouse-ros-sqlite = rosSuper.warehouse-ros-sqlite.overrideAttrs ({
-    postPatch ? "", ...
-  }: {
-    # https://github.com/moveit/warehouse_ros_sqlite/pull/61
-    postPatch = postPatch + ''
-      substituteInPlace CMakeLists.txt --replace-fail " system" ""
-    '';
-  });
-
   webots-ros2-driver = rosSuper.webots-ros2-driver.overrideAttrs ({
     postPatch ? "", ...
   }: {

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -3,6 +3,7 @@ self:
 # Distro package set
 rosSelf: rosSuper: let
   inherit (rosSelf) lib;
+  inherit (lib) pipe patchExternalProjectGit patchVendorUrl;
 in {
   azure-iot-sdk-c = rosSuper.azure-iot-sdk-c.overrideAttrs ({
     postPatch ? "", ...
@@ -313,14 +314,27 @@ in {
     };
   });
 
-  librealsense2 = (lib.patchExternalProjectGit rosSuper.librealsense2 {
-    file = "CMake/external_libcurl.cmake";
-    originalUrl = ''"https://github.com/curl/curl.git"'';
-    url = "https://github.com/curl/curl.git";
-    originalRev = ''"curl-8_8_0"'';
-    rev = "curl-8_8_0";
-    fetchgitArgs.hash = "sha256-MjB6k8mDJypyuh6BN2hxy2My7/DfImjw+5iI729snBg=";
-  }).overrideAttrs ({
+  librealsense2 = (pipe rosSuper.librealsense2 [
+    (pkg: patchExternalProjectGit pkg {
+      file = "CMake/external_libcurl.cmake";
+      originalUrl = ''"https://github.com/curl/curl.git"'';
+      url = "https://github.com/curl/curl.git";
+      originalRev = ''"curl-8_8_0"'';
+      rev = "curl-8_8_0";
+      fetchgitArgs.hash = "sha256-MjB6k8mDJypyuh6BN2hxy2My7/DfImjw+5iI729snBg=";
+    })
+    (pkg: patchVendorUrl pkg {
+      file = "CMake/external_sqlite3.cmake";
+      url = "https://sqlite.org/2025/sqlite-amalgamation-3490100.zip";
+      hash = "sha256-bOvR2EA/xYww6Tk5skbz5uWNB2WlzVBUbxbAD9gF0sM=";
+    })
+    (pkg: patchExternalProjectGit pkg {
+      file = "CMake/external_yaml_cpp.cmake";
+      url = "https://github.com/jbeder/yaml-cpp.git";
+      rev = "yaml-cpp-0.7.0";
+      fetchgitArgs.hash = "sha256-2tFWccifn0c2lU/U1WNg2FHrBohjx8CXMllPJCevaNk=";
+    })
+  ]).overrideAttrs ({
     buildInputs ? [], postPatch ? "", ...
   }: {
     buildInputs = buildInputs ++ [ self.nlohmann_json ];
@@ -331,6 +345,17 @@ in {
       # Don't try to install to $HOME
       substituteInPlace tools/realsense-viewer/CMakeLists.txt \
         --replace-fail '$ENV{HOME}/Documents/librealsense2/presets' ''\'''${CMAKE_INSTALL_PREFIX}/share/librealsense2/presets'
+      substituteInPlace CMake/external_fastcdr.cmake \
+        --replace-fail ''\'''${CMAKE_BINARY_DIR}/third-party/fastcdr' '${fetchTarball {
+          url = "https://github.com/eProsima/Fast-CDR/archive/refs/tags/v1.0.25.tar.gz";
+          sha256 = "sha256:14v85zj5b5fnswhkpps09jk68w6miad8zbhlp625d2kj0yfw4cyp";
+        }}'
+      # If the command below fails, update the above command!
+      substituteInPlace CMake/external_fastcdr.cmake \
+        --replace-fail '--branch v1.0.25' 'see the comment'
+      # https://github.com/realsenseai/librealsense/issues/15120#issuecomment-4586244495
+      substituteInPlace third-party/realsense-file/CMakeLists.txt \
+        --replace-fail '$<$<COMPILE_LANGUAGE:C>:-include stdint.h>' ""
     '';
   });
 

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -491,18 +491,6 @@ in {
     '';
   });
 
-  ompl = rosSuper.ompl.overrideAttrs ({
-    patches ? [], ...
-  }: {
-    patches = patches ++ [
-      # https://github.com/ompl/ompl/pull/1306 merged
-      (self.fetchpatch2 {
-        url = "https://github.com/ompl/ompl/commit/44eaf82b6e9829d15317884f9b78ab24618c5f6f.patch?full_index=1";
-        hash = "sha256-SSC0Uk3ddHwRdv81cY7DRJS9uekYgr2Zv13Yk0bWl2M=";
-      })
-    ];
-  });
-
   pcl-conversions = rosSuper.pcl-conversions.overrideAttrs ({
     patches ? [], ...
   }: {

--- a/distros/rolling/protobuf-comm/default.nix
+++ b/distros/rolling/protobuf-comm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, openssl, protobuf, spdlog }:
 buildRosPackage {
   pname = "ros-rolling-protobuf-comm";
-  version = "0.9.3-r2";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/protobuf_comm-release/archive/release/rolling/protobuf_comm/0.9.3-2.tar.gz";
-    name = "0.9.3-2.tar.gz";
-    sha256 = "df8b4d5481f816e6565f3e67aa72f8d2785d9f6e4ce76ca36dc5872ea8951eaa";
+    url = "https://github.com/ros2-gbp/protobuf_comm-release/archive/release/rolling/protobuf_comm/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "32b95c74e5e75c9cc787cb7658d3d8a47e7ebb8a9d1c795a7373b46252579a63";
   };
 
   buildType = "cmake";

--- a/distros/rolling/qt-dotgraph/default.nix
+++ b/distros/rolling/qt-dotgraph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python-qt-binding, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-qt-dotgraph";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_dotgraph/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "2f91b51ed1362d848c1252d4eb48bfe1a244dd65a8586f75146110d241b8b658";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_dotgraph/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "faf2c2effba6231407108a5af7cd2283097aad3c32886603fd2fd762b47d4379";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/qt-gui-app/default.nix
+++ b/distros/rolling/qt-gui-app/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, qt-gui }:
 buildRosPackage {
   pname = "ros-rolling-qt-gui-app";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_app/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "a226ffc4667c71f299df31e27ddbeec92160778dd17e7e8e066edb024b32f8e6";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_app/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "e917107a1b921e66f47d6e1a250ad09fe977ab72e568889376709f43376d8fe7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/qt-gui-core/default.nix
+++ b/distros/rolling/qt-gui-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, qt-dotgraph, qt-gui, qt-gui-app, qt-gui-cpp, qt-gui-py-common }:
 buildRosPackage {
   pname = "ros-rolling-qt-gui-core";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_core/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "2bad40b8486a65c28d89d19c89ddc22333f350eadf4716a9801c4e5676ebb98a";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_core/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "50cdaf9daaf98587c0784bfb0de7f395fd5d6f9199049bf9576c24cf5a8cdaac";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/qt-gui-cpp/default.nix
+++ b/distros/rolling/qt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, pkg-config, pluginlib, python-qt-binding, qt-gui, qt6, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-rolling-qt-gui-cpp";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_cpp/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "f17396a10881d2aacb17ab28e750485be98d2dd9531586ab6d75419a92f8b876";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_cpp/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "d5a371b864786c50161676e59acda03ee1ca131c2e85baa1096b4bfcb421d168";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/qt-gui-py-common/default.nix
+++ b/distros/rolling/qt-gui-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding }:
 buildRosPackage {
   pname = "ros-rolling-qt-gui-py-common";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_py_common/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "edda57b56ef0be04ae2f533538fbea52ce4265ebb2617fffa0dd174f0746cc82";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_py_common/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "a5a666a6ab8f7b031a3c89db14340880dd1f02e15318adce89e871af3c0e5edb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/qt-gui/default.nix
+++ b/distros/rolling/qt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages, tango-icons-vendor }:
 buildRosPackage {
   pname = "ros-rolling-qt-gui";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "1ee0f9e3beb71cffdbb2066561f91e3604eef6c4a68993070a690711c94fe799";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "df476d61ce0cf565cae5b2defef1d6baaac69a4c67e5816dd57e8370e9f3a7af";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag-timing-inspector/default.nix
+++ b/distros/rolling/rosbag-timing-inspector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, glfw3, libGL, libGLU, rosbag2-cpp, rosbag2-storage }:
 buildRosPackage {
   pname = "ros-rolling-rosbag-timing-inspector";
-  version = "1.0.0-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag_timing_inspector-release/archive/release/rolling/rosbag_timing_inspector/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "fc81aac954c258e01d7e6c3b6b6ea324407a74dadf9d72bfb35074f5e40ce036";
+    url = "https://github.com/ros2-gbp/rosbag_timing_inspector-release/archive/release/rolling/rosbag_timing_inspector/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "ce7d50a9778c93acb375d4bd1d87c7e2da736f4bdb86a65bcf9917ec265c2565";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-bag-plugins/default.nix
+++ b/distros/rolling/rqt-bag-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, builtin-interfaces, geometry-msgs, python3Packages, rclpy, rosbag2, rqt-bag, rqt-gui, rqt-gui-py, rqt-plot, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-bag-plugins";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/rolling/rqt_bag_plugins/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "b4797632b7c2fb20405899f552385f2de7771665e7890c2244655bad2ed94e7a";
+    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/rolling/rqt_bag_plugins/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "18b52a7116f0e1c1994cc03e3b3dd8a84b7a0cf79381f6a812cb2fb7a81d8c71";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-bag/default.nix
+++ b/distros/rolling/rqt-bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, builtin-interfaces, python-qt-binding, python3Packages, rclpy, rosbag2-py, rosidl-runtime-py, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-bag";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/rolling/rqt_bag/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "0b640c55a7ca1b2bc4ea1340b2a3dee5c2e660fd25e88a7b8a3d4692e9fcb635";
+    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/rolling/rqt_bag/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "2742656819544d82ee17558987376ba7be4fac5c4c771947b13849a3e7430590";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-gui-cpp/default.nix
+++ b/distros/rolling/rqt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, qt-gui-cpp, qt6, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-rqt-gui-cpp";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui_cpp/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "4cc753fb3145df6a1ae83ad3bf253845a4a795b87fad028aef6019b3d74fc727";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui_cpp/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "5378a41f0950de8e8f3dbd300de65c4c4b984c6e934752f22d425138fabed845";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-gui-py/default.nix
+++ b/distros/rolling/rqt-gui-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui }:
 buildRosPackage {
   pname = "ros-rolling-rqt-gui-py";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui_py/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "9e6e0179d6eb60815fc14143e00e4c51299cc758b640ed609101964034c9b914";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui_py/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "4022118b7dea75887d347efb20d7fb261357680b974c7a8461bdd44b31725738";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-gui/default.nix
+++ b/distros/rolling/rqt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, python-qt-binding, python3Packages, qt-gui, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-rqt-gui";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "d28886e47edb54ed88363bdb18d8757d673776027d073456883d51edf085ca8b";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "c06b9714739004fab8cf1bfbf9688b92f77b479c429979bd2f563da5dc249e21";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-py-common/default.nix
+++ b/distros/rolling/rqt-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, python-qt-binding, qt-gui, qt6, rclpy, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rqt-py-common";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_py_common/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "0a6d92b70e0f5050ecbed92e2fecef707f9c1cb84e72272a21f60e9771f069d0";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_py_common/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "77e393fe0aa7b26349f1b28ba1e0c0db93651cd229d3bb23da7c2fe0df56fd96";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt/default.nix
+++ b/distros/rolling/rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages, rqt-gui, rqt-gui-cpp, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-rolling-rqt";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "9e998e9de4acd18b2ab7bc236ab40a4d7b131e04dc92dcc0b24bde74a6d5fb30";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "ac73914616a9b5f42cc5c41f3258ae72d5f4b2f46cb1706933e41764850d1e6a";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/septentrio-gnss-driver/default.nix
+++ b/distros/rolling/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, gtest-vendor, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-septentrio-gnss-driver";
-  version = "1.4.6-r2";
+  version = "1.4.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/rolling/septentrio_gnss_driver/1.4.6-2.tar.gz";
-    name = "1.4.6-2.tar.gz";
-    sha256 = "4156ab2d4540c5592cca39702e4755aaf958b2518b1e1a00d7344e3eb72065e3";
+    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/rolling/septentrio_gnss_driver/1.4.7-2.tar.gz";
+    name = "1.4.7-2.tar.gz";
+    sha256 = "7a3886e20870fa2c5160e468abe41048b47a2fd2ef6445331cad686d86ffd949";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/turtlesim-msgs/default.nix
+++ b/distros/rolling/turtlesim-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-turtlesim-msgs";
-  version = "1.11.1-r1";
+  version = "1.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/rolling/turtlesim_msgs/1.11.1-1.tar.gz";
-    name = "1.11.1-1.tar.gz";
-    sha256 = "20d4e637aaf24cb265d9e85317021769dc648f84dedbf9e2163d2dc64058c3f6";
+    url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/rolling/turtlesim_msgs/1.11.2-1.tar.gz";
+    name = "1.11.2-1.tar.gz";
+    sha256 = "6f2392f4396c42eeafa0d2472c618782fba907f4e7753dfcbd2968ed1aa7b108";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/turtlesim/default.nix
+++ b/distros/rolling/turtlesim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, qt6, rclcpp, rclcpp-action, std-msgs, std-srvs, turtlesim-msgs }:
 buildRosPackage {
   pname = "ros-rolling-turtlesim";
-  version = "1.11.1-r1";
+  version = "1.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/rolling/turtlesim/1.11.1-1.tar.gz";
-    name = "1.11.1-1.tar.gz";
-    sha256 = "a985a87111d04207a275bb202dec7168f65add32acfd58a293cd0dacff94abd0";
+    url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/rolling/turtlesim/1.11.2-1.tar.gz";
+    name = "1.11.2-1.tar.gz";
+    sha256 = "bde49368892ae4dcfbee5279574d19bb8dafe852d1962c857f760cd3d254f591";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-dgnss-node/default.nix
+++ b/distros/rolling/ublox-dgnss-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-index-cpp, ament-lint-auto, ament-lint-common, libusb1, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ublox-dgnss-node";
-  version = "0.7.4-r2";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_dgnss_node/0.7.4-2.tar.gz";
-    name = "0.7.4-2.tar.gz";
-    sha256 = "dd272f90866e499f7fbc2777b25b5b6325fbf7db7c9cd82a88a4fc19f190a3a8";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_dgnss_node/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "bd5ea120783d195c5e257fa121d19c459d0f383db160db4f6bb8f71b87f6f94d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-dgnss/default.nix
+++ b/distros/rolling/ublox-dgnss/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ntrip-client-node, ublox-dgnss-node, ublox-nav-sat-fix-hp-node, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ublox-dgnss";
-  version = "0.7.4-r2";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_dgnss/0.7.4-2.tar.gz";
-    name = "0.7.4-2.tar.gz";
-    sha256 = "e980ef86f73ea2005095f18141c1e781081aa339284600c26c795953339914e7";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_dgnss/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "5cfb1fae8facaf7578b28e37f878e15be0cd73be585ccdbd307d0c2d2a9ca9b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-nav-sat-fix-hp-node/default.nix
+++ b/distros/rolling/ublox-nav-sat-fix-hp-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ublox-nav-sat-fix-hp-node";
-  version = "0.7.4-r2";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_nav_sat_fix_hp_node/0.7.4-2.tar.gz";
-    name = "0.7.4-2.tar.gz";
-    sha256 = "8cfad403fadbe4b39f19f9d67d497c298590333fd9e973d4d0260d988dbda841";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_nav_sat_fix_hp_node/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "c18352f2f17e3187f3c7fa6ae6c63ce8bd3029287d7de1a0182f638f390cb00d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-ubx-interfaces/default.nix
+++ b/distros/rolling/ublox-ubx-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-rolling-ublox-ubx-interfaces";
-  version = "0.7.4-r2";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_ubx_interfaces/0.7.4-2.tar.gz";
-    name = "0.7.4-2.tar.gz";
-    sha256 = "164b30da650fcc5b533f5139ecd895e68b17dd17af919b1171fea1183611c4e7";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_ubx_interfaces/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "eec0ec55c5093301dcbffcf1a5d63b0619d39d3c9797a1ac3cab87bb73391e0f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-ubx-msgs/default.nix
+++ b/distros/rolling/ublox-ubx-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ublox-ubx-msgs";
-  version = "0.7.4-r2";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_ubx_msgs/0.7.4-2.tar.gz";
-    name = "0.7.4-2.tar.gz";
-    sha256 = "529bce0a911f61a3bded774770e510de4cd690bad304bc4d860deb4b2bb41ce2";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_ubx_msgs/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "374b160798e8d447a61e5b1607c58e09adb80499679fe2d24f8368c0ee546ffc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/warehouse-ros-sqlite/default.nix
+++ b/distros/rolling/warehouse-ros-sqlite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite, warehouse-ros }:
 buildRosPackage {
   pname = "ros-rolling-warehouse-ros-sqlite";
-  version = "1.0.7-r2";
+  version = "1.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/rolling/warehouse_ros_sqlite/1.0.7-2.tar.gz";
-    name = "1.0.7-2.tar.gz";
-    sha256 = "f467ca763a63cce556c8c9455e95ca41d6ea12902aaa73bef18c222dc9b899e4";
+    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/rolling/warehouse_ros_sqlite/1.0.8-2.tar.gz";
+    name = "1.0.8-2.tar.gz";
+    sha256 = "4719cd9c869a396dde11d09b56891e7055fb19f50c45ef342c552def1e3c1d87";
   };
 
   buildType = "ament_cmake";

--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
     "rosdistro": {
       "flake": false,
       "locked": {
-        "lastModified": 1781869206,
-        "narHash": "sha256-R4z1i9ud5wCUuyYgr+F+bLP0cMJgjk6/y/OiT5iSRJs=",
+        "lastModified": 1782470688,
+        "narHash": "sha256-9MkdEHS6wGHb1PyHyBuHIHKGA7z//1nBB+zXOq5F3Wc=",
         "owner": "ros",
         "repo": "rosdistro",
-        "rev": "f650d990cad69b0898e83e636c09863f05a0b08c",
+        "rev": "27f5821b9025f00cecf2936dd6698788fc87cf6a",
         "type": "github"
       },
       "original": {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,6 +1,9 @@
 self: super: with self.lib; {
   inherit (self.python3Packages) bloom;
 
+  # TODO: Remove after https://github.com/ros/rosdistro/pull/52350 is merged.
+  _unresolved_qtbase5-private-dev = self.qt5.qtbase;
+
   cargo-ament-build = self.python3Packages.cargo-ament-build;
 
   colcon = with self.python3Packages; colcon-core.withExtensions [

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -219,4 +219,13 @@ self: super: with self.lib; {
       self.ninja
     ];
   });
+  # TODO: Remove after https://github.com/NixOS/nixpkgs/pull/536748 is
+  # merged and available in this overlay.
+  vtkWithQt6 = super.vtkWithQt6.overrideAttrs ({
+    propagatedBuildInputs ? [], ...
+  }: {
+    propagatedBuildInputs = propagatedBuildInputs ++ [
+      self.qt6.qttools
+    ];
+  });
 }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -199,6 +199,9 @@ self: super: with self.lib; {
     qt6 = self.qt5;
     vtk = self.vtkWithQt5;
   };
+  pclWithQt6 = self.pcl.override {
+    vtk = self.vtkWithQt6;
+  };
 
   vtkWithQt5 = self.vtk.overrideAttrs ({
     cmakeFlags ? [], nativeBuildInputs ? [], propagatedBuildInputs ? [], ...


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'kilted', 'lyrical', 'rolling'] from nix-ros-overlay commit 4e8847b057fa630678977b6157852d862c972d7c.
This pull request was generated by running the following command:

```
superflore-gen-nix --dry-run --output-repository-path . --all --tar-archive-dir /home/runner/.ros/tar --upstream-branch develop
```

Changes:
========
Humble Changes:
---------------
* *autoware-cmake 1.2.0-r3 --> 1.4.0-r1*
* *autoware-lint-common 1.2.0-r3 --> 1.4.0-r1*
* *callback-isolated-executor 1.0.0-r1*
* *cie-config-msgs 1.0.0-r1*
* *cie-sample-application 1.0.0-r1*
* *cie-thread-configurator 1.0.0-r1*
* *clearpath-config-live 1.2.0-r1 --> 1.2.1-r1*
* *clearpath-desktop 1.2.0-r1 --> 1.2.1-r1*
* *clearpath-viz 1.2.0-r1 --> 1.2.1-r1*
* *clips-vendor 6.4.3-r1 --> 6.4.4-r1*
* *compass-msgs 0.3.0-r1 --> 0.3.1-r1*
* *fkie-message-filters 3.3.1-r1 --> 3.4.0-r1*
* *foxglove-bridge 3.4.1-r1 --> 3.4.2-r1*
* *foxglove-msgs 3.4.1-r1 --> 3.4.2-r1*
* *fusioncore-core 0.3.0-r1 --> 0.3.1-r1*
* *fusioncore-datasets 0.3.0-r1 --> 0.3.1-r1*
* *fusioncore-gazebo 0.3.0-r1 --> 0.3.1-r1*
* *fusioncore-ros 0.3.0-r1 --> 0.3.1-r1*
* *fusioncore-ublox 0.3.1-r1*
* *launch-pal 0.20.1-r1 --> 0.21.1-r1*
* *mobile-robot-simulator 2.0.1-r1*
* *nao-meshes 2.1.1-r1 --> 2.1.2-r1*
* *naoqi-bridge-msgs 2.1.0-r1 --> 2.1.1-r1*
* *naoqi-driver 2.1.1-r1 --> 2.1.2-r1*
* *naoqi-libqi 3.0.2-r1 --> 3.0.3-r1*
* *naoqi-libqicore 3.0.0-r1 --> 3.0.1-r1*
* *ntrip-client-node 0.7.4-r1 --> 0.7.5-r1*
* *omni-base-2dnav 2.22.0-r1 --> 2.22.1-r1*
* *omni-base-bringup 2.15.1-r1 --> 2.17.0-r1*
* *omni-base-controller-configuration 2.15.1-r1 --> 2.17.0-r1*
* *omni-base-description 2.15.1-r1 --> 2.17.0-r1*
* *omni-base-gazebo 2.11.1-r1 --> 2.14.1-r1*
* *omni-base-laser-sensors 2.22.0-r1 --> 2.22.1-r1*
* *omni-base-navigation 2.22.0-r1 --> 2.22.1-r1*
* *omni-base-rgbd-sensors 2.22.0-r1 --> 2.22.1-r1*
* *omni-base-robot 2.15.1-r1 --> 2.17.0-r1*
* *omni-base-simulation 2.11.1-r1 --> 2.14.1-r1*
* *onnxruntime-vendor 0.1.0-r2*
* *pal-gazebo-worlds 4.14.0-r1 --> 4.15.1-r1*
* *pal-gripper 3.6.5-r1 --> 3.6.6-r1*
* *pal-gripper-controller-configuration 3.6.5-r1 --> 3.6.6-r1*
* *pal-gripper-description 3.6.5-r1 --> 3.6.6-r1*
* *pal-gripper-simulation 3.6.5-r1 --> 3.6.6-r1*
* *pal-maps 0.5.0-r1 --> 0.6.0-r1*
* *pal-pro-gripper 1.11.3-r1 --> 1.12.5-r1*
* *pal-pro-gripper-bringup 1.11.3-r1 --> 1.12.5-r1*
* *pal-pro-gripper-controller-configuration 1.11.3-r1 --> 1.12.5-r1*
* *pal-pro-gripper-description 1.11.3-r1 --> 1.12.5-r1*
* *pal-pro-gripper-simulation 1.12.5-r1*
* *pal-pro-gripper-wrapper 1.11.3-r1 --> 1.12.5-r1*
* *pal-robotiq-controller-configuration 2.2.0-r1 --> 2.3.0-r1*
* *pal-robotiq-description 2.2.0-r1 --> 2.3.0-r1*
* *pal-robotiq-gripper 2.2.0-r1 --> 2.3.0-r1*
* *pal-sea-arm 1.23.2-r1 --> 2.6.0-r1*
* *pal-sea-arm-bringup 1.23.2-r1 --> 2.6.0-r1*
* *pal-sea-arm-controller-configuration 1.23.2-r1 --> 2.6.0-r1*
* *pal-sea-arm-description 1.23.2-r1 --> 2.6.0-r1*
* *pal-sea-arm-gazebo 1.0.4-r1 --> 1.1.2-r1*
* *pal-sea-arm-moveit-config 1.0.5-r1 --> 1.0.7-r1*
* *pal-sea-arm-mujoco 1.1.2-r1*
* *pal-sea-arm-simulation 1.0.4-r1 --> 1.1.2-r1*
* *pal-urdf-utils 2.3.3-r1 --> 2.9.1-r1*
* *pick-ik 1.1.1-r1 --> 1.1.2-r2*
* *play-motion2 1.8.4-r1 --> 1.8.5-r1*
* *play-motion2-cli 1.8.4-r1 --> 1.8.5-r1*
* *play-motion2-msgs 1.8.4-r1 --> 1.8.5-r1*
* *pmb2-2dnav 4.21.0-r1 --> 4.21.1-r1*
* *pmb2-bringup 5.11.2-r1 --> 5.12.0-r1*
* *pmb2-controller-configuration 5.11.2-r1 --> 5.12.0-r1*
* *pmb2-description 5.11.2-r1 --> 5.12.0-r1*
* *pmb2-gazebo 4.11.1-r1 --> 4.12.1-r1*
* *pmb2-laser-sensors 4.21.0-r1 --> 4.21.1-r1*
* *pmb2-navigation 4.21.0-r1 --> 4.21.1-r1*
* *pmb2-rgbd-sensors 4.21.0-r1 --> 4.21.1-r1*
* *pmb2-robot 5.11.2-r1 --> 5.12.0-r1*
* *pmb2-simulation 4.11.1-r1 --> 4.12.1-r1*
* *protobuf-comm 0.9.4-r1*
* *ros2-medkit-action-status-bridge 0.6.0-r1*
* *ros2-medkit-beacon-common 0.5.0-r2 --> 0.6.0-r1*
* *ros2-medkit-cmake 0.5.0-r2 --> 0.6.0-r1*
* *ros2-medkit-diagnostic-bridge 0.5.0-r2 --> 0.6.0-r1*
* *ros2-medkit-fault-manager 0.5.0-r2 --> 0.6.0-r1*
* *ros2-medkit-fault-reporter 0.5.0-r2 --> 0.6.0-r1*
* *ros2-medkit-gateway 0.5.0-r2 --> 0.6.0-r1*
* *ros2-medkit-graph-provider 0.5.0-r2 --> 0.6.0-r1*
* *ros2-medkit-integration-tests 0.5.0-r2 --> 0.6.0-r1*
* *ros2-medkit-linux-introspection 0.5.0-r2 --> 0.6.0-r1*
* *ros2-medkit-log-bridge 0.6.0-r1*
* *ros2-medkit-msgs 0.5.0-r2 --> 0.6.0-r1*
* *ros2-medkit-param-beacon 0.5.0-r2 --> 0.6.0-r1*
* *ros2-medkit-serialization 0.5.0-r2 --> 0.6.0-r1*
* *ros2-medkit-sovd-service-interface 0.5.0-r2 --> 0.6.0-r1*
* *ros2-medkit-topic-beacon 0.5.0-r2 --> 0.6.0-r1*
* *rosbag-timing-inspector 1.0.0-r1 --> 1.0.1-r1*
* *rtabmap 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-conversions 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-costmap-plugins 0.23.7-r1*
* *rtabmap-demos 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-examples 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-launch 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-msgs 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-odom 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-python 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-ros 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-rviz-plugins 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-slam 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-sync 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-util 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-viz 0.22.1-r1 --> 0.23.7-r1*
* *septentrio-gnss-driver 1.4.6-r1 --> 1.4.7-r2*
* *tiago-pro-bringup 1.35.4-r1 --> 2.4.1-r1*
* *tiago-pro-controller-configuration 1.35.4-r1 --> 2.4.1-r1*
* *tiago-pro-description 1.35.4-r1 --> 2.4.1-r1*
* *tiago-pro-gazebo 1.14.1-r1 --> 1.17.1-r1*
* *tiago-pro-head-bringup 1.9.0-r1 --> 1.12.0-r1*
* *tiago-pro-head-controller-configuration 1.9.0-r1 --> 1.12.0-r1*
* *tiago-pro-head-description 1.9.0-r1 --> 1.12.0-r1*
* *tiago-pro-head-robot 1.9.0-r1 --> 1.12.0-r1*
* *tiago-pro-moveit-config 1.4.1-r1 --> 1.5.1-r1*
* *tiago-pro-mujoco 1.17.1-r1*
* *tiago-pro-robot 1.35.4-r1 --> 2.4.1-r1*
* *tiago-pro-simulation 1.14.1-r1 --> 1.17.1-r1*
* *ublox-dgnss 0.7.4-r1 --> 0.7.5-r1*
* *ublox-dgnss-node 0.7.4-r1 --> 0.7.5-r1*
* *ublox-nav-sat-fix-hp-node 0.7.4-r1 --> 0.7.5-r1*
* *ublox-ubx-interfaces 0.7.4-r1 --> 0.7.5-r1*
* *ublox-ubx-msgs 0.7.4-r1 --> 0.7.5-r1*
* *ur 2.13.0-r1 --> 2.13.2-r1*
* *ur-bringup 2.13.0-r1 --> 2.13.2-r1*
* *ur-calibration 2.13.0-r1 --> 2.13.2-r1*
* *ur-controllers 2.13.0-r1 --> 2.13.2-r1*
* *ur-dashboard-msgs 2.13.0-r1 --> 2.13.2-r1*
* *ur-moveit-config 2.13.0-r1 --> 2.13.2-r1*
* *ur-robot-driver 2.13.0-r1 --> 2.13.2-r1*
* *urdf-test 2.1.1-r1 --> 2.1.2-r1*
* *warehouse-ros-sqlite 1.0.5-r1 --> 1.0.8-r1*

Jazzy Changes:
--------------
* *autoware-cmake 1.2.0-r2 --> 1.4.0-r1*
* *autoware-lint-common 1.2.0-r2 --> 1.4.0-r1*
* *callback-isolated-executor 1.0.0-r1*
* *cie-config-msgs 1.0.0-r1*
* *cie-sample-application 1.0.0-r1*
* *cie-thread-configurator 1.0.0-r1*
* *clearpath-config-live 2.7.0-r2 --> 2.9.0-r1*
* *clearpath-desktop 2.7.0-r2 --> 2.9.0-r1*
* *clearpath-offboard-sensors 2.7.0-r2 --> 2.9.0-r1*
* *clearpath-viz 2.7.0-r2 --> 2.9.0-r1*
* *clips-vendor 6.4.3-r2 --> 6.4.4-r1*
* *compass-msgs 0.3.0-r1 --> 0.3.1-r1*
* *fkie-message-filters 3.3.1-r1 --> 3.4.0-r1*
* *foxglove-bridge 3.4.1-r1 --> 3.4.2-r1*
* *foxglove-msgs 3.4.1-r1 --> 3.4.2-r1*
* *fusioncore-core 0.3.0-r1 --> 0.3.1-r1*
* *fusioncore-datasets 0.3.0-r1 --> 0.3.1-r1*
* *fusioncore-gazebo 0.3.0-r1 --> 0.3.1-r1*
* *fusioncore-ros 0.3.0-r1 --> 0.3.1-r1*
* *fusioncore-ublox 0.3.1-r1*
* *husarion-gz-worlds 0.1.0-r1*
* *mobile-robot-simulator 2.0.0-r1 --> 2.0.1-r1*
* *nao-meshes 2.1.2-r1*
* *naoqi-bridge-msgs 2.1.1-r1*
* *naoqi-libqicore 3.0.1-r1*
* *onnxruntime-vendor 0.1.0-r2*
* *pepper-meshes 3.0.0-r1*
* *pick-ik 1.1.1-r1 --> 1.1.2-r1*
* *protobuf-comm 0.9.3-r1 --> 0.9.4-r1*
* *ros2-medkit-action-status-bridge 0.6.0-r1*
* *ros2-medkit-beacon-common 0.5.0-r1 --> 0.6.0-r1*
* *ros2-medkit-cmake 0.5.0-r1 --> 0.6.0-r1*
* *ros2-medkit-diagnostic-bridge 0.5.0-r1 --> 0.6.0-r1*
* *ros2-medkit-fault-manager 0.5.0-r1 --> 0.6.0-r1*
* *ros2-medkit-fault-reporter 0.5.0-r1 --> 0.6.0-r1*
* *ros2-medkit-gateway 0.5.0-r1 --> 0.6.0-r1*
* *ros2-medkit-graph-provider 0.5.0-r1 --> 0.6.0-r1*
* *ros2-medkit-integration-tests 0.5.0-r1 --> 0.6.0-r1*
* *ros2-medkit-linux-introspection 0.5.0-r1 --> 0.6.0-r1*
* *ros2-medkit-log-bridge 0.6.0-r1*
* *ros2-medkit-msgs 0.5.0-r1 --> 0.6.0-r1*
* *ros2-medkit-param-beacon 0.5.0-r1 --> 0.6.0-r1*
* *ros2-medkit-serialization 0.5.0-r1 --> 0.6.0-r1*
* *ros2-medkit-sovd-service-interface 0.5.0-r1 --> 0.6.0-r1*
* *ros2-medkit-topic-beacon 0.5.0-r1 --> 0.6.0-r1*
* *rosbag-timing-inspector 1.0.0-r1 --> 1.0.1-r1*
* *rosbot-mavlink-bridge 2.0.1-r1*
* *rtabmap 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-conversions 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-costmap-plugins 0.23.7-r1*
* *rtabmap-demos 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-examples 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-launch 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-msgs 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-odom 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-python 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-ros 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-rviz-plugins 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-slam 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-sync 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-util 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-viz 0.22.1-r1 --> 0.23.7-r1*
* *septentrio-gnss-driver 1.4.7-r2 --> 1.4.7-r3*
* *warehouse-ros-sqlite 1.0.5-r1 --> 1.0.8-r1*

Kilted Changes:
---------------
* *clips-vendor 6.4.3-r1 --> 6.4.4-r1*
* *fkie-message-filters 3.3.1-r1 --> 3.4.0-r1*
* *foxglove-bridge 3.4.1-r1 --> 3.4.2-r1*
* *foxglove-msgs 3.4.1-r1 --> 3.4.2-r1*
* *mobile-robot-simulator 2.0.0-r1 --> 2.0.1-r1*
* *nao-meshes 2.1.2-r1*
* *naoqi-bridge-msgs 2.1.1-r1*
* *naoqi-libqi 3.0.3-r1*
* *ntrip-client-node 0.7.4-r1 --> 0.7.5-r1*
* *onnxruntime-vendor 0.1.0-r2*
* *pepper-meshes 3.0.0-r1*
* *pick-ik 1.1.1-r2 --> 1.1.2-r1*
* *protobuf-comm 0.9.3-r1 --> 0.9.4-r1*
* *rosbag-timing-inspector 1.0.0-r1 --> 1.0.1-r1*
* *rtabmap 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-conversions 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-costmap-plugins 0.23.7-r1*
* *rtabmap-demos 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-examples 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-launch 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-msgs 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-odom 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-python 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-ros 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-rviz-plugins 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-slam 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-sync 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-util 0.22.1-r1 --> 0.23.7-r1*
* *rtabmap-viz 0.22.1-r1 --> 0.23.7-r1*
* *septentrio-gnss-driver 1.4.6-r1 --> 1.4.7-r2*
* *ublox-dgnss 0.7.4-r1 --> 0.7.5-r1*
* *ublox-dgnss-node 0.7.4-r1 --> 0.7.5-r1*
* *ublox-nav-sat-fix-hp-node 0.7.4-r1 --> 0.7.5-r1*
* *ublox-ubx-interfaces 0.7.4-r1 --> 0.7.5-r1*
* *ublox-ubx-msgs 0.7.4-r1 --> 0.7.5-r1*
* *warehouse-ros-sqlite 1.0.5-r2 --> 1.0.8-r1*

Lyrical Changes:
----------------
* *aruco-opencv 6.1.2-r1 --> 7.0.0-r1*
* *aruco-opencv-msgs 6.1.2-r1 --> 7.0.0-r1*
* *automatika-embodied-agents 0.7.0-r3 --> 0.7.4-r1*
* *clips-vendor 6.4.3-r3 --> 6.4.4-r1*
* *fkie-message-filters 3.3.1-r1 --> 3.4.0-r1*
* *foxglove-bridge 3.4.1-r1 --> 3.4.2-r1*
* *foxglove-msgs 3.4.1-r1 --> 3.4.2-r1*
* *franka-inria-inverse-dynamics-solver 3.0.0-r1*
* *hitch-estimation-apriltag-array 0.0.3-r1*
* *inverse-dynamics-solver 3.0.0-r1*
* *kdl-inverse-dynamics-solver 3.0.0-r1*
* *mavlink 2026.6.6-r1 --> 2026.6.19-r1*
* *mobile-robot-simulator 2.0.1-r1*
* *ntrip-client-node 0.7.4-r3 --> 0.7.5-r1*
* *ompl 1.7.0-r4 --> 2.0.1-r3*
* *onnxruntime-vendor 0.1.0-r2*
* *protobuf-comm 0.9.3-r3 --> 0.9.4-r1*
* *qt-dotgraph 2.11.0-r1 --> 2.11.1-r1*
* *qt-gui 2.11.0-r1 --> 2.11.1-r1*
* *qt-gui-app 2.11.0-r1 --> 2.11.1-r1*
* *qt-gui-core 2.11.0-r1 --> 2.11.1-r1*
* *qt-gui-cpp 2.11.0-r1 --> 2.11.1-r1*
* *qt-gui-py-common 2.11.0-r1 --> 2.11.1-r1*
* *rmw-desert 4.0.1-r4 --> 4.0.2-r1*
* *ros2-medkit-action-status-bridge 0.6.0-r1*
* *ros2-medkit-beacon-common 0.5.0-r3 --> 0.6.0-r1*
* *ros2-medkit-cmake 0.5.0-r3 --> 0.6.0-r1*
* *ros2-medkit-diagnostic-bridge 0.5.0-r3 --> 0.6.0-r1*
* *ros2-medkit-fault-manager 0.5.0-r3 --> 0.6.0-r1*
* *ros2-medkit-fault-reporter 0.5.0-r3 --> 0.6.0-r1*
* *ros2-medkit-gateway 0.5.0-r3 --> 0.6.0-r1*
* *ros2-medkit-graph-provider 0.5.0-r3 --> 0.6.0-r1*
* *ros2-medkit-integration-tests 0.5.0-r3 --> 0.6.0-r1*
* *ros2-medkit-linux-introspection 0.5.0-r3 --> 0.6.0-r1*
* *ros2-medkit-log-bridge 0.6.0-r1*
* *ros2-medkit-msgs 0.5.0-r3 --> 0.6.0-r1*
* *ros2-medkit-param-beacon 0.5.0-r3 --> 0.6.0-r1*
* *ros2-medkit-serialization 0.5.0-r3 --> 0.6.0-r1*
* *ros2-medkit-sovd-service-interface 0.5.0-r3 --> 0.6.0-r1*
* *ros2-medkit-topic-beacon 0.5.0-r3 --> 0.6.0-r1*
* *rosbag-timing-inspector 1.0.2-r1*
* *rqt 1.10.5-r1 --> 1.10.6-r1*
* *rqt-bag 2.2.4-r1 --> 2.2.5-r1*
* *rqt-bag-plugins 2.2.4-r1 --> 2.2.5-r1*
* *rqt-gui 1.10.5-r1 --> 1.10.6-r1*
* *rqt-gui-cpp 1.10.5-r1 --> 1.10.6-r1*
* *rqt-gui-py 1.10.5-r1 --> 1.10.6-r1*
* *rqt-py-common 1.10.5-r1 --> 1.10.6-r1*
* *rtabmap 0.22.1-r3 --> 0.23.7-r1*
* *rtabmap-conversions 0.23.7-r1*
* *rtabmap-demos 0.23.7-r1*
* *rtabmap-examples 0.23.7-r1*
* *rtabmap-launch 0.23.7-r1*
* *rtabmap-msgs 0.23.7-r1*
* *rtabmap-odom 0.23.7-r1*
* *rtabmap-python 0.23.7-r1*
* *rtabmap-ros 0.23.7-r1*
* *rtabmap-rviz-plugins 0.23.7-r1*
* *rtabmap-slam 0.23.7-r1*
* *rtabmap-sync 0.23.7-r1*
* *rtabmap-util 0.23.7-r1*
* *rtabmap-viz 0.23.7-r1*
* *septentrio-gnss-driver 1.4.6-r3 --> 1.4.7-r2*
* *ublox-dgnss 0.7.4-r3 --> 0.7.5-r1*
* *ublox-dgnss-node 0.7.4-r3 --> 0.7.5-r1*
* *ublox-nav-sat-fix-hp-node 0.7.4-r3 --> 0.7.5-r1*
* *ublox-ubx-interfaces 0.7.4-r3 --> 0.7.5-r1*
* *ublox-ubx-msgs 0.7.4-r3 --> 0.7.5-r1*
* *ur-client-library 2.12.0-r1 --> 2.13.0-r1*
* *ur10-inverse-dynamics-solver 3.0.0-r1*
* *warehouse-ros-sqlite 1.0.7-r3 --> 1.0.8-r1*

Rolling Changes:
----------------
* *aruco-opencv 6.1.2-r2 --> 7.0.0-r1*
* *aruco-opencv-msgs 6.1.2-r2 --> 7.0.0-r1*
* *autoware-cmake 1.2.0-r1 --> 1.4.0-r1*
* *autoware-lint-common 1.2.0-r1 --> 1.4.0-r1*
* *clips-vendor 6.4.3-r2 --> 6.4.4-r1*
* *fkie-message-filters 3.3.1-r1 --> 3.4.0-r1*
* *foxglove-bridge 3.4.1-r1 --> 3.4.2-r1*
* *foxglove-msgs 3.4.1-r1 --> 3.4.2-r1*
* *librealsense2 2.57.7-r2 --> 2.58.2-r1*
* *mavlink 2026.6.6-r1 --> 2026.6.19-r1*
* *ntrip-client-node 0.7.4-r2 --> 0.7.5-r1*
* *ompl 1.7.0-r3 --> 2.0.1-r3*
* *onnxruntime-vendor 0.1.0-r2*
* *protobuf-comm 0.9.3-r2 --> 0.9.4-r1*
* *qt-dotgraph 3.0.0-r1 --> 3.0.1-r1*
* *qt-gui 3.0.0-r1 --> 3.0.1-r1*
* *qt-gui-app 3.0.0-r1 --> 3.0.1-r1*
* *qt-gui-core 3.0.0-r1 --> 3.0.1-r1*
* *qt-gui-cpp 3.0.0-r1 --> 3.0.1-r1*
* *qt-gui-py-common 3.0.0-r1 --> 3.0.1-r1*
* *rosbag-timing-inspector 1.0.0-r1 --> 1.0.2-r1*
* *rqt 2.0.0-r1 --> 2.0.1-r1*
* *rqt-bag 2.3.2-r1 --> 2.3.3-r1*
* *rqt-bag-plugins 2.3.2-r1 --> 2.3.3-r1*
* *rqt-gui 2.0.0-r1 --> 2.0.1-r1*
* *rqt-gui-cpp 2.0.0-r1 --> 2.0.1-r1*
* *rqt-gui-py 2.0.0-r1 --> 2.0.1-r1*
* *rqt-py-common 2.0.0-r1 --> 2.0.1-r1*
* *septentrio-gnss-driver 1.4.6-r2 --> 1.4.7-r2*
* *turtlesim 1.11.1-r1 --> 1.11.2-r1*
* *turtlesim-msgs 1.11.1-r1 --> 1.11.2-r1*
* *ublox-dgnss 0.7.4-r2 --> 0.7.5-r1*
* *ublox-dgnss-node 0.7.4-r2 --> 0.7.5-r1*
* *ublox-nav-sat-fix-hp-node 0.7.4-r2 --> 0.7.5-r1*
* *ublox-ubx-interfaces 0.7.4-r2 --> 0.7.5-r1*
* *ublox-ubx-msgs 0.7.4-r2 --> 0.7.5-r1*
* *warehouse-ros-sqlite 1.0.7-r2 --> 1.0.8-r2*


No missing dependencies.