### PR TITLE
Fix some eval and build errors on Darwin

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -9,6 +9,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v31.8.1
+    - uses: cachix/cachix-action@v17
+      with:
+        name: ros-darwin
+        authToken: "${{ secrets.CACHIX_AUTH_TOKEN_ROS_DARWIN }}"
     - run: maintainers/scripts/eval-darwin.sh
   build-ros-base:
     runs-on: macos-latest
@@ -24,4 +28,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v31.8.1
+    - uses: cachix/cachix-action@v17
+      with:
+        name: ros-darwin
+        authToken: "${{ secrets.CACHIX_AUTH_TOKEN_ROS_DARWIN }}"
     - run: nix-build -A rosPackages.${{ matrix.distro }}.ros-base

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -1,0 +1,12 @@
+name: "Eval Darwin"
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  eval:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v31.8.1
+    - run: maintainers/scripts/eval-darwin.sh

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -1,4 +1,4 @@
-name: "Eval Darwin"
+name: "Darwin"
 on:
   push:
   pull_request:
@@ -10,3 +10,18 @@ jobs:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v31.8.1
     - run: maintainers/scripts/eval-darwin.sh
+  build-ros-base:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - humble
+          - jazzy
+          - kilted
+          - lyrical
+          - rolling
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v31.8.1
+    - run: nix-build -A rosPackages.${{ matrix.distro }}.ros-base

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ What works:
 
 What still needs to be done:
 1. Updating ROS packages to recent nixpkgs and upstreaming that
-2. macOS support
+2. Improving macOS support
 
 ## Setup
 

--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -83,6 +83,20 @@ in {
     '';
   });
 
