### PR TITLE
lyrical.rtabmap-rviz-plugins: Fix Qt5/Qt6 collision

### DIFF
--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -661,6 +661,8 @@ in {
     ];
   });
 
+  rtabmap-rviz-plugins = rosSuper.rtabmap-rviz-plugins.override { qt5 = self.qt6; };
+
   rviz-ogre-vendor = lib.patchAmentVendorGit rosSuper.rviz-ogre-vendor {
     tarSourceArgs.hook = let
       version = "1.79";


### PR DESCRIPTION
All lyrical packages are compiled against Qt6 by default. When rtabmap is put into a buildEnv with other Qt6-based packages, we get an error about Qt version mismatch.