### PR TITLE
add lely-core patch for python 3.14 to fix canopen-tests

### DIFF
--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -453,7 +453,12 @@ in with lib; {
     })];
   });
 
-  lely-core-libraries = (lib.patchExternalProjectGit rosSuper.lely-core-libraries {
+  lely-core-libraries = let
+    fix-pkg-resources = self.fetchpatch2 {
+      url = "https://gitlab.com/lely_industries/lely-core/-/merge_requests/150.patch";
+      hash = "sha256-YDmLYVnwsxYtLOCaOy3LuqBNTo63LZ3bb2vStxN3yO0=";
+    };
+  in (lib.patchExternalProjectGit rosSuper.lely-core-libraries {
     url = "https://gitlab.com/lely_industries/lely-core.git";
     rev = "fb735b79cab5f0cdda45bc5087414d405ef8f3ab";
     fetchgitArgs = {
@@ -464,11 +469,13 @@ in with lib; {
     postPatch ? "", ...
   }: {
     # ref. https://gitlab.com/lely_industries/lely-core/-/merge_requests/143
+    # ref. https://gitlab.com/lely_industries/lely-core/-/merge_requests/150
     postPatch = postPatch + ''
       substituteInPlace CMakeLists.txt --replace-fail \
         "CONFIGURE_COMMAND autoreconf -i <SOURCE_DIR>" \
         "PATCH_COMMAND sed -i \"s|ATOMIC_VAR_INIT(0)|0|\" include/lely/util/spscring.h
         && sed -i \"s|static const char tab.64. =|static const char tab[] =|\" src/util/print.c
+        COMMAND git apply --whitespace=fix --reject ${fix-pkg-resources}
         CONFIGURE_COMMAND autoreconf -i <SOURCE_DIR>"
     '';
   });

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -542,6 +542,19 @@ in {
       hash = "sha256-A7RsVQwzj59M9+eGTeNt+/yb3rFziJl3fy33K5c36z0=";
       leaveDotGit = true;
     };
+  }).overrideAttrs ({
+    patches ? [], ...
+  }: {
+    patches = patches ++ [
+      # fix for python 3.14
+      # ref. https://github.com/ros-industrial/ros2_canopen/pull/441/changes
+      (self.fetchpatch2 {
+        url = "https://github.com/ros-industrial/ros2_canopen/commit/56fc4ec3359dbd07f91b5240a13f633df7d2f785.patch?full_index=1";
+        stripLen = 1;
+        hash = "sha256-Sx9H06E1aOYPzcLNJcyb9y+FxcNbTgSkS5hxDny1IeA=";
+      })
+    ];
+
   });
 
   libphidget22 = lib.patchVendorUrl rosSuper.libphidget22 {

--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -379,6 +379,19 @@ in {
       hash = "sha256-A7RsVQwzj59M9+eGTeNt+/yb3rFziJl3fy33K5c36z0=";
       leaveDotGit = true;
     };
+  }).overrideAttrs ({
+    patches ? [], ...
+  }: {
+    patches = patches ++ [
+      # fix for python 3.14
+      # ref. https://github.com/ros-industrial/ros2_canopen/pull/441/changes
+      (self.fetchpatch2 {
+        url = "https://github.com/ros-industrial/ros2_canopen/commit/56fc4ec3359dbd07f91b5240a13f633df7d2f785.patch?full_index=1";
+        stripLen = 1;
+        hash = "sha256-Sx9H06E1aOYPzcLNJcyb9y+FxcNbTgSkS5hxDny1IeA=";
+      })
+    ];
+
   });
 
   libphidget22 = lib.patchVendorUrl rosSuper.libphidget22 {

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -322,6 +322,19 @@ in {
       hash = "sha256-A7RsVQwzj59M9+eGTeNt+/yb3rFziJl3fy33K5c36z0=";
       leaveDotGit = true;
     };
+  }).overrideAttrs ({
+    patches ? [], ...
+  }: {
+    patches = patches ++ [
+      # fix for python 3.14
+      # ref. https://github.com/ros-industrial/ros2_canopen/pull/441/changes
+      (self.fetchpatch2 {
+        url = "https://github.com/ros-industrial/ros2_canopen/commit/56fc4ec3359dbd07f91b5240a13f633df7d2f785.patch?full_index=1";
+        stripLen = 1;
+        hash = "sha256-Sx9H06E1aOYPzcLNJcyb9y+FxcNbTgSkS5hxDny1IeA=";
+      })
+    ];
+
   });
 
   libphidget22 = lib.patchVendorUrl rosSuper.libphidget22 {

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -324,6 +324,18 @@ in {
       hash = "sha256-A7RsVQwzj59M9+eGTeNt+/yb3rFziJl3fy33K5c36z0=";
       leaveDotGit = true;
     };
+  }).overrideAttrs ({
+    patches ? [], ...
+  }: {
+    patches = patches ++ [
+      # fix for python 3.14
+      # ref. https://github.com/ros-industrial/ros2_canopen/pull/441/changes
+      (self.fetchpatch2 {
+        url = "https://github.com/ros-industrial/ros2_canopen/commit/56fc4ec3359dbd07f91b5240a13f633df7d2f785.patch?full_index=1";
+        stripLen = 1;
+        hash = "sha256-Sx9H06E1aOYPzcLNJcyb9y+FxcNbTgSkS5hxDny1IeA=";
+      })
+    ];
   });
 
   librealsense2 = (pipe rosSuper.librealsense2 [


### PR DESCRIPTION
ref. https://github.com/ros-industrial/ros2_canopen/pull/441 
ref. https://gitlab.com/lely_industries/lely-core/-/merge_requests/150