### PR TITLE
foonathan-memory-vendor: Use system package

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -98,6 +98,13 @@ let
     inherit (self) jrl-cmakemodules eiquadprog;
     inherit (self.python3Packages) coal eigenpy nanoeigenpy pinocchio proxsuite crocoddyl ndcurves tsid;
 
+    foonathan-memory-vendor = rosSuper.foonathan-memory-vendor.overrideAttrs ({
+      propagatedBuildInputs ? [], ...
+    }: {
+      # Use system package instead of fetching source from github
+      propagatedBuildInputs = propagatedBuildInputs ++ [ self.foonathan-memory ];
+    });
+
     freeimage = null; # Get rid of freeimage
 
     gazebo-ros = rosSuper.gazebo-ros.overrideAttrs ({ ... }:{

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -267,17 +267,6 @@ in with lib; {
     ];
   });
 
-  # This is a newer version than the build system tries to download, but this
-  # version doesn't try to run host platform binaries on the build platform
-  # and fixes "Allocator foonathan::memory::memory_pool received invalid size"
-  # error on MacOS
-  foonathan-memory-vendor = patchExternalProjectGit rosSuper.foonathan-memory-vendor {
-    url = "https://github.com/foonathan/memory.git";
-    originalRev = "v0.7-1";
-    rev = "v0.7-3";
-    fetchgitArgs.hash = "sha256-nLBnxPbPKiLCFF2TJgD/eJKJJfzktVBW3SRW2m3WK/s=";
-  };
-
   foxglove-bridge = rosSuper.foxglove-bridge.overrideAttrs({
     postPatch ? "", ...
   }: {

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -266,12 +266,6 @@ in {
     buildInputs = buildInputs ++ [ self.sqlite ];
   });
 
-  foonathan-memory-vendor = lib.patchExternalProjectGit rosSuper.foonathan-memory-vendor {
-    url = "https://github.com/foonathan/memory.git";
-    rev = "v0.7-3";
-    fetchgitArgs.hash = "sha256-nLBnxPbPKiLCFF2TJgD/eJKJJfzktVBW3SRW2m3WK/s=";
-  };
-
   foxglove-bridge = rosSuper.foxglove-bridge.overrideAttrs({
     postPatch ? "", ...
   }: {

--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -83,12 +83,6 @@ in {
     '';
   });
 
-  foonathan-memory-vendor = lib.patchExternalProjectGit rosSuper.foonathan-memory-vendor {
-    url = "https://github.com/foonathan/memory.git";
-    rev = "v0.7-3";
-    fetchgitArgs.hash = "sha256-nLBnxPbPKiLCFF2TJgD/eJKJJfzktVBW3SRW2m3WK/s=";
-  };
-
   foxglove-bridge = rosSuper.foxglove-bridge.overrideAttrs({
     postPatch ? "", ...
   }: {

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -70,12 +70,6 @@ in {
     ];
   });
 
-  foonathan-memory-vendor = lib.patchExternalProjectGit rosSuper.foonathan-memory-vendor {
-    url = "https://github.com/eProsima/memory.git";
-    rev = "vendor-1.4.1";
-    fetchgitArgs.hash = "sha256-1cQgCT7NvhAgJ5dgF8ZCrrPG/p65zz1UuGDQGrGJOpo=";
-  };
-
   foxglove-bridge = rosSuper.foxglove-bridge.overrideAttrs({
     postPatch ? "", ...
   }: {

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -71,12 +71,6 @@ in {
     ];
   });
 
-  foonathan-memory-vendor = lib.patchExternalProjectGit rosSuper.foonathan-memory-vendor {
-    url = "https://github.com/foonathan/memory.git";
-    rev = "v0.7-3";
-    fetchgitArgs.hash = "sha256-nLBnxPbPKiLCFF2TJgD/eJKJJfzktVBW3SRW2m3WK/s=";
-  };
-
   foxglove-bridge = rosSuper.foxglove-bridge.overrideAttrs({
     postPatch ? "", ...
   }: {


### PR DESCRIPTION
This replaces fetching of source code and building the package ourselves. The -vendor package supports this out of the box. Because our previous patching didn't use `originalRev` in all cases, we where using outdated versions in some distros.

This also fixes a build failure on MacOS.