### PR TITLE
workflow: Don't fail update if tarball cache is empty (again)

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -39,7 +39,7 @@ jobs:
           path: |
             ~/.ros/tar
       - name: Mark all cached files as untouched
-        run: "find ~/.ros/tar/ -type f -print0 | xargs -0 touch --date=@0"
+        run: "find ~/.ros/tar/ -type f -print0 | xargs -0 --no-run-if-empty touch --date=@0"
       - name: Update overlay
         env:
           GITHUB_RUNNER_TEMP: ${{ runner.temp }}


### PR DESCRIPTION
I should test more. This fixes [this error](https://github.com/lopsided98/nix-ros-overlay/actions/runs/28671752786/job/85036372688).