+  fastdds = rosSuper.fastdds.overrideAttrs ({
+    postPatch ? "", ...
+  }: lib.optionalAttrs self.stdenv.isDarwin {
+    # `value` (std::string) is implicitly constructed from a null
+    # `const char*` for the false branch, tripping -Wnonnull on
+    # Apple Clang. Fixed upstream in Fast-DDS 3.3 by
+    # https://github.com/eProsima/Fast-DDS/pull/6415.
+    postPatch = postPatch + ''
+      substituteInPlace src/cpp/fastdds/xtypes/type_representation/TypeObjectRegistry.cpp --replace-fail \
+        'TypeObjectUtils::build_annotation_parameter_value(!value.empty() ? value : 0);' \
+        "TypeObjectUtils::build_annotation_parameter_value(!value.empty() ? value[0] : '\\0');"
+    '';
+  });
+
   foxglove-bridge = rosSuper.foxglove-bridge.overrideAttrs({
     postPatch ? "", ...
   }: {

--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -85,7 +85,7 @@ in {
 
   fastdds = rosSuper.fastdds.overrideAttrs ({
     postPatch ? "", ...
-  }: lib.optionalAttrs self.stdenv.isDarwin {
+  }: lib.optionalAttrs self.stdenv.hostPlatform.isDarwin {
     # `value` (std::string) is implicitly constructed from a null
     # `const char*` for the false branch, tripping -Wnonnull on
     # Apple Clang. Fixed upstream in Fast-DDS 3.3 by

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -565,6 +565,19 @@ in {
     propagatedNativeBuildInputs = [ self.qt6.wrapQtAppsHook ];
   };
 
+  rcutils = rosSuper.rcutils.overrideAttrs ({
+    postPatch ? "", ...
+  }: lib.optionalAttrs self.stdenv.hostPlatform.isDarwin {
+    # Apple Clang rejects brace-init of an _Atomic scalar ("illegal
+    # initializer type 'atomic_int_least64_t'").
+    # https://github.com/ros2/rcutils/pull/586
+    postPatch = postPatch + ''
+      substituteInPlace src/testing/fault_injection.c --replace-fail \
+        'atomic_int_least64_t g_rcutils_fault_injection_count = {-1};' \
+        'atomic_int_least64_t g_rcutils_fault_injection_count = -1;'
+    '';
+  });
+
   rmf-task-sequence = rosSuper.rmf-task-sequence.overrideAttrs ({
     postPatch ? "", ...
   }: {

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -602,6 +602,19 @@ in {
     '';
   });
 
+  rclcpp-components = rosSuper.rclcpp-components.overrideAttrs ({
+    postPatch ? "", ...
+  }: lib.optionalAttrs self.stdenv.hostPlatform.isDarwin {
+    # debug_msg is passed as the format string instead of as an
+    # argument; -Wformat-security is an error on Apple Clang.
+    # https://github.com/ros2/rclcpp/pull/3229
+    postPatch = postPatch + ''
+      substituteInPlace src/component_container.cpp --replace-fail \
+        'RCUTILS_LOG_DEBUG_NAMED("component_container", debug_msg.c_str());' \
+        'RCUTILS_LOG_DEBUG_NAMED("component_container", "%s", debug_msg.c_str());'
+    '';
+  });
+
   rmf-task-sequence = rosSuper.rmf-task-sequence.overrideAttrs ({
     postPatch ? "", ...
   }: {

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -578,6 +578,30 @@ in {
     '';
   });
 
+  rcl-yaml-param-parser = rosSuper.rcl-yaml-param-parser.overrideAttrs ({
+    patches ? [], postPatch ? "", ...
+  }: {
+    # Apple platforms don't provide the C11 threads API; map
+    # once_flag/call_once to pthread_once.
+    # https://github.com/ros2/rcl/pull/1325
+    patches = patches ++ [
+      (self.fetchpatch2 {
+        url = "https://github.com/ros2/rcl/commit/15aeab9f4a2d93fdc45f3d84338453046c18ec22.patch?full_index=1";
+        hash = "sha256-xIR/axNf3yvNqhq1jsSQrkrlpV7bhYW+hS/IEfFleu8=";
+        stripLen = 1;
+      })
+    ];
+    # Apple's <locale.h> doesn't declare locale_t/newlocale/uselocale/
+    # LC_NUMERIC_MASK; they live in <xlocale.h>.
+    # https://github.com/ros2/rcl/pull/1327
+    postPatch = postPatch + lib.optionalString self.stdenv.hostPlatform.isDarwin ''
+      substituteInPlace src/parse.c --replace-fail \
+        '#include <locale.h>' \
+        '#include <locale.h>
+      #include <xlocale.h>'
+    '';
+  });
+
   rmf-task-sequence = rosSuper.rmf-task-sequence.overrideAttrs ({
     postPatch ? "", ...
   }: {

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -554,6 +554,19 @@ in {
     '';
   });
 
+  rclcpp-components = rosSuper.rclcpp-components.overrideAttrs ({
+    postPatch ? "", ...
+  }: lib.optionalAttrs self.stdenv.hostPlatform.isDarwin {
+    # debug_msg is passed as the format string instead of as an
+    # argument; -Wformat-security is an error on Apple Clang.
+    # https://github.com/ros2/rclcpp/pull/3229
+    postPatch = postPatch + ''
+      substituteInPlace src/component_container.cpp --replace-fail \
+        'RCUTILS_LOG_DEBUG_NAMED("component_container", debug_msg.c_str());' \
+        'RCUTILS_LOG_DEBUG_NAMED("component_container", "%s", debug_msg.c_str());'
+    '';
+  });
+
   roboplan-examples = rosSuper.roboplan-examples.overrideAttrs ({
     buildInputs ? [], ...
   }: {

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -530,6 +530,30 @@ in {
     '';
   });
 
+  rcl-yaml-param-parser = rosSuper.rcl-yaml-param-parser.overrideAttrs ({
+    patches ? [], postPatch ? "", ...
+  }: {
+    # Apple platforms don't provide the C11 threads API; map
+    # once_flag/call_once to pthread_once.
+    # https://github.com/ros2/rcl/pull/1325
+    patches = patches ++ [
+      (self.fetchpatch2 {
+        url = "https://github.com/ros2/rcl/commit/15aeab9f4a2d93fdc45f3d84338453046c18ec22.patch?full_index=1";
+        hash = "sha256-xIR/axNf3yvNqhq1jsSQrkrlpV7bhYW+hS/IEfFleu8=";
+        stripLen = 1;
+      })
+    ];
+    # Apple's <locale.h> doesn't declare locale_t/newlocale/uselocale/
+    # LC_NUMERIC_MASK; they live in <xlocale.h>.
+    # https://github.com/ros2/rcl/pull/1327
+    postPatch = postPatch + lib.optionalString self.stdenv.hostPlatform.isDarwin ''
+      substituteInPlace src/parse.c --replace-fail \
+        '#include <locale.h>' \
+        '#include <locale.h>
+      #include <xlocale.h>'
+    '';
+  });
+
   roboplan-examples = rosSuper.roboplan-examples.overrideAttrs ({
     buildInputs ? [], ...
   }: {

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -517,6 +517,19 @@ in {
     propagatedNativeBuildInputs = [ self.qt6.wrapQtAppsHook ];
   };
 
+  rcutils = rosSuper.rcutils.overrideAttrs ({
+    postPatch ? "", ...
+  }: lib.optionalAttrs self.stdenv.hostPlatform.isDarwin {
+    # Apple Clang rejects brace-init of an _Atomic scalar ("illegal
+    # initializer type 'atomic_int_least64_t'").
+    # https://github.com/ros2/rcutils/pull/586
+    postPatch = postPatch + ''
+      substituteInPlace src/testing/fault_injection.c --replace-fail \
+        'atomic_int_least64_t g_rcutils_fault_injection_count = {-1};' \
+        'atomic_int_least64_t g_rcutils_fault_injection_count = -1;'
+    '';
+  });
+
   roboplan-examples = rosSuper.roboplan-examples.overrideAttrs ({
     buildInputs ? [], ...
   }: {

--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -65,7 +65,13 @@ with rosSelf.lib; {
     '';
   });
 
-  backward-ros = rosSuper.backward-ros.overrideAttrs ({ postPatch ? "", ... }: {
+  # elfutils is Linux-only, and BackwardConfigAment.cmake already degrades to
+  # libbfd or to no debug info when libdw is absent. Declaring it
+  # unconditionally makes backward-ros, and everything depending on it, fail
+  # to evaluate on Darwin.
+  backward-ros = (rosSuper.backward-ros.override (optionalAttrs self.stdenv.hostPlatform.isDarwin {
+    elfutils = null;
+  })).overrideAttrs ({ postPatch ? "", ... }: {
 
     # The `--as-needed` flag directs the linker to search all libraries specified
     # during its invocation to identify which ones contain the symbols required by the binary.
@@ -298,6 +304,13 @@ with rosSelf.lib; {
       buildInputs;
   });
 
+  # libcap is Linux-only, and realtime_tools already links it under
+  # `if(UNIX AND NOT APPLE)` and includes <sys/capability.h> under
+  # `#if defined(__unix__)`. Only the Nix dependency needs dropping.
+  realtime-tools = rosSuper.realtime-tools.override (optionalAttrs self.stdenv.hostPlatform.isDarwin {
+    libcap = null;
+  });
+
   ros-gz-sim = rosSuper.ros-gz-sim.overrideAttrs ({
     postPatch ? "", ...
   }: {
@@ -361,6 +374,15 @@ with rosSelf.lib; {
     meta = meta // {
       mainProgram = "rviz2";
     };
+  });
+
+  # tango-icon-theme is Linux-only, and tango_icons_vendor exists precisely to
+  # supply the icons where it is unavailable: its CMakeLists installs the
+  # bundled copy under `if(WIN32 OR APPLE)`. The exec_depend only applies to
+  # Linux, so nothing is lost by dropping it on Darwin. Without this,
+  # qt-gui and every rqt plugin fail to evaluate.
+  tango-icons-vendor = rosSuper.tango-icons-vendor.override (optionalAttrs self.stdenv.hostPlatform.isDarwin {
+    tango-icon-theme = null;
   });
 
   # The build gets stuck in an infinite loop with absolute CMAKE_INSTALL_LIBDIR:

--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -166,7 +166,7 @@ with rosSelf.lib; {
   }: {
     cmakeFlags = cmakeFlags ++ optionals (!self.stdenv.buildPlatform.canExecute self.stdenv.hostPlatform) (
       [ "-DSM_RUN_RESULT=0" ] ++
-      optional (self.stdenv.isLinux || self.stdenv.isDarwin)
+      optional (self.stdenv.isLinux || self.stdenv.hostPlatform.isDarwin)
         "-DSM_RUN_RESULT__TRYRUN_OUTPUT=PTHREAD_RWLOCK_PREFER_READER_NP"
     );
   });
@@ -298,7 +298,7 @@ with rosSelf.lib; {
       rmw-fastrtps-cpp
     ] ++ propagatedBuildInputs;
     # rmw-cyclonedds-cpp fails to build on MacOS.
-    buildInputs = if self.stdenv.isDarwin then
+    buildInputs = if self.stdenv.hostPlatform.isDarwin then
       builtins.filter (p: p.pname != "ros-${p.rosDistro}-rmw-cyclonedds-cpp") buildInputs
     else
       buildInputs;

--- a/maintainers/scripts/eval-darwin.sh
+++ b/maintainers/scripts/eval-darwin.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash --pure  -I nixpkgs=. --packages nix findutils
+# shellcheck shell=bash
+set -euo pipefail
+
+system=${1:-aarch64-darwin}
+
+for distro in $(find distros -mindepth 1 -maxdepth 1 -type d -not -name '*-*' -printf '%f\n'); do
+    if [[ $(nix-instantiate --eval --raw -A stdenv.hostPlatform.system) != "$system" ]]; then
+        # TODO: We have IFD in zenoh-cpp-vendor, which causes eval
+        # failure in these distros. See
+        # https://github.com/lopsided98/nix-ros-overlay/pull/912
+        [[ $distro = kilted ]] && continue
+        [[ $distro = lyrical ]] && continue
+        [[ $distro = rolling ]] && continue
+    fi
+    (
+        set -x
+        nix-instantiate -A rosPackages."${distro}".ros-base --argstr system "$system"
+        nix-instantiate -A rosPackages."${distro}".desktop --argstr system "$system"
+    )
+done
+
+# Local Variables:
+# sh-shell: bash
+# End:

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -228,4 +228,11 @@ self: super: with self.lib; {
       self.qt6.qttools
     ];
   });
+} // super.lib.optionalAttrs super.stdenv.hostPlatform.isDarwin {
+  # lttng is not available on Darwin and ROS packages depending it
+  # fail to evaluate. If set to null, packages like tracetools can
+  # deal with that, because their CMakeLists.txt contains:
+  # if(WIN32 OR APPLE OR ANDROID OR BSD) set(DISABLED_DEFAULT ON) ...
+  lttng-tools = null;
+  lttng-ust = null;
 }


### PR DESCRIPTION
This is a continuation of #909 proposed by @matias-albacore. Since we're dealing with eval errors, it's not necessary to have full Darwin support in CI. I've added a simple CI job, that evalues `ros-base` and `desktop` packages for Darwin platforms. Without this PR the script failed, now, it succeeds. Hopefully, it will be sufficient for discovering biggest regressions. For build errors, I added a simple CI (GitHub workflow), which builds `ros-base` for every distro.

Tagging users who have dealt with this overlay and Darwin recently: @BrockoliniMorgan (#863), @klaxalk.

Closes #863.