### PR TITLE
foxglove-bridge: add Darwin SDK platforms and hashes

### DIFF
--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -290,10 +290,14 @@ in with lib; {
       systemToPlatform = {
         "x86_64-linux" = "x86_64-unknown-linux-gnu";
         "aarch64-linux" = "aarch64-unknown-linux-gnu";
+        "x86_64-darwin" = "x86_64-apple-darwin";
+        "aarch64-darwin" = "aarch64-apple-darwin";
       };
       systemToHash = {
         "x86_64-linux" = "sha256-j7A7BhEneIrXCJGNGG101P21hxixHP+XydYFUTq1fMY=";
         "aarch64-linux" = "sha256-BxDy7Fq8OVSs9iA7k6lnaNzNGddCr5t4/Nj7u6X2Ilo=";
+        "x86_64-darwin" = "sha256-TlkrT+RHufq5EnBvhjp1gzz2vtxcF9PqR01FMe7HIq4=";
+        "aarch64-darwin" = "sha256-quLM/rzOS2/3LjZpEqktZXb2EA55zfcdeeQoiXet0PA=";
       };
       FOXGLOVE_SDK_PLATFORM = systemToPlatform.${self.stdenv.hostPlatform.system};
       sdk = self.fetchurl {

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -284,10 +284,14 @@ in {
       systemToPlatform = {
         "x86_64-linux" = "x86_64-unknown-linux-gnu";
         "aarch64-linux" = "aarch64-unknown-linux-gnu";
+        "x86_64-darwin" = "x86_64-apple-darwin";
+        "aarch64-darwin" = "aarch64-apple-darwin";
       };
       systemToHash = {
         "x86_64-linux" = "sha256-j7A7BhEneIrXCJGNGG101P21hxixHP+XydYFUTq1fMY=";
         "aarch64-linux" = "sha256-BxDy7Fq8OVSs9iA7k6lnaNzNGddCr5t4/Nj7u6X2Ilo=";
+        "x86_64-darwin" = "sha256-TlkrT+RHufq5EnBvhjp1gzz2vtxcF9PqR01FMe7HIq4=";
+        "aarch64-darwin" = "sha256-quLM/rzOS2/3LjZpEqktZXb2EA55zfcdeeQoiXet0PA=";
       };
       FOXGLOVE_SDK_PLATFORM = systemToPlatform.${self.stdenv.hostPlatform.system};
       sdk = self.fetchurl {

--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -101,10 +101,14 @@ in {
       systemToPlatform = {
         "x86_64-linux" = "x86_64-unknown-linux-gnu";
         "aarch64-linux" = "aarch64-unknown-linux-gnu";
+        "x86_64-darwin" = "x86_64-apple-darwin";
+        "aarch64-darwin" = "aarch64-apple-darwin";
       };
       systemToHash = {
         "x86_64-linux" = "sha256-j7A7BhEneIrXCJGNGG101P21hxixHP+XydYFUTq1fMY=";
         "aarch64-linux" = "sha256-BxDy7Fq8OVSs9iA7k6lnaNzNGddCr5t4/Nj7u6X2Ilo=";
+        "x86_64-darwin" = "sha256-TlkrT+RHufq5EnBvhjp1gzz2vtxcF9PqR01FMe7HIq4=";
+        "aarch64-darwin" = "sha256-quLM/rzOS2/3LjZpEqktZXb2EA55zfcdeeQoiXet0PA=";
       };
       FOXGLOVE_SDK_PLATFORM = systemToPlatform.${self.stdenv.hostPlatform.system};
       sdk = self.fetchurl {

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -88,10 +88,14 @@ in {
       systemToPlatform = {
         "x86_64-linux" = "x86_64-unknown-linux-gnu";
         "aarch64-linux" = "aarch64-unknown-linux-gnu";
+        "x86_64-darwin" = "x86_64-apple-darwin";
+        "aarch64-darwin" = "aarch64-apple-darwin";
       };
       systemToHash = {
         "x86_64-linux" = "sha256-j7A7BhEneIrXCJGNGG101P21hxixHP+XydYFUTq1fMY=";
         "aarch64-linux" = "sha256-BxDy7Fq8OVSs9iA7k6lnaNzNGddCr5t4/Nj7u6X2Ilo=";
+        "x86_64-darwin" = "sha256-TlkrT+RHufq5EnBvhjp1gzz2vtxcF9PqR01FMe7HIq4=";
+        "aarch64-darwin" = "sha256-quLM/rzOS2/3LjZpEqktZXb2EA55zfcdeeQoiXet0PA=";
       };
       FOXGLOVE_SDK_PLATFORM = systemToPlatform.${self.stdenv.hostPlatform.system};
       sdk = self.fetchurl {

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -89,10 +89,14 @@ in {
       systemToPlatform = {
         "x86_64-linux" = "x86_64-unknown-linux-gnu";
         "aarch64-linux" = "aarch64-unknown-linux-gnu";
+        "x86_64-darwin" = "x86_64-apple-darwin";
+        "aarch64-darwin" = "aarch64-apple-darwin";
       };
       systemToHash = {
         "x86_64-linux" = "sha256-j7A7BhEneIrXCJGNGG101P21hxixHP+XydYFUTq1fMY=";
         "aarch64-linux" = "sha256-BxDy7Fq8OVSs9iA7k6lnaNzNGddCr5t4/Nj7u6X2Ilo=";
+        "x86_64-darwin" = "sha256-TlkrT+RHufq5EnBvhjp1gzz2vtxcF9PqR01FMe7HIq4=";
+        "aarch64-darwin" = "sha256-quLM/rzOS2/3LjZpEqktZXb2EA55zfcdeeQoiXet0PA=";
       };
       FOXGLOVE_SDK_PLATFORM = systemToPlatform.${self.stdenv.hostPlatform.system};
       sdk = self.fetchurl {


### PR DESCRIPTION
`foxglove-bridge` fails to **evaluate** on Darwin:

```
error: attribute 'aarch64-darwin' missing
at distros/jazzy/overrides.nix:295:16:
   295|         hash = systemToHash.${self.stdenv.hostPlatform.system};
```

`systemToPlatform` and `systemToHash` map only `x86_64-linux` and `aarch64-linux`, and both are indexed with a bare `.${system}`, so any other system is an eval error rather than a graceful "unsupported".

Foxglove publishes Darwin C++ SDK archives for the same `0.26.0` release the expression already pins:

```
foxglove-v0.26.0-cpp-aarch64-apple-darwin.zip
foxglove-v0.26.0-cpp-x86_64-apple-darwin.zip
```

so both entries just need mapping. Hashes obtained with `nix store prefetch-file` against the exact URLs the expression constructs.

The `foxglove-bridge` block is duplicated verbatim across `humble`, `jazzy`, `kilted`, `lyrical` and `rolling` — same SDK version, same hashes — so all five are updated together. Happy to hoist it into `distros/ros2-overlay.nix` instead if you would prefer that; it seemed out of scope for a fix.

## Verified

Evaluated against nixpkgs-weekly with this overlay only:

- `aarch64-darwin`: `rosPackages.jazzy.foxglove-bridge` evaluates. Fails on master.
- `x86_64-linux`: unchanged, still evaluates.

Eval-level only on Darwin — CI here covers `x86_64-linux` and `aarch64-linux`, and I have no Darwin builder. No effect on Linux either way.