### PR TITLE
ros2-overlay: don't declare Linux-only dependencies on Darwin

### DIFF
--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -65,7 +65,13 @@ with rosSelf.lib; {
     '';
   });
 
-  backward-ros = rosSuper.backward-ros.overrideAttrs ({ postPatch ? "", ... }: {
+  # elfutils is Linux-only, and BackwardConfigAment.cmake already degrades to
+  # libbfd or to no debug info when libdw is absent. Declaring it
+  # unconditionally makes backward-ros, and everything depending on it, fail
+  # to evaluate on Darwin.
+  backward-ros = (rosSuper.backward-ros.override (optionalAttrs self.stdenv.isDarwin {
+    elfutils = null;
+  })).overrideAttrs ({ postPatch ? "", ... }: {
 
     # The `--as-needed` flag directs the linker to search all libraries specified
     # during its invocation to identify which ones contain the symbols required by the binary.
@@ -298,6 +304,13 @@ with rosSelf.lib; {
       buildInputs;
   });
 
+  # libcap is Linux-only, and realtime_tools already links it under
+  # `if(UNIX AND NOT APPLE)` and includes <sys/capability.h> under
+  # `#if defined(__unix__)`. Only the Nix dependency needs dropping.
+  realtime-tools = rosSuper.realtime-tools.override (optionalAttrs self.stdenv.isDarwin {
+    libcap = null;
+  });
+
   ros-gz-sim = rosSuper.ros-gz-sim.overrideAttrs ({
     postPatch ? "", ...
   }: {
@@ -361,6 +374,15 @@ with rosSelf.lib; {
     meta = meta // {
       mainProgram = "rviz2";
     };
+  });
+
+  # tango-icon-theme is Linux-only, and tango_icons_vendor exists precisely to
+  # supply the icons where it is unavailable: its CMakeLists installs the
+  # bundled copy under `if(WIN32 OR APPLE)`. The exec_depend only applies to
+  # Linux, so nothing is lost by dropping it on Darwin. Without this,
+  # qt-gui and every rqt plugin fail to evaluate.
+  tango-icons-vendor = rosSuper.tango-icons-vendor.override (optionalAttrs self.stdenv.isDarwin {
+    tango-icon-theme = null;
   });
 
   # The build gets stuck in an infinite loop with absolute CMAKE_INSTALL_LIBDIR:


### PR DESCRIPTION
Three ROS 2 packages declare a Linux-only nixpkgs dependency unconditionally, so `rosPackages.<distro>` fails to **evaluate** on `aarch64-darwin` — before any build is attempted.

| package | dep | error |
| --- | --- | --- |
| `backward-ros` | `elfutils` | `Refusing to evaluate package 'elfutils-0.195' … hostPlatform.system = "aarch64-darwin"` |
| `realtime-tools` | `libcap` | same, `libcap-2.78` |
| `tango-icons-vendor` | `tango-icon-theme` | same, `tango-icon-theme-0.8.90` |

They are declared flat in the generated definitions, e.g. `distros/jazzy/backward-ros/default.nix`:

```nix
{ lib, buildRosPackage, fetchurl, cmake, elfutils }:
  propagatedBuildInputs = [ elfutils ];
```

Each reaches much further than the one package. `elfutils` takes out the whole ros2-control stack (`controller-manager`, `controller-interface`, `hardware-interface`, `joint-state-broadcaster`, `gpio-controllers`, `ros2-control`, `ros2-controllers`) plus `nav2-route`. `tango-icon-theme` goes `rqt-image-view` → `qt-gui-cpp` → `qt-gui` → `tango-icons-vendor`, so it takes out every rqt plugin, `mapviz`, `mapviz-plugins`, `desktop` and `desktop-full`.

## Why guarding the Nix side is sufficient

In all three cases the ROS package already handles the dependency being absent on Darwin — this is purely a packaging-side over-declaration:

- **backward_ros** — `cmake/BackwardConfigAment.cmake` is `if (LIBDW_FOUND) … elseif (LIBBFD_FOUND) …`, so it degrades to libbfd or to no debug info.
- **realtime_tools** — `CMakeLists.txt` links `cap` under `if(UNIX AND NOT APPLE)`, and `src/realtime_helpers.cpp` includes `<sys/capability.h>` under `#if defined(__unix__)`, which macOS does not define.
- **tango_icons_vendor** — its `CMakeLists.txt` sets `INSTALL_TANGO_ICONS_DEFAULT_VALUE TRUE` under `if(WIN32 OR APPLE)` and installs the bundled `resource/` copy. The package exists precisely to supply the icons where the system theme is unavailable, so the `tango-icon-theme` `exec_depend` is the Linux path only, and **no icons are lost on Darwin**.

## Approach

`.override { dep = null; }` guarded by `optionalAttrs self.stdenv.isDarwin`, following the existing `.override` usage in this file (`cloudini-lib`, `plotjuggler`) and the existing Darwin accommodation in `rmw-implementation` just above.

I deliberately did not relax `meta.platforms` on the nixpkgs packages — those are accurate, and overriding them only converts an eval error into a build error. Tried it to confirm: relaxing `tango-icon-theme` just surfaces `gnome-icon-theme` behind it.

## Verified

Evaluated with this overlay only (no downstream patches), against nixpkgs-weekly:

- `aarch64-darwin`: `backward-ros`, `realtime-tools`, `tango-icons-vendor`, `ros2-control`, `nav2-route`, `mapviz`, `desktop-full` all evaluate. Before this change, all but `tango-icons-vendor` fail.
- `x86_64-linux`: unchanged — all three still evaluate, and `backward-ros.propagatedBuildInputs` is still `["elfutils"]`.

I appreciate CI only covers `x86_64-linux` and `aarch64-linux`, so this is eval-level evidence on Darwin rather than a build. It is a strict improvement there and a no-op on Linux.