### PR TITLE
rosdistro sync, Fri Aug  7 18:57:21 2026

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -253,6 +253,12 @@ let
       '';
     });
 
+    # TODO: Replace with #905
+    rviz-visual-tools =
+      if builtins.elem distro ["humble" "jazzy" "kilted"]
+      then rosSuper.rviz-visual-tools.override { qt6 = self.qt5; }
+      else rosSuper.rviz-visual-tools;
+
     # We map ROS packages that depend on Ubuntu's libexpected-dev to
     # depend on tl-expected-nixpkgs. We cannot use the name
     # tl-expected because it is shadowed by tl-expected package from

--- a/distros/humble/ackermann-steering-controller/default.nix
+++ b/distros/humble/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-ackermann-steering-controller";
-  version = "2.53.2-r1";
+  version = "2.53.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.53.2-1.tar.gz";
-    name = "2.53.2-1.tar.gz";
-    sha256 = "f9bec9c6b216506952484f80359f842328bdad03822debfb3f0a9fe6f32846be";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.53.3-1.tar.gz";
+    name = "2.53.3-1.tar.gz";
+    sha256 = "b5ac07e198457455d8d3b6c569747a7f2741302a642ad8f8fd2ad40d3ebe0037";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/admittance-controller/default.nix
+++ b/distros/humble/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, tinyxml-2, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-admittance-controller";
-  version = "2.53.2-r1";
+  version = "2.53.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.53.2-1.tar.gz";
-    name = "2.53.2-1.tar.gz";
-    sha256 = "56d465238cc5696e518e220d4bd6a256509446c0c774e9762c2c16697a3f55a3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.53.3-1.tar.gz";
+    name = "2.53.3-1.tar.gz";
+    sha256 = "8be36ec7d6013cc728222f9b6576c54af9df4728b2fd76acafc897fa52db99f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/bicycle-steering-controller/default.nix
+++ b/distros/humble/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-bicycle-steering-controller";
-  version = "2.53.2-r1";
+  version = "2.53.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.53.2-1.tar.gz";
-    name = "2.53.2-1.tar.gz";
-    sha256 = "cbf3b0b8bcfb2e8cab79270d3984be5554853e882b1997d0c3d57d723a27608a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.53.3-1.tar.gz";
+    name = "2.53.3-1.tar.gz";
+    sha256 = "fa3c8ca2b357c7ef3263f814a20003069dfefef6d4e003cd1601bebb0f867816";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diff-drive-controller/default.nix
+++ b/distros/humble/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-diff-drive-controller";
-  version = "2.53.2-r1";
+  version = "2.53.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.53.2-1.tar.gz";
-    name = "2.53.2-1.tar.gz";
-    sha256 = "a30d0ac1b654ce8236134aa36971b3bf71eed7b258a84da9287f2fc97f9be8e7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.53.3-1.tar.gz";
+    name = "2.53.3-1.tar.gz";
+    sha256 = "e0d36e397e0a9300c3b8e5fd1d07e6aa2b72b66a985fd21c9971db871272968b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/effort-controllers/default.nix
+++ b/distros/humble/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-effort-controllers";
-  version = "2.53.2-r1";
+  version = "2.53.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.53.2-1.tar.gz";
-    name = "2.53.2-1.tar.gz";
-    sha256 = "dc8bf8f43a0d43860fa269b378ac7a61be476bd441cc026d893d4bb94a0292cb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.53.3-1.tar.gz";
+    name = "2.53.3-1.tar.gz";
+    sha256 = "1001b3147e9bf923dcaa827cd8bc64a2af0f0bef07f2a6d7338a12d4d16b5ebc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/force-torque-sensor-broadcaster/default.nix
+++ b/distros/humble/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-force-torque-sensor-broadcaster";
-  version = "2.53.2-r1";
+  version = "2.53.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.53.2-1.tar.gz";
-    name = "2.53.2-1.tar.gz";
-    sha256 = "51fd1e7fdef1ebf7adb0d8f69cacd90df379da959820d20e1c40d84ecb47cf1f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.53.3-1.tar.gz";
+    name = "2.53.3-1.tar.gz";
+    sha256 = "26868da2b4e5b291be01638950239e4a70404104c614835f7eb18e7e3723930b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/forward-command-controller/default.nix
+++ b/distros/humble/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-forward-command-controller";
-  version = "2.53.2-r1";
+  version = "2.53.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.53.2-1.tar.gz";
-    name = "2.53.2-1.tar.gz";
-    sha256 = "80d25db09d7b8f679479231a3823fe8ad744641c37b6f4bfeb73c01aa5cf168e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.53.3-1.tar.gz";
+    name = "2.53.3-1.tar.gz";
+    sha256 = "721fb6b547043f8af67dabe7fb98e1c25b53a31394a32c30ddb1d6bfca94f51d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gpio-controllers/default.nix
+++ b/distros/humble/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gpio-controllers";
-  version = "2.53.2-r1";
+  version = "2.53.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gpio_controllers/2.53.2-1.tar.gz";
-    name = "2.53.2-1.tar.gz";
-    sha256 = "46d13ea1ec3d64c51d791c346f39060e2d80a939e1443bdc453566a19df533be";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gpio_controllers/2.53.3-1.tar.gz";
+    name = "2.53.3-1.tar.gz";
+    sha256 = "3406f5add4f853bfddadc08364b5bff90175d73d5c89f3faf00d8c9f81ba20c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/graph-msgs/default.nix
+++ b/distros/humble/graph-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-graph-msgs";
-  version = "0.2.0-r3";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/graph_msgs-release/archive/release/humble/graph_msgs/0.2.0-3.tar.gz";
-    name = "0.2.0-3.tar.gz";
-    sha256 = "b715949f2f7db997521cac9fd8f61da7fc53fccf8e6c4394150fe0d41acac447";
+    url = "https://github.com/ros2-gbp/graph_msgs-release/archive/release/humble/graph_msgs/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "3711ab642009191dbb978879740b6f74908d9a61f59ae93306b9b31074e60b2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gripper-controllers/default.nix
+++ b/distros/humble/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gripper-controllers";
-  version = "2.53.2-r1";
+  version = "2.53.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.53.2-1.tar.gz";
-    name = "2.53.2-1.tar.gz";
-    sha256 = "1e60959d62b60fa42f1174f11aa0416cbeacfef87d1f3ad17204cfd8efbe80fb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.53.3-1.tar.gz";
+    name = "2.53.3-1.tar.gz";
+    sha256 = "1fa806e7830b2fec306ba4977ad027ae3b225d886a813d2bfb7cf494906439e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/imu-sensor-broadcaster/default.nix
+++ b/distros/humble/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-imu-sensor-broadcaster";
-  version = "2.53.2-r1";
+  version = "2.53.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.53.2-1.tar.gz";
-    name = "2.53.2-1.tar.gz";
-    sha256 = "903fe3468e8827b35aa07f84e24307dcb3dcfd356d9a1c6806e24c2337da0f1f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.53.3-1.tar.gz";
+    name = "2.53.3-1.tar.gz";
+    sha256 = "a06cf3927fe940442b555cb7b62df8b52d49ccc2869a7b1e137413c1f8581d8f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-state-broadcaster/default.nix
+++ b/distros/humble/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-state-broadcaster";
-  version = "2.53.2-r1";
+  version = "2.53.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.53.2-1.tar.gz";
-    name = "2.53.2-1.tar.gz";
-    sha256 = "f9b20bfafbe7de2123dbb37d32167d623ab8b397b709ee69bfb42a972d2f7d5f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.53.3-1.tar.gz";
+    name = "2.53.3-1.tar.gz";
+    sha256 = "3f202af5d2f4614736926229d251c35b00498eafaba991cc80fa7c2a4a286018";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-trajectory-controller/default.nix
+++ b/distros/humble/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected-nixpkgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-trajectory-controller";
-  version = "2.53.2-r1";
+  version = "2.53.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.53.2-1.tar.gz";
-    name = "2.53.2-1.tar.gz";
-    sha256 = "36de336979f5aa8ed3fbf82bb67146eaa05e20c31b7bbabd4f5b1345d9b2f5b0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.53.3-1.tar.gz";
+    name = "2.53.3-1.tar.gz";
+    sha256 = "9ddb59f53a3608ec524bfb2b2c4b49e19b1e57ab5040c2f557efc36e9bac5478";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mecanum-drive-controller/default.nix
+++ b/distros/humble/mecanum-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-mecanum-drive-controller";
-  version = "2.53.2-r1";
+  version = "2.53.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/mecanum_drive_controller/2.53.2-1.tar.gz";
-    name = "2.53.2-1.tar.gz";
-    sha256 = "d8256b38a30fb103fcbca368a41063d4b59f4a75a87bbff52e96bb6c7ee47edb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/mecanum_drive_controller/2.53.3-1.tar.gz";
+    name = "2.53.3-1.tar.gz";
+    sha256 = "4a2211f619b40bc68c484dde763f3dd4258b19e3d99dea41fd3c1dd11f83c96a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-visual-tools/default.nix
+++ b/distros/humble/moveit-visual-tools/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, graph-msgs, moveit-common, moveit-core, moveit-ros-planning, rclcpp, rviz-visual-tools, std-msgs, tf2-eigen, tf2-ros, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, geometric-shapes, geometry-msgs, graph-msgs, interactive-markers, moveit-common, moveit-core, moveit-msgs, moveit-ros-planning, rclcpp, rviz-visual-tools, std-msgs, tf2-eigen, tf2-ros, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-moveit-visual-tools";
-  version = "4.1.2-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_visual_tools-release/archive/release/humble/moveit_visual_tools/4.1.2-1.tar.gz";
-    name = "4.1.2-1.tar.gz";
-    sha256 = "09a0c95e65a20ec258d3ff706205e248e01ec0b3b8f5306893157e5b80cde0f1";
+    url = "https://github.com/ros2-gbp/moveit_visual_tools-release/archive/release/humble/moveit_visual_tools/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "59247553632a69c70e2163d99abac8a12c32e0703528fdc572abb1e31efcd301";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs graph-msgs moveit-common moveit-core moveit-ros-planning rclcpp rviz-visual-tools std-msgs tf2-eigen tf2-ros trajectory-msgs visualization-msgs ];
+  propagatedBuildInputs = [ ament-index-cpp geometric-shapes geometry-msgs graph-msgs interactive-markers moveit-common moveit-core moveit-msgs moveit-ros-planning rclcpp rviz-visual-tools std-msgs tf2-eigen tf2-ros trajectory-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -759,15 +759,6 @@ in with lib; {
     ];
   });
 
