### PR TITLE
workflow: Don't fail update if tarball cache is empty

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -39,7 +39,7 @@ jobs:
           path: |
             ~/.ros/tar
       - name: Mark all cached files as untouched
-        run: "touch --date=@0 ~/.ros/tar/*"
+        run: "find ~/.ros/tar/ -type f -print0 | xargs -0 touch --date=@0"
       - name: Update overlay
         env:
           GITHUB_RUNNER_TEMP: ${{ runner.temp }}


### PR DESCRIPTION
This should fix the error reported [here](https://github.com/lopsided98/nix-ros-overlay/actions/runs/28666511819/job/85019463521).