### PR TITLE
Fix mujoco-* packages

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -167,6 +167,20 @@ let
       '';
     });
 
+    mujoco-vendor = rosSuper.mujoco-vendor.overrideAttrs ({
+      cmakeFlags ? [], propagatedBuildInputs ? [], patches ? [], ...
+    }: {
+      cmakeFlags = cmakeFlags ++ [ "-DAMENT_VENDOR_POLICY=NEVER_VENDOR" ];
+      propagatedBuildInputs = propagatedBuildInputs ++ [ self.mujoco ];
+      patches = patches ++ [
+        # Add support for the AMENT_VENDOR_POLICY variable to support unvendoring (#9)
+        (self.fetchpatch2 {
+          url = "https://github.com/pal-robotics/mujoco_vendor/commit/5585496493479578449de92616b4a36ac28fa1a9.patch?full_index=1";
+          hash = "sha256-cAtJmf4Q5ML9CcYUjeZEC+B6tvQn27fL4JJHBQ5XWxo=";
+        })
+      ];
+    });
+
     mrt-cmake-modules = rosSuper.mrt-cmake-modules.overrideAttrs ({
       postPatch ? "", ...
     }: {

--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -181,6 +181,21 @@ let
       ];
     });
 
+    mujoco-ros2-control = (patchExternalProjectGit rosSuper.mujoco-ros2-control {
+      url = "https://github.com/lvandeve/lodepng.git";
+      originalRev = "\${MUJOCO_DEP_VERSION_lodepng}";
+      rev = self.mujoco.pin.lodepng.rev;
+      fetchgitArgs.hash = "sha256-vnw52G0lY68471dzH7NXc++bTbLRsITSxGYXOTicA5w=";
+    }).overrideAttrs ({
+      postPatch ? "", ...
+    }: {
+      postPatch = postPatch + ''
+        substituteInPlace CMakeLists.txt --replace-fail \
+            'set(MUJOCO_ROOT "''${MUJOCO_PREFIX}")' \
+            'set(MUJOCO_ROOT "${self.mujoco}")'
+      '';
+    });
+
     mrt-cmake-modules = rosSuper.mrt-cmake-modules.overrideAttrs ({
       postPatch ? "", ...
     }: {


### PR DESCRIPTION
This is possible thanks to https://github.com/pal-robotics/mujoco_vendor/pull/9. Without it, building `mujoco-vendor` requires patching multiple nested vendored dependencies, which is difficult. With the mentioned PR, we can simply reuse the version from nixpkgs.