-  moveit-visual-tools = rosSuper.moveit-visual-tools.overrideAttrs ({
-    postPatch ? "", ...
-  }: {
-    # https://github.com/moveit/moveit_visual_tools/pull/154
-    postPatch = postPatch + ''
-      substituteInPlace CMakeLists.txt --replace-fail " system" ""
-    '';
-  });
-
   mrpt-containers = rosSuper.mrpt-containers.overrideAttrs ({
     buildInputs ? [], nativeBuildInputs ? [], ...
   }: {

--- a/distros/humble/pid-controller/default.nix
+++ b/distros/humble/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-pid-controller";
-  version = "2.53.2-r1";
+  version = "2.53.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pid_controller/2.53.2-1.tar.gz";
-    name = "2.53.2-1.tar.gz";
-    sha256 = "09e16d401c5b1314df5ab2e6e229f2c3c6ac9834de90f6bd8548ae669f832eb3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pid_controller/2.53.3-1.tar.gz";
+    name = "2.53.3-1.tar.gz";
+    sha256 = "a873c640d07d69148b4cb8deba1f51ae595655c01a2677ac20dd9a62448c413a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pose-broadcaster/default.nix
+++ b/distros/humble/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-pose-broadcaster";
-  version = "2.53.2-r1";
+  version = "2.53.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pose_broadcaster/2.53.2-1.tar.gz";
-    name = "2.53.2-1.tar.gz";
-    sha256 = "25a01a82b867aa0649e452ba72ae128a895c9fda06b5f376a01627607b7e238e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pose_broadcaster/2.53.3-1.tar.gz";
+    name = "2.53.3-1.tar.gz";
+    sha256 = "d1b2f3911e6671005fbe98bcbd6e385891c233ef844c0d228ba7a7f58f4752c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/position-controllers/default.nix
+++ b/distros/humble/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-position-controllers";
-  version = "2.53.2-r1";
+  version = "2.53.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.53.2-1.tar.gz";
-    name = "2.53.2-1.tar.gz";
-    sha256 = "e63c411961c5dc706097ecded2442353834b29bc0876215b2530177ceae74237";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.53.3-1.tar.gz";
+    name = "2.53.3-1.tar.gz";
+    sha256 = "977b33c22c8a725760b0ff7c2bd3e9711a84f116445ad8128166789a83413a85";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/range-sensor-broadcaster/default.nix
+++ b/distros/humble/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-range-sensor-broadcaster";
-  version = "2.53.2-r1";
+  version = "2.53.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/range_sensor_broadcaster/2.53.2-1.tar.gz";
-    name = "2.53.2-1.tar.gz";
-    sha256 = "c27e2db1e0256aebc7dc284beefb326c395ff337e01017021d24a7bff731bf6b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/range_sensor_broadcaster/2.53.3-1.tar.gz";
+    name = "2.53.3-1.tar.gz";
+    sha256 = "87ba7ec8e5f7844de8b12ad81cf3e12994971f54bc057b0dc57c250b8441ece3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-controllers-test-nodes/default.nix
+++ b/distros/humble/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers-test-nodes";
-  version = "2.53.2-r1";
+  version = "2.53.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.53.2-1.tar.gz";
-    name = "2.53.2-1.tar.gz";
-    sha256 = "c290be6c0a5752005b57e2aaffb2c481c282d680d6c15df8006318d327cf7578";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.53.3-1.tar.gz";
+    name = "2.53.3-1.tar.gz";
+    sha256 = "745da84956b96244f2ca491368b9c538b30e9610c9c98aabba7e35c973f64b87";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2-controllers/default.nix
+++ b/distros/humble/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gripper-controllers, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers";
-  version = "2.53.2-r1";
+  version = "2.53.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.53.2-1.tar.gz";
-    name = "2.53.2-1.tar.gz";
-    sha256 = "3ce153266a79daf017cb0a48fc15ea8aeeda2be151b8c10c5cfe7981e402476d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.53.3-1.tar.gz";
+    name = "2.53.3-1.tar.gz";
+    sha256 = "cf940769ee9ca36672649d8e2e96e756e2e25a6cbb776a66a24334865a932148";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rqt-joint-trajectory-controller/default.nix
+++ b/distros/humble/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, launch-testing, launch-testing-ros, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-rqt-joint-trajectory-controller";
-  version = "2.53.2-r1";
+  version = "2.53.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.53.2-1.tar.gz";
-    name = "2.53.2-1.tar.gz";
-    sha256 = "66a11ae74c1249a8f3d8f886c47c8e1e3edbd1c1673a09d274042ca20af55b59";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.53.3-1.tar.gz";
+    name = "2.53.3-1.tar.gz";
+    sha256 = "50c6e9075f97f89297ab1bab6769426e669664b10c5139e392af76f8be74777d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rviz-visual-tools/default.nix
+++ b/distros/humble/rviz-visual-tools/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, interactive-markers, launch, launch-ros, pluginlib, qt5, rclcpp, rclcpp-components, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz2, sensor-msgs, shape-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, interactive-markers, launch, launch-ros, pluginlib, qt6, rclcpp, rclcpp-components, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz2, sensor-msgs, shape-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rviz-visual-tools";
-  version = "4.1.4-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz_visual_tools-release/archive/release/humble/rviz_visual_tools/4.1.4-1.tar.gz";
-    name = "4.1.4-1.tar.gz";
-    sha256 = "baf9906b3fac2f11574c7e994f70d14afe5aed78d2890aa2d13790c6d0cc9f32";
+    url = "https://github.com/ros2-gbp/rviz_visual_tools-release/archive/release/humble/rviz_visual_tools/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "9466d29dc0123dfad427557f82bb71637a08b2dfcfcbf846678cfa8e8040907b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python eigen eigen-stl-containers eigen3-cmake-module geometry-msgs interactive-markers launch launch-ros pluginlib qt5.qtbase rclcpp rclcpp-components rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering rviz2 sensor-msgs shape-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs visualization-msgs ];
+  propagatedBuildInputs = [ ament-index-python eigen eigen-stl-containers eigen3-cmake-module geometry-msgs interactive-markers launch launch-ros pluginlib qt6.qtbase rclcpp rclcpp-components rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering rviz2 sensor-msgs shape-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 
   meta = {

--- a/distros/humble/septentrio-gnss-driver/default.nix
+++ b/distros/humble/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, gtest-vendor, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-septentrio-gnss-driver";
-  version = "1.4.7-r2";
+  version = "1.4.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/humble/septentrio_gnss_driver/1.4.7-2.tar.gz";
-    name = "1.4.7-2.tar.gz";
-    sha256 = "677a2e456a0a2e72fcfbfdb1c439b0c13b5fdd17e215f2ab2eff30f105570701";
+    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/humble/septentrio_gnss_driver/1.4.8-1.tar.gz";
+    name = "1.4.8-1.tar.gz";
+    sha256 = "1a755baba734e6d565927e78a0b1388402321df1268fd0011ac0284b87528f7f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/steering-controllers-library/default.nix
+++ b/distros/humble/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-steering-controllers-library";
-  version = "2.53.2-r1";
+  version = "2.53.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.53.2-1.tar.gz";
-    name = "2.53.2-1.tar.gz";
-    sha256 = "fac9ce08a833c64337b6be7c31ce9c6acea2c40e5b634e3fa9ed889c3917798d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.53.3-1.tar.gz";
+    name = "2.53.3-1.tar.gz";
+    sha256 = "b204899c03b1cd625ebbfed9be88cceed55ea057524c2a44fdd2469a0e9d60e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-controller/default.nix
+++ b/distros/humble/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-tricycle-controller";
-  version = "2.53.2-r1";
+  version = "2.53.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.53.2-1.tar.gz";
-    name = "2.53.2-1.tar.gz";
-    sha256 = "7a29d7edbebee9d2ee1db2dde3a048993eeb35dc383baa2b0d1011d8512a3518";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.53.3-1.tar.gz";
+    name = "2.53.3-1.tar.gz";
+    sha256 = "8ca0ce72b835b7f0b86b0890d11d4dd84c33e6d2d93dfaf5bc79f28738fa728a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-steering-controller/default.nix
+++ b/distros/humble/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-tricycle-steering-controller";
-  version = "2.53.2-r1";
+  version = "2.53.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.53.2-1.tar.gz";
-    name = "2.53.2-1.tar.gz";
-    sha256 = "9751eba7690b70af229083bbe51560e244e493396e414a87b4cb02d4973bb811";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.53.3-1.tar.gz";
+    name = "2.53.3-1.tar.gz";
+    sha256 = "5f06ce7e3a4a36900e31144ea58cfc623f22c47e03b86ac09bfbd449470e7d51";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/velocity-controllers/default.nix
+++ b/distros/humble/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-velocity-controllers";
-  version = "2.53.2-r1";
+  version = "2.53.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.53.2-1.tar.gz";
-    name = "2.53.2-1.tar.gz";
-    sha256 = "ddd8f425294aa9c0ee72aa1878caac9f9a4285ac3bb413e9a791b42c417453bd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.53.3-1.tar.gz";
+    name = "2.53.3-1.tar.gz";
+    sha256 = "7b8719317aaa427c6a718479d86ae4ff19ac189e11231c937b52ad5084b4453d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/warehouse-ros-sqlite/default.nix
+++ b/distros/humble/warehouse-ros-sqlite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite, warehouse-ros }:
 buildRosPackage {
   pname = "ros-humble-warehouse-ros-sqlite";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/humble/warehouse_ros_sqlite/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "c87956600dbe7daccac64be231fa00f56ca9b7d157bccc02fb26416a07bdacd2";
+    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/humble/warehouse_ros_sqlite/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "909b56f1fb44cbd956419c0a291c6197c49e008fbb696036f80e70477e7a8e74";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/warehouse-ros/default.nix
+++ b/distros/humble/warehouse-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-lint-auto, boost, geometry-msgs, openssl, pluginlib, rclcpp, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-warehouse-ros";
-  version = "2.0.5-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/warehouse_ros-release/archive/release/humble/warehouse_ros/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "89a5415959d2903d6e46841095898db9fed7e44ea787d88b2d813945c9b12551";
+    url = "https://github.com/ros2-gbp/warehouse_ros-release/archive/release/humble/warehouse_ros/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "f0bf63bafa190c3e7eae9bbd572fcedd9796979d7ced30ffd8532e74248d911a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -1718,6 +1718,14 @@ self: super: {
 
  jrl-cmakemodules = self.callPackage ./jrl-cmakemodules {};
 
+ jsk-common-msgs = self.callPackage ./jsk-common-msgs {};
+
+ jsk-footstep-msgs = self.callPackage ./jsk-footstep-msgs {};
+
+ jsk-gui-msgs = self.callPackage ./jsk-gui-msgs {};
+
+ jsk-hark-msgs = self.callPackage ./jsk-hark-msgs {};
+
  kartech-linear-actuator-msgs = self.callPackage ./kartech-linear-actuator-msgs {};
 
  kdl-inverse-dynamics-solver = self.callPackage ./kdl-inverse-dynamics-solver {};
@@ -2938,6 +2946,8 @@ self: super: {
 
  pose-cov-ops = self.callPackage ./pose-cov-ops {};
 
+ posedetection-msgs = self.callPackage ./posedetection-msgs {};
+
  position-controllers = self.callPackage ./position-controllers {};
 
  proto2ros = self.callPackage ./proto2ros {};
@@ -3285,6 +3295,16 @@ self: super: {
  roboplan-examples = self.callPackage ./roboplan-examples {};
 
  roboplan-oink = self.callPackage ./roboplan-oink {};
+
+ roboplan-ros-cpp = self.callPackage ./roboplan-ros-cpp {};
+
+ roboplan-ros-examples = self.callPackage ./roboplan-ros-examples {};
+
+ roboplan-ros-franka = self.callPackage ./roboplan-ros-franka {};
+
+ roboplan-ros-py = self.callPackage ./roboplan-ros-py {};
+
+ roboplan-ros-visualization = self.callPackage ./roboplan-ros-visualization {};
 
  roboplan-rrt = self.callPackage ./roboplan-rrt {};
 
@@ -3927,6 +3947,8 @@ self: super: {
  spatio-temporal-voxel-layer = self.callPackage ./spatio-temporal-voxel-layer {};
 
  spdlog-vendor = self.callPackage ./spdlog-vendor {};
+
+ speech-recognition-msgs = self.callPackage ./speech-recognition-msgs {};
 
  spinnaker-camera-driver = self.callPackage ./spinnaker-camera-driver {};
 

--- a/distros/jazzy/graph-msgs/default.nix
+++ b/distros/jazzy/graph-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-graph-msgs";
-  version = "0.2.0-r6";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/graph_msgs-release/archive/release/jazzy/graph_msgs/0.2.0-6.tar.gz";
-    name = "0.2.0-6.tar.gz";
-    sha256 = "1d45b78db80eb6af2161b2b1e9901ff2b31f649d182a673c1b71e09426b1a5ba";
+    url = "https://github.com/ros2-gbp/graph_msgs-release/archive/release/jazzy/graph_msgs/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "d5ceb882eab189ed01dae8efdb6df173a8b5c8c0f1dd6c4840e3d7c47a6ed92e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-state-publisher-gui/default.nix
+++ b/distros/jazzy/joint-state-publisher-gui/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, joint-state-publisher, python-qt-binding, rclpy }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, joint-state-publisher, python-qt-binding, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-joint-state-publisher-gui";
-  version = "2.4.1-r1";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/jazzy/joint_state_publisher_gui/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "d136b7a4a7737f58b1458c4cb359a5b38566ee59d824556e5f8a1ff0031ff5e3";
+    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/jazzy/joint_state_publisher_gui/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "fa83bd0fb88a35fdbff863a661880b207f383ed9e23ac0fb7f5b9b82a139dd1e";
   };
 
   buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest ];
   propagatedBuildInputs = [ joint-state-publisher python-qt-binding rclpy ];
 
   meta = {

--- a/distros/jazzy/joint-state-publisher/default.nix
+++ b/distros/jazzy/joint-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2topic, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-joint-state-publisher";
-  version = "2.4.1-r1";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/jazzy/joint_state_publisher/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "e01cfb5c559ebca2677d4c8f830739c51e9706d660ff8a68b081d670a7747bd4";
+    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/jazzy/joint_state_publisher/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "dc08b3e2332bd55c502b822b803c815e78b76951eff86982280a35e668a3e63c";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/jsk-common-msgs/default.nix
+++ b/distros/jazzy/jsk-common-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, jsk-footstep-msgs, jsk-gui-msgs, jsk-hark-msgs, posedetection-msgs, ros-environment, speech-recognition-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-jsk-common-msgs";
+  version = "5.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common_msgs-release/archive/release/jazzy/jsk_common_msgs/5.0.1-3.tar.gz";
+    name = "5.0.1-3.tar.gz";
+    sha256 = "8a5059f1ea173b744ab4b8b271b6c926a7451eb6faae4bbb966430c7864ca3cf";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ jsk-footstep-msgs jsk-gui-msgs jsk-hark-msgs posedetection-msgs speech-recognition-msgs ];
+  nativeBuildInputs = [ ament-cmake ros-environment ];
+
+  meta = {
+    description = "<p>Metapackage that contains commonly used messages for jsk-ros-pkg</p>";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/jsk-footstep-msgs/default.nix
+++ b/distros/jazzy/jsk-footstep-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-jsk-footstep-msgs";
+  version = "5.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common_msgs-release/archive/release/jazzy/jsk_footstep_msgs/5.0.1-3.tar.gz";
+    name = "5.0.1-3.tar.gz";
+    sha256 = "e07f6c326e0282e280133eea8029fc68e65d54ec38fed786b2757772921e72df";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "jsk_footstep_msgs";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/jsk-gui-msgs/default.nix
+++ b/distros/jazzy/jsk-gui-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-jsk-gui-msgs";
+  version = "5.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common_msgs-release/archive/release/jazzy/jsk_gui_msgs/5.0.1-3.tar.gz";
+    name = "5.0.1-3.tar.gz";
+    sha256 = "543316a5a4a802060f01fe427978489d6b30c1c1904f1efe29e4fa37562d6ab3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "jsk_gui_msgs";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/jsk-hark-msgs/default.nix
+++ b/distros/jazzy/jsk-hark-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-jsk-hark-msgs";
+  version = "5.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common_msgs-release/archive/release/jazzy/jsk_hark_msgs/5.0.1-3.tar.gz";
+    name = "5.0.1-3.tar.gz";
+    sha256 = "976e7004cfd82c600ab60712b6657ea30a24ea3f5031b334b1d43f4503141fee";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "jsk_hark_msgs";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/moveit-visual-tools/default.nix
+++ b/distros/jazzy/moveit-visual-tools/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, graph-msgs, moveit-common, moveit-core, moveit-ros-planning, rclcpp, rviz-visual-tools, std-msgs, tf2-eigen, tf2-ros, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, geometric-shapes, geometry-msgs, graph-msgs, interactive-markers, moveit-common, moveit-core, moveit-msgs, moveit-ros-planning, rclcpp, rviz-visual-tools, std-msgs, tf2-eigen, tf2-ros, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-visual-tools";
-  version = "4.1.2-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_visual_tools-release/archive/release/jazzy/moveit_visual_tools/4.1.2-1.tar.gz";
-    name = "4.1.2-1.tar.gz";
-    sha256 = "253f64ef6be72257c498d61cb1bedffdbe107c9edf2f009b284fd71094c15ad8";
+    url = "https://github.com/ros2-gbp/moveit_visual_tools-release/archive/release/jazzy/moveit_visual_tools/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "928216f3328521c740303d661f47106ee9c151257cd151a7c9ca2fcbbeb09dd4";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs graph-msgs moveit-common moveit-core moveit-ros-planning rclcpp rviz-visual-tools std-msgs tf2-eigen tf2-ros trajectory-msgs visualization-msgs ];
+  propagatedBuildInputs = [ ament-index-cpp geometric-shapes geometry-msgs graph-msgs interactive-markers moveit-common moveit-core moveit-msgs moveit-ros-planning rclcpp rviz-visual-tools std-msgs tf2-eigen tf2-ros trajectory-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -772,15 +772,6 @@ in {
     ];
   });
 
-  moveit-visual-tools = rosSuper.moveit-visual-tools.overrideAttrs ({
-    postPatch ? "", ...
-  }: {
-    # https://github.com/moveit/moveit_visual_tools/pull/154
-    postPatch = postPatch + ''
-      substituteInPlace CMakeLists.txt --replace-fail " system" ""
-    '';
-  });
-
   mp-units-vendor = lib.patchAmentVendorGit rosSuper.mp-units-vendor {};
 
   mqtt-client = rosSuper.mqtt-client.overrideAttrs ({

--- a/distros/jazzy/posedetection-msgs/default.nix
+++ b/distros/jazzy/posedetection-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, message-filters, rclcpp, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-posedetection-msgs";
+  version = "5.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common_msgs-release/archive/release/jazzy/posedetection_msgs/5.0.1-3.tar.gz";
+    name = "5.0.1-3.tar.gz";
+    sha256 = "0010fe388ade127d9540567e92219e07cfef2fdffbbf6febde8b8f8edd51d677";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs message-filters rclcpp rosidl-default-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "posedetection_msgs provides messages and services to facilitate passing pose detection results and features.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/roboplan-cartesian-planning/default.nix
+++ b/distros/jazzy/roboplan-cartesian-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, python3, python3Packages, roboplan, roboplan-example-models, roboplan-oink, roboplan-toppra }:
 buildRosPackage {
   pname = "ros-jazzy-roboplan-cartesian-planning";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/jazzy/roboplan_cartesian_planning/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "0e3f7fa6e789b2ac15888554e1436b141f3eebe1fd7d5ab1f6c2d9618d5985b1";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/jazzy/roboplan_cartesian_planning/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "c12ca9726d05ab619d2e1407af40cd20ac08c8e29a8a617520292cc8481b15e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/roboplan-example-models/default.nix
+++ b/distros/jazzy/roboplan-example-models/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-roboplan-example-models";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/jazzy/roboplan_example_models/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "10efff762949a1f414ac34946af082810e52a67608c63d2807fd36dce862dedd";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/jazzy/roboplan_example_models/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "7c0b9035f6e9b6ac939b2e1e568afbf6d3205df9054c784547b656807eddf907";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/roboplan-examples/default.nix
+++ b/distros/jazzy/roboplan-examples/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, roboplan, roboplan-cartesian-planning, roboplan-example-models, roboplan-oink, roboplan-rrt, roboplan-simple-ik, roboplan-toppra, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, roboplan, roboplan-cartesian-planning, roboplan-example-models, roboplan-oink, roboplan-rrt, roboplan-simple-ik, roboplan-toppra, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-roboplan-examples";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/jazzy/roboplan_examples/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "674f20984ba5af9f862141ef2ec8bef1d3e962f148ce988f468da8fe9e8328ad";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/jazzy/roboplan_examples/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "be1c83123c605f2646dd5bc730cda7146d7239e22c5d976f568552f8bd2ea0f9";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-pytest ];
   propagatedBuildInputs = [ roboplan roboplan-cartesian-planning roboplan-example-models roboplan-oink roboplan-rrt roboplan-simple-ik roboplan-toppra xacro ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/jazzy/roboplan-oink/default.nix
+++ b/distros/jazzy/roboplan-oink/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, gtest, osqp-vendor, python3, python3Packages, roboplan, roboplan-example-models }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, gtest, proxsuite, python3, python3Packages, roboplan, roboplan-example-models }:
 buildRosPackage {
   pname = "ros-jazzy-roboplan-oink";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/jazzy/roboplan_oink/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "ab7ddc7f68e5850c25970c2ee0800ad2f1bdd07d1d247802fc96487fe5d43c4d";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/jazzy/roboplan_oink/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "e9a958c7f560a574ceb83ceded889b09ce5649fa4c21dc1905b5420ed7cecc0f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python python3 python3Packages.nanobind ];
   checkInputs = [ ament-cmake-gmock gtest roboplan-example-models ];
-  propagatedBuildInputs = [ osqp-vendor roboplan ];
+  propagatedBuildInputs = [ proxsuite roboplan ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/jazzy/roboplan-ros-cpp/default.nix
+++ b/distros/jazzy/roboplan-ros-cpp/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, builtin-interfaces, eigen, geometry-msgs, pinocchio, python3, python3Packages, roboplan, roboplan-example-models, rosidl-generator-cpp, sensor-msgs, tf2-eigen, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-roboplan-ros-cpp";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan_ros-release/archive/release/jazzy/roboplan_ros_cpp/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "411c6d13e646fada2489fb16b708464a894aaa09ddf8507c8cd37cde7b5bda31";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake builtin-interfaces python3 python3Packages.nanobind ];
+  checkInputs = [ ament-index-cpp roboplan-example-models ];
+  propagatedBuildInputs = [ eigen geometry-msgs pinocchio roboplan rosidl-generator-cpp sensor-msgs tf2-eigen trajectory-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS 2 C++ bindings for the RoboPlan motion planning library.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/roboplan-ros-examples/default.nix
+++ b/distros/jazzy/roboplan-ros-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-python, control-msgs, rclpy, roboplan, sensor-msgs, std-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-roboplan-ros-examples";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan_ros-release/archive/release/jazzy/roboplan_ros_examples/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "c4c442306e18f6e9f7d04fac64e2e475f46b7935dc119d5ee8863fa9bd38498a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-python ];
+  propagatedBuildInputs = [ control-msgs rclpy roboplan sensor-msgs std-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake-python ];
+
+  meta = {
+    description = "Examples of using RoboPlan in the ROS ecosystem.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/roboplan-ros-franka/default.nix
+++ b/distros/jazzy/roboplan-ros-franka/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, joint-state-broadcaster, joint-trajectory-controller, mujoco-ros2-control, parallel-gripper-controller, roboplan, roboplan-example-models, roboplan-ros-examples, robot-state-publisher, topic-tools, xacro }:
+buildRosPackage {
+  pname = "ros-jazzy-roboplan-ros-franka";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan_ros-release/archive/release/jazzy/roboplan_ros_franka/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "18b7af1859228c58d292a15998bb26a2ac3aaaa1d0090af6ffa7e0ec8328a860";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ controller-manager joint-state-broadcaster joint-trajectory-controller mujoco-ros2-control parallel-gripper-controller roboplan roboplan-example-models roboplan-ros-examples robot-state-publisher topic-tools xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Franka arm ROS example for RoboPlan.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/roboplan-ros-py/default.nix
+++ b/distros/jazzy/roboplan-ros-py/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, builtin-interfaces, python3Packages, rclpy, roboplan, roboplan-ros-cpp, sensor-msgs, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-roboplan-ros-py";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan_ros-release/archive/release/jazzy/roboplan_ros_py/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "df27446125635b07b9183ec769e47f039b5b5c460251f6b7806581a876fe70b6";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ python3Packages.pytest ];
+  propagatedBuildInputs = [ builtin-interfaces rclpy roboplan roboplan-ros-cpp sensor-msgs trajectory-msgs ];
+
+  meta = {
+    description = "ROS 2 Python bindings for the roboplan motion planning library.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/roboplan-ros-visualization/default.nix
+++ b/distros/jazzy/roboplan-ros-visualization/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-cpp, geometry-msgs, interactive-markers, python3, python3Packages, rclcpp, rclpy, roboplan, roboplan-ros-cpp, roboplan-simple-ik, rviz2, sensor-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-roboplan-ros-visualization";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan_ros-release/archive/release/jazzy/roboplan_ros_visualization/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "1773c7079643b7240ca90c410f0b1bdafa4351776389be031bec283e4da8cf90";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python python3 python3Packages.nanobind ];
+  propagatedBuildInputs = [ ament-index-cpp geometry-msgs interactive-markers rclcpp rclpy roboplan roboplan-ros-cpp roboplan-simple-ik rviz2 sensor-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "ROS 2 visualization tools for the RoboPlan library.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/roboplan-rrt/default.nix
+++ b/distros/jazzy/roboplan-rrt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, python3, python3Packages, roboplan, roboplan-example-models }:
 buildRosPackage {
   pname = "ros-jazzy-roboplan-rrt";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/jazzy/roboplan_rrt/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "449f8407b81ed06e33dc23a136139bea0707988a8bff0d6ae20b80b6d87e4274";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/jazzy/roboplan_rrt/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "e8cc02f606e38a58ec7a116d5f7deb5aa4a4f461980cf785d7afe08d56b2ebfa";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/roboplan-simple-ik/default.nix
+++ b/distros/jazzy/roboplan-simple-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, python3, python3Packages, roboplan }:
 buildRosPackage {
   pname = "ros-jazzy-roboplan-simple-ik";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/jazzy/roboplan_simple_ik/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "0040bb189f57eeff7ca9bc9e7ab7b3287ae3f681b7280b2ead3d36d98e0f33d4";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/jazzy/roboplan_simple_ik/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "419eb91e5757a61858747b62ae70836528312b1abe58f2454829cc7e11c97334";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/roboplan-toppra/default.nix
+++ b/distros/jazzy/roboplan-toppra/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, python3, python3Packages, roboplan, roboplan-example-models, toppra }:
 buildRosPackage {
   pname = "ros-jazzy-roboplan-toppra";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/jazzy/roboplan_toppra/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "524b3b3579befacf6b9ff80df7a977a24b31ae3a44b02d5bd7709ef96f1f1133";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/jazzy/roboplan_toppra/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "6f1ae6bb20dd841ffacd7eda4aa24f14dd8ca5b367601499d7f77d5ea83c03f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/roboplan/default.nix
+++ b/distros/jazzy/roboplan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, eigen, gtest, pinocchio, python3, python3Packages, roboplan-example-models, tinyxml2-vendor, tl-expected-nixpkgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-roboplan";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/jazzy/roboplan/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "b5e68abf377017480235040456534012fdd4e30b845c04834dd2e6e91cdda70c";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/jazzy/roboplan/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "3cccc319e1ae5bc779b6df1ed493429c245b2b23ad42b5f779d26b55511bca1c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-visual-tools/default.nix
+++ b/distros/jazzy/rviz-visual-tools/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, interactive-markers, launch, launch-ros, pluginlib, qt5, rclcpp, rclcpp-components, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz2, sensor-msgs, shape-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, interactive-markers, launch, launch-ros, pluginlib, qt6, rclcpp, rclcpp-components, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz2, sensor-msgs, shape-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-visual-tools";
-  version = "4.1.4-r4";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz_visual_tools-release/archive/release/jazzy/rviz_visual_tools/4.1.4-4.tar.gz";
-    name = "4.1.4-4.tar.gz";
-    sha256 = "67485862189e107a05b2d09edb20cf636b2ef7940a255ef1d6d52b22071d4c13";
+    url = "https://github.com/ros2-gbp/rviz_visual_tools-release/archive/release/jazzy/rviz_visual_tools/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "8cf8ebc3e67618554c8280de536e9a1d75fdce0488a20f503fc76fafe0d63b26";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python eigen eigen-stl-containers eigen3-cmake-module geometry-msgs interactive-markers launch launch-ros pluginlib qt5.qtbase rclcpp rclcpp-components rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering rviz2 sensor-msgs shape-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs visualization-msgs ];
+  propagatedBuildInputs = [ ament-index-python eigen eigen-stl-containers eigen3-cmake-module geometry-msgs interactive-markers launch launch-ros pluginlib qt6.qtbase rclcpp rclcpp-components rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering rviz2 sensor-msgs shape-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 
   meta = {

--- a/distros/jazzy/septentrio-gnss-driver/default.nix
+++ b/distros/jazzy/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, gtest-vendor, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-septentrio-gnss-driver";
-  version = "1.4.7-r3";
+  version = "1.4.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/jazzy/septentrio_gnss_driver/1.4.7-3.tar.gz";
-    name = "1.4.7-3.tar.gz";
-    sha256 = "fdb0714829a0d25b89de1c1323b3ff9512a7552fe778dda7698e7789ff1dd63a";
+    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/jazzy/septentrio_gnss_driver/1.4.8-2.tar.gz";
+    name = "1.4.8-2.tar.gz";
+    sha256 = "f454a98f3e52291d1cef5a6a1eeeafb25e4a4c8709eb035915a5551ad7c230e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/speech-recognition-msgs/default.nix
+++ b/distros/jazzy/speech-recognition-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-speech-recognition-msgs";
+  version = "5.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common_msgs-release/archive/release/jazzy/speech_recognition_msgs/5.0.1-3.tar.gz";
+    name = "5.0.1-3.tar.gz";
+    sha256 = "dc7a21068034aaa5e011c99413e785ea7219faa2d6369ee455e235fcdfe648ea";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "speech_recognition_msgs";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/warehouse-ros-sqlite/default.nix
+++ b/distros/jazzy/warehouse-ros-sqlite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite, warehouse-ros }:
 buildRosPackage {
   pname = "ros-jazzy-warehouse-ros-sqlite";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/jazzy/warehouse_ros_sqlite/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "47259eeded0a19240dd4bafd3569f05885a7aa12e37c54d8300a7889dbe134f6";
+    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/jazzy/warehouse_ros_sqlite/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "c5e6f78b834165d0054ff8d745854aa268d0fc86f6b2516a15aae7b9ff7a3b2c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/warehouse-ros/default.nix
+++ b/distros/jazzy/warehouse-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-lint-auto, boost, geometry-msgs, openssl, pluginlib, rclcpp, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-warehouse-ros";
-  version = "2.0.5-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/warehouse_ros-release/archive/release/jazzy/warehouse_ros/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "f994a507de271317ab28c70a6bf6298b39bdf09aa98727308b7c1bd1ddaf82df";
+    url = "https://github.com/ros2-gbp/warehouse_ros-release/archive/release/jazzy/warehouse_ros/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "d31b924baee74e0bc9861bb8ad0186327c117c3b91d19be1687c1d1985e035bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/generated.nix
+++ b/distros/kilted/generated.nix
@@ -1202,6 +1202,14 @@ self: super: {
 
  jrl-cmakemodules = self.callPackage ./jrl-cmakemodules {};
 
+ jsk-common-msgs = self.callPackage ./jsk-common-msgs {};
+
+ jsk-footstep-msgs = self.callPackage ./jsk-footstep-msgs {};
+
+ jsk-gui-msgs = self.callPackage ./jsk-gui-msgs {};
+
+ jsk-hark-msgs = self.callPackage ./jsk-hark-msgs {};
+
  kartech-linear-actuator-msgs = self.callPackage ./kartech-linear-actuator-msgs {};
 
  kdl-parser = self.callPackage ./kdl-parser {};
@@ -2188,6 +2196,8 @@ self: super: {
 
  pose-cov-ops = self.callPackage ./pose-cov-ops {};
 
+ posedetection-msgs = self.callPackage ./posedetection-msgs {};
+
  position-controllers = self.callPackage ./position-controllers {};
 
  protobuf-comm = self.callPackage ./protobuf-comm {};
@@ -2491,6 +2501,16 @@ self: super: {
  roboplan-examples = self.callPackage ./roboplan-examples {};
 
  roboplan-oink = self.callPackage ./roboplan-oink {};
+
+ roboplan-ros-cpp = self.callPackage ./roboplan-ros-cpp {};
+
+ roboplan-ros-examples = self.callPackage ./roboplan-ros-examples {};
+
+ roboplan-ros-franka = self.callPackage ./roboplan-ros-franka {};
+
+ roboplan-ros-py = self.callPackage ./roboplan-ros-py {};
+
+ roboplan-ros-visualization = self.callPackage ./roboplan-ros-visualization {};
 
  roboplan-rrt = self.callPackage ./roboplan-rrt {};
 
@@ -3027,6 +3047,8 @@ self: super: {
  spatio-temporal-voxel-layer = self.callPackage ./spatio-temporal-voxel-layer {};
 
  spdlog-vendor = self.callPackage ./spdlog-vendor {};
+
+ speech-recognition-msgs = self.callPackage ./speech-recognition-msgs {};
 
  spinnaker-camera-driver = self.callPackage ./spinnaker-camera-driver {};
 

--- a/distros/kilted/graph-msgs/default.nix
+++ b/distros/kilted/graph-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-graph-msgs";
-  version = "0.2.0-r6";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/graph_msgs-release/archive/release/kilted/graph_msgs/0.2.0-6.tar.gz";
-    name = "0.2.0-6.tar.gz";
-    sha256 = "3070a18fca5073f08542b2c0ebd192a4b395fdd48d3b42a21df587553f3e2497";
+    url = "https://github.com/ros2-gbp/graph_msgs-release/archive/release/kilted/graph_msgs/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "eb558c91a69aa171f74a4212c6cd8e440bd7586710c5ac1dfda5139422cd7720";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/joint-state-publisher-gui/default.nix
+++ b/distros/kilted/joint-state-publisher-gui/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, joint-state-publisher, python-qt-binding, rclpy }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, joint-state-publisher, python-qt-binding, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-kilted-joint-state-publisher-gui";
-  version = "2.4.1-r1";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/kilted/joint_state_publisher_gui/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "df80a9c3273d322ed33d6674ca28d93c7f156d6146a6978dfd95865459a1a68b";
+    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/kilted/joint_state_publisher_gui/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "f0d2ccab95a3f1d0ed4768b04b935f998ceffc59d0a9a473ff549be75bcf3fdb";
   };
 
   buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest ];
   propagatedBuildInputs = [ joint-state-publisher python-qt-binding rclpy ];
 
   meta = {

--- a/distros/kilted/joint-state-publisher/default.nix
+++ b/distros/kilted/joint-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2topic, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-joint-state-publisher";
-  version = "2.4.1-r1";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/kilted/joint_state_publisher/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "982c27687ebd45fd400e979e8377428e0d048af18c7115c679db9cabc3ed7788";
+    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/kilted/joint_state_publisher/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "2dbfb357655cc5bedbf2ea219c46bc8e4410a362af31aab0e325d3b6be716b83";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/jsk-common-msgs/default.nix
+++ b/distros/kilted/jsk-common-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, jsk-footstep-msgs, jsk-gui-msgs, jsk-hark-msgs, posedetection-msgs, ros-environment, speech-recognition-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-jsk-common-msgs";
+  version = "5.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common_msgs-release/archive/release/kilted/jsk_common_msgs/5.0.1-3.tar.gz";
+    name = "5.0.1-3.tar.gz";
+    sha256 = "959bf2809278798dde471e8bb2ab2b5b2c44fbb42134622ca96b4fa5fa3221db";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ jsk-footstep-msgs jsk-gui-msgs jsk-hark-msgs posedetection-msgs speech-recognition-msgs ];
+  nativeBuildInputs = [ ament-cmake ros-environment ];
+
+  meta = {
+    description = "<p>Metapackage that contains commonly used messages for jsk-ros-pkg</p>";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/jsk-footstep-msgs/default.nix
+++ b/distros/kilted/jsk-footstep-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-jsk-footstep-msgs";
+  version = "5.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common_msgs-release/archive/release/kilted/jsk_footstep_msgs/5.0.1-3.tar.gz";
+    name = "5.0.1-3.tar.gz";
+    sha256 = "c0524aaf3921a02502f5c0c0f8a817b94a57ca2e927a5f729d89ad31a42991bb";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "jsk_footstep_msgs";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/jsk-gui-msgs/default.nix
+++ b/distros/kilted/jsk-gui-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-jsk-gui-msgs";
+  version = "5.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common_msgs-release/archive/release/kilted/jsk_gui_msgs/5.0.1-3.tar.gz";
+    name = "5.0.1-3.tar.gz";
+    sha256 = "110093a19dfa04fcd32bc2229ff42e030871f7d894ba7dc51a69eec192b6c72e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "jsk_gui_msgs";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kilted/jsk-hark-msgs/default.nix
+++ b/distros/kilted/jsk-hark-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-jsk-hark-msgs";
+  version = "5.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common_msgs-release/archive/release/kilted/jsk_hark_msgs/5.0.1-3.tar.gz";
+    name = "5.0.1-3.tar.gz";
+    sha256 = "24927a70ff02350a0d89f584f91dd06bb39a8ffc64944a36a7e4de9b00af3899";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "jsk_hark_msgs";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/moveit-visual-tools/default.nix
+++ b/distros/kilted/moveit-visual-tools/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, graph-msgs, moveit-common, moveit-core, moveit-ros-planning, rclcpp, rviz-visual-tools, std-msgs, tf2-eigen, tf2-ros, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, geometric-shapes, geometry-msgs, graph-msgs, interactive-markers, moveit-common, moveit-core, moveit-msgs, moveit-ros-planning, rclcpp, rviz-visual-tools, std-msgs, tf2-eigen, tf2-ros, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-moveit-visual-tools";
-  version = "4.1.2-r2";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_visual_tools-release/archive/release/kilted/moveit_visual_tools/4.1.2-2.tar.gz";
-    name = "4.1.2-2.tar.gz";
-    sha256 = "92ec9d74e14d7292340cc8946072e47ecc3b28af570731a789373326bed67e96";
+    url = "https://github.com/ros2-gbp/moveit_visual_tools-release/archive/release/kilted/moveit_visual_tools/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "2bd581e8aa10e0e9c0224bc8b98462e9ee51f73f1f5b949eb87b3d96b9a007ff";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs graph-msgs moveit-common moveit-core moveit-ros-planning rclcpp rviz-visual-tools std-msgs tf2-eigen tf2-ros trajectory-msgs visualization-msgs ];
+  propagatedBuildInputs = [ ament-index-cpp geometric-shapes geometry-msgs graph-msgs interactive-markers moveit-common moveit-core moveit-msgs moveit-ros-planning rclcpp rviz-visual-tools std-msgs tf2-eigen tf2-ros trajectory-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -760,6 +760,13 @@ in {
     ];
   });
 
+  proxsuite = rosSuper.proxsuite.overrideAttrs ({
+    propagatedBuildInputs ? [], ...
+  }: {
+    # TODO: Remove after https://github.com/Simple-Robotics/proxsuite/pull/469 appears in a release
+    propagatedBuildInputs = propagatedBuildInputs ++ [ self.simde ];
+  });
+
   pybind11-json-vendor = lib.patchAmentVendorGit rosSuper.pybind11-json-vendor {
     patchesFor.pybind11_json_vendor = [
       (self.writeText "cmakelist.patch" ''

--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -604,15 +604,6 @@ in {
     ];
   });
 
-  moveit-visual-tools = rosSuper.moveit-visual-tools.overrideAttrs ({
-    postPatch ? "", ...
-  }: {
-    # https://github.com/moveit/moveit_visual_tools/pull/154
-    postPatch = postPatch + ''
-      substituteInPlace CMakeLists.txt --replace-fail " system" ""
-    '';
-  });
-
   mp-units-vendor = lib.patchAmentVendorGit rosSuper.mp-units-vendor {};
 
   mqtt-client = rosSuper.mqtt-client.overrideAttrs ({

--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -825,10 +825,7 @@ in {
     propagatedBuildInputs = propagatedBuildInputs ++ [ rosSelf.toppra ];
   });
 
-  roboplan-oink = (rosSuper.roboplan-oink.override {
-    # https://github.com/tier4/osqp_vendor/issues/26
-    osqp-vendor = null;
-  }).overrideAttrs ({
+  roboplan-oink = rosSuper.roboplan-oink.overrideAttrs ({
     propagatedBuildInputs ? [], ...
   }: {
     # Prevent cmake from fetching osqp-eigen via git

--- a/distros/kilted/posedetection-msgs/default.nix
+++ b/distros/kilted/posedetection-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, message-filters, rclcpp, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-posedetection-msgs";
+  version = "5.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common_msgs-release/archive/release/kilted/posedetection_msgs/5.0.1-3.tar.gz";
+    name = "5.0.1-3.tar.gz";
+    sha256 = "29c1db4d90f76e97ff2c50f7a20064c6aad288246bf240e4999ec4a5f478d386";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs message-filters rclcpp rosidl-default-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "posedetection_msgs provides messages and services to facilitate passing pose detection results and features.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/roboplan-cartesian-planning/default.nix
+++ b/distros/kilted/roboplan-cartesian-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, python3, python3Packages, roboplan, roboplan-example-models, roboplan-oink, roboplan-toppra }:
 buildRosPackage {
   pname = "ros-kilted-roboplan-cartesian-planning";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/kilted/roboplan_cartesian_planning/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "213cb017676bbacb73257bc8d826ca8c681175a243e81b52ed0865e88624b988";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/kilted/roboplan_cartesian_planning/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "03d1571f2bdec29c821e23d9d8381dca6913b0ca38c607516c0a8c57aa61da78";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/roboplan-example-models/default.nix
+++ b/distros/kilted/roboplan-example-models/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-kilted-roboplan-example-models";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/kilted/roboplan_example_models/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "d880303d3d54de03e69c95bfa5d93f9baf53214323b5bf8abdb57525a4379198";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/kilted/roboplan_example_models/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "0824782accc2b93280480e625fa740505d03c75ec7cf5a30a351e0d549e4f09f";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/roboplan-examples/default.nix
+++ b/distros/kilted/roboplan-examples/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, roboplan, roboplan-cartesian-planning, roboplan-example-models, roboplan-oink, roboplan-rrt, roboplan-simple-ik, roboplan-toppra, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, roboplan, roboplan-cartesian-planning, roboplan-example-models, roboplan-oink, roboplan-rrt, roboplan-simple-ik, roboplan-toppra, xacro }:
 buildRosPackage {
   pname = "ros-kilted-roboplan-examples";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/kilted/roboplan_examples/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "4fc476485a513d7c86d846e15c0518310fc934a73b20040809b79fb13bac2cf6";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/kilted/roboplan_examples/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "97fa689f16702120de8e79e7b394b2df27b70c7e7446900bb27df1606e52b5aa";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-pytest ];
   propagatedBuildInputs = [ roboplan roboplan-cartesian-planning roboplan-example-models roboplan-oink roboplan-rrt roboplan-simple-ik roboplan-toppra xacro ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/kilted/roboplan-oink/default.nix
+++ b/distros/kilted/roboplan-oink/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, gtest, osqp-vendor, python3, python3Packages, roboplan, roboplan-example-models }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, gtest, proxsuite, python3, python3Packages, roboplan, roboplan-example-models }:
 buildRosPackage {
   pname = "ros-kilted-roboplan-oink";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/kilted/roboplan_oink/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "f2927c12d47c9b1c7d1f529b2639da80925e6588db8ccf41c694cd29b6c70d0d";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/kilted/roboplan_oink/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "4be954ae24d76a560bb6fbc926a170fb121127cfa63b71009bf1750560dd6464";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python python3 python3Packages.nanobind ];
   checkInputs = [ ament-cmake-gmock gtest roboplan-example-models ];
-  propagatedBuildInputs = [ osqp-vendor roboplan ];
+  propagatedBuildInputs = [ proxsuite roboplan ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/kilted/roboplan-ros-cpp/default.nix
+++ b/distros/kilted/roboplan-ros-cpp/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, builtin-interfaces, eigen, geometry-msgs, pinocchio, python3, python3Packages, roboplan, roboplan-example-models, rosidl-generator-cpp, sensor-msgs, tf2-eigen, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-roboplan-ros-cpp";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan_ros-release/archive/release/kilted/roboplan_ros_cpp/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "af72ae460405812fd58297514ae0cda9cd598b25d54895aa509f82fda7d24d9d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake builtin-interfaces python3 python3Packages.nanobind ];
+  checkInputs = [ ament-index-cpp roboplan-example-models ];
+  propagatedBuildInputs = [ eigen geometry-msgs pinocchio roboplan rosidl-generator-cpp sensor-msgs tf2-eigen trajectory-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS 2 C++ bindings for the RoboPlan motion planning library.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kilted/roboplan-ros-examples/default.nix
+++ b/distros/kilted/roboplan-ros-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-python, control-msgs, rclpy, roboplan, sensor-msgs, std-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-roboplan-ros-examples";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan_ros-release/archive/release/kilted/roboplan_ros_examples/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "ea5f75516c308c687e6361f022dac84cb4eac2c9427d2ae9e564db0c46d4c4f3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-python ];
+  propagatedBuildInputs = [ control-msgs rclpy roboplan sensor-msgs std-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake-python ];
+
+  meta = {
+    description = "Examples of using RoboPlan in the ROS ecosystem.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kilted/roboplan-ros-franka/default.nix
+++ b/distros/kilted/roboplan-ros-franka/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, joint-state-broadcaster, joint-trajectory-controller, mujoco-ros2-control, parallel-gripper-controller, roboplan, roboplan-example-models, roboplan-ros-examples, robot-state-publisher, topic-tools, xacro }:
+buildRosPackage {
+  pname = "ros-kilted-roboplan-ros-franka";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan_ros-release/archive/release/kilted/roboplan_ros_franka/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "ec040bf2eaf2995f75edaad3b644b47f4c569bc1c261ea93b8addc204539ad2f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ controller-manager joint-state-broadcaster joint-trajectory-controller mujoco-ros2-control parallel-gripper-controller roboplan roboplan-example-models roboplan-ros-examples robot-state-publisher topic-tools xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Franka arm ROS example for RoboPlan.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kilted/roboplan-ros-py/default.nix
+++ b/distros/kilted/roboplan-ros-py/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, builtin-interfaces, python3Packages, rclpy, roboplan, roboplan-ros-cpp, sensor-msgs, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-roboplan-ros-py";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan_ros-release/archive/release/kilted/roboplan_ros_py/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "0dd4dec926f7f756e659c0cdf3f7055b106ffb8a77d9de2c593b813d0559796d";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ python3Packages.pytest ];
+  propagatedBuildInputs = [ builtin-interfaces rclpy roboplan roboplan-ros-cpp sensor-msgs trajectory-msgs ];
+
+  meta = {
+    description = "ROS 2 Python bindings for the roboplan motion planning library.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kilted/roboplan-ros-visualization/default.nix
+++ b/distros/kilted/roboplan-ros-visualization/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-cpp, geometry-msgs, interactive-markers, python3, python3Packages, rclcpp, rclpy, roboplan, roboplan-ros-cpp, roboplan-simple-ik, rviz2, sensor-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-roboplan-ros-visualization";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan_ros-release/archive/release/kilted/roboplan_ros_visualization/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "3d65a47854938bce5b717a88c985c2bb00a4a2d29200ad0161788f34acf09274";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python python3 python3Packages.nanobind ];
+  propagatedBuildInputs = [ ament-index-cpp geometry-msgs interactive-markers rclcpp rclpy roboplan roboplan-ros-cpp roboplan-simple-ik rviz2 sensor-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "ROS 2 visualization tools for the RoboPlan library.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kilted/roboplan-rrt/default.nix
+++ b/distros/kilted/roboplan-rrt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, python3, python3Packages, roboplan, roboplan-example-models }:
 buildRosPackage {
   pname = "ros-kilted-roboplan-rrt";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/kilted/roboplan_rrt/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "89c8393e6d4e97b5eab12787f35c75a086d7609b8fa8acabdd14ae5bf3894e0c";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/kilted/roboplan_rrt/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "db8eba7098fc6c0d613215aadb0f268dcab68dde2d91fb047b2af1d5882063b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/roboplan-simple-ik/default.nix
+++ b/distros/kilted/roboplan-simple-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, python3, python3Packages, roboplan }:
 buildRosPackage {
   pname = "ros-kilted-roboplan-simple-ik";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/kilted/roboplan_simple_ik/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "6563679f34adbc20ac41986babbee44d6f754285423e552d84ae71a2952a43eb";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/kilted/roboplan_simple_ik/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "db6c9f067ef1a694c85f127fc26adbd4df54d0b00d1f777ecec59df2dad13949";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/roboplan-toppra/default.nix
+++ b/distros/kilted/roboplan-toppra/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, python3, python3Packages, roboplan, roboplan-example-models, toppra }:
 buildRosPackage {
   pname = "ros-kilted-roboplan-toppra";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/kilted/roboplan_toppra/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "9fa930e27f6320a73913968ba39866456da451b820b2182f34fa4243cb87af29";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/kilted/roboplan_toppra/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "743fb296ae597371735a01da5f829425955bc10286dd31bfc619269242356fd8";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/roboplan/default.nix
+++ b/distros/kilted/roboplan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, eigen, gtest, pinocchio, python3, python3Packages, roboplan-example-models, tinyxml2-vendor, tl-expected-nixpkgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-kilted-roboplan";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/kilted/roboplan/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "942a4bef9fdfa87245dc284fd805d14d32891b9e5139e5d405379fa21c01afd6";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/kilted/roboplan/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "ce5154ca6b8a796559744a95bc983d1260634460e92870e4a46c94b9789befc0";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/rviz-visual-tools/default.nix
+++ b/distros/kilted/rviz-visual-tools/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, interactive-markers, launch, launch-ros, pluginlib, qt5, rclcpp, rclcpp-components, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz2, sensor-msgs, shape-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, interactive-markers, launch, launch-ros, pluginlib, qt6, rclcpp, rclcpp-components, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz2, sensor-msgs, shape-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-rviz-visual-tools";
-  version = "4.1.4-r4";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz_visual_tools-release/archive/release/kilted/rviz_visual_tools/4.1.4-4.tar.gz";
-    name = "4.1.4-4.tar.gz";
-    sha256 = "ace88eb4b69a609b9128162113c3f6b8ad384cfeb0d2259fcd3b9de83ebbdf22";
+    url = "https://github.com/ros2-gbp/rviz_visual_tools-release/archive/release/kilted/rviz_visual_tools/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "821984ad5bb35d92a48ee93762ef3dbea06436b451456c56a643141a2d2046a4";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python eigen eigen-stl-containers eigen3-cmake-module geometry-msgs interactive-markers launch launch-ros pluginlib qt5.qtbase rclcpp rclcpp-components rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering rviz2 sensor-msgs shape-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs visualization-msgs ];
+  propagatedBuildInputs = [ ament-index-python eigen eigen-stl-containers eigen3-cmake-module geometry-msgs interactive-markers launch launch-ros pluginlib qt6.qtbase rclcpp rclcpp-components rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering rviz2 sensor-msgs shape-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 
   meta = {

--- a/distros/kilted/septentrio-gnss-driver/default.nix
+++ b/distros/kilted/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, gtest-vendor, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-septentrio-gnss-driver";
-  version = "1.4.7-r2";
+  version = "1.4.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/kilted/septentrio_gnss_driver/1.4.7-2.tar.gz";
-    name = "1.4.7-2.tar.gz";
-    sha256 = "601fe589983346e20a36a924d947e34f965a0fb75842578752b3da38c60f7539";
+    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/kilted/septentrio_gnss_driver/1.4.8-1.tar.gz";
+    name = "1.4.8-1.tar.gz";
+    sha256 = "ec2599440aa9b1b352699f2de808ea7e56a81835d4df209f17e83ff3af1508f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/speech-recognition-msgs/default.nix
+++ b/distros/kilted/speech-recognition-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-speech-recognition-msgs";
+  version = "5.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common_msgs-release/archive/release/kilted/speech_recognition_msgs/5.0.1-3.tar.gz";
+    name = "5.0.1-3.tar.gz";
+    sha256 = "fbc8d482689704f7256a9e12d86d92022e02a19f64b703b063bc2cd6e82b3f96";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "speech_recognition_msgs";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kilted/warehouse-ros-sqlite/default.nix
+++ b/distros/kilted/warehouse-ros-sqlite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite, warehouse-ros }:
 buildRosPackage {
   pname = "ros-kilted-warehouse-ros-sqlite";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/kilted/warehouse_ros_sqlite/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "aa674e87db0bad12b2ee8adb5fbf7f29c3a62882e55b00a3a44d80650942d020";
+    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/kilted/warehouse_ros_sqlite/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "eada2865504e87fac8f152cb911ffd7f1c072850e14d83ee928211a64edf45c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/warehouse-ros/default.nix
+++ b/distros/kilted/warehouse-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-lint-auto, boost, geometry-msgs, openssl, pluginlib, rclcpp, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-warehouse-ros";
-  version = "2.0.5-r2";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/warehouse_ros-release/archive/release/kilted/warehouse_ros/2.0.5-2.tar.gz";
-    name = "2.0.5-2.tar.gz";
-    sha256 = "646d75b9ef1b020f5efef925a3ba7f378701f9957807f4ace90a45c4b9cefe37";
+    url = "https://github.com/ros2-gbp/warehouse_ros-release/archive/release/kilted/warehouse_ros/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "d3268cc44ab97387eb94c406c0ff6ccfdaf9fd219be1e635ead4ba5901f5ddd2";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/costmap-queue/default.nix
+++ b/distros/lyrical/costmap-queue/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, backward-ros, nav2-common, nav2-costmap-2d, rclcpp }:
+buildRosPackage {
+  pname = "ros-lyrical-costmap-queue";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/costmap_queue/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "dbf0ad75c9ffee55d7d32b11add7672281817ceb3dc9fdf1055180e372b3a1cd";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-ros ament-lint-auto ament-lint-common rclcpp ];
+  propagatedBuildInputs = [ backward-ros nav2-costmap-2d ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The costmap_queue package";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/lyrical/dwb-core/default.nix
+++ b/distros/lyrical/dwb-core/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, backward-ros, builtin-interfaces, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-ros-common, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-dwb-core";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/dwb_core/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "702e2ab28e0dd4d9ea5c9e831191d6d9480bbc24b4bba92fc93bccb26359d398";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-ros ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ backward-ros builtin-interfaces dwb-msgs geometry-msgs nav-2d-msgs nav-2d-utils nav-msgs nav2-core nav2-costmap-2d nav2-ros-common nav2-util pluginlib rclcpp rclcpp-lifecycle sensor-msgs tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "DWB core interfaces package";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/lyrical/dwb-critics/default.nix
+++ b/distros/lyrical/dwb-critics/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, angles, backward-ros, costmap-queue, dwb-core, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-ros-common, nav2-util, pluginlib, rclcpp, tf2, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-dwb-critics";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/dwb_critics/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "08471fd28b8c84c7d6ac64fcfb27a7c8fd1a6ec8a56c847f970b36e58e0510f8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake angles nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-ros ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ backward-ros costmap-queue dwb-core dwb-msgs geometry-msgs nav-2d-msgs nav-2d-utils nav2-costmap-2d nav2-ros-common nav2-util pluginlib rclcpp tf2 tf2-geometry-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The dwb_critics package";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/lyrical/dwb-msgs/default.nix
+++ b/distros/lyrical/dwb-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, backward-ros, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-dwb-msgs";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/dwb_msgs/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "5506e27cf71a1fa16820f9ddd8ef8de2519e9367a878270516a3d894c9547c59";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ backward-ros builtin-interfaces geometry-msgs nav-2d-msgs nav-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "Message/Service definitions specifically for the dwb_core";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/lyrical/dwb-plugins/default.nix
+++ b/distros/lyrical/dwb-plugins/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, backward-ros, dwb-core, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-ros-common, nav2-util, pluginlib, rcl-interfaces, rclcpp, rclcpp-lifecycle }:
+buildRosPackage {
+  pname = "ros-lyrical-dwb-plugins";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/dwb_plugins/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "55c8f44cb8e96e1825e7ded27bc966020e3c794c5eaa4b9a4dc2e0b7d9ffaad4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-ros ament-lint-auto ament-lint-common nav2-costmap-2d rclcpp-lifecycle ];
+  propagatedBuildInputs = [ backward-ros dwb-core dwb-msgs geometry-msgs nav-2d-msgs nav-2d-utils nav2-ros-common nav2-util pluginlib rcl-interfaces rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Standard implementations of the GoalChecker
+      and TrajectoryGenerators for dwb_core";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/lyrical/generated.nix
+++ b/distros/lyrical/generated.nix
@@ -434,6 +434,8 @@ self: super: {
 
  controller-manager-msgs = self.callPackage ./controller-manager-msgs {};
 
+ costmap-queue = self.callPackage ./costmap-queue {};
+
  cras-bag-tools = self.callPackage ./cras-bag-tools {};
 
  cras-cpp-common = self.callPackage ./cras-cpp-common {};
@@ -579,6 +581,14 @@ self: super: {
  dummy-robot-bringup = self.callPackage ./dummy-robot-bringup {};
 
  dummy-sensors = self.callPackage ./dummy-sensors {};
+
+ dwb-core = self.callPackage ./dwb-core {};
+
+ dwb-critics = self.callPackage ./dwb-critics {};
+
+ dwb-msgs = self.callPackage ./dwb-msgs {};
+
+ dwb-plugins = self.callPackage ./dwb-plugins {};
 
  dynamixel-hardware = self.callPackage ./dynamixel-hardware {};
 
@@ -1129,6 +1139,14 @@ self: super: {
  joy-tester = self.callPackage ./joy-tester {};
 
  jrl-cmakemodules = self.callPackage ./jrl-cmakemodules {};
+
+ jsk-common-msgs = self.callPackage ./jsk-common-msgs {};
+
+ jsk-footstep-msgs = self.callPackage ./jsk-footstep-msgs {};
+
+ jsk-gui-msgs = self.callPackage ./jsk-gui-msgs {};
+
+ jsk-hark-msgs = self.callPackage ./jsk-hark-msgs {};
 
  kartech-linear-actuator-msgs = self.callPackage ./kartech-linear-actuator-msgs {};
 
@@ -1776,13 +1794,87 @@ self: super: {
 
  nao-sensor-msgs = self.callPackage ./nao-sensor-msgs {};
 
+ nav2-amcl = self.callPackage ./nav2-amcl {};
+
+ nav2-behavior-tree = self.callPackage ./nav2-behavior-tree {};
+
+ nav2-behaviors = self.callPackage ./nav2-behaviors {};
+
+ nav2-bringup = self.callPackage ./nav2-bringup {};
+
+ nav2-bt-navigator = self.callPackage ./nav2-bt-navigator {};
+
+ nav2-collision-monitor = self.callPackage ./nav2-collision-monitor {};
+
+ nav2-common = self.callPackage ./nav2-common {};
+
+ nav2-constrained-smoother = self.callPackage ./nav2-constrained-smoother {};
+
+ nav2-controller = self.callPackage ./nav2-controller {};
+
+ nav2-core = self.callPackage ./nav2-core {};
+
+ nav2-costmap-2d = self.callPackage ./nav2-costmap-2d {};
+
+ nav2-dwb-controller = self.callPackage ./nav2-dwb-controller {};
+
+ nav2-graceful-controller = self.callPackage ./nav2-graceful-controller {};
+
+ nav2-lifecycle-manager = self.callPackage ./nav2-lifecycle-manager {};
+
+ nav2-loopback-sim = self.callPackage ./nav2-loopback-sim {};
+
+ nav2-map-server = self.callPackage ./nav2-map-server {};
+
  nav2-minimal-tb3-sim = self.callPackage ./nav2-minimal-tb3-sim {};
 
  nav2-minimal-tb4-description = self.callPackage ./nav2-minimal-tb4-description {};
 
  nav2-minimal-tb4-sim = self.callPackage ./nav2-minimal-tb4-sim {};
 
+ nav2-mppi-controller = self.callPackage ./nav2-mppi-controller {};
+
+ nav2-msgs = self.callPackage ./nav2-msgs {};
+
+ nav2-navfn-planner = self.callPackage ./nav2-navfn-planner {};
+
+ nav2-planner = self.callPackage ./nav2-planner {};
+
+ nav2-regulated-pure-pursuit-controller = self.callPackage ./nav2-regulated-pure-pursuit-controller {};
+
+ nav2-ros-common = self.callPackage ./nav2-ros-common {};
+
+ nav2-rotation-shim-controller = self.callPackage ./nav2-rotation-shim-controller {};
+
+ nav2-route = self.callPackage ./nav2-route {};
+
+ nav2-rviz-plugins = self.callPackage ./nav2-rviz-plugins {};
+
+ nav2-simple-commander = self.callPackage ./nav2-simple-commander {};
+
+ nav2-smac-planner = self.callPackage ./nav2-smac-planner {};
+
+ nav2-smoother = self.callPackage ./nav2-smoother {};
+
+ nav2-system-tests = self.callPackage ./nav2-system-tests {};
+
+ nav2-theta-star-planner = self.callPackage ./nav2-theta-star-planner {};
+
+ nav2-util = self.callPackage ./nav2-util {};
+
+ nav2-velocity-smoother = self.callPackage ./nav2-velocity-smoother {};
+
+ nav2-voxel-grid = self.callPackage ./nav2-voxel-grid {};
+
+ nav2-waypoint-follower = self.callPackage ./nav2-waypoint-follower {};
+
+ nav-2d-msgs = self.callPackage ./nav-2d-msgs {};
+
+ nav-2d-utils = self.callPackage ./nav-2d-utils {};
+
  nav-msgs = self.callPackage ./nav-msgs {};
+
+ navigation2 = self.callPackage ./navigation2 {};
 
  navmap-core = self.callPackage ./navmap-core {};
 
@@ -1901,6 +1993,14 @@ self: super: {
  open-manipulator-teleop = self.callPackage ./open-manipulator-teleop {};
 
  openeb-vendor = self.callPackage ./openeb-vendor {};
+
+ opennav-docking = self.callPackage ./opennav-docking {};
+
+ opennav-docking-bt = self.callPackage ./opennav-docking-bt {};
+
+ opennav-docking-core = self.callPackage ./opennav-docking-core {};
+
+ opennav-following = self.callPackage ./opennav-following {};
 
  openni2-camera = self.callPackage ./openni2-camera {};
 
@@ -2083,6 +2183,8 @@ self: super: {
  pose-broadcaster = self.callPackage ./pose-broadcaster {};
 
  pose-cov-ops = self.callPackage ./pose-cov-ops {};
+
+ posedetection-msgs = self.callPackage ./posedetection-msgs {};
 
  protobuf-comm = self.callPackage ./protobuf-comm {};
 
@@ -2397,6 +2499,16 @@ self: super: {
  roboplan-examples = self.callPackage ./roboplan-examples {};
 
  roboplan-oink = self.callPackage ./roboplan-oink {};
+
+ roboplan-ros-cpp = self.callPackage ./roboplan-ros-cpp {};
+
+ roboplan-ros-examples = self.callPackage ./roboplan-ros-examples {};
+
+ roboplan-ros-franka = self.callPackage ./roboplan-ros-franka {};
+
+ roboplan-ros-py = self.callPackage ./roboplan-ros-py {};
+
+ roboplan-ros-visualization = self.callPackage ./roboplan-ros-visualization {};
 
  roboplan-rrt = self.callPackage ./roboplan-rrt {};
 
@@ -2967,6 +3079,8 @@ self: super: {
  spacenav = self.callPackage ./spacenav {};
 
  spdlog-vendor = self.callPackage ./spdlog-vendor {};
+
+ speech-recognition-msgs = self.callPackage ./speech-recognition-msgs {};
 
  spinnaker-camera-driver = self.callPackage ./spinnaker-camera-driver {};
 

--- a/distros/lyrical/graph-msgs/default.nix
+++ b/distros/lyrical/graph-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-graph-msgs";
-  version = "0.2.0-r7";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/graph_msgs-release/archive/release/lyrical/graph_msgs/0.2.0-7.tar.gz";
-    name = "0.2.0-7.tar.gz";
-    sha256 = "f5d9fcc785d525f70812dc95566bf1b085a6fcf1f1dbb259e80203599ea9caa8";
+    url = "https://github.com/ros2-gbp/graph_msgs-release/archive/release/lyrical/graph_msgs/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "1e7314ea68852f972450d6ed7e06416a06d7db8e4b14ca555d936f06ec69c5e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/joint-state-publisher-gui/default.nix
+++ b/distros/lyrical/joint-state-publisher-gui/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, joint-state-publisher, python-qt-binding, rclpy }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, joint-state-publisher, python-qt-binding, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-lyrical-joint-state-publisher-gui";
-  version = "2.4.2-r1";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/lyrical/joint_state_publisher_gui/2.4.2-1.tar.gz";
-    name = "2.4.2-1.tar.gz";
-    sha256 = "4b029e37e35ed2cfb627be2c685987ee8b30273d304a699191a0780b99b4c3b9";
+    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/lyrical/joint_state_publisher_gui/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "791a052f27f9bc03031d318db67393b91c21613d86fe5b79cf43b972574a218c";
   };
 
   buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest ];
   propagatedBuildInputs = [ joint-state-publisher python-qt-binding rclpy ];
 
   meta = {

--- a/distros/lyrical/joint-state-publisher/default.nix
+++ b/distros/lyrical/joint-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2topic, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-joint-state-publisher";
-  version = "2.4.2-r1";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/lyrical/joint_state_publisher/2.4.2-1.tar.gz";
-    name = "2.4.2-1.tar.gz";
-    sha256 = "0e3427880ceb142ee116bfd91653430e2499398f80db1a138c57a66e7a4e72a0";
+    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/lyrical/joint_state_publisher/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "4e079549446a3cd54bbb41e067958041e01909709f1595936ea807bd406cba26";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/jsk-common-msgs/default.nix
+++ b/distros/lyrical/jsk-common-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, jsk-footstep-msgs, jsk-gui-msgs, jsk-hark-msgs, posedetection-msgs, ros-environment, speech-recognition-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-jsk-common-msgs";
+  version = "5.0.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common_msgs-release/archive/release/lyrical/jsk_common_msgs/5.0.1-2.tar.gz";
+    name = "5.0.1-2.tar.gz";
+    sha256 = "bb1e2639435abd70086b1a56470ab8f2bebba8f26d0d5677be5ad88b8cd5a506";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ jsk-footstep-msgs jsk-gui-msgs jsk-hark-msgs posedetection-msgs speech-recognition-msgs ];
+  nativeBuildInputs = [ ament-cmake ros-environment ];
+
+  meta = {
+    description = "<p>Metapackage that contains commonly used messages for jsk-ros-pkg</p>";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/jsk-footstep-msgs/default.nix
+++ b/distros/lyrical/jsk-footstep-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-jsk-footstep-msgs";
+  version = "5.0.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common_msgs-release/archive/release/lyrical/jsk_footstep_msgs/5.0.1-2.tar.gz";
+    name = "5.0.1-2.tar.gz";
+    sha256 = "2a22d314ea30b972642ea1986df129c3602c3a623b16d02a423c31038116925b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "jsk_footstep_msgs";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/jsk-gui-msgs/default.nix
+++ b/distros/lyrical/jsk-gui-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-jsk-gui-msgs";
+  version = "5.0.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common_msgs-release/archive/release/lyrical/jsk_gui_msgs/5.0.1-2.tar.gz";
+    name = "5.0.1-2.tar.gz";
+    sha256 = "41879c8f926741efb9d9c1cf67fe5b69b8c7992e395084d30598a0e9112c6c9f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "jsk_gui_msgs";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/jsk-hark-msgs/default.nix
+++ b/distros/lyrical/jsk-hark-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-jsk-hark-msgs";
+  version = "5.0.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common_msgs-release/archive/release/lyrical/jsk_hark_msgs/5.0.1-2.tar.gz";
+    name = "5.0.1-2.tar.gz";
+    sha256 = "1c3c7bdd5b2b563727a544b44638db3401b6bbe734f52e1096179a1179f1cd7a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "jsk_hark_msgs";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/moveit-visual-tools/default.nix
+++ b/distros/lyrical/moveit-visual-tools/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, graph-msgs, moveit-common, moveit-core, moveit-ros-planning, rclcpp, rviz-visual-tools, std-msgs, tf2-eigen, tf2-ros, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, geometric-shapes, geometry-msgs, graph-msgs, interactive-markers, moveit-common, moveit-core, moveit-msgs, moveit-ros-planning, rclcpp, rviz-visual-tools, std-msgs, tf2-eigen, tf2-ros, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-moveit-visual-tools";
-  version = "4.1.2-r3";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_visual_tools-release/archive/release/lyrical/moveit_visual_tools/4.1.2-3.tar.gz";
-    name = "4.1.2-3.tar.gz";
-    sha256 = "040caf06f3cf3e39dcc89bc2dec943bca9213e659bbe1043666e1d2cd4eb0c48";
+    url = "https://github.com/ros2-gbp/moveit_visual_tools-release/archive/release/lyrical/moveit_visual_tools/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "395535da531c80a59ecea97bc835fa1028827379258d1c0de5dd5e021e142a17";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs graph-msgs moveit-common moveit-core moveit-ros-planning rclcpp rviz-visual-tools std-msgs tf2-eigen tf2-ros trajectory-msgs visualization-msgs ];
+  propagatedBuildInputs = [ ament-index-cpp geometric-shapes geometry-msgs graph-msgs interactive-markers moveit-common moveit-core moveit-msgs moveit-ros-planning rclcpp rviz-visual-tools std-msgs tf2-eigen tf2-ros trajectory-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/lyrical/nav-2d-msgs/default.nix
+++ b/distros/lyrical/nav-2d-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, backward-ros, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-nav-2d-msgs";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav_2d_msgs/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "2f4614c9025df38052d51eb6e159d7cb97e7b54cfd23837173ed61548b5468df";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "Basic message types for two dimensional navigation, extending from geometry_msgs::Pose.";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/lyrical/nav-2d-utils/default.nix
+++ b/distros/lyrical/nav-2d-utils/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, backward-ros, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-nav-2d-utils";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav_2d_utils/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "a660c614626c22bc137f03d4708cc758249bd14287b62bd3fd249463da095468";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-ros ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs nav-2d-msgs nav-msgs nav2-msgs nav2-util rclcpp tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A handful of useful utility functions for nav_2d packages.";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/lyrical/nav2-amcl/default.nix
+++ b/distros/lyrical/nav2-amcl/default.nix
@@ -1,0 +1,35 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, backward-ros, geometry-msgs, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-ros-common, nav2-util, pluginlib, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-amcl";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_amcl/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "58a369d67345afac1243a589d75216efbe02883b551dadb78ca5fbb081381395";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  checkInputs = [ ament-cmake-ros ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs message-filters nav-msgs nav2-msgs nav2-ros-common nav2-util pluginlib rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "<p>
+      amcl is a probabilistic localization system for a robot moving in
+      2D. It implements the adaptive (or KLD-sampling) Monte Carlo
+      localization approach (as described by Dieter Fox), which uses a
+      particle filter to track the pose of a robot against a known map.
+    </p>
+    <p>
+      This node is derived, with thanks, from Andrew Howard's excellent
+      'amcl' Player driver.
+    </p>";
+    license = with lib.licenses; [ "LGPL-2.1-or-later" ];
+  };
+}

--- a/distros/lyrical/nav2-behavior-tree/default.nix
+++ b/distros/lyrical/nav2-behavior-tree/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, backward-ros, behaviortree-cpp, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-ros-common, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, test-msgs, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-behavior-tree";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_behavior_tree/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "b3eafde56c70cd6bfe9a26d5af4896a21265a4aec1f3923cde9e4758ac651dee";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-ros ament-lint-auto ament-lint-common lifecycle-msgs test-msgs ];
+  propagatedBuildInputs = [ action-msgs backward-ros behaviortree-cpp geometry-msgs nav-msgs nav2-msgs nav2-ros-common nav2-util rclcpp rclcpp-action rclcpp-lifecycle sensor-msgs std-msgs std-srvs tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Nav2 behavior tree wrappers, nodes, and utilities";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-behaviors/default.nix
+++ b/distros/lyrical/nav2-behaviors/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, backward-ros, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-ros-common, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-components, rclcpp-lifecycle, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-behaviors";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_behaviors/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "b3f3f406bcd98a146281aca4cf6505daa891135e0ff0f5964a1cbcf6abb3e893";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-ros ament-lint-auto ament-lint-common rclcpp-action ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs nav2-core nav2-costmap-2d nav2-msgs nav2-ros-common nav2-util pluginlib rclcpp rclcpp-components rclcpp-lifecycle std-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Nav2 behavior server";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-bringup/default.nix
+++ b/distros/lyrical/nav2-bringup/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ament-mypy, backward-ros, diff-drive-controller, joint-state-broadcaster, launch, launch-ros, launch-testing, nav2-common, nav2-loopback-sim, nav2-minimal-tb3-sim, nav2-minimal-tb4-sim, navigation2, ros-gz-bridge, ros-gz-sim, slam-toolbox, xacro }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-bringup";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_bringup/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "98993f3c2659776aa5eccf489c8619862b82b8b1446ace541b03ad9da4bf9c7e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-cmake-ros ament-lint-auto ament-lint-common ament-mypy launch launch-testing ];
+  propagatedBuildInputs = [ backward-ros diff-drive-controller joint-state-broadcaster launch-ros nav2-common nav2-loopback-sim nav2-minimal-tb3-sim nav2-minimal-tb4-sim navigation2 ros-gz-bridge ros-gz-sim slam-toolbox xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Bringup scripts and configurations for the Nav2 stack";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-bt-navigator/default.nix
+++ b/distros/lyrical/nav2-bt-navigator/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, backward-ros, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-msgs, nav2-ros-common, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-components, rclcpp-lifecycle, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-bt-navigator";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_bt_navigator/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "914eb4022a3ed1bd87c650c839869aa0baa942d1b2ead5db068967153183eb03";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  checkInputs = [ ament-cmake-ros ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-cpp backward-ros geometry-msgs nav-msgs nav2-behavior-tree nav2-core nav2-msgs nav2-ros-common nav2-util pluginlib rclcpp rclcpp-action rclcpp-components rclcpp-lifecycle tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Nav2 BT Navigator Server";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-collision-monitor/default.nix
+++ b/distros/lyrical/nav2-collision-monitor/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, backward-ros, geometry-msgs, launch-testing-ament-cmake, nav2-common, nav2-costmap-2d, nav2-msgs, nav2-ros-common, nav2-util, point-cloud-transport, point-cloud-transport-plugins, rclcpp, rclcpp-components, rclcpp-lifecycle, rosgraph-msgs, sensor-msgs, std-msgs, tf2, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-collision-monitor";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_collision_monitor/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "ec7a73d38afec59f32985589cee926bd0bd9100e5060b010f942b7afcb210021";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-cmake-ros ament-lint-auto ament-lint-common launch-testing-ament-cmake rosgraph-msgs ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs nav2-costmap-2d nav2-msgs nav2-ros-common nav2-util point-cloud-transport point-cloud-transport-plugins rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs std-msgs tf2 tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Collision Monitor";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-common/default.nix
+++ b/distros/lyrical/nav2-common/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-cmake-test, ament-lint-auto, ament-lint-common, ament-mypy, backward-ros, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-common";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_common/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "4f0f6dcafc96b6af2c92e6ed2f52b7cd88c464a9da27015446cf68ecd0f68819";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-python ];
+  checkInputs = [ ament-cmake-pytest ament-cmake-ros ament-cmake-test ament-lint-auto ament-lint-common ament-mypy python3Packages.pytest ];
+  propagatedBuildInputs = [ ament-cmake-core backward-ros launch launch-ros osrf-pycommon python3Packages.pyyaml python3Packages.types-pyyaml rclpy ];
+  nativeBuildInputs = [ ament-cmake-core ];
+
+  meta = {
+    description = "Common support functionality used throughout the navigation 2 stack";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-constrained-smoother/default.nix
+++ b/distros/lyrical/nav2-constrained-smoother/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, angles, backward-ros, ceres-solver, eigen, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-ros-common, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-constrained-smoother";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_constrained_smoother/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "4b68ed185a39cb73bc910a4008c61eb56dc2d8d20ac2b30edd8ef0ba1cdc4a96";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ceres-solver eigen nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-cmake-ros ament-lint-auto ament-lint-common angles ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs nav2-core nav2-costmap-2d nav2-msgs nav2-ros-common nav2-util pluginlib rclcpp rclcpp-lifecycle tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Ceres constrained smoother";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-controller/default.nix
+++ b/distros/lyrical/nav2-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, angles, backward-ros, geometry-msgs, lifecycle-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-ros-common, nav2-util, pluginlib, rcl-interfaces, rclcpp, rclcpp-components, rclcpp-lifecycle, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-controller";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_controller/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "c2515d32e01e4c8b4bed1177167327cb8cd541be8b52a67e2ac47c95d6504158";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake angles nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-cmake-ros ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs lifecycle-msgs nav2-core nav2-costmap-2d nav2-msgs nav2-ros-common nav2-util pluginlib rcl-interfaces rclcpp rclcpp-components rclcpp-lifecycle tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Controller action interface";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-core/default.nix
+++ b/distros/lyrical/nav2-core/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, backward-ros, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-core";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_core/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "9d12af75acb183d7354c9d165ba6efead86b0843e87a90c3cbe6650f49c2a23c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-ros ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs nav-msgs nav2-behavior-tree nav2-costmap-2d nav2-util pluginlib rclcpp rclcpp-lifecycle tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A set of headers for plugins core to the Nav2 stack";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-costmap-2d/default.nix
+++ b/distros/lyrical/nav2-costmap-2d/default.nix
@@ -1,0 +1,32 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, angles, backward-ros, eigen, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-ros-common, nav2-util, nav2-voxel-grid, pluginlib, point-cloud-transport, point-cloud-transport-plugins, rclcpp, rclcpp-lifecycle, rmw, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-costmap-2d";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_costmap_2d/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "68a27275e388a6ff2df0824c85f330139bfe76f0d415a5cea664de1713abc1bf";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake angles eigen nav2-common ];
+  checkInputs = [ ament-cmake-google-benchmark ament-cmake-gtest ament-cmake-ros ament-lint-auto ament-lint-common launch launch-testing nav2-lifecycle-manager nav2-map-server ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs laser-geometry map-msgs message-filters nav-msgs nav2-msgs nav2-ros-common nav2-util nav2-voxel-grid pluginlib point-cloud-transport point-cloud-transport-plugins rclcpp rclcpp-lifecycle rmw sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros tf2-sensor-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "This package provides an implementation of a 2D costmap that takes in sensor
+    data from the world, builds a 2D or 3D occupancy grid of the data (depending
+    on whether a voxel based implementation is used), and inflates costs in a
+    2D costmap based on the occupancy grid and a user specified inflation radius.
+    This package also provides support for map_server based initialization of a
+    costmap, rolling window based costmaps, and parameter based subscription to
+    and configuration of sensor topics.";
+    license = with lib.licenses; [ bsd3 asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-dwb-controller/default.nix
+++ b/distros/lyrical/nav2-dwb-controller/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, backward-ros, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils, nav2-common }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-dwb-controller";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_dwb_controller/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "af2f6a40dcb9fbf35cb0f50d5cf9965a44110f4f94bc88c9b3c65849f7d44ee6";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  propagatedBuildInputs = [ backward-ros costmap-queue dwb-core dwb-critics dwb-msgs dwb-plugins nav-2d-msgs nav-2d-utils ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS2 controller (DWB) metapackage";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-graceful-controller/default.nix
+++ b/distros/lyrical/nav2-graceful-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, angles, backward-ros, geometry-msgs, nav-msgs, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-ros-common, nav2-util, pluginlib, rcl-interfaces, rclcpp, rclcpp-lifecycle, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-graceful-controller";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_graceful_controller/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "267a51a48c012403b4eebe3142afcc083ae4a1d96f70fabc268dddf8c80d9111";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake angles nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-ros ament-lint-auto ament-lint-common nav2-controller ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs nav-msgs nav2-core nav2-costmap-2d nav2-ros-common nav2-util pluginlib rcl-interfaces rclcpp rclcpp-lifecycle tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Graceful motion controller";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-lifecycle-manager/default.nix
+++ b/distros/lyrical/nav2-lifecycle-manager/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, backward-ros, bondcpp, diagnostic-updater, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-ros-common, nav2-util, rclcpp, rclcpp-action, rclcpp-components, rclcpp-lifecycle, std-srvs }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-lifecycle-manager";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_lifecycle_manager/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "c6713457b688ed0a91b51b50c579019b08907ea50652e76300d38f6b720ef732";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-cmake-ros ament-lint-auto ament-lint-common rclcpp-lifecycle ];
+  propagatedBuildInputs = [ backward-ros bondcpp diagnostic-updater geometry-msgs lifecycle-msgs nav2-msgs nav2-ros-common nav2-util rclcpp rclcpp-action rclcpp-components std-srvs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A controller/manager for the lifecycle nodes of the Navigation 2 system";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-loopback-sim/default.nix
+++ b/distros/lyrical/nav2-loopback-sim/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, backward-ros, geometry-msgs, nav-msgs, nav2-common, nav2-ros-common, nav2-util, rcl-interfaces, rclcpp, rclcpp-components, rclcpp-lifecycle, rosgraph-msgs, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-loopback-sim";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_loopback_sim/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "e83626c77149707f31c413901c441c1695c590670dfb338dcdc65d595055efea";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-ros ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs nav-msgs nav2-ros-common nav2-util rcl-interfaces rclcpp rclcpp-components rclcpp-lifecycle rosgraph-msgs sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A loopback simulator to replace physics simulation";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-map-server/default.nix
+++ b/distros/lyrical/nav2-map-server/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, backward-ros, eigen, geometry-msgs, graphicsmagick, launch, launch-ros, launch-testing, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-ros-common, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, tf2-ros, util-linux, yaml-cpp-vendor }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-map-server";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_map_server/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "2245c86b59bf7d73fcd8489339ba305959e3cf8f5bda1c19ec1028882ab1bb07";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake eigen nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-cmake-ros ament-lint-auto ament-lint-common launch launch-testing ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs graphicsmagick launch-ros lifecycle-msgs nav-msgs nav2-msgs nav2-ros-common nav2-util rclcpp rclcpp-lifecycle std-msgs tf2 tf2-ros util-linux yaml-cpp-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Refactored map server for ROS2 Navigation";
+    license = with lib.licenses; [ asl20 bsd3 ];
+  };
+}

--- a/distros/lyrical/nav2-mppi-controller/default.nix
+++ b/distros/lyrical/nav2-mppi-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, angles, backward-ros, eigen, gbenchmark, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-ros-common, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-mppi-controller";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_mppi_controller/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "9f9bb20955a10f23eb791503cf9670206f571cc2031c634ea5dbee935e46ac48";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-ros angles eigen nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common gbenchmark ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs nav-msgs nav2-core nav2-costmap-2d nav2-msgs nav2-ros-common nav2-util pluginlib rclcpp rclcpp-lifecycle std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
+
+  meta = {
+    description = "nav2_mppi_controller";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/lyrical/nav2-msgs/default.nix
+++ b/distros/lyrical/nav2-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, backward-ros, builtin-interfaces, geographic-msgs, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-msgs";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_msgs/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "5d3aae5fc0539cfb5d6939f101741039c7241bcd5827320ee4d30cc1c55dddb7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common rosidl-default-generators ];
+  propagatedBuildInputs = [ action-msgs backward-ros builtin-interfaces geographic-msgs geometry-msgs nav-msgs rclcpp rosidl-default-runtime std-msgs unique-identifier-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "Messages and service files for the Nav2 stack";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-navfn-planner/default.nix
+++ b/distros/lyrical/nav2-navfn-planner/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, backward-ros, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-ros-common, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-navfn-planner";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_navfn_planner/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "95c661a66cd642f43dc33a5c43171f80ed874eb021d7750c6ea18b589231b955";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-ros ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ backward-ros builtin-interfaces geometry-msgs nav-msgs nav2-core nav2-costmap-2d nav2-ros-common nav2-util pluginlib rclcpp rclcpp-lifecycle tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Nav2 NavFn planner";
+    license = with lib.licenses; [ asl20 bsd3 ];
+  };
+}

--- a/distros/lyrical/nav2-planner/default.nix
+++ b/distros/lyrical/nav2-planner/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, backward-ros, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-ros-common, nav2-util, pluginlib, rclcpp, rclcpp-components, rclcpp-lifecycle, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-planner";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_planner/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "7fdb64d1c57caa4c72af81330c3e05fc60972796f88a2b9b5f90f162629a731a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-ros ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs lifecycle-msgs nav-msgs nav2-core nav2-costmap-2d nav2-msgs nav2-ros-common nav2-util pluginlib rclcpp rclcpp-components rclcpp-lifecycle tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Nav2 planner server package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-regulated-pure-pursuit-controller/default.nix
+++ b/distros/lyrical/nav2-regulated-pure-pursuit-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, angles, backward-ros, geometry-msgs, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-ros-common, nav2-util, pluginlib, rcl-interfaces, rclcpp, rclcpp-lifecycle, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-regulated-pure-pursuit-controller";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_regulated_pure_pursuit_controller/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "de8f5e1161baec2e73e0f626f2ebf08ce5eafc38410274d84fe1aab99ceff6e3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake angles nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-ros ament-lint-auto ament-lint-common nav2-controller tf2-geometry-msgs ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs nav2-core nav2-costmap-2d nav2-msgs nav2-ros-common nav2-util pluginlib rcl-interfaces rclcpp rclcpp-lifecycle std-msgs tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Regulated Pure Pursuit Controller";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-ros-common/default.nix
+++ b/distros/lyrical/nav2-ros-common/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, backward-ros, bond, bondcpp, builtin-interfaces, geometry-msgs, lifecycle-msgs, map-msgs, nav-msgs, nav2-common, nav2-msgs, pluginlib, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-ros-common";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_ros_common/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "bfdcb8987524b84c6ab0faf0edc4daa57f6581629aa31e56903137b4ab5ea214";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-cmake-ros ament-lint-auto ament-lint-common std-srvs test-msgs ];
+  propagatedBuildInputs = [ ament-index-cpp backward-ros bond bondcpp builtin-interfaces geometry-msgs lifecycle-msgs map-msgs nav-msgs nav2-msgs pluginlib rcl-interfaces rclcpp rclcpp-action rclcpp-lifecycle sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Nav2 utilities";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-rotation-shim-controller/default.nix
+++ b/distros/lyrical/nav2-rotation-shim-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, angles, backward-ros, geometry-msgs, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-regulated-pure-pursuit-controller, nav2-ros-common, nav2-util, pluginlib, rcl-interfaces, rclcpp, rclcpp-lifecycle, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-rotation-shim-controller";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_rotation_shim_controller/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "c22c5207b98526b4bbcee55c1278258637ff379320ce7e0c8815a58281d13fcc";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake angles nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-ros ament-lint-auto ament-lint-common nav2-controller nav2-regulated-pure-pursuit-controller ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs nav2-controller nav2-core nav2-costmap-2d nav2-msgs nav2-ros-common nav2-util pluginlib rcl-interfaces rclcpp rclcpp-lifecycle tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Rotation Shim Controller";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-route/default.nix
+++ b/distros/lyrical/nav2-route/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, angles, backward-ros, geometry-msgs, launch, launch-testing, nanoflann, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-ros-common, nav2-util, nlohmann_json, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-route";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_route/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "43d73b5b69c1abefc8eba88663cab1659a80b8458a5ecb6af05439d31722e425";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake angles nanoflann nav2-common nlohmann_json ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-cmake-ros ament-lint-auto ament-lint-common launch launch-testing ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs nav-msgs nav2-core nav2-costmap-2d nav2-msgs nav2-ros-common nav2-util pluginlib rclcpp rclcpp-lifecycle std-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A Route Graph planner to compliment the Planner Server";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-rviz-plugins/default.nix
+++ b/distros/lyrical/nav2-rviz-plugins/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, _unresolved_libqt6statemachine6, _unresolved_qt6-scxml-dev, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, backward-ros, geometry-msgs, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-msgs, nav2-ros-common, nav2-route, nav2-util, pluginlib, qt6, rclcpp, rclcpp-action, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, visualization-msgs, yaml-cpp-vendor }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-rviz-plugins";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_rviz_plugins/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "0954a569665160eebb8e4e87836a4f975636b9b8fc702eee20684c93c539f8cb";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ _unresolved_qt6-scxml-dev ament-cmake nav2-common ];
+  checkInputs = [ ament-cmake-ros ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ _unresolved_libqt6statemachine6 backward-ros geometry-msgs nav-msgs nav2-lifecycle-manager nav2-msgs nav2-ros-common nav2-route nav2-util pluginlib qt6.qtbase rclcpp rclcpp-action rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering std-msgs tf2-geometry-msgs visualization-msgs yaml-cpp-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Navigation 2 plugins for rviz";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-simple-commander/default.nix
+++ b/distros/lyrical/nav2-simple-commander/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, geometry-msgs, lifecycle-msgs, nav2-msgs, python3Packages, rclpy }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-simple-commander";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_simple_commander/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "ee265677dd487f10354ae28ac5f3c983a4d6ea84308403c773498a2f1951096f";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-mypy ament-pep257 ament-xmllint python3Packages.pytest ];
+  propagatedBuildInputs = [ action-msgs geometry-msgs lifecycle-msgs nav2-msgs rclpy ];
+
+  meta = {
+    description = "An importable library for writing mobile robot applications in python3";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-smac-planner/default.nix
+++ b/distros/lyrical/nav2-smac-planner/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, backward-ros, eigen, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-ros-common, nav2-util, nlohmann_json, ompl, pluginlib, rcl-interfaces, rclcpp, rclcpp-lifecycle, tf2, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-smac-planner";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_smac_planner/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "0d3f1707d8a0d86e8dcadbbb2be7cc65a9c411f9fdc00645694775674b12e5dd";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake angles eigen nav2-common nlohmann_json ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-ros ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-cpp backward-ros geometry-msgs nav-msgs nav2-core nav2-costmap-2d nav2-ros-common nav2-util ompl pluginlib rcl-interfaces rclcpp rclcpp-lifecycle tf2 tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Smac global planning plugin: A*, Hybrid-A*, State Lattice";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-smoother/default.nix
+++ b/distros/lyrical/nav2-smoother/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, angles, backward-ros, eigen, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-ros-common, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-components, rclcpp-lifecycle, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-smoother";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_smoother/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "34a2b3bb9c5cb2f2dea859be376d22ac530d8db118c7eba85790961152d35370";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake angles eigen nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-ros ament-lint-auto ament-lint-common rclcpp-action ];
+  propagatedBuildInputs = [ backward-ros nav2-core nav2-costmap-2d nav2-msgs nav2-ros-common nav2-util pluginlib rclcpp rclcpp-components rclcpp-lifecycle tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Smoother action interface";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-system-tests/default.nix
+++ b/distros/lyrical/nav2-system-tests/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-behavior-tree, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-minimal-tb3-sim, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-ros-common, nav2-util, navigation2, python3Packages, rclcpp, rclcpp-lifecycle, rclpy, robot-state-publisher, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-system-tests";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_system_tests/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "49062f591881c0cd069cc5e52f59e46ef9d6934211e6bad6d5ff42d74cce35c0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-cmake-ros ament-index-cpp ament-lint-auto ament-lint-common geometry-msgs launch launch-ros launch-testing lcov nav-msgs nav2-amcl nav2-behavior-tree nav2-bringup nav2-lifecycle-manager nav2-map-server nav2-minimal-tb3-sim nav2-msgs nav2-navfn-planner nav2-planner nav2-ros-common nav2-util navigation2 python3Packages.pyzmq rclcpp rclcpp-lifecycle rclpy robot-state-publisher std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A sets of system-level tests for Nav2 usually involving full robot simulation";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-theta-star-planner/default.nix
+++ b/distros/lyrical/nav2-theta-star-planner/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, backward-ros, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-ros-common, nav2-util, pluginlib, rcl-interfaces, rclcpp, rclcpp-lifecycle, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-theta-star-planner";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_theta_star_planner/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "a6422e0ae21a4232ea9ca6475637c0a2c6ad72ccfe3dd9ba480d565c63a5a434";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-ros ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs nav-msgs nav2-core nav2-costmap-2d nav2-ros-common nav2-util pluginlib rcl-interfaces rclcpp rclcpp-lifecycle tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Theta* Global Planning Plugin";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-util/default.nix
+++ b/distros/lyrical/nav2-util/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, angles, backward-ros, bond, bondcpp, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-ros-common, pluginlib, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, tf2, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-util";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_util/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "9fd6b0ab4a21f15d26a920cf7a92dd29b3c450e8e9b79145d7decc9dc67701c1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake angles nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-cmake-ros ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ backward-ros bond bondcpp builtin-interfaces geometry-msgs lifecycle-msgs nav-msgs nav2-msgs nav2-ros-common pluginlib rcl-interfaces rclcpp rclcpp-action rclcpp-lifecycle std-msgs tf2 tf2-geometry-msgs tf2-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Nav2 utilities";
+    license = with lib.licenses; [ asl20 bsd3 ];
+  };
+}

--- a/distros/lyrical/nav2-velocity-smoother/default.nix
+++ b/distros/lyrical/nav2-velocity-smoother/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, backward-ros, geometry-msgs, nav-msgs, nav2-common, nav2-ros-common, nav2-util, rclcpp, rclcpp-components, rclcpp-lifecycle }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-velocity-smoother";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_velocity_smoother/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "cbdfec6ac323863f0ae45d33a6122748eb07a5d7addc1870260a08a63544e36d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-ros ament-lint-auto ament-lint-common nav-msgs ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs nav2-ros-common nav2-util rclcpp rclcpp-components rclcpp-lifecycle ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Nav2's Output velocity smoother";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/nav2-voxel-grid/default.nix
+++ b/distros/lyrical/nav2-voxel-grid/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, backward-ros, nav2-common, rclcpp }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-voxel-grid";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_voxel_grid/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "8bde05dd71b547d2584d6632427009a48fde7b585b3c414274ed90b7bfb628ac";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-ros ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ backward-ros rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "voxel_grid provides an implementation of an efficient 3D voxel grid. The occupancy grid can support 3 different representations for the state of a cell: marked, free, or unknown. Due to the underlying implementation relying on bitwise and and or integer operations, the voxel grid only supports 16 different levels per voxel column. However, this limitation yields raytracing and cell marking performance in the grid comparable to standard 2D structures making it quite fast compared to most 3D structures.";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/lyrical/nav2-waypoint-follower/default.nix
+++ b/distros/lyrical/nav2-waypoint-follower/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, backward-ros, cv-bridge, geographic-msgs, geometry-msgs, image-transport, nav-msgs, nav2-common, nav2-core, nav2-msgs, nav2-ros-common, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-components, rclcpp-lifecycle, robot-localization, sensor-msgs, std-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-nav2-waypoint-follower";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/nav2_waypoint_follower/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "dc6f15c326c9cb2eab6cf6905a86db5b67c021e97b5550f08b3b1d261c78ce9d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-ros ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ backward-ros cv-bridge geographic-msgs geometry-msgs image-transport nav-msgs nav2-core nav2-msgs nav2-ros-common nav2-util pluginlib rclcpp rclcpp-action rclcpp-components rclcpp-lifecycle robot-localization sensor-msgs std-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A waypoint follower navigation server";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/navigation2/default.nix
+++ b/distros/lyrical/navigation2/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-behaviors, nav2-bt-navigator, nav2-collision-monitor, nav2-common, nav2-constrained-smoother, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-graceful-controller, nav2-lifecycle-manager, nav2-loopback-sim, nav2-map-server, nav2-mppi-controller, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-regulated-pure-pursuit-controller, nav2-ros-common, nav2-rotation-shim-controller, nav2-route, nav2-rviz-plugins, nav2-simple-commander, nav2-smac-planner, nav2-smoother, nav2-theta-star-planner, nav2-util, nav2-velocity-smoother, nav2-voxel-grid, nav2-waypoint-follower, opennav-docking, opennav-docking-bt, opennav-docking-core, opennav-following }:
+buildRosPackage {
+  pname = "ros-lyrical-navigation2";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/navigation2/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "9bfe224a5c7377b3f7dc12bf9a445010f3c8408c851d342e9aeea0864da295f9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  propagatedBuildInputs = [ nav2-amcl nav2-behavior-tree nav2-behaviors nav2-bt-navigator nav2-collision-monitor nav2-constrained-smoother nav2-controller nav2-core nav2-costmap-2d nav2-dwb-controller nav2-graceful-controller nav2-lifecycle-manager nav2-loopback-sim nav2-map-server nav2-mppi-controller nav2-msgs nav2-navfn-planner nav2-planner nav2-regulated-pure-pursuit-controller nav2-ros-common nav2-rotation-shim-controller nav2-route nav2-rviz-plugins nav2-simple-commander nav2-smac-planner nav2-smoother nav2-theta-star-planner nav2-util nav2-velocity-smoother nav2-voxel-grid nav2-waypoint-follower opennav-docking opennav-docking-bt opennav-docking-core opennav-following ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS2 Navigation Stack";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/opennav-docking-bt/default.nix
+++ b/distros/lyrical/opennav-docking-bt/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, backward-ros, behaviortree-cpp, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-msgs, nav2-ros-common, nav2-util, rclcpp, rclcpp-action }:
+buildRosPackage {
+  pname = "ros-lyrical-opennav-docking-bt";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/opennav_docking_bt/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "c8ec27907f821b554b670adf8058163ce0d7497fe603e237351e7706bcf04637";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  checkInputs = [ ament-cmake-ros ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ backward-ros behaviortree-cpp geometry-msgs nav-msgs nav2-behavior-tree nav2-core nav2-msgs nav2-ros-common nav2-util rclcpp rclcpp-action ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A set of BT nodes and XMLs for docking";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/opennav-docking-core/default.nix
+++ b/distros/lyrical/opennav-docking-core/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, backward-ros, geometry-msgs, nav2-common, nav2-ros-common, rclcpp-lifecycle, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-opennav-docking-core";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/opennav_docking_core/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "a9215ed9b2bae0495b0d8abef21b41eb5c1f2e54a170a4b7188bb11318cc2e93";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake nav2-common ];
+  checkInputs = [ ament-cmake-ros ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs nav2-ros-common rclcpp-lifecycle tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A set of headers for plugins core to the opennav docking framework";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/opennav-docking/default.nix
+++ b/distros/lyrical/opennav-docking/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, backward-ros, geometry-msgs, nav-msgs, nav2-common, nav2-graceful-controller, nav2-msgs, nav2-ros-common, nav2-util, opennav-docking-core, pluginlib, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp-vendor }:
+buildRosPackage {
+  pname = "ros-lyrical-opennav-docking";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/opennav_docking/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "43c15a916bcdeaacf176a788d86ec520d4fcb534313d35958025c18b122f4c0c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake angles nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-cmake-ros ament-index-cpp ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs nav-msgs nav2-graceful-controller nav2-msgs nav2-ros-common nav2-util opennav-docking-core pluginlib rcl-interfaces rclcpp rclcpp-action rclcpp-components rclcpp-lifecycle sensor-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros yaml-cpp-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A Task Server for robot charger docking";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/opennav-following/default.nix
+++ b/distros/lyrical/opennav-following/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav2-common, nav2-msgs, nav2-ros-common, nav2-util, opennav-docking, opennav-docking-core, rclcpp, rclcpp-components, rclcpp-lifecycle, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-opennav-following";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/navigation2-release/archive/release/lyrical/opennav_following/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "6d5479fb38e2c2e31f1e67126380a8f9a083e8f204875f0526d41d7b28f957a8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake angles nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-cmake-ros ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs nav2-msgs nav2-ros-common nav2-util opennav-docking opennav-docking-core rclcpp rclcpp-components rclcpp-lifecycle tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A Task Server for dynamic following object";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -449,6 +449,18 @@ in {
     ];
   });
 
+  nav2-mppi-controller = rosSuper.nav2-mppi-controller.overrideAttrs({
+    CXXFLAGS ? "", ...
+  }: {
+    CXXFLAGS = "${CXXFLAGS} -Wno-error=null-dereference";
+  });
+
+  nav2-smoother = rosSuper.nav2-smoother.overrideAttrs({
+    CXXFLAGS ? "", ...
+  }: {
+    CXXFLAGS = "${CXXFLAGS} -Wno-error=null-dereference";
+  });
+
   nav2-util = rosSuper.nav2-util.overrideAttrs({
     propagatedBuildInputs ? [], ...
   }: {

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -678,6 +678,8 @@ in {
     '';
   });
 
+  slam-toolbox = rosSuper.slam-toolbox.override { qt5 = self.qt6; };
+
   turtlesim = rosSuper.turtlesim.overrideAttrs ({
     nativeBuildInputs ? [], ...
   }: {

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -449,6 +449,13 @@ in {
     ];
   });
 
+  nav2-util = rosSuper.nav2-util.overrideAttrs({
+    propagatedBuildInputs ? [], ...
+  }: {
+    # https://github.com/ros-navigation/navigation2/pull/6323
+    propagatedBuildInputs = propagatedBuildInputs ++ [ rosSelf.angles ];
+  });
+
   nlohmann-json-schema-validator-vendor = (lib.patchExternalProjectGit rosSuper.nlohmann-json-schema-validator-vendor {
     url = "https://github.com/pboettch/json-schema-validator.git";
     rev = "5ef4f903af055550e06955973a193e17efded896";

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -518,6 +518,13 @@ in {
     ];
   });
 
+  proxsuite = rosSuper.proxsuite.overrideAttrs ({
+    propagatedBuildInputs ? [], ...
+  }: {
+    # TODO: Remove after https://github.com/Simple-Robotics/proxsuite/pull/469 appears in a release
+    propagatedBuildInputs = propagatedBuildInputs ++ [ self.simde ];
+  });
+
   pybind11-json-vendor = lib.patchAmentVendorGit rosSuper.pybind11-json-vendor { };
 
   # This meta-package is referenced by the rosdep key python3-qt-bindings,

--- a/distros/lyrical/pick-ik/default.nix
+++ b/distros/lyrical/pick-ik/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_tl_expected, ament-cmake-ros, fmt, generate-parameter-library, moveit-core, moveit-resources-panda-moveit-config, pluginlib, range-v3, rclcpp, rsl, tf2-geometry-msgs, tf2-kdl }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, fmt, generate-parameter-library, git, moveit-core, moveit-resources-panda-moveit-config, pluginlib, range-v3, rclcpp, rsl, tf2, tf2-geometry-msgs, tf2-kdl, tl-expected-nixpkgs }:
 buildRosPackage {
   pname = "ros-lyrical-pick-ik";
-  version = "1.1.1-r3";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pick_ik-release/archive/release/lyrical/pick_ik/1.1.1-3.tar.gz";
-    name = "1.1.1-3.tar.gz";
-    sha256 = "aa97d2f737b1b5866987d6932521381fff515b967ebb0225d513296ab50415ff";
+    url = "https://github.com/ros2-gbp/pick_ik-release/archive/release/lyrical/pick_ik/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "41891de3709c2626e5e7a91a26734cf2232c3603bd61f0b14d363e481894db95";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
-  checkInputs = [ moveit-resources-panda-moveit-config ];
-  propagatedBuildInputs = [ _unresolved_tl_expected fmt generate-parameter-library moveit-core pluginlib range-v3 rclcpp rsl tf2-geometry-msgs tf2-kdl ];
+  checkInputs = [ git moveit-resources-panda-moveit-config ];
+  propagatedBuildInputs = [ fmt generate-parameter-library moveit-core pluginlib range-v3 rclcpp rsl tf2 tf2-geometry-msgs tf2-kdl tl-expected-nixpkgs ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/lyrical/posedetection-msgs/default.nix
+++ b/distros/lyrical/posedetection-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, message-filters, rclcpp, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-posedetection-msgs";
+  version = "5.0.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common_msgs-release/archive/release/lyrical/posedetection_msgs/5.0.1-2.tar.gz";
+    name = "5.0.1-2.tar.gz";
+    sha256 = "e682875df8a4cc78022ef1a34415b3091a6f08f39c87ff90cd6c796d7a9cea52";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs message-filters rclcpp rosidl-default-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "posedetection_msgs provides messages and services to facilitate passing pose detection results and features.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/roboplan-cartesian-planning/default.nix
+++ b/distros/lyrical/roboplan-cartesian-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, python3, python3Packages, roboplan, roboplan-example-models, roboplan-oink, roboplan-toppra }:
 buildRosPackage {
   pname = "ros-lyrical-roboplan-cartesian-planning";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/lyrical/roboplan_cartesian_planning/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "fbe5102ea08f29fcaa42c53b3aee8ac152cf1e1eabca805c2bb226854e0ecb79";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/lyrical/roboplan_cartesian_planning/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "c7a376ad0215804242380c9c0c88f8ddc7f4b185caa53838ed0623fdc9c78a38";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/roboplan-example-models/default.nix
+++ b/distros/lyrical/roboplan-example-models/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-lyrical-roboplan-example-models";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/lyrical/roboplan_example_models/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "514b6a0e7121e07ea6b39c0f09c0aad681362bb4eda5ea22ae62e9a4f1360bfd";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/lyrical/roboplan_example_models/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "950ee27ecefcf901718820c071179ee3e76a1df0f339acf844ac72ab317781d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/roboplan-examples/default.nix
+++ b/distros/lyrical/roboplan-examples/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, roboplan, roboplan-cartesian-planning, roboplan-example-models, roboplan-oink, roboplan-rrt, roboplan-simple-ik, roboplan-toppra, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, roboplan, roboplan-cartesian-planning, roboplan-example-models, roboplan-oink, roboplan-rrt, roboplan-simple-ik, roboplan-toppra, xacro }:
 buildRosPackage {
   pname = "ros-lyrical-roboplan-examples";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/lyrical/roboplan_examples/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "ac6fdcafb5fb5f639039da22eddeed8a8b332ab5107f1aef62cef649fe343454";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/lyrical/roboplan_examples/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "6110a04701db79a07726eccf01551ca0d8b1ebf82f506ff2837f91fa32959567";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-pytest ];
   propagatedBuildInputs = [ roboplan roboplan-cartesian-planning roboplan-example-models roboplan-oink roboplan-rrt roboplan-simple-ik roboplan-toppra xacro ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/lyrical/roboplan-oink/default.nix
+++ b/distros/lyrical/roboplan-oink/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, gtest, python3, python3Packages, roboplan, roboplan-example-models }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, gtest, proxsuite, python3, python3Packages, roboplan, roboplan-example-models }:
 buildRosPackage {
   pname = "ros-lyrical-roboplan-oink";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/lyrical/roboplan_oink/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "3414e8c34cb0d04f9bdbbd032a9ea6fcee93d4f933e48a651c2ae30c3a355ac9";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/lyrical/roboplan_oink/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "d9c2904614296aafa279448215a95cd3f277b66c03d6c7fc8391b2b6fae98e38";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python python3 python3Packages.nanobind ];
   checkInputs = [ ament-cmake-gmock gtest roboplan-example-models ];
-  propagatedBuildInputs = [ roboplan ];
+  propagatedBuildInputs = [ proxsuite roboplan ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/lyrical/roboplan-ros-cpp/default.nix
+++ b/distros/lyrical/roboplan-ros-cpp/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, builtin-interfaces, eigen, geometry-msgs, pinocchio, python3, python3Packages, roboplan, roboplan-example-models, rosidl-generator-cpp, sensor-msgs, tf2-eigen, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-roboplan-ros-cpp";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan_ros-release/archive/release/lyrical/roboplan_ros_cpp/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "b6924fa31f58bd3f339039fc57211a3486aba9869afd87ce7b1d75f6ab6044bc";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake builtin-interfaces python3 python3Packages.nanobind ];
+  checkInputs = [ ament-index-cpp roboplan-example-models ];
+  propagatedBuildInputs = [ eigen geometry-msgs pinocchio roboplan rosidl-generator-cpp sensor-msgs tf2-eigen trajectory-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS 2 C++ bindings for the RoboPlan motion planning library.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/lyrical/roboplan-ros-examples/default.nix
+++ b/distros/lyrical/roboplan-ros-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-python, control-msgs, rclpy, roboplan, sensor-msgs, std-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-roboplan-ros-examples";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan_ros-release/archive/release/lyrical/roboplan_ros_examples/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "43b0d869ca055b56da0fda202476ddd4bb9b62b9b606a2090a85d9436545671e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-python ];
+  propagatedBuildInputs = [ control-msgs rclpy roboplan sensor-msgs std-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake-python ];
+
+  meta = {
+    description = "Examples of using RoboPlan in the ROS ecosystem.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/lyrical/roboplan-ros-franka/default.nix
+++ b/distros/lyrical/roboplan-ros-franka/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, joint-state-broadcaster, joint-trajectory-controller, parallel-gripper-controller, roboplan, roboplan-example-models, roboplan-ros-examples, robot-state-publisher, topic-tools, xacro }:
+buildRosPackage {
+  pname = "ros-lyrical-roboplan-ros-franka";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan_ros-release/archive/release/lyrical/roboplan_ros_franka/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "7c53b4e256c200119313d17120b9319a63c4d27ce9586b504d8e6f8371c3cdbb";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ controller-manager joint-state-broadcaster joint-trajectory-controller parallel-gripper-controller roboplan roboplan-example-models roboplan-ros-examples robot-state-publisher topic-tools xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Franka arm ROS example for RoboPlan.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/lyrical/roboplan-ros-py/default.nix
+++ b/distros/lyrical/roboplan-ros-py/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, builtin-interfaces, python3Packages, rclpy, roboplan, roboplan-ros-cpp, sensor-msgs, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-roboplan-ros-py";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan_ros-release/archive/release/lyrical/roboplan_ros_py/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "2ce379fcfb63a1150540648287e3d4980137cecfa18fe58b5ca7317f2fad3b4a";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ python3Packages.pytest ];
+  propagatedBuildInputs = [ builtin-interfaces rclpy roboplan roboplan-ros-cpp sensor-msgs trajectory-msgs ];
+
+  meta = {
+    description = "ROS 2 Python bindings for the roboplan motion planning library.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/lyrical/roboplan-ros-visualization/default.nix
+++ b/distros/lyrical/roboplan-ros-visualization/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-cpp, geometry-msgs, interactive-markers, python3, python3Packages, rclcpp, rclpy, roboplan, roboplan-ros-cpp, roboplan-simple-ik, rviz2, sensor-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-roboplan-ros-visualization";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan_ros-release/archive/release/lyrical/roboplan_ros_visualization/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "f0ee96adf836ab38a04f142b73dd23da76d087901e0c852ea95924cdb36ef378";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python python3 python3Packages.nanobind ];
+  propagatedBuildInputs = [ ament-index-cpp geometry-msgs interactive-markers rclcpp rclpy roboplan roboplan-ros-cpp roboplan-simple-ik rviz2 sensor-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "ROS 2 visualization tools for the RoboPlan library.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/lyrical/roboplan-rrt/default.nix
+++ b/distros/lyrical/roboplan-rrt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, python3, python3Packages, roboplan, roboplan-example-models }:
 buildRosPackage {
   pname = "ros-lyrical-roboplan-rrt";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/lyrical/roboplan_rrt/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "f3586e889060e16b5a409da47fc040df367c201c859cfb8d2eb81c3c2154a183";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/lyrical/roboplan_rrt/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "301fdb6ff8ec279f2a3fa66c773be8c88b4711a7b170eaeb724b2a5bea8d9e05";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/roboplan-simple-ik/default.nix
+++ b/distros/lyrical/roboplan-simple-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, python3, python3Packages, roboplan }:
 buildRosPackage {
   pname = "ros-lyrical-roboplan-simple-ik";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/lyrical/roboplan_simple_ik/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "35bfdac55dacf981cc851181f3dae4160d15b7e3c788f41df00d079a794f300b";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/lyrical/roboplan_simple_ik/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "354e8d43cdb7bac79872a27024af330deba1c03155582e6e45f10a44ac70f20b";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/roboplan-toppra/default.nix
+++ b/distros/lyrical/roboplan-toppra/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, python3, python3Packages, roboplan, roboplan-example-models, toppra }:
 buildRosPackage {
   pname = "ros-lyrical-roboplan-toppra";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/lyrical/roboplan_toppra/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "5994b8871e4e82f4f88665373f25201d03b5a92019615c99526dd41ea39cc131";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/lyrical/roboplan_toppra/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "ff4fa37adc602c78910f1f1036432878dc7bb034402693c90f6603d8ec37146c";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/roboplan/default.nix
+++ b/distros/lyrical/roboplan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, eigen, gtest, pinocchio, python3, python3Packages, roboplan-example-models, tinyxml-2, tl-expected-nixpkgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-lyrical-roboplan";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/lyrical/roboplan/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "51df1cdd3d20f99d83a1e2ce86e716a5d0f2e2667e94728aaa8fb627ed62441b";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/lyrical/roboplan/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "b0ef26feb9d0979dff1983fd5a08cb1e7da76b99cc2bfb2968d7d8f7eaf5abeb";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rviz-visual-tools/default.nix
+++ b/distros/lyrical/rviz-visual-tools/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, interactive-markers, launch, launch-ros, pluginlib, qt5, rclcpp, rclcpp-components, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz2, sensor-msgs, shape-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, interactive-markers, launch, launch-ros, pluginlib, qt6, rclcpp, rclcpp-components, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz2, sensor-msgs, shape-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-rviz-visual-tools";
-  version = "4.1.4-r5";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz_visual_tools-release/archive/release/lyrical/rviz_visual_tools/4.1.4-5.tar.gz";
-    name = "4.1.4-5.tar.gz";
-    sha256 = "a3aef7837a7d034c16e3147505a474d0968713497edbe43681219bda5e7ef52a";
+    url = "https://github.com/ros2-gbp/rviz_visual_tools-release/archive/release/lyrical/rviz_visual_tools/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "40bcbc641dee0d64d11e2d36b571361808ce41168c7cf1538dbbeb9cec40736f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python eigen eigen-stl-containers eigen3-cmake-module geometry-msgs interactive-markers launch launch-ros pluginlib qt5.qtbase rclcpp rclcpp-components rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering rviz2 sensor-msgs shape-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs visualization-msgs ];
+  propagatedBuildInputs = [ ament-index-python eigen eigen-stl-containers eigen3-cmake-module geometry-msgs interactive-markers launch launch-ros pluginlib qt6.qtbase rclcpp rclcpp-components rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering rviz2 sensor-msgs shape-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 
   meta = {

--- a/distros/lyrical/slam-toolbox/default.nix
+++ b/distros/lyrical/slam-toolbox/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_nav2_map_server, ament-cmake, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-uncrustify, ament-lint-auto, bond, bondcpp, boost, builtin-interfaces, ceres-solver, eigen, geometry-msgs, interactive-markers, launch, launch-testing, liblapack, lifecycle-msgs, llvmPackages, message-filters, nav-msgs, onetbb, pluginlib, qt5, rclcpp, rclcpp-lifecycle, rosidl-default-generators, rosidl-default-runtime, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, suitesparse, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-uncrustify, ament-lint-auto, bond, bondcpp, boost, builtin-interfaces, ceres-solver, eigen, geometry-msgs, interactive-markers, launch, launch-testing, liblapack, lifecycle-msgs, llvmPackages, message-filters, nav-msgs, nav2-map-server, onetbb, pluginlib, qt5, rclcpp, rclcpp-lifecycle, rosidl-default-generators, rosidl-default-runtime, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, suitesparse, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-slam-toolbox";
   version = "2.10.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gtest ament-cmake-uncrustify ament-lint-auto launch launch-testing ];
-  propagatedBuildInputs = [ _unresolved_nav2_map_server bond bondcpp boost builtin-interfaces ceres-solver eigen geometry-msgs interactive-markers liblapack lifecycle-msgs llvmPackages.openmp message-filters nav-msgs onetbb pluginlib qt5.qtbase rclcpp rclcpp-lifecycle rosidl-default-generators rosidl-default-runtime rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering sensor-msgs std-msgs std-srvs suitesparse tf2 tf2-geometry-msgs tf2-ros tf2-sensor-msgs visualization-msgs ];
+  propagatedBuildInputs = [ bond bondcpp boost builtin-interfaces ceres-solver eigen geometry-msgs interactive-markers liblapack lifecycle-msgs llvmPackages.openmp message-filters nav-msgs nav2-map-server onetbb pluginlib qt5.qtbase rclcpp rclcpp-lifecycle rosidl-default-generators rosidl-default-runtime rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering sensor-msgs std-msgs std-srvs suitesparse tf2 tf2-geometry-msgs tf2-ros tf2-sensor-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/lyrical/speech-recognition-msgs/default.nix
+++ b/distros/lyrical/speech-recognition-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-speech-recognition-msgs";
+  version = "5.0.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common_msgs-release/archive/release/lyrical/speech_recognition_msgs/5.0.1-2.tar.gz";
+    name = "5.0.1-2.tar.gz";
+    sha256 = "c366b4411b7abed5e574fffa49b7cb3b7077f407aa149bfd8872fb9e57585601";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "speech_recognition_msgs";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/lyrical/warehouse-ros-sqlite/default.nix
+++ b/distros/lyrical/warehouse-ros-sqlite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite, warehouse-ros }:
 buildRosPackage {
   pname = "ros-lyrical-warehouse-ros-sqlite";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/lyrical/warehouse_ros_sqlite/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "55b9a60b17ff187835a4cd722396a1d733871269f724b255526c6a5b25b00b36";
+    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/lyrical/warehouse_ros_sqlite/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "699ca37f569c3a280702eb7eb94e765341f1d1d4a2d7c01335352dc44964c898";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/warehouse-ros/default.nix
+++ b/distros/lyrical/warehouse-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-lint-auto, boost, geometry-msgs, openssl, pluginlib, rclcpp, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-lyrical-warehouse-ros";
-  version = "2.0.6-r3";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/warehouse_ros-release/archive/release/lyrical/warehouse_ros/2.0.6-3.tar.gz";
-    name = "2.0.6-3.tar.gz";
-    sha256 = "5ac65a3d564890f23134844f1f8b45404b8d64c9139d7f82d4f45461653ec519";
+    url = "https://github.com/ros2-gbp/warehouse_ros-release/archive/release/lyrical/warehouse_ros/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "91073987f90c32c43c8ca01795a3e0329e1525433cd41eac5c8d306a9727642f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -2234,6 +2234,16 @@ self: super: {
 
  roboplan-oink = self.callPackage ./roboplan-oink {};
 
+ roboplan-ros-cpp = self.callPackage ./roboplan-ros-cpp {};
+
+ roboplan-ros-examples = self.callPackage ./roboplan-ros-examples {};
+
+ roboplan-ros-franka = self.callPackage ./roboplan-ros-franka {};
+
+ roboplan-ros-py = self.callPackage ./roboplan-ros-py {};
+
+ roboplan-ros-visualization = self.callPackage ./roboplan-ros-visualization {};
+
  roboplan-rrt = self.callPackage ./roboplan-rrt {};
 
  roboplan-simple-ik = self.callPackage ./roboplan-simple-ik {};
@@ -2638,6 +2648,8 @@ self: super: {
 
  rviz-visual-testing-framework = self.callPackage ./rviz-visual-testing-framework {};
 
+ rviz-visual-tools = self.callPackage ./rviz-visual-tools {};
+
  sdformat-test-files = self.callPackage ./sdformat-test-files {};
 
  sdformat-urdf = self.callPackage ./sdformat-urdf {};
@@ -2697,8 +2709,6 @@ self: super: {
  smach-ros = self.callPackage ./smach-ros {};
 
  smclib = self.callPackage ./smclib {};
-
- snowbot-operating-system = self.callPackage ./snowbot-operating-system {};
 
  soccer-geometry-msgs = self.callPackage ./soccer-geometry-msgs {};
 

--- a/distros/rolling/graph-msgs/default.nix
+++ b/distros/rolling/graph-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-graph-msgs";
-  version = "0.2.0-r6";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/graph_msgs-release/archive/release/rolling/graph_msgs/0.2.0-6.tar.gz";
-    name = "0.2.0-6.tar.gz";
-    sha256 = "4ff04525b1f388d593d3bee0a7432a5ae9dad24748dfe64de4cf7d998f017a02";
+    url = "https://github.com/ros2-gbp/graph_msgs-release/archive/release/rolling/graph_msgs/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "1894ad2e967347a03ca922652b01ab7dc62c98fff97564cf81ed2ebf275c3d89";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-sim-vendor/default.nix
+++ b/distros/rolling/gz-sim-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, binutils, cmake, elfutils, freeglut, freeimage, gbenchmark, glew, gz-cmake-vendor, gz-common-vendor, gz-fuel-tools-vendor, gz-gui-vendor, gz-math-vendor, gz-msgs-vendor, gz-physics-vendor, gz-plugin-vendor, gz-rendering-vendor, gz-sensors-vendor, gz-tools-vendor, gz-transport-vendor, gz-utils-vendor, libdwarf, libwebsockets, libxi, libxmu, protobuf, python3Packages, qt6, sdformat-vendor, tinyxml-2, util-linux, xorg }:
 buildRosPackage {
   pname = "ros-rolling-gz-sim-vendor";
-  version = "0.5.0-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_sim_vendor-release/archive/release/rolling/gz_sim_vendor/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "a554f34b33a98e25b62d031a8e9dbe8d028e5f3ab901debde47ed1957e8b4b89";
+    url = "https://github.com/ros2-gbp/gz_sim_vendor-release/archive/release/rolling/gz_sim_vendor/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "48681d7ddcb8233f75eaf7173ee1769480e8187112dceef95b259c9e73aa9a15";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-sim 10.1.1
+    description = "Vendor package for: gz-sim 10.5.0
 
     Gazebo Sim : A Robotic Simulator";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-sim-vendor/vendored-source.json
+++ b/distros/rolling/gz-sim-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_sim_vendor": {
     "url": "https://github.com/gazebosim/gz-sim.git",
-    "rev": "gz-sim10_10.1.1",
-    "hash": "sha256-pFzpusR7bJAQOZqTGZ79DP9fMIcKNl2gbWW+Zw5tNgs="
+    "rev": "gz-sim10_10.5.0",
+    "hash": "sha256-Ubs1J3myDRCz6LVBtPlLb3H6jo874OuidfuN+6001hw="
   }
 }

--- a/distros/rolling/joint-state-publisher-gui/default.nix
+++ b/distros/rolling/joint-state-publisher-gui/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, joint-state-publisher, python-qt-binding, rclpy }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, joint-state-publisher, python-qt-binding, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-joint-state-publisher-gui";
-  version = "2.4.2-r1";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/rolling/joint_state_publisher_gui/2.4.2-1.tar.gz";
-    name = "2.4.2-1.tar.gz";
-    sha256 = "65f59b3a59aae318f7e811e4e840cd491275ad4f5a207395cc299890af0a6bd5";
+    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/rolling/joint_state_publisher_gui/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "da88ca1196759ae2e243eb901de4fcbbb10cdd2188fb84082d67f82ef38f9342";
   };
 
   buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest ];
   propagatedBuildInputs = [ joint-state-publisher python-qt-binding rclpy ];
 
   meta = {

--- a/distros/rolling/joint-state-publisher/default.nix
+++ b/distros/rolling/joint-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2topic, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-joint-state-publisher";
-  version = "2.4.2-r1";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/rolling/joint_state_publisher/2.4.2-1.tar.gz";
-    name = "2.4.2-1.tar.gz";
-    sha256 = "e68bf86f7e40e9ef343c1cba438641280b3a82be7a4edfaf950a421e6199e562";
+    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/rolling/joint_state_publisher/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "c70256c5798d8e897c7e2ad9f45ba09e976b5dedb9e826607ceea7d9e865bfc8";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/mola-bridge-ros2/default.nix
+++ b/distros/rolling/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, diagnostic-msgs, geographic-msgs, geometry-msgs, gps-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mola-bridge-ros2";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_bridge_ros2/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "0de2f394568c39dcb987a9279943a812cc9d6c72d5307b2dba2680d86e815522";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_bridge_ros2/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "b8e520f1654d1882c5468528c28b1eac836cc173c1485bdca8a035551fc8e959";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-demos/default.nix
+++ b/distros/rolling/mola-demos/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, cmake, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-xmllint, ament-lint-auto, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-demos";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_demos/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "d12ac755ac0d4f91ed2dda1903827e1f0447baaab8f084c58c7666f3b24c35d0";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_demos/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "de85301a85cd43905cfdfbc1fd2207406947a85bfdad40dd3d0936db9747d764";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest cmake ros-environment ];
-  checkInputs = [ ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  checkInputs = [ ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-xmllint ament-lint-auto ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/rolling/mola-input-lidar-bin-dataset/default.nix
+++ b/distros/rolling/mola-input-lidar-bin-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-lidar-bin-dataset";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_lidar_bin_dataset/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "7e9aa96755a7d8095e182196744068a7748ac677e77def61c143a51cdc2a5498";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_lidar_bin_dataset/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "c9a997c999baa904e15c03310c4869032135b1ef0d9a0464a67522f66e246d69";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-rawlog/default.nix
+++ b/distros/rolling/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-rawlog";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rawlog/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "e2a543064e9dfdf1c1299e75acc7ae52b3737d33d1c4ec4a4f17e53939f04f7a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rawlog/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "298bf15b556fa8919e4347543af10ab6eddecbbad1ba9ad1e37e70328f6b07a8";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-rosbag2/default.nix
+++ b/distros/rolling/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, gps-msgs, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-rosbag2";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rosbag2/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "a4294ba150cd0929f55330ab01144c504fe6754380e324be508d5e27cd89f2da";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rosbag2/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "bb5bd0435613a1e0f121d14ff8daee4726e1decdfdeeb2a28d035753c4724da4";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-video/default.nix
+++ b/distros/rolling/mola-input-video/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libhwdrivers, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-video";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_video/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "0f4c094b72490d752744a1a3b149e17c7169cc9c267a0d66e2426dc5f98b6781";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_video/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "f7e47514c4b5e113bc83f48c2092ff456ef2255a7007b5174ea8d5bb277e0918";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-kernel/default.nix
+++ b/distros/rolling/mola-kernel/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libgui, mrpt-libmaps, mrpt-libobs }:
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-kernel";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_kernel/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "06525015c840efae6c568cde28fe11979231305fa3d3050620ee162191a0459b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_kernel/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "503b6f96e7a99c5784a96f6be8118b250e80449bb22c481bee5963c3621d8cfc";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
-  propagatedBuildInputs = [ mola-common mola-yaml mrpt-libgui mrpt-libmaps mrpt-libobs ];
+  propagatedBuildInputs = [ mola-common mola-yaml mrpt-libmaps mrpt-libobs ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/rolling/mola-launcher/default.nix
+++ b/distros/rolling/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-xmllint, ament-lint-auto, cli11, cmake, mola-kernel, mrpt-libbase, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-launcher";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_launcher/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "2e085759befc7f828118de1e50e613a7fd8eb381b9fcfd414e00cd09a98c7646";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_launcher/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "e150be7f87c3b084f81146c2abd405534ea211e4c3fe2b36c6f711b2e120af6e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-lidar-odometry/default.nix
+++ b/distros/rolling/mola-lidar-odometry/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-imu-preintegration, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cli11, cmake, mola-common, mola-imu-preintegration, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mola-yaml, mp2p-icp, mrpt-libmaps, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-rolling-mola-lidar-odometry";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/rolling/mola_lidar_odometry/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "22378c66a4fb39f6b399aa40ceffeb3d106780eaae952f43a807acf63feafc70";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/rolling/mola_lidar_odometry/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "02f585ff07c8d120a1ef03e795ad96ade63506dd1fab38ff8ff3c6eaf265f903";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-test-datasets rosbag2-storage-mcap ];
-  propagatedBuildInputs = [ mola-common mola-imu-preintegration mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-pose-list mola-state-estimation-simple mola-viz mp2p-icp mrpt-libmaps mrpt-libtclap ];
+  propagatedBuildInputs = [ cli11 mola-common mola-imu-preintegration mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-pose-list mola-state-estimation-simple mola-viz mola-yaml mp2p-icp mrpt-libmaps ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/rolling/mola-metric-maps/default.nix
+++ b/distros/rolling/mola-metric-maps/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cli11, cmake, mola-common, mola-kernel, mp2p-icp, mrpt-libmaps, onetbb, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cli11, cmake, mola-common, mola-kernel, mp2p-icp, mrpt-libmaps, nanoflann, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-metric-maps";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_metric_maps/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "d992aec9470594fe22bf62945259e482ef0fbee8fee561214443345a30bfa53b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_metric_maps/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "777ef89bd7d6f64ac289eb7dcbbd2287486d1aeed3e64a2ea537a38450de4329";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ cli11 mola-common mola-kernel mp2p-icp mrpt-libmaps onetbb ];
+  propagatedBuildInputs = [ cli11 mola-common mola-kernel mp2p-icp mrpt-libmaps nanoflann onetbb ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/rolling/mola-msgs/default.nix
+++ b/distros/rolling/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-mola-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "2da1d13d6d06febc0552b3f2f1f7ed584f35b7ffd06a5123e2c68aa9f907bd58";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "2e1693bebfc60d8da41cacb21b617914322298454c8c8065529cc969563b99e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-pose-list/default.nix
+++ b/distros/rolling/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-rolling-mola-pose-list";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_pose_list/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "252fb89c037750f272b8b25758da265227ba39a3ca19b51baba86a8d7e19754d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_pose_list/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "b29eff5ab311851b64109d2300bd64aea0d1a633aa6885b3bb5ed41c8a748576";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-relocalization/default.nix
+++ b/distros/rolling/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-rolling-mola-relocalization";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_relocalization/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "9365e5afb114bad6d5d89571f1b95ff0636973f7eb121badb30aea9167563901";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_relocalization/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "b7d594184cb803526d6a62e07e8e4135992e7d5b05e0df095f9b8342926a5cdf";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-traj-tools/default.nix
+++ b/distros/rolling/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-rolling-mola-traj-tools";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_traj_tools/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "71fdcad7219f177bf3dd3f551090b6b0ce367caaba0a908bad6f5e2d31499690";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_traj_tools/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "40e4c750dbd1718d5995d7300ac7c84bfc1ca39226ea8c735ade1bcb32619b38";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-viz-imgui/default.nix
+++ b/distros/rolling/mola-viz-imgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, freeglut, glfw3, libGL, libGLU, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-rolling-mola-viz-imgui";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz_imgui/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "0d7db0e93301adab1a7c24913f752f232619da6046ab66e2fc30144473410e2b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz_imgui/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "3b60676528a4898894ddb4eaae0c36d4ac2e440ea7f7f56fa7bc82b544179560";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-viz/default.nix
+++ b/distros/rolling/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-rolling-mola-viz";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "edbc6884ae751efb8d985ae742ef59cc290b20b09ca56d3a1d31c7d6b4a8cfb1";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "3eaaa9a76d35e931d6931cacd8319a213d70aa39769c4de07db10bc828e022b1";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-yaml/default.nix
+++ b/distros/rolling/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-rolling-mola-yaml";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_yaml/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "f66f6fdd9e408bc6d81956bf135392de431799d74f8aa2836b0d31544e1ab99b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_yaml/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "483effcdffb57aa10a4405f4de17c537db05e514c743b2785fe5f55585e97b1e";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola/default.nix
+++ b/distros/rolling/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-bridge-ros2, mola-demos, mola-input-rawlog, mola-input-rosbag2, mola-input-video, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-rolling-mola";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "504e0b0e0b461be6968e2199e95e93d142da7e15791548c904b65c6dde534005";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "6278c567deb4deba288caba8014031d729d8bca4aefc040744f67e682e38289d";
   };
 
   buildType = "cmake";

--- a/distros/rolling/moveit-visual-tools/default.nix
+++ b/distros/rolling/moveit-visual-tools/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_rviz_visual_tools, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, graph-msgs, moveit-common, moveit-core, moveit-ros-planning, rclcpp, std-msgs, tf2-eigen, tf2-ros, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, geometric-shapes, geometry-msgs, graph-msgs, interactive-markers, moveit-common, moveit-core, moveit-msgs, moveit-ros-planning, rclcpp, rviz-visual-tools, std-msgs, tf2-eigen, tf2-ros, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-visual-tools";
-  version = "4.1.2-r2";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_visual_tools-release/archive/release/rolling/moveit_visual_tools/4.1.2-2.tar.gz";
-    name = "4.1.2-2.tar.gz";
-    sha256 = "148cd5dcd3841aeb5cab5001b501bcd39f5e91c746d806f5ebb5b3db46311315";
+    url = "https://github.com/ros2-gbp/moveit_visual_tools-release/archive/release/rolling/moveit_visual_tools/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "2ae9ffeccf9dea884e7d6893e3c676e90bbc11a6e5efb5592abb0b3ccbe1bc3d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ _unresolved_rviz_visual_tools geometry-msgs graph-msgs moveit-common moveit-core moveit-ros-planning rclcpp std-msgs tf2-eigen tf2-ros trajectory-msgs visualization-msgs ];
+  propagatedBuildInputs = [ ament-index-cpp geometric-shapes geometry-msgs graph-msgs interactive-markers moveit-common moveit-core moveit-msgs moveit-ros-planning rclcpp rviz-visual-tools std-msgs tf2-eigen tf2-ros trajectory-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -552,10 +552,7 @@ in {
     buildInputs = buildInputs ++ [ rosSelf.toppra ];
   });
 
-  roboplan-oink = (rosSuper.roboplan-oink.override {
-    # https://github.com/tier4/osqp_vendor/issues/26
-    osqp-vendor = null;
-  }).overrideAttrs ({
+  roboplan-oink = rosSuper.roboplan-oink.overrideAttrs ({
     buildInputs ? [], ...
   }: {
     # Prevent cmake from fetching osqp-eigen via git

--- a/distros/rolling/pick-ik/default.nix
+++ b/distros/rolling/pick-ik/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_tl_expected, ament-cmake-ros, fmt, generate-parameter-library, moveit-core, moveit-resources-panda-moveit-config, pluginlib, range-v3, rclcpp, rsl, tf2-geometry-msgs, tf2-kdl }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, fmt, generate-parameter-library, git, moveit-core, moveit-resources-panda-moveit-config, pluginlib, range-v3, rclcpp, rsl, tf2, tf2-geometry-msgs, tf2-kdl, tl-expected-nixpkgs }:
 buildRosPackage {
   pname = "ros-rolling-pick-ik";
-  version = "1.1.1-r2";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pick_ik-release/archive/release/rolling/pick_ik/1.1.1-2.tar.gz";
-    name = "1.1.1-2.tar.gz";
-    sha256 = "dcb785456d85c46fcc666e191831af456fb18b3f5c3ab17706e4ffb1a6f10977";
+    url = "https://github.com/ros2-gbp/pick_ik-release/archive/release/rolling/pick_ik/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "e267f6ee7c0d86c68950230f2a290d6ca9c2809ed821b7bdc5d56fe31c3c4260";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
-  checkInputs = [ moveit-resources-panda-moveit-config ];
-  propagatedBuildInputs = [ _unresolved_tl_expected fmt generate-parameter-library moveit-core pluginlib range-v3 rclcpp rsl tf2-geometry-msgs tf2-kdl ];
+  checkInputs = [ git moveit-resources-panda-moveit-config ];
+  propagatedBuildInputs = [ fmt generate-parameter-library moveit-core pluginlib range-v3 rclcpp rsl tf2 tf2-geometry-msgs tf2-kdl tl-expected-nixpkgs ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/rolling/roboplan-cartesian-planning/default.nix
+++ b/distros/rolling/roboplan-cartesian-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, python3, python3Packages, roboplan, roboplan-example-models, roboplan-oink, roboplan-toppra }:
 buildRosPackage {
   pname = "ros-rolling-roboplan-cartesian-planning";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/rolling/roboplan_cartesian_planning/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "9169d6fa989ebb5a4f730d4de69f24c63d32d251d51e3cbe619f91ddc0e8df63";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/rolling/roboplan_cartesian_planning/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "7cbdde992c892d47a1cf3e73642488a81e5509016f345ebf4155d1b500274611";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/roboplan-example-models/default.nix
+++ b/distros/rolling/roboplan-example-models/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-roboplan-example-models";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/rolling/roboplan_example_models/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "e41777589d844be3ad17c125e217724141ec39dcb36ca607918686b9ea08e94a";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/rolling/roboplan_example_models/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "7dfdfec7ee72ee5132e47b4d565335f111d3512a598fb345ca27e249379eac1a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/roboplan-examples/default.nix
+++ b/distros/rolling/roboplan-examples/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, roboplan, roboplan-cartesian-planning, roboplan-example-models, roboplan-oink, roboplan-rrt, roboplan-simple-ik, roboplan-toppra, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, roboplan, roboplan-cartesian-planning, roboplan-example-models, roboplan-oink, roboplan-rrt, roboplan-simple-ik, roboplan-toppra, xacro }:
 buildRosPackage {
   pname = "ros-rolling-roboplan-examples";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/rolling/roboplan_examples/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "0035802dca24b2e32e85d10392801d227adc8f4de83c375f06f1c31d068e2e72";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/rolling/roboplan_examples/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "5c31dd2717f6009a372548c7514952c14b82659aee0915a3ae41a22ff2084335";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-pytest ];
   propagatedBuildInputs = [ roboplan roboplan-cartesian-planning roboplan-example-models roboplan-oink roboplan-rrt roboplan-simple-ik roboplan-toppra xacro ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/roboplan-oink/default.nix
+++ b/distros/rolling/roboplan-oink/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, gtest, osqp-vendor, python3, python3Packages, roboplan, roboplan-example-models }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, gtest, proxsuite, python3, python3Packages, roboplan, roboplan-example-models }:
 buildRosPackage {
   pname = "ros-rolling-roboplan-oink";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/rolling/roboplan_oink/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "61f6f701ae6ef69b4d4c11196487fbd42118efd679d6a529b13022528e10fd9a";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/rolling/roboplan_oink/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "de66cf920ed045dd379fd9ca55653143db0689020c6b8b7cf0d5ff109b1f8eb1";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python python3 python3Packages.nanobind ];
   checkInputs = [ ament-cmake-gmock gtest roboplan-example-models ];
-  propagatedBuildInputs = [ osqp-vendor roboplan ];
+  propagatedBuildInputs = [ proxsuite roboplan ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/rolling/roboplan-ros-cpp/default.nix
+++ b/distros/rolling/roboplan-ros-cpp/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, builtin-interfaces, eigen, geometry-msgs, pinocchio, python3, python3Packages, roboplan, roboplan-example-models, rosidl-generator-cpp, sensor-msgs, tf2-eigen, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-roboplan-ros-cpp";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan_ros-release/archive/release/rolling/roboplan_ros_cpp/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "2ad25a7adb51f679114d4c2d310acbcf078ae360d92f2764f2d230bf89a32271";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake builtin-interfaces python3 python3Packages.nanobind ];
+  checkInputs = [ ament-index-cpp roboplan-example-models ];
+  propagatedBuildInputs = [ eigen geometry-msgs pinocchio roboplan rosidl-generator-cpp sensor-msgs tf2-eigen trajectory-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS 2 C++ bindings for the RoboPlan motion planning library.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/roboplan-ros-examples/default.nix
+++ b/distros/rolling/roboplan-ros-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-python, control-msgs, rclpy, roboplan, sensor-msgs, std-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-roboplan-ros-examples";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan_ros-release/archive/release/rolling/roboplan_ros_examples/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "9b62c7294a140b9ffd31607783cb25b1aa6b93b54adf403080a5a1f3f1caa3ae";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-python ];
+  propagatedBuildInputs = [ control-msgs rclpy roboplan sensor-msgs std-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake-python ];
+
+  meta = {
+    description = "Examples of using RoboPlan in the ROS ecosystem.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/roboplan-ros-franka/default.nix
+++ b/distros/rolling/roboplan-ros-franka/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, joint-state-broadcaster, joint-trajectory-controller, parallel-gripper-controller, roboplan, roboplan-example-models, roboplan-ros-examples, robot-state-publisher, topic-tools, xacro }:
+buildRosPackage {
+  pname = "ros-rolling-roboplan-ros-franka";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan_ros-release/archive/release/rolling/roboplan_ros_franka/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "f838b97585478d37a96f79843b3af9d5a7cadcf57249ad1bea8428bf19d4ebde";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ controller-manager joint-state-broadcaster joint-trajectory-controller parallel-gripper-controller roboplan roboplan-example-models roboplan-ros-examples robot-state-publisher topic-tools xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Franka arm ROS example for RoboPlan.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/roboplan-ros-py/default.nix
+++ b/distros/rolling/roboplan-ros-py/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, builtin-interfaces, python3Packages, rclpy, roboplan, roboplan-ros-cpp, sensor-msgs, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-roboplan-ros-py";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan_ros-release/archive/release/rolling/roboplan_ros_py/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "641b6378adab1d88925dc2e18aedb7377b5a70cf46f84ba0d53200cca5dd330f";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ python3Packages.pytest ];
+  propagatedBuildInputs = [ builtin-interfaces rclpy roboplan roboplan-ros-cpp sensor-msgs trajectory-msgs ];
+
+  meta = {
+    description = "ROS 2 Python bindings for the roboplan motion planning library.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/roboplan-ros-visualization/default.nix
+++ b/distros/rolling/roboplan-ros-visualization/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-cpp, geometry-msgs, interactive-markers, python3, python3Packages, rclcpp, rclpy, roboplan, roboplan-ros-cpp, roboplan-simple-ik, rviz2, sensor-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-roboplan-ros-visualization";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/roboplan_ros-release/archive/release/rolling/roboplan_ros_visualization/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "8448f10713002f03a2b648cb201816788cb6cec7017519df98498be76e2668af";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python python3 python3Packages.nanobind ];
+  propagatedBuildInputs = [ ament-index-cpp geometry-msgs interactive-markers rclcpp rclpy roboplan roboplan-ros-cpp roboplan-simple-ik rviz2 sensor-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "ROS 2 visualization tools for the RoboPlan library.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/roboplan-rrt/default.nix
+++ b/distros/rolling/roboplan-rrt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, python3, python3Packages, roboplan, roboplan-example-models }:
 buildRosPackage {
   pname = "ros-rolling-roboplan-rrt";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/rolling/roboplan_rrt/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "873f2ca1ffc1f614fd320fd94167e87f9def72b31e38ac5ce90ebf8bc45eeae0";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/rolling/roboplan_rrt/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "5e74fe876d2c6f7e9493d0a646aebffc9373741ab9113d0419d7137f0c6b40e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/roboplan-simple-ik/default.nix
+++ b/distros/rolling/roboplan-simple-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, python3, python3Packages, roboplan }:
 buildRosPackage {
   pname = "ros-rolling-roboplan-simple-ik";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/rolling/roboplan_simple_ik/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "063945725ee055005970937d3c1a0522584631bba33cd58821c85fdcb66fd55a";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/rolling/roboplan_simple_ik/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "cf6259e9093e216583840eec56eb034a48e8bae8641c1df893faeaf5cac473d7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/roboplan-toppra/default.nix
+++ b/distros/rolling/roboplan-toppra/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, python3, python3Packages, roboplan, roboplan-example-models, toppra }:
 buildRosPackage {
   pname = "ros-rolling-roboplan-toppra";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/rolling/roboplan_toppra/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "9c22229876316ba7627c740d7970ae0603238dc496def7f287550935038637c1";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/rolling/roboplan_toppra/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "ff0be00551216167992a7a5d95ee72576dacb92e61354a0a87deaa99ff56c544";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/roboplan/default.nix
+++ b/distros/rolling/roboplan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, eigen, gtest, pinocchio, python3, python3Packages, roboplan-example-models, tinyxml-2, tl-expected-nixpkgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-roboplan";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/rolling/roboplan/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "d2bfd391a17c78c79d30c6a70ef46a552463ecc10348688eb2b076554a37ea4c";
+    url = "https://github.com/ros2-gbp/roboplan-release/archive/release/rolling/roboplan/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "9fa1b6e45a6d5f33410589bb86b2c2e23ef68531b5264ba7887c64e39641ddbb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-gui-cpp/default.nix
+++ b/distros/rolling/rqt-gui-cpp/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, qt-gui-cpp, qt6, rclcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros-core, ament-lint-auto, ament-lint-common, pluginlib, qt-gui-cpp, qt6, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-rqt-gui-cpp";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui_cpp/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "5378a41f0950de8e8f3dbd300de65c4c4b984c6e934752f22d425138fabed845";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui_cpp/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "db8cdc32fc202ad82421a7a1ddfd3cbe091fa3376dab59725338f368413c48dc";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake qt6.qtbase ];
-  checkInputs = [ ament-lint-auto ament-lint-common ];
+  buildInputs = [ ament-cmake ament-cmake-ros-core qt6.qtbase ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ pluginlib qt-gui-cpp rclcpp ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros-core ];
 
   meta = {
     description = "rqt_gui_cpp enables GUI plugins to use the C++ client library for ROS.";

--- a/distros/rolling/rqt-gui-py/default.nix
+++ b/distros/rolling/rqt-gui-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui }:
 buildRosPackage {
   pname = "ros-rolling-rqt-gui-py";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui_py/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "4022118b7dea75887d347efb20d7fb261357680b974c7a8461bdd44b31725738";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui_py/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "0d04302d51c6f1c196f43f998c2633d3c5da6abbf419d803004414bb9ba1dfa9";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-gui/default.nix
+++ b/distros/rolling/rqt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, python-qt-binding, python3Packages, qt-gui, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-rqt-gui";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "c06b9714739004fab8cf1bfbf9688b92f77b479c429979bd2f563da5dc249e21";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "5d870773a684e584b2542fdaa3574c08bebfce83d51a9f0ea1517a118e4b0bf8";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-py-common/default.nix
+++ b/distros/rolling/rqt-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, python-qt-binding, qt-gui, qt6, rclpy, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rqt-py-common";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_py_common/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "77e393fe0aa7b26349f1b28ba1e0c0db93651cd229d3bb23da7c2fe0df56fd96";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_py_common/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "c3e1902a54546750b84484efb8951cacc99030ace3a19367b8f2740a4c6131e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt/default.nix
+++ b/distros/rolling/rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages, rqt-gui, rqt-gui-cpp, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-rolling-rqt";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "ac73914616a9b5f42cc5c41f3258ae72d5f4b2f46cb1706933e41764850d1e6a";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "e80cf80717fa926e098ce56cd696d92f12d8d4361d51085f13825a45fe640e47";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rviz-visual-tools/default.nix
+++ b/distros/rolling/rviz-visual-tools/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, interactive-markers, launch, launch-ros, pluginlib, qt5, rclcpp, rclcpp-components, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz2, sensor-msgs, shape-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, interactive-markers, launch, launch-ros, pluginlib, qt6, rclcpp, rclcpp-components, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz2, sensor-msgs, shape-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz-visual-tools";
-  version = "4.1.4-r4";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz_visual_tools-release/archive/release/rolling/rviz_visual_tools/4.1.4-4.tar.gz";
-    name = "4.1.4-4.tar.gz";
-    sha256 = "1f3cbf8993ad2b33484c3e3d5f3346d8154342002225c24e507ea7e34a3c7aff";
+    url = "https://github.com/ros2-gbp/rviz_visual_tools-release/archive/release/rolling/rviz_visual_tools/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "ae049484597e33ce92e6ec09c01ec450161a877bd5e451bcfdb02d7aebaef74c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python eigen eigen-stl-containers eigen3-cmake-module geometry-msgs interactive-markers launch launch-ros pluginlib qt5.qtbase rclcpp rclcpp-components rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering rviz2 sensor-msgs shape-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs visualization-msgs ];
+  propagatedBuildInputs = [ ament-index-python eigen eigen-stl-containers eigen3-cmake-module geometry-msgs interactive-markers launch launch-ros pluginlib qt6.qtbase rclcpp rclcpp-components rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering rviz2 sensor-msgs shape-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 
   meta = {

--- a/distros/rolling/warehouse-ros-sqlite/default.nix
+++ b/distros/rolling/warehouse-ros-sqlite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite, warehouse-ros }:
 buildRosPackage {
   pname = "ros-rolling-warehouse-ros-sqlite";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/rolling/warehouse_ros_sqlite/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "4719cd9c869a396dde11d09b56891e7055fb19f50c45ef342c552def1e3c1d87";
+    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/rolling/warehouse_ros_sqlite/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "227f03ac62d1a70831ee0608019b5e8b09b901cc62bf6eb0d280f6970222e27f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/warehouse-ros/default.nix
+++ b/distros/rolling/warehouse-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-lint-auto, boost, geometry-msgs, openssl, pluginlib, rclcpp, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-warehouse-ros";
-  version = "2.0.6-r2";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/warehouse_ros-release/archive/release/rolling/warehouse_ros/2.0.6-2.tar.gz";
-    name = "2.0.6-2.tar.gz";
-    sha256 = "377b59c265219dff4d6e27c240bc7fc2a1be71ceb66448b5a20956451ce7f3df";
+    url = "https://github.com/ros2-gbp/warehouse_ros-release/archive/release/rolling/warehouse_ros/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "e843919d82d836e39ce94b313af711d63dfb53ebbd9c40cf2737075b17f8007d";
   };
 
   buildType = "ament_cmake";

--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
     "rosdistro": {
       "flake": false,
       "locked": {
-        "lastModified": 1785506537,
-        "narHash": "sha256-F/E9AWF3V2coFM0tz8Rpgjs7KZELZ617OUrfiF5Tb3I=",
+        "lastModified": 1786041351,
+        "narHash": "sha256-hVeiIBsoOlgNtOht0IDVsW33V+oy1fYl4LSAjEWV7Lo=",
         "owner": "ros",
         "repo": "rosdistro",
-        "rev": "16a90886be745b6ec535942294969c2228a8c59a",
+        "rev": "5f1e4c9cd5e9f09fae69fc412b23e43a32882a64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'kilted', 'lyrical', 'rolling'] from nix-ros-overlay commit e97737e1327c76976f2e4cfe9b4bdefec63b9f1a.
This pull request was generated by running the following command:

```
superflore-gen-nix --dry-run --output-repository-path . --all --tar-archive-dir /home/runner/.ros/tar --upstream-branch develop
```

Changes:
========
Humble Changes:
---------------
* *ackermann-steering-controller 2.53.2-r1 --> 2.53.3-r1*
* *admittance-controller 2.53.2-r1 --> 2.53.3-r1*
* *bicycle-steering-controller 2.53.2-r1 --> 2.53.3-r1*
* *diff-drive-controller 2.53.2-r1 --> 2.53.3-r1*
* *effort-controllers 2.53.2-r1 --> 2.53.3-r1*
* *force-torque-sensor-broadcaster 2.53.2-r1 --> 2.53.3-r1*
* *forward-command-controller 2.53.2-r1 --> 2.53.3-r1*
* *gpio-controllers 2.53.2-r1 --> 2.53.3-r1*
* *graph-msgs 0.2.0-r3 --> 0.2.1-r1*
* *gripper-controllers 2.53.2-r1 --> 2.53.3-r1*
* *imu-sensor-broadcaster 2.53.2-r1 --> 2.53.3-r1*
* *joint-state-broadcaster 2.53.2-r1 --> 2.53.3-r1*
* *joint-trajectory-controller 2.53.2-r1 --> 2.53.3-r1*
* *mecanum-drive-controller 2.53.2-r1 --> 2.53.3-r1*
* *moveit-visual-tools 4.1.2-r1 --> 4.2.0-r1*
* *pid-controller 2.53.2-r1 --> 2.53.3-r1*
* *pose-broadcaster 2.53.2-r1 --> 2.53.3-r1*
* *position-controllers 2.53.2-r1 --> 2.53.3-r1*
* *range-sensor-broadcaster 2.53.2-r1 --> 2.53.3-r1*
* *ros2-controllers 2.53.2-r1 --> 2.53.3-r1*
* *ros2-controllers-test-nodes 2.53.2-r1 --> 2.53.3-r1*
* *rqt-joint-trajectory-controller 2.53.2-r1 --> 2.53.3-r1*
* *rviz-visual-tools 4.1.4-r1 --> 4.2.0-r1*
* *septentrio-gnss-driver 1.4.7-r2 --> 1.4.8-r1*
* *steering-controllers-library 2.53.2-r1 --> 2.53.3-r1*
* *tricycle-controller 2.53.2-r1 --> 2.53.3-r1*
* *tricycle-steering-controller 2.53.2-r1 --> 2.53.3-r1*
* *velocity-controllers 2.53.2-r1 --> 2.53.3-r1*
* *warehouse-ros 2.0.5-r1 --> 2.0.7-r1*
* *warehouse-ros-sqlite 1.0.8-r1 --> 1.0.9-r1*

Jazzy Changes:
--------------
* *graph-msgs 0.2.0-r6 --> 0.2.1-r1*
* *joint-state-publisher 2.4.1-r1 --> 2.4.3-r1*
* *joint-state-publisher-gui 2.4.1-r1 --> 2.4.3-r1*
* *jsk-common-msgs 5.0.1-r3*
* *jsk-footstep-msgs 5.0.1-r3*
* *jsk-gui-msgs 5.0.1-r3*
* *jsk-hark-msgs 5.0.1-r3*
* *moveit-visual-tools 4.1.2-r1 --> 4.2.0-r1*
* *posedetection-msgs 5.0.1-r3*
* *roboplan 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-cartesian-planning 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-example-models 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-examples 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-oink 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-ros-cpp 0.6.0-r1*
* *roboplan-ros-examples 0.6.0-r1*
* *roboplan-ros-franka 0.6.0-r1*
* *roboplan-ros-py 0.6.0-r1*
* *roboplan-ros-visualization 0.6.0-r1*
* *roboplan-rrt 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-simple-ik 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-toppra 0.5.1-r1 --> 0.6.0-r1*
* *rviz-visual-tools 4.1.4-r4 --> 4.2.0-r1*
* *septentrio-gnss-driver 1.4.7-r3 --> 1.4.8-r2*
* *speech-recognition-msgs 5.0.1-r3*
* *warehouse-ros 2.0.5-r1 --> 2.0.7-r1*
* *warehouse-ros-sqlite 1.0.8-r1 --> 1.0.9-r1*

Kilted Changes:
---------------
* *graph-msgs 0.2.0-r6 --> 0.2.1-r1*
* *joint-state-publisher 2.4.1-r1 --> 2.4.3-r1*
* *joint-state-publisher-gui 2.4.1-r1 --> 2.4.3-r1*
* *jsk-common-msgs 5.0.1-r3*
* *jsk-footstep-msgs 5.0.1-r3*
* *jsk-gui-msgs 5.0.1-r3*
* *jsk-hark-msgs 5.0.1-r3*
* *moveit-visual-tools 4.1.2-r2 --> 4.2.0-r1*
* *posedetection-msgs 5.0.1-r3*
* *roboplan 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-cartesian-planning 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-example-models 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-examples 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-oink 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-ros-cpp 0.6.0-r1*
* *roboplan-ros-examples 0.6.0-r1*
* *roboplan-ros-franka 0.6.0-r1*
* *roboplan-ros-py 0.6.0-r1*
* *roboplan-ros-visualization 0.6.0-r1*
* *roboplan-rrt 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-simple-ik 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-toppra 0.5.1-r1 --> 0.6.0-r1*
* *rviz-visual-tools 4.1.4-r4 --> 4.2.0-r1*
* *septentrio-gnss-driver 1.4.7-r2 --> 1.4.8-r1*
* *speech-recognition-msgs 5.0.1-r3*
* *warehouse-ros 2.0.5-r2 --> 2.0.7-r1*
* *warehouse-ros-sqlite 1.0.8-r1 --> 1.0.9-r1*

Lyrical Changes:
----------------
* *costmap-queue 1.5.0-r1*
* *dwb-core 1.5.0-r1*
* *dwb-critics 1.5.0-r1*
* *dwb-msgs 1.5.0-r1*
* *dwb-plugins 1.5.0-r1*
* *graph-msgs 0.2.0-r7 --> 0.2.1-r1*
* *joint-state-publisher 2.4.2-r1 --> 2.4.3-r1*
* *joint-state-publisher-gui 2.4.2-r1 --> 2.4.3-r1*
* *jsk-common-msgs 5.0.1-r2*
* *jsk-footstep-msgs 5.0.1-r2*
* *jsk-gui-msgs 5.0.1-r2*
* *jsk-hark-msgs 5.0.1-r2*
* *moveit-visual-tools 4.1.2-r3 --> 4.2.0-r1*
* *nav-2d-msgs 1.5.0-r1*
* *nav-2d-utils 1.5.0-r1*
* *nav2-amcl 1.5.0-r1*
* *nav2-behavior-tree 1.5.0-r1*
* *nav2-behaviors 1.5.0-r1*
* *nav2-bringup 1.5.0-r1*
* *nav2-bt-navigator 1.5.0-r1*
* *nav2-collision-monitor 1.5.0-r1*
* *nav2-common 1.5.0-r1*
* *nav2-constrained-smoother 1.5.0-r1*
* *nav2-controller 1.5.0-r1*
* *nav2-core 1.5.0-r1*
* *nav2-costmap-2d 1.5.0-r1*
* *nav2-dwb-controller 1.5.0-r1*
* *nav2-graceful-controller 1.5.0-r1*
* *nav2-lifecycle-manager 1.5.0-r1*
* *nav2-loopback-sim 1.5.0-r1*
* *nav2-map-server 1.5.0-r1*
* *nav2-mppi-controller 1.5.0-r1*
* *nav2-msgs 1.5.0-r1*
* *nav2-navfn-planner 1.5.0-r1*
* *nav2-planner 1.5.0-r1*
* *nav2-regulated-pure-pursuit-controller 1.5.0-r1*
* *nav2-ros-common 1.5.0-r1*
* *nav2-rotation-shim-controller 1.5.0-r1*
* *nav2-route 1.5.0-r1*
* *nav2-rviz-plugins 1.5.0-r1*
* *nav2-simple-commander 1.5.0-r1*
* *nav2-smac-planner 1.5.0-r1*
* *nav2-smoother 1.5.0-r1*
* *nav2-system-tests 1.5.0-r1*
* *nav2-theta-star-planner 1.5.0-r1*
* *nav2-util 1.5.0-r1*
* *nav2-velocity-smoother 1.5.0-r1*
* *nav2-voxel-grid 1.5.0-r1*
* *nav2-waypoint-follower 1.5.0-r1*
* *navigation2 1.5.0-r1*
* *opennav-docking 1.5.0-r1*
* *opennav-docking-bt 1.5.0-r1*
* *opennav-docking-core 1.5.0-r1*
* *opennav-following 1.5.0-r1*
* *pick-ik 1.1.1-r3 --> 1.1.3-r1*
* *posedetection-msgs 5.0.1-r2*
* *roboplan 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-cartesian-planning 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-example-models 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-examples 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-oink 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-ros-cpp 0.6.0-r1*
* *roboplan-ros-examples 0.6.0-r1*
* *roboplan-ros-franka 0.6.0-r1*
* *roboplan-ros-py 0.6.0-r1*
* *roboplan-ros-visualization 0.6.0-r1*
* *roboplan-rrt 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-simple-ik 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-toppra 0.5.1-r1 --> 0.6.0-r1*
* *rviz-visual-tools 4.1.4-r5 --> 4.2.0-r1*
* *speech-recognition-msgs 5.0.1-r2*
* *warehouse-ros 2.0.6-r3 --> 2.0.7-r1*
* *warehouse-ros-sqlite 1.0.8-r1 --> 1.0.9-r1*

Rolling Changes:
----------------
* *graph-msgs 0.2.0-r6 --> 0.2.1-r1*
* *gz-sim-vendor 0.5.0-r1 --> 0.5.2-r1*
* *joint-state-publisher 2.4.2-r1 --> 2.4.3-r1*
* *joint-state-publisher-gui 2.4.2-r1 --> 2.4.3-r1*
* *mola 3.0.0-r1 --> 3.1.0-r1*
* *mola-bridge-ros2 3.0.0-r1 --> 3.1.0-r1*
* *mola-demos 3.0.0-r1 --> 3.1.0-r1*
* *mola-input-lidar-bin-dataset 3.0.0-r1 --> 3.1.0-r1*
* *mola-input-rawlog 3.0.0-r1 --> 3.1.0-r1*
* *mola-input-rosbag2 3.0.0-r1 --> 3.1.0-r1*
* *mola-input-video 3.0.0-r1 --> 3.1.0-r1*
* *mola-kernel 3.0.0-r1 --> 3.1.0-r1*
* *mola-launcher 3.0.0-r1 --> 3.1.0-r1*
* *mola-lidar-odometry 3.0.0-r1 --> 3.1.0-r1*
* *mola-metric-maps 3.0.0-r1 --> 3.1.0-r1*
* *mola-msgs 3.0.0-r1 --> 3.1.0-r1*
* *mola-pose-list 3.0.0-r1 --> 3.1.0-r1*
* *mola-relocalization 3.0.0-r1 --> 3.1.0-r1*
* *mola-traj-tools 3.0.0-r1 --> 3.1.0-r1*
* *mola-viz 3.0.0-r1 --> 3.1.0-r1*
* *mola-viz-imgui 3.0.0-r1 --> 3.1.0-r1*
* *mola-yaml 3.0.0-r1 --> 3.1.0-r1*
* *moveit-visual-tools 4.1.2-r2 --> 4.2.0-r1*
* *pick-ik 1.1.1-r2 --> 1.1.3-r1*
* *roboplan 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-cartesian-planning 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-example-models 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-examples 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-oink 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-ros-cpp 0.6.0-r1*
* *roboplan-ros-examples 0.6.0-r1*
* *roboplan-ros-franka 0.6.0-r1*
* *roboplan-ros-py 0.6.0-r1*
* *roboplan-ros-visualization 0.6.0-r1*
* *roboplan-rrt 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-simple-ik 0.5.1-r1 --> 0.6.0-r1*
* *roboplan-toppra 0.5.1-r1 --> 0.6.0-r1*
* *rqt 2.0.1-r1 --> 2.0.2-r1*
* *rqt-gui 2.0.1-r1 --> 2.0.2-r1*
* *rqt-gui-cpp 2.0.1-r1 --> 2.0.2-r1*
* *rqt-gui-py 2.0.1-r1 --> 2.0.2-r1*
* *rqt-py-common 2.0.1-r1 --> 2.0.2-r1*
* *rviz-visual-tools 4.1.4-r4 --> 4.2.0-r1*
* *warehouse-ros 2.0.6-r2 --> 2.0.7-r1*
* *warehouse-ros-sqlite 1.0.8-r2 --> 1.0.9-r1*


No missing dependencies.