### PR TITLE
buildEnv: expose derivationArgs

### DIFF
--- a/distros/build-env/default.nix
+++ b/distros/build-env/default.nix
@@ -17,7 +17,7 @@
 # take precedence over Nix-built packages. This can be achieved by setting
 # underlay to true.
 { lib, stdenv, buildPackages, writeText, buildEnv, makeWrapper, python, ros-environment }:
-{ paths ? [], wrapPrograms ? true, underlay ? false, postBuild ? "", passthru ? { }, ... }@args:
+{ paths ? [], wrapPrograms ? true, underlay ? false, derivationArgs ? { }, postBuild ? "", passthru ? { }, ... }@args:
 
 with lib;
 assert assertMsg (underlay -> wrapPrograms)
@@ -52,7 +52,7 @@ let
     # nix-shell -p does.
     paths = propagatedPaths.rosPackages;
 
-    derivationArgs = {
+    derivationArgs = derivationArgs // {
       nativeBuildInputs = optional wrapPrograms makeWrapper;
       propagatedBuildInputs = propagatedPaths.otherPackages;
 


### PR DESCRIPTION
Hi,

This expose `derivationArgs` in `buildEnv` to allow setting eg. `preBuild`.

My current issue is `/nix/store/p6l8racl5dqgs4bdjbahj4fzpmhnxnrb-validate-pkg-config/nix-support/setup-hook: line 10: --validate: command not found`. That line is `if ! $PKG_CONFIG --validate "$pc"; then`. So somehow the pkg-config-wrapper is not correctly setting `export PKG_CONFIG=…`, maybe because of a new `strictDeps` somewhere.

This need more work, but for now a `derivationArgs.preBuild = "export PKG_CONFIG=${lib.getExe pkgs.pkg-config}";` is a valid workaround, but for that we need to be able to set `preBuild` here, and I guess this is a useful thing regardless of my current issue.

Another option would be to set only `preBuild`, like https://github.com/nim65s/nix-ros-overlay/commit/9629c00be2efe38f23690553812bf41fd6a3fa04