### PR TITLE
rosdistro sync, Sat Aug 22 00:49:52 2026

### DIFF
--- a/distros/humble/adi-imu/default.nix
+++ b/distros/humble/adi-imu/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-copyright, ament-lint-auto, ament-pep257, builtin-interfaces, geometry-msgs, libiio, rclcpp, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-adi-imu";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/adi_imu-release/archive/release/humble/adi_imu/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "aded4759ba5fb51d90d2f107b9aadb8e70ebcfb3d88a4868f586873d3e7d2e84";
+    url = "https://github.com/ros2-gbp/adi_imu-release/archive/release/humble/adi_imu/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "4caf13925869154605ab8f9327daee028eca7334bba9222751c16ddc7ce79ab0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/crazyflie-description/default.nix
+++ b/distros/humble/crazyflie-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-crazyflie-description";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie_description/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "c145afdd40eea5d7c41864ef4667af68c1e06b81e8d51c8c8e56a68991c3104c";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie_description/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "f2fe6eeb66f43af98c18545b5fe5c8acea5e1fe3e4a8db33316ac477b69f8c83";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/crazyflie-examples/default.nix
+++ b/distros/humble/crazyflie-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, crazyflie-py, geometry-msgs, nav-msgs, python3Packages, rclpy, sensor-msgs, tf-transformations, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-crazyflie-examples";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie_examples/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "8120bc9062587b266b49d548a964c01bbadcbe5957f3445dc7d184e1a75442b0";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie_examples/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "5192932c5f1f7c5e26e0c495c93709bded57b84bfbac4b887bbb983cedbd9ab0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/crazyflie-interfaces/default.nix
+++ b/distros/humble/crazyflie-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-crazyflie-interfaces";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie_interfaces/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "8bcce999ae32e4b46dc0a92c168bebd3935a730e4472cba9168159dc53ea2b61";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie_interfaces/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "2c8be5cd021b6dd74e5a2638afa3837605fd455369a1eb62b1a572679ccee42e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/crazyflie-py/default.nix
+++ b/distros/humble/crazyflie-py/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, crazyflie-interfaces, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-crazyflie-py";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie_py/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "d11ff4989247daeeb1bc4a1e87b66b5aa8839fd3fb4988cf854558160ead5608";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie_py/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "f899cb74ae5c874eed6ba742de338c16175e8c1d78a789a618f251cd96fadb52";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
-  propagatedBuildInputs = [ crazyflie-interfaces rclpy ];
+  propagatedBuildInputs = [ crazyflie-interfaces python3Packages.transforms3d rclpy ];
 
   meta = {
     description = "Simple Python Interface for Crayzswarm2";

--- a/distros/humble/crazyflie-server-cpp/default.nix
+++ b/distros/humble/crazyflie-server-cpp/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, crazyflie-interfaces, eigen, geometry-msgs, libusb1, motion-capture-tracking-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, std-srvs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-crazyflie-server-cpp";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie_server_cpp/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "1d9eb21ca4b9df6bac60e6db7c0c1696b31dd12243b02a524ce6ab360fc23762";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ boost crazyflie-interfaces eigen geometry-msgs libusb1 motion-capture-tracking-interfaces nav-msgs rclcpp ros-environment sensor-msgs std-srvs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "C++ ROS 2 server node for Bitcraze Crazyflie robots";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/crazyflie-server-py/default.nix
+++ b/distros/humble/crazyflie-server-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, crazyflie-interfaces, geometry-msgs, motion-capture-tracking-interfaces, nav-msgs, python3Packages, rcl-interfaces, rclpy, sensor-msgs, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-crazyflie-server-py";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie_server_py/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "a7f181dcfa40c6cc67d4aa2a4c6ea9350715687199c22796b104756b37f49307";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie_server_py/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "c18f7d8d066fa2947d38594c2344f1b87b14e401762f87604df0fe8dc10563db";
   };
 
   buildType = "ament_python";

--- a/distros/humble/crazyflie-sim/default.nix
+++ b/distros/humble/crazyflie-sim/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, crazyflie-interfaces, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-crazyflie-sim";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie_sim/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "42c0444bfbd0aafb4b8fb399f9908df658817783df61a1d9e97326b35edd3462";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie_sim/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "6feaf8941fe8e7b4fefa172bb05e850dda8235735b9ffa607e28dcebc1627d4c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-cmake-pytest ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
-  propagatedBuildInputs = [ crazyflie-interfaces rclpy ];
+  propagatedBuildInputs = [ crazyflie-interfaces python3Packages.transforms3d rclpy ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/humble/crazyflie/default.nix
+++ b/distros/humble/crazyflie/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, boost, crazyflie-description, crazyflie-interfaces, eigen, geometry-msgs, libusb1, motion-capture-tracking-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, std-srvs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, crazyflie-description, crazyflie-interfaces, crazyflie-server-cpp, eigen, geometry-msgs, rclcpp, rclpy, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-crazyflie";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "acf1780dd5b77802a69b9d65da7f7d369e388256063db442610c3cced6ec7ec7";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/humble/crazyflie/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "d41fa1020c985317eb325aa5cc5e05c4365dab30d99b9435b71a0f49a9fb6e6a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ boost crazyflie-description crazyflie-interfaces eigen geometry-msgs libusb1 motion-capture-tracking-interfaces nav-msgs rclcpp ros-environment sensor-msgs std-srvs tf2-ros ];
+  propagatedBuildInputs = [ crazyflie-description crazyflie-interfaces crazyflie-server-cpp eigen geometry-msgs rclcpp rclpy sensor-msgs std-srvs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/humble/depthai-v3/default.nix
+++ b/distros/humble/depthai-v3/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, curl, fmt, gfortran, libtar, libusb1, nlohmann_json, opencv, ros-environment, spdlog, udev, unzip, zip }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, curl, fmt, gfortran, libusb1, nlohmann_json, opencv, ros-environment, spdlog, udev, unzip, zip }:
 buildRosPackage {
   pname = "ros-humble-depthai-v3";
-  version = "3.7.1-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-v3-release/archive/release/humble/depthai_v3/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "dfc029e7d10cd0e6539c2a8fc478ce6ca13fe8067946c005d9ac4114ef1e3ffd";
+    url = "https://github.com/luxonis/depthai-core-v3-release/archive/release/humble/depthai_v3/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "18fe729e94402285e780954c949550d458fa51f7743331190b000680ed763032";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ curl fmt gfortran libtar libusb1 nlohmann_json opencv opencv.cxxdev spdlog udev unzip zip ];
+  propagatedBuildInputs = [ curl fmt gfortran libusb1 nlohmann_json opencv opencv.cxxdev spdlog udev unzip zip ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/elite-robots-calibration/default.nix
+++ b/distros/humble/elite-robots-calibration/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, yaml-cpp }:
+buildRosPackage {
+  pname = "ros-humble-elite-robots-calibration";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Driver-release/archive/release/humble/elite_robots_calibration/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "319fd3e9ce974118d24cdef1a74a3e8ea551faeacdbb83375ba5789c4593c3a0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ eigen rclcpp yaml-cpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Package for extracting the factory calibration from a CS robot and change it such that it can be used by elite_robots_description to gain a correct URDF";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/elite-robots-controllers/default.nix
+++ b/distros/humble/elite-robots-controllers/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, angles, controller-interface, elite-robots-msgs, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-humble-elite-robots-controllers";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Driver-release/archive/release/humble/elite_robots_controllers/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "bd196ff23f3e06a724cb8dd38d98c66e71cc7bc0d81a28bb540f3d3d626735a0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ angles controller-interface elite-robots-msgs joint-trajectory-controller lifecycle-msgs pluginlib rclcpp-lifecycle rcutils realtime-tools std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Provides controllers that use the speed scaling interface of Elite CS series robots.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/elite-robots-dashboard-msgs/default.nix
+++ b/distros/humble/elite-robots-dashboard-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-humble-elite-robots-dashboard-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Driver-release/archive/release/humble/elite_robots_dashboard_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "0f5a2a7578a5c0c99ba82ce956e1e2c0b16dc1f6660ddddae398d50097df89db";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "Dashboard message interface";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/elite-robots-driver/default.nix
+++ b/distros/humble/elite-robots-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, backward-ros, control-msgs, controller-manager, controller-manager-msgs, elite-robots-dashboard-msgs, elite-robots-description, elite-robots-msgs, force-torque-sensor-broadcaster, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, pluginlib, position-controllers, rclcpp, rclcpp-action, rclcpp-components, rclcpp-lifecycle, rclpy, robot-state-publisher, ros2-control, ros2-controllers, ros2-controllers-test-nodes, rviz2, sensor-msgs, std-msgs, std-srvs, tf2-geometry-msgs, trajectory-msgs, urdf, velocity-controllers, xacro }:
+buildRosPackage {
+  pname = "ros-humble-elite-robots-driver";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Driver-release/archive/release/humble/elite_robots_driver/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "e3cb224a89bbb1f705c389c0c53ad6af0cec228b010e983238f8849be9162328";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common launch-testing-ament-cmake ];
+  propagatedBuildInputs = [ backward-ros control-msgs controller-manager controller-manager-msgs elite-robots-dashboard-msgs elite-robots-description elite-robots-msgs force-torque-sensor-broadcaster geometry-msgs hardware-interface joint-state-broadcaster joint-state-publisher joint-trajectory-controller launch launch-ros pluginlib position-controllers rclcpp rclcpp-action rclcpp-components rclcpp-lifecycle rclpy robot-state-publisher ros2-control ros2-controllers ros2-controllers-test-nodes rviz2 sensor-msgs std-msgs std-srvs tf2-geometry-msgs trajectory-msgs urdf velocity-controllers xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Elite CS series robot ros2 driver";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/elite-robots-moveit-config/default.nix
+++ b/distros/humble/elite-robots-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, elite-robots-description, launch, launch-ros, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, rviz2, urdf, warehouse-ros-sqlite, xacro }:
+buildRosPackage {
+  pname = "ros-humble-elite-robots-moveit-config";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Driver-release/archive/release/humble/elite_robots_moveit_config/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "b1a60becbc8d0c73de3259fab0662df934a47e31afb3875abbe8e14993a7de3a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  propagatedBuildInputs = [ elite-robots-description launch launch-ros moveit-kinematics moveit-planners-ompl moveit-ros-move-group moveit-ros-visualization moveit-servo moveit-simple-controller-manager rviz2 urdf warehouse-ros-sqlite xacro ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "An example package with MoveIt2 configurations for ELITE CS robots.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/elite-robots-msgs/default.nix
+++ b/distros/humble/elite-robots-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-humble-elite-robots-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Driver-release/archive/release/humble/elite_robots_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "f8e093a2c2e3117901fbe2a582ebc85e938379f3c97c45a95dcabbcf14102cc3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "Message and service definitions for interacting with Elite Robots robot controllers.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/elite-robots/default.nix
+++ b/distros/humble/elite-robots/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, elite-robots-calibration, elite-robots-controllers, elite-robots-dashboard-msgs, elite-robots-driver, elite-robots-moveit-config, elite-robots-msgs }:
+buildRosPackage {
+  pname = "ros-humble-elite-robots";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Driver-release/archive/release/humble/elite_robots/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "b3ace12599e5a3d1b73b582d8aa051e4c4fa260cc252489f2d2e0b79a2388677";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ elite-robots-calibration elite-robots-controllers elite-robots-dashboard-msgs elite-robots-driver elite-robots-moveit-config elite-robots-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Metapackage providing a single installation point for the Elite Robots ROS 2 packages.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -840,6 +840,8 @@ self: super: {
 
  crazyflie-py = self.callPackage ./crazyflie-py {};
 
+ crazyflie-server-cpp = self.callPackage ./crazyflie-server-cpp {};
+
  crazyflie-server-py = self.callPackage ./crazyflie-server-py {};
 
  crazyflie-sim = self.callPackage ./crazyflie-sim {};
@@ -1140,7 +1142,21 @@ self: super: {
 
  elite-cs-series-sdk = self.callPackage ./elite-cs-series-sdk {};
 
+ elite-robots = self.callPackage ./elite-robots {};
+
+ elite-robots-calibration = self.callPackage ./elite-robots-calibration {};
+
+ elite-robots-controllers = self.callPackage ./elite-robots-controllers {};
+
+ elite-robots-dashboard-msgs = self.callPackage ./elite-robots-dashboard-msgs {};
+
  elite-robots-description = self.callPackage ./elite-robots-description {};
+
+ elite-robots-driver = self.callPackage ./elite-robots-driver {};
+
+ elite-robots-moveit-config = self.callPackage ./elite-robots-moveit-config {};
+
+ elite-robots-msgs = self.callPackage ./elite-robots-msgs {};
 
  ess-imu-driver2 = self.callPackage ./ess-imu-driver2 {};
 
@@ -1666,6 +1682,8 @@ self: super: {
 
  imu-transformer = self.callPackage ./imu-transformer {};
 
+ int2dds-ffi-vendor = self.callPackage ./int2dds-ffi-vendor {};
+
  integration-launch-testing = self.callPackage ./integration-launch-testing {};
 
  interactive-marker-twist-server = self.callPackage ./interactive-marker-twist-server {};
@@ -1736,7 +1754,13 @@ self: super: {
 
  kangaroo-description = self.callPackage ./kangaroo-description {};
 
+ kangaroo-moveit-config = self.callPackage ./kangaroo-moveit-config {};
+
+ kangaroo-mujoco = self.callPackage ./kangaroo-mujoco {};
+
  kangaroo-robot = self.callPackage ./kangaroo-robot {};
+
+ kangaroo-simulation = self.callPackage ./kangaroo-simulation {};
 
  kartech-linear-actuator-msgs = self.callPackage ./kartech-linear-actuator-msgs {};
 
@@ -2439,6 +2463,8 @@ self: super: {
  mrpt-viz = self.callPackage ./mrpt-viz {};
 
  mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
+
+ mujoco-3d-lidar = self.callPackage ./mujoco-3d-lidar {};
 
  mujoco-ros2-control = self.callPackage ./mujoco-ros2-control {};
 
@@ -3354,6 +3380,10 @@ self: super: {
 
  rmw-implementation-cmake = self.callPackage ./rmw-implementation-cmake {};
 
+ rmw-int2dds-cpp = self.callPackage ./rmw-int2dds-cpp {};
+
+ rmw-int2dds-validation = self.callPackage ./rmw-int2dds-validation {};
+
  rmw-stats-shim = self.callPackage ./rmw-stats-shim {};
 
  rmw-zenoh-cpp = self.callPackage ./rmw-zenoh-cpp {};
@@ -3998,8 +4028,6 @@ self: super: {
 
  swri-opencv-util = self.callPackage ./swri-opencv-util {};
 
- swri-roscpp = self.callPackage ./swri-roscpp {};
-
  swri-route-util = self.callPackage ./swri-route-util {};
 
  swri-serial-util = self.callPackage ./swri-serial-util {};
@@ -4112,13 +4140,19 @@ self: super: {
 
  tiago-dual-description = self.callPackage ./tiago-dual-description {};
 
+ tiago-dual-gazebo = self.callPackage ./tiago-dual-gazebo {};
+
  tiago-dual-laser-sensors = self.callPackage ./tiago-dual-laser-sensors {};
+
+ tiago-dual-moveit-config = self.callPackage ./tiago-dual-moveit-config {};
 
  tiago-dual-navigation = self.callPackage ./tiago-dual-navigation {};
 
  tiago-dual-rgbd-sensors = self.callPackage ./tiago-dual-rgbd-sensors {};
 
  tiago-dual-robot = self.callPackage ./tiago-dual-robot {};
+
+ tiago-dual-simulation = self.callPackage ./tiago-dual-simulation {};
 
  tiago-gazebo = self.callPackage ./tiago-gazebo {};
 
@@ -4407,6 +4441,8 @@ self: super: {
  udp-driver = self.callPackage ./udp-driver {};
 
  udp-msgs = self.callPackage ./udp-msgs {};
+
+ unbag = self.callPackage ./unbag {};
 
  uncrustify-vendor = self.callPackage ./uncrustify-vendor {};
 

--- a/distros/humble/gps-msgs/default.nix
+++ b/distros/humble/gps-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-gps-msgs";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/humble/gps_msgs/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "32b4938dfadbe0fd078ffbb76b2ed17dc319f4c0be9e0d50940c7e0f25ee86e5";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/humble/gps_msgs/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "416b14aae7bda4bdea2621925bc08baa6fd4fbe84bfe34de32f702c473e28a84";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gps-tools/default.nix
+++ b/distros/humble/gps-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, gps-msgs, nav-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-gps-tools";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/humble/gps_tools/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "80f1ccda742ac0d721156ef7c5795b2ddee86b40a11a801a623d11a8144331f7";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/humble/gps_tools/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "3f77d8fbacb45b95778ab7bfbc5b458bf05d3ce29cc4403c615625924c26755f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gps-umd/default.nix
+++ b/distros/humble/gps-umd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gps-msgs, gps-tools, gpsd-client }:
 buildRosPackage {
   pname = "ros-humble-gps-umd";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/humble/gps_umd/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "5a56d5d30da1482b33b83259e6a2132bcee5ee3139c1d084693c1cc9e1ac2551";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/humble/gps_umd/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "059a7c3b14129be8f974a783fc9eced520c9e3714ffe2913bc1fdad2873bbf2f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gpsd-client/default.nix
+++ b/distros/humble/gpsd-client/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, gps-msgs, gpsd, pkg-config, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, gps-msgs, gpsd, pkg-config, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-gpsd-client";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/humble/gpsd_client/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "d10b570d825767debea5ec6bf1fe650328cdfd75b7f25aa4ea4a9be38602b6b1";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/humble/gpsd_client/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "1c04f23a6e93f92b944c952d8afb980b0e5eff9a4c90d11239e33b0eb34ee1c2";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ros-environment ];
+  buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ];
   propagatedBuildInputs = [ gps-msgs gpsd pkg-config rclcpp rclcpp-components sensor-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake pkg-config ];
 
   meta = {
     description = "connects to a GPSd server and broadcasts GPS fixes 

--- a/distros/humble/int2dds-ffi-vendor/default.nix
+++ b/distros/humble/int2dds-ffi-vendor/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-humble-int2dds-ffi-vendor";
+  version = "0.1.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/IntellectusCorp/rmw_int2dds-release/archive/release/humble/int2dds_ffi_vendor/0.1.0-3.tar.gz";
+    name = "0.1.0-3.tar.gz";
+    sha256 = "abda23c34708aafb6af5cd204510d29f030467beb2a31f67af2858f5695f7dac";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Vendor package that fetches the prebuilt int2DDS FFI library
+    (shared library + C header) for the host platform and exposes it to
+    the ROS 2 build as an imported CMake target. Used by rmw_int2dds_cpp.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/jrl-cmakemodules/default.nix
+++ b/distros/humble/jrl-cmakemodules/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catch2, cmake, doxygen, eigen, git, matio, pkg-config, python3Packages, simde }:
 buildRosPackage {
   pname = "ros-humble-jrl-cmakemodules";
-  version = "2.0.0-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/jrl_cmakemodules-release/archive/release/humble/jrl_cmakemodules/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "28e9764714799d1138c10fa916f58f8161d8bdc06b9635aa27f9397d6ebeb92e";
+    url = "https://github.com/ros2-gbp/jrl_cmakemodules-release/archive/release/humble/jrl_cmakemodules/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "a020b19287a87a715df0c1fc4f44effe9fd0c19b32197bbf763263612efc5a46";
   };
 
   buildType = "cmake";

--- a/distros/humble/kangaroo-bringup/default.nix
+++ b/distros/humble/kangaroo-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-index-python, ament-lint-auto, ament-lint-common, diagnostic-aggregator, joy-linux, joy-teleop, kangaroo-controller-configuration, kangaroo-description, play-motion2, play-motion2-cli, twist-mux }:
 buildRosPackage {
   pname = "ros-humble-kangaroo-bringup";
-  version = "2.14.1-r1";
+  version = "2.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kangaroo_robot-release/archive/release/humble/kangaroo_bringup/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "a0eb6620cee6ebbe878ee55928d75fae8efd0bb8cfd50f3e49c57783dff1f5ce";
+    url = "https://github.com/ros2-gbp/kangaroo_robot-release/archive/release/humble/kangaroo_bringup/2.15.0-1.tar.gz";
+    name = "2.15.0-1.tar.gz";
+    sha256 = "41f1c39e7b22cab8fd802552167a65142d943fe4edb3e28c3ebc2bf21da0de92";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kangaroo-controller-configuration/default.nix
+++ b/distros/humble/kangaroo-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-index-python, ament-lint-auto, ament-lint-common, diagnostic-aggregator, joint-state-broadcaster, joint-trajectory-controller, launch, launch-pal, ros2controlcli }:
 buildRosPackage {
   pname = "ros-humble-kangaroo-controller-configuration";
-  version = "2.14.1-r1";
+  version = "2.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kangaroo_robot-release/archive/release/humble/kangaroo_controller_configuration/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "20743e74ad40b5216f98e91578dc4b5ada5aec3b8792a2bc0ab4b7944f9b4865";
+    url = "https://github.com/ros2-gbp/kangaroo_robot-release/archive/release/humble/kangaroo_controller_configuration/2.15.0-1.tar.gz";
+    name = "2.15.0-1.tar.gz";
+    sha256 = "f16a769770c7f1c50df5bd6fba4f06f9e33bb2fd776ed67dc99e2002012da104";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kangaroo-description/default.nix
+++ b/distros/humble/kangaroo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, ament-lint-auto, ament-lint-common, kangaroo-controller-configuration, launch, launch-pal, launch-param-builder, launch-ros, launch-testing-ament-cmake, pal-sea-arm-description, pal-urdf-utils, rcl-interfaces, rclcpp, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-kangaroo-description";
-  version = "2.14.1-r1";
+  version = "2.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kangaroo_robot-release/archive/release/humble/kangaroo_description/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "d9eb628516a06c87e0803ba33937bdf065ed68712e89febc5051d525847e9815";
+    url = "https://github.com/ros2-gbp/kangaroo_robot-release/archive/release/humble/kangaroo_description/2.15.0-1.tar.gz";
+    name = "2.15.0-1.tar.gz";
+    sha256 = "f15087a6476408cd5e4b815e428dffef844a95ba21b0f6ea989f334750867ff9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kangaroo-moveit-config/default.nix
+++ b/distros/humble/kangaroo-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, kangaroo-description, launch-pal, moveit-configs-utils, moveit-kinematics, moveit-planners-chomp, moveit-planners-ompl, moveit-ros-control-interface, moveit-ros-move-group, moveit-ros-perception, moveit-ros-visualization, pal-sea-arm-moveit-config }:
+buildRosPackage {
+  pname = "ros-humble-kangaroo-moveit-config";
+  version = "2.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/kangaroo_moveit_config-release/archive/release/humble/kangaroo_moveit_config/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "907dccb0285e3d31af1d744cb13ec347cca61ef769823dd87eddc77cd62d6591";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto ];
+  propagatedBuildInputs = [ kangaroo-description launch-pal moveit-configs-utils moveit-kinematics moveit-planners-chomp moveit-planners-ompl moveit-ros-control-interface moveit-ros-move-group moveit-ros-perception moveit-ros-visualization pal-sea-arm-moveit-config ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = "An automatically generated package with all the configuration and launch files for using the kangaroo with the MoveIt! Motion Planning Framework";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/kangaroo-mujoco/default.nix
+++ b/distros/humble/kangaroo-mujoco/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, kangaroo-bringup, kangaroo-controller-configuration, kangaroo-description, launch, launch-pal, launch-ros, mujoco-ros2-control, rclpy, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-kangaroo-mujoco";
+  version = "2.7.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/kangaroo_simulation-release/archive/release/humble/kangaroo_mujoco/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "ca4f53f44fe9f0b524dbeaee2fd2ba265b247352346142a2abc347359f9be6ea";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto ];
+  checkInputs = [ ament-cmake-pytest ];
+  propagatedBuildInputs = [ kangaroo-bringup kangaroo-controller-configuration kangaroo-description launch launch-pal launch-ros mujoco-ros2-control rclpy std-msgs ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = "Kangaroo MuJoCo simulation package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/kangaroo-robot/default.nix
+++ b/distros/humble/kangaroo-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, kangaroo-bringup, kangaroo-controller-configuration, kangaroo-description }:
 buildRosPackage {
   pname = "ros-humble-kangaroo-robot";
-  version = "2.14.1-r1";
+  version = "2.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kangaroo_robot-release/archive/release/humble/kangaroo_robot/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "bb3bab6369aa367dceb55b2f34c83621243b7284ed9f41f898d0674165530b82";
+    url = "https://github.com/ros2-gbp/kangaroo_robot-release/archive/release/humble/kangaroo_robot/2.15.0-1.tar.gz";
+    name = "2.15.0-1.tar.gz";
+    sha256 = "6ebd47b7094f1c9c49230c70797e447c408cd0b5432f0eb2316b8bdec28f42fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kangaroo-simulation/default.nix
+++ b/distros/humble/kangaroo-simulation/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, kangaroo-mujoco }:
+buildRosPackage {
+  pname = "ros-humble-kangaroo-simulation";
+  version = "2.7.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/kangaroo_simulation-release/archive/release/humble/kangaroo_simulation/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "7f0e1738993769c006a1eda9df6053f72fb6554fd71169d98caa84f53c10d458";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ kangaroo-mujoco ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The kangaroo_simulation metapackage";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/launch-pal/default.nix
+++ b/distros/humble/launch-pal/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-launch-pal";
-  version = "0.22.0-r1";
+  version = "0.22.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_pal-release/archive/release/humble/launch_pal/0.22.0-1.tar.gz";
-    name = "0.22.0-1.tar.gz";
-    sha256 = "a109d2b747e82c137c2ac4bad4a9522776e0c41d937c1e7103f9e4aa759e2e13";
+    url = "https://github.com/ros2-gbp/launch_pal-release/archive/release/humble/launch_pal/0.22.1-1.tar.gz";
+    name = "0.22.1-1.tar.gz";
+    sha256 = "a9a8515ee9891c9b42d859e9b4b02de104ce2434af08c32b6593cf636ecd9153";
   };
 
   buildType = "ament_python";

--- a/distros/humble/libbno055-linux/default.nix
+++ b/distros/humble/libbno055-linux/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, geometry-msgs, lifecycle-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, geometry-msgs, lifecycle-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-libbno055-linux";
-  version = "1.7.2-r1";
+  version = "1.9.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/lazytatzv/libbno055_linux-release/archive/release/humble/libbno055_linux/1.7.2-1.tar.gz";
-    name = "1.7.2-1.tar.gz";
-    sha256 = "37ac75c2d80116c85516f05d64e11db31f2312d16da4d0c15441df6f5f2c9d7e";
+    url = "https://github.com/lazytatzv/libbno055_linux-release/archive/release/humble/libbno055_linux/1.9.0-3.tar.gz";
+    name = "1.9.0-3.tar.gz";
+    sha256 = "8d8c8d1da6b6a0c47efed05070de3b5788470f98eb5f41641cabb417525014de";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ diagnostic-msgs geometry-msgs lifecycle-msgs rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs std-srvs ];
+  propagatedBuildInputs = [ diagnostic-msgs geometry-msgs lifecycle-msgs rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/mapviz-interfaces/default.nix
+++ b/distros/humble/mapviz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-mapviz-interfaces";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz_interfaces/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "8e9fc9b9154bbe3b7308041a9805e4091ea63c19df485c086e7b383b2671ff39";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz_interfaces/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "dfe946c3a6a568c2265c926feb85274c47fe71d3c5c394f73950b490413bab12";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mapviz-plugins/default.nix
+++ b/distros/humble/mapviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, assimp, cv-bridge, geometry-msgs, gps-msgs, image-transport, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-sensor-msgs, marti-visualization-msgs, opencv, pluginlib, qt-gui-cpp, qt5or6, rclcpp, rclcpp-action, sensor-msgs, std-msgs, std-srvs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, tf2, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-mapviz-plugins";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz_plugins/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "7afa69011ceebe285dcde6eca1ba3c95a34eda33f6b99bf20fc276fee861e009";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz_plugins/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "b09c73c6a4aa91dc1841110bd839e173acc8a7b6b08e6e20ac8ffeecae3d4b23";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mapviz/default.nix
+++ b/distros/humble/mapviz/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, image-transport, libxi, libxmu, mapviz-interfaces, opencv, pkg-config, pluginlib, qt5or6, rclcpp, rqt-gui, rqt-gui-cpp, std-srvs, swri-math-util, swri-transform-util, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-mapviz";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "249f6c06c337061595268ce72f250315958731411d479a9dcf8558ca045d3251";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "1eb85941f7de837c82920e6bf40ade16a1e486a509a776f200cd6c189fecf943";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake pkg-config ];
-  propagatedBuildInputs = [ geometry-msgs image-transport libxi libxmu mapviz-interfaces opencv opencv.cxxdev pluginlib qt5or6.qtbase rclcpp rqt-gui rqt-gui-cpp std-srvs swri-math-util swri-transform-util tf2 tf2-geometry-msgs tf2-ros yaml-cpp ];
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ geometry-msgs image-transport libxi libxmu mapviz-interfaces opencv opencv.cxxdev pkg-config pluginlib qt5or6.qtbase rclcpp rqt-gui rqt-gui-cpp std-srvs swri-math-util swri-transform-util tf2 tf2-geometry-msgs tf2-ros yaml-cpp ];
   nativeBuildInputs = [ ament-cmake pkg-config ];
 
   meta = {

--- a/distros/humble/metavision-driver/default.nix
+++ b/distros/humble/metavision-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-xmllint, event-camera-msgs, openeb-vendor, rclcpp, rclcpp-components, ros-environment, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-metavision-driver";
-  version = "3.0.0-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/metavision_driver-release/archive/release/humble/metavision_driver/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "97eb662902caed0c8b7cef5a840f410d93637c9020f7c4786dfefbd9436e5040";
+    url = "https://github.com/ros2-gbp/metavision_driver-release/archive/release/humble/metavision_driver/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "d7165c9c4df5dcdcd1d65bed04044d26322786a0af2ff95a4cf2933e0fcd8420";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ros-environment ];
 
   meta = {
-    description = "ROS1 and ROS2 drivers for metavision based event cameras";
+    description = "ROS2 driver for metavision based event cameras";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/humble/mola-bridge-ros2/default.nix
+++ b/distros/humble/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, diagnostic-msgs, geographic-msgs, geometry-msgs, gps-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-mola-bridge-ros2";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_bridge_ros2/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "ad9f459a22f61e30e373544d278631448c33d5b9d43f83bebf229f2d9f681e42";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_bridge_ros2/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "7baa0c26c7340bd0879bb6c288eeda23255b14c6d307a68929d5259a4ccf7952";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-demos/default.nix
+++ b/distros/humble/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-xmllint, ament-lint-auto, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-demos";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_demos/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "012d996bf8c3d279d725c48abafd1e38b9903c71591c9305fa55a9b06d99e8f8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_demos/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "0c2c857eb2ba27248b02cc656f5ce3636eb0cf2b5546fe252c8df1f0e591db72";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-input-lidar-bin-dataset/default.nix
+++ b/distros/humble/mola-input-lidar-bin-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-humble-mola-input-lidar-bin-dataset";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_lidar_bin_dataset/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "801c68c5a446b96c447fb26d9dbaaf9fdbf85362c5ac4e7e0d9853119f947956";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_lidar_bin_dataset/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "956cc03ba9d4851899bd537ea4d3256c4d0cc249d02907ef832d9195ee86fa7e";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-rawlog/default.nix
+++ b/distros/humble/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-input-rawlog";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rawlog/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "753067ec1958c95bb42f291463f98d5eb3380e535d8569947295fbf680a2be15";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rawlog/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "f88fa4cf3d61b093913c38b74627e0ab0be3f336ac91e8e0e56dc33203286d41";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-rosbag2/default.nix
+++ b/distros/humble/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, gps-msgs, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-mola-input-rosbag2";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rosbag2/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "40bff43af600459885151df06163752ec46fe69f2d0a465f3ce79a7b4e03853b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rosbag2/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "32e481caa57f4a42cb5c6f3379454706ea03be9cf7887e2748cded71ee88dec6";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-video/default.nix
+++ b/distros/humble/mola-input-video/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libhwdrivers, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-input-video";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_video/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "4f94babcf35649817cdfb02c4133e902a8edee81114e916b5c6b583f5627f927";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_video/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "3fa296067253e31477c391118d234afcd25e85fef30a3449d61c9e310c75438a";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-kernel/default.nix
+++ b/distros/humble/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-kernel";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_kernel/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "35794438449c97b345ea9b4f6a40e60baee4aef3d2440ddb8440effe6179bab2";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_kernel/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "396e53b2127b6b27398b6be44b5579a738137587905a629ecea41f732ca689df";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-launcher/default.nix
+++ b/distros/humble/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-xmllint, ament-lint-auto, cli11, cmake, mola-kernel, mrpt-libbase, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-launcher";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_launcher/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "69dd552441f2511961712d9752898f08294824436cb127e5f9fb92018523d95d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_launcher/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "dfb1a66dc8df8245aa3c22b8978b7ba86fd44de1778707df6ff4c4bb59c5fc89";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-lidar-odometry/default.nix
+++ b/distros/humble/mola-lidar-odometry/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cli11, cmake, mola-common, mola-imu-preintegration, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mola-yaml, mp2p-icp, mrpt-libmaps, ros-environment, rosbag2-storage-mcap }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cli11, cmake, mola-bridge-ros2, mola-common, mola-imu-preintegration, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-state-estimation-smoother, mola-test-datasets, mola-viz, mola-viz-imgui, mola-yaml, mp2p-icp, mrpt-libmaps, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-humble-mola-lidar-odometry";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/humble/mola_lidar_odometry/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "e8da13dedb2fa8b5db434b3d65ea33e2fcce0d77e9cd7e308c4a84f6fe9958a3";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/humble/mola_lidar_odometry/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "fc643e048c27a04b7d6559597b7862798079b98800a19e9159a1af9504efa286";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-test-datasets rosbag2-storage-mcap ];
-  propagatedBuildInputs = [ cli11 mola-common mola-imu-preintegration mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-pose-list mola-state-estimation-simple mola-viz mola-yaml mp2p-icp mrpt-libmaps ];
+  propagatedBuildInputs = [ cli11 mola-bridge-ros2 mola-common mola-imu-preintegration mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-pose-list mola-state-estimation-simple mola-state-estimation-smoother mola-viz mola-viz-imgui mola-yaml mp2p-icp mrpt-libmaps ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/humble/mola-metric-maps/default.nix
+++ b/distros/humble/mola-metric-maps/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cli11, cmake, mola-common, mola-kernel, mp2p-icp, mrpt-libmaps, nanoflann, onetbb, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cli11, cmake, mola-common, mola-kernel, mp2p-icp, mrpt-libmaps, nanoflann-vendor, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-metric-maps";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_metric_maps/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "c4a50011c8a3508c417d61c31501abdb06dee74376737f4fa3566c5e58f661f5";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_metric_maps/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "8df9dbd5790fd4b11cd23835b1b61cb4bd7462787e2e1d717f4c90b3aaaf7fd5";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ cli11 mola-common mola-kernel mp2p-icp mrpt-libmaps nanoflann onetbb ];
+  propagatedBuildInputs = [ cli11 mola-common mola-kernel mp2p-icp mrpt-libmaps nanoflann-vendor onetbb ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/humble/mola-msgs/default.nix
+++ b/distros/humble/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-mola-msgs";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_msgs/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "9114ce6e79fffc97cc0721c0bbd119a714cb6900f5b0ad0abfa476a4b1aab09b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_msgs/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "ee11d13a8556618bd50c6c4e61e5f0f23521b5eb8d90fa2bdeff1de408347481";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-pose-list/default.nix
+++ b/distros/humble/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-humble-mola-pose-list";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_pose_list/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "6b05ce76c140e62516f85da095d46f07c1f25915d5997c57a8c6e38b303b5be1";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_pose_list/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "4f3a3f8dc6dc4c8116d31faaeb822c9365c4f4054c71644ad9d93e54e976eb7e";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-relocalization/default.nix
+++ b/distros/humble/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-humble-mola-relocalization";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_relocalization/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "f2409f411adb203b4110a70ae51debaf7d465becaafc7b693c5d3d7dbd1686be";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_relocalization/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "b17669b4f23886378a5d2b1798eeda78e42d8597275375f4b72a84a78c7683d2";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-traj-tools/default.nix
+++ b/distros/humble/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-humble-mola-traj-tools";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_traj_tools/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "5f8082dd4f7dac9c220fc1ce7b413215c7700f35a805cd9f8055816403319e41";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_traj_tools/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "d010dd4118ef3c78c4ec25ce532f22e5209237b299c4e91d03a35ab0dac832c4";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-viz-imgui/default.nix
+++ b/distros/humble/mola-viz-imgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, freeglut, glfw3, libGL, libGLU, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-humble-mola-viz-imgui";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_viz_imgui/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "d6dab0280f6c3aeab117e79487bd74c1aef1d11b01f9a3fa29ed77c5a5307dc0";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_viz_imgui/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "1f5ad8a3f3ead66eaf824b1c6a71736fa12228f68b2018af88be8ab3007dc388";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-viz/default.nix
+++ b/distros/humble/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-humble-mola-viz";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_viz/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "b396f05fb04f69e29a6e5cd161e277a761bf72c3ec17df6fd829d0247bef9a5b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_viz/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "914c3f0e3bfb1cc10dbe62f8fee29c1ca503615d272f2e66fbf2afc0991c512e";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-yaml/default.nix
+++ b/distros/humble/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-humble-mola-yaml";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_yaml/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "ee2f7d1acd564e78a05c9268f08d2fe72b6b2e464f4111f17720ec197aa0a4cc";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_yaml/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "9fe1f91c901ca0dad0d7c37eec9cc00825de7193cbff9be5e6aaf0974e31cd2c";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola/default.nix
+++ b/distros/humble/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-bridge-ros2, mola-demos, mola-input-rawlog, mola-input-rosbag2, mola-input-video, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-humble-mola";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "9f030cc310b5f6c22fe833579fae4c4694d7bd1e1151b26f8b13de80f0ce9bae";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "5f5199e573649a47bebb4bdb02538a11d1256c5291dfac5dd070423f112fa09f";
   };
 
   buildType = "cmake";

--- a/distros/humble/mp2p-icp-core/default.nix
+++ b/distros/humble/mp2p-icp-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cli11, cmake, mola-common, mola-imu-preintegration, mrpt-libbase, mrpt-libmaps, mrpt-libobs, mrpt-libposes, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mp2p-icp-core";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp_core/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "c7b501dfe1fe80527cbb6d0cdc4e9dcee7413527e91c41f905424cb51363b187";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp_core/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "7909aa04889467c0cc8b745f810f206e29316ffff282eb1e56f9c7aa6a979b78";
   };
 
   buildType = "cmake";

--- a/distros/humble/mp2p-icp-viz/default.nix
+++ b/distros/humble/mp2p-icp-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cli11, cmake, mola-common, mp2p-icp-core, mrpt-libgui, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mp2p-icp-viz";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp_viz/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "b51d5613a81873cf272334ed6f0f344649b1a0ce038d1aa472096fba2f1f11d8";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp_viz/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "bde7c7bb2ad176c1baffdf82cbc51a14928a1ef479b15f00d855793c3abf5c52";
   };
 
   buildType = "cmake";

--- a/distros/humble/mp2p-icp/default.nix
+++ b/distros/humble/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mp2p-icp-core, mp2p-icp-viz }:
 buildRosPackage {
   pname = "ros-humble-mp2p-icp";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "55ca4cc22473bf3e84033795d55b161a1865eafe6bbe8d4b499ce528ad0bf4c3";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "86f61acfd67e21407c92c6c09b37a2c0d4910659699f4245639ea7f292e87db2";
   };
 
   buildType = "cmake";

--- a/distros/humble/mujoco-3d-lidar/default.nix
+++ b/distros/humble/mujoco-3d-lidar/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, mujoco-vendor }:
+buildRosPackage {
+  pname = "ros-humble-mujoco-3d-lidar";
+  version = "0.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/humble/mujoco_3d_lidar/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "71a336abc4e7b5d8190597dee512bdbf456eb92e29ec0a6b09ffff547f08e315";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ mujoco-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Plugin for mujoco to use raycasters to simulate lidar";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/mujoco-ros2-control-demos/default.nix
+++ b/distros/humble/mujoco-ros2-control-demos/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, forward-command-controller, joint-state-broadcaster, mujoco-ros2-control, mujoco-ros2-control-msgs, robot-state-publisher, rviz2, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, forward-command-controller, joint-state-broadcaster, launch, launch-ros, mujoco-ros2-control, mujoco-ros2-control-msgs, pose-broadcaster, robot-state-publisher, rviz2, xacro }:
 buildRosPackage {
   pname = "ros-humble-mujoco-ros2-control-demos";
-  version = "0.0.3-r1";
+  version = "0.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/humble/mujoco_ros2_control_demos/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "9e9ec8aa34d59301f8e59a9f1a85670a9383a81f5f6020d7a12d70383daeef54";
+    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/humble/mujoco_ros2_control_demos/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "b18b07558570469a6fe93f17f57dba3f38bb27c7c99e9c379abc3df468bb75ad";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ controller-manager forward-command-controller joint-state-broadcaster mujoco-ros2-control mujoco-ros2-control-msgs robot-state-publisher rviz2 xacro ];
+  propagatedBuildInputs = [ controller-manager forward-command-controller joint-state-broadcaster launch launch-ros mujoco-ros2-control mujoco-ros2-control-msgs pose-broadcaster robot-state-publisher rviz2 xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/mujoco-ros2-control-msgs/default.nix
+++ b/distros/humble/mujoco-ros2-control-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-mujoco-ros2-control-msgs";
-  version = "0.0.3-r1";
+  version = "0.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/humble/mujoco_ros2_control_msgs/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "7f5e131fa008c9247578d43ae16f1567c71f408dc4cc4fa8908656bcdae111ac";
+    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/humble/mujoco_ros2_control_msgs/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "69d3305764182bee1fc38b8a2a953ee5b746a7788e34c07979d6722a5c0fa35a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime sensor-msgs std-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/humble/mujoco-ros2-control-plugins/default.nix
+++ b/distros/humble/mujoco-ros2-control-plugins/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, backward-ros, geometry-msgs, mujoco-ros2-control-msgs, mujoco-vendor, pluginlib, rclcpp, realtime-tools, ros2-control-cmake, std-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, backward-ros, geometry-msgs, glfw3, libGL, libGLU, mujoco-3d-lidar, mujoco-ros2-control-msgs, mujoco-vendor, pluginlib, rclcpp, realtime-tools, ros2-control-cmake, sensor-msgs, std-msgs, std-srvs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-mujoco-ros2-control-plugins";
-  version = "0.0.3-r1";
+  version = "0.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/humble/mujoco_ros2_control_plugins/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "0890bfdd43b84331bca708334d8f711ef1b66a46aa9898704c53d8fd067fcb21";
+    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/humble/mujoco_ros2_control_plugins/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "0a7bbe02cf385b0b53a8819e6d7e82cb6c524a8eaadda3b7bf164f29aee765e3";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gtest ];
-  propagatedBuildInputs = [ backward-ros geometry-msgs mujoco-ros2-control-msgs mujoco-vendor pluginlib rclcpp realtime-tools ros2-control-cmake std-msgs visualization-msgs ];
+  checkInputs = [ ament-cmake-gtest ament-index-cpp mujoco-3d-lidar ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs glfw3 libGL libGLU mujoco-ros2-control-msgs mujoco-vendor pluginlib rclcpp realtime-tools ros2-control-cmake sensor-msgs std-msgs std-srvs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/mujoco-ros2-control/default.nix
+++ b/distros/humble/mujoco-ros2-control/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-index-python, backward-ros, control-toolbox, controller-manager, fmt, git, glfw3, hardware-interface, mujoco-ros2-control-msgs, mujoco-ros2-control-plugins, mujoco-vendor, nav-msgs, pluginlib, python3, python3Packages, rclcpp, rclcpp-lifecycle, ros2-control-cmake, sensor-msgs, transmission-interface, urdfdom-py }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-index-cpp, ament-index-python, backward-ros, control-toolbox, controller-manager, eigen, fmt, geometry-msgs, git, glfw3, hardware-interface, mujoco-ros2-control-msgs, mujoco-ros2-control-plugins, mujoco-vendor, nav-msgs, pluginlib, python3, python3Packages, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2pkg, rosgraph-msgs, sensor-msgs, std-msgs, tinyxml2-vendor, transmission-interface, urdfdom-py }:
 buildRosPackage {
   pname = "ros-humble-mujoco-ros2-control";
-  version = "0.0.3-r1";
+  version = "0.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/humble/mujoco_ros2_control/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "9cf5576d4d4928dd30de34ca89699fc324521d05f291c2ff302e433bcaf90aef";
+    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/humble/mujoco_ros2_control/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "8ae39057db2f64f96151ebc34148cc97990bf1c393587e6f0aec0bb2fa762f37";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python git ros2-control-cmake ];
   checkInputs = [ ament-cmake-gtest ament-cmake-pytest ];
-  propagatedBuildInputs = [ ament-index-python backward-ros control-toolbox controller-manager fmt glfw3 hardware-interface mujoco-ros2-control-msgs mujoco-ros2-control-plugins mujoco-vendor nav-msgs pluginlib python3 python3Packages.importlib-resources python3Packages.numpy python3Packages.pip python3Packages.pykdl rclcpp rclcpp-lifecycle sensor-msgs transmission-interface urdfdom-py ];
+  propagatedBuildInputs = [ ament-index-cpp ament-index-python backward-ros control-toolbox controller-manager eigen fmt geometry-msgs glfw3 hardware-interface mujoco-ros2-control-msgs mujoco-ros2-control-plugins mujoco-vendor nav-msgs pluginlib python3 python3Packages.importlib-resources python3Packages.numpy python3Packages.pip python3Packages.pykdl rclcpp rclcpp-lifecycle realtime-tools ros2pkg rosgraph-msgs sensor-msgs std-msgs tinyxml2-vendor transmission-interface urdfdom-py ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python git ];
 
   meta = {

--- a/distros/humble/mujoco-vendor/default.nix
+++ b/distros/humble/mujoco-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, git, glfw3, patchelf, pkg-config }:
 buildRosPackage {
   pname = "ros-humble-mujoco-vendor";
-  version = "0.0.9-r1";
+  version = "0.0.9-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mujoco_vendor-release/archive/release/humble/mujoco_vendor/0.0.9-1.tar.gz";
-    name = "0.0.9-1.tar.gz";
-    sha256 = "18aaf093d1d456cebc394c241600f52538b97d49236943dfbdfae51e6459c825";
+    url = "https://github.com/ros2-gbp/mujoco_vendor-release/archive/release/humble/mujoco_vendor/0.0.9-2.tar.gz";
+    name = "0.0.9-2.tar.gz";
+    sha256 = "bb7f25806a94e687fb5243eee99643c62eb482e94b58f0e7510213576cf93639";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/multires-image/default.nix
+++ b/distros/humble/multires-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, gps-msgs, mapviz, mapviz-interfaces, marti-common-msgs, pluginlib, python3Packages, qt-gui-cpp, qt5or6, rclcpp, rclpy, swri-math-util, swri-transform-util, tf2 }:
 buildRosPackage {
   pname = "ros-humble-multires-image";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/multires_image/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "028031c24a157f39aa1205e1b68dc290d4bd99764b1035cf6ecb7f13f2af0b45";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/multires_image/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "26cffe702660b399296367157853df39ab0e3ddc9b0fb0930f2f2406555738e8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/novatel-gps-driver/default.nix
+++ b/distros/humble/novatel-gps-driver/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, boost, diagnostic-msgs, diagnostic-updater, gps-msgs, libpcap, nav-msgs, novatel-gps-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, swri-math-util, swri-roscpp, swri-serial-util, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, _unresolved_swri_roscpp, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, boost, diagnostic-msgs, diagnostic-updater, gps-msgs, libpcap, nav-msgs, novatel-gps-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, swri-math-util, swri-serial-util, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-novatel-gps-driver";
   version = "4.3.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ];
-  propagatedBuildInputs = [ boost diagnostic-msgs diagnostic-updater gps-msgs libpcap nav-msgs novatel-gps-msgs rclcpp rclcpp-components sensor-msgs std-msgs swri-math-util swri-roscpp swri-serial-util tf2 tf2-geometry-msgs ];
+  propagatedBuildInputs = [ _unresolved_swri_roscpp boost diagnostic-msgs diagnostic-updater gps-msgs libpcap nav-msgs novatel-gps-msgs rclcpp rclcpp-components sensor-msgs std-msgs swri-math-util swri-serial-util tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -253,6 +253,13 @@ in with lib; {
     '';
   });
 
+  elite-robots-msgs = rosSuper.elite-robots-msgs.overrideAttrs ({
+    buildInputs ? [], ...
+  }: {
+    # https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Driver/pull/1
+    buildInputs = buildInputs ++ [ rosSelf.geometry-msgs ];
+  });
+
   fastrtps = rosSuper.fastrtps.overrideAttrs ({
     patches ? [], ...
   }: {

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -402,6 +402,30 @@ in with lib; {
 
   inverse-dynamics-solver = rosSuper.inverse-dynamics-solver.override { python = self.python3; };
 
+  int2dds-ffi-vendor = let
+    version = "0.1.1";
+  in
+    (patchVendorUrl rosSuper.int2dds-ffi-vendor {
+      #revVariable = "INT2DDS_FFI_VERSION";
+      originalUrl = "\${INT2DDS_FFI_BASE_URL}/\${_asset}";
+      url = "https://github.com/IntellectusCorp/int2dds_ffi_vendor/releases/download/v${version}/int2dds-ffi-${version}-linux.tar.gz";
+      hash = "sha256-sM6qG0+BEPCbcLpT3KOlfwsLUXbKXtB3LxUD6j9/B6o=";
+    }).overrideAttrs ({
+      postPatch ? "", ...
+    }: {
+      postPatch = postPatch + ''
+        # Fail if the version in CMakeLists.txt doesn't match the one in the URL above.
+        # See https://github.com/IntellectusCorp/rmw_int2dds/blob/humble/int2dds_ffi_vendor/CMakeLists.txt
+        substituteInPlace CMakeLists.txt --replace-fail \
+          'set(INT2DDS_FFI_VERSION "${version}")' \
+          'set(INT2DDS_FFI_VERSION "${version}")'
+
+        substituteInPlace CMakeLists.txt --replace-fail \
+          'file(DOWNLOAD "''${_url}"' \
+          'file(DOWNLOAD "file://''${_url}"'
+      '';
+    });
+
   io-context = rosSuper.io-context.overrideAttrs ({
     patches ? [], ...
   }: {

--- a/distros/humble/pal-pro-gripper-bringup/default.nix
+++ b/distros/humble/pal-pro-gripper-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, joint-state-broadcaster, joint-trajectory-controller, pal-pro-gripper-controller-configuration, pal-pro-gripper-description }:
 buildRosPackage {
   pname = "ros-humble-pal-pro-gripper-bringup";
-  version = "1.12.5-r1";
+  version = "1.12.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_pro_gripper-release/archive/release/humble/pal_pro_gripper_bringup/1.12.5-1.tar.gz";
-    name = "1.12.5-1.tar.gz";
-    sha256 = "ced08d1d3eac4cac531839e65adf03dd7777759415dc792816908826d2f9acae";
+    url = "https://github.com/ros2-gbp/pal_pro_gripper-release/archive/release/humble/pal_pro_gripper_bringup/1.12.6-1.tar.gz";
+    name = "1.12.6-1.tar.gz";
+    sha256 = "868532e97ac76caacc899d03e2407332b11ff724ca1b9fedb1df1bc5b7107cac";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-pro-gripper-controller-configuration/default.nix
+++ b/distros/humble/pal-pro-gripper-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, joint-state-broadcaster, joint-trajectory-controller, launch, launch-pal, launch-ros, pal-pro-gripper-wrapper }:
 buildRosPackage {
   pname = "ros-humble-pal-pro-gripper-controller-configuration";
-  version = "1.12.5-r1";
+  version = "1.12.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_pro_gripper-release/archive/release/humble/pal_pro_gripper_controller_configuration/1.12.5-1.tar.gz";
-    name = "1.12.5-1.tar.gz";
-    sha256 = "9ab5c649bde1e27f8bcf346741c792d1f87503fd1927efbb573082b762bd2905";
+    url = "https://github.com/ros2-gbp/pal_pro_gripper-release/archive/release/humble/pal_pro_gripper_controller_configuration/1.12.6-1.tar.gz";
+    name = "1.12.6-1.tar.gz";
+    sha256 = "54c8137aae525ead4311c947bab6590b3491e3be02ba90a75a5883120c4ece3e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-pro-gripper-description/default.nix
+++ b/distros/humble/pal-pro-gripper-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, pal-urdf-utils, xacro }:
 buildRosPackage {
   pname = "ros-humble-pal-pro-gripper-description";
-  version = "1.12.5-r1";
+  version = "1.12.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_pro_gripper-release/archive/release/humble/pal_pro_gripper_description/1.12.5-1.tar.gz";
-    name = "1.12.5-1.tar.gz";
-    sha256 = "0851bf0a601a3aa3c6636b660d6596ac847b5b1822493150a222023804d933fb";
+    url = "https://github.com/ros2-gbp/pal_pro_gripper-release/archive/release/humble/pal_pro_gripper_description/1.12.6-1.tar.gz";
+    name = "1.12.6-1.tar.gz";
+    sha256 = "d15f683e40e589a31557a6e8707627da68fb2b06e4ee799100b6ad6c98b50307";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-pro-gripper-simulation/default.nix
+++ b/distros/humble/pal-pro-gripper-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, launch-pal, pal-gazebo-worlds, pal-pro-gripper-controller-configuration, pal-pro-gripper-description }:
 buildRosPackage {
   pname = "ros-humble-pal-pro-gripper-simulation";
-  version = "1.12.5-r1";
+  version = "1.12.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_pro_gripper-release/archive/release/humble/pal_pro_gripper_simulation/1.12.5-1.tar.gz";
-    name = "1.12.5-1.tar.gz";
-    sha256 = "99efdfba2f50f1b29d51a5dc6b15c32d7dc343dd42f3ce238430dc4e8f850151";
+    url = "https://github.com/ros2-gbp/pal_pro_gripper-release/archive/release/humble/pal_pro_gripper_simulation/1.12.6-1.tar.gz";
+    name = "1.12.6-1.tar.gz";
+    sha256 = "1a828f9da931a2a92646ea669330bc1e693c2c1d28c1009a622f25dfcc46f3fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-pro-gripper-wrapper/default.nix
+++ b/distros/humble/pal-pro-gripper-wrapper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-copyright, ament-flake8, ament-lint-auto, ament-lint-common, ament-pep257, python3Packages, rclpy, sensor-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-pal-pro-gripper-wrapper";
-  version = "1.12.5-r1";
+  version = "1.12.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_pro_gripper-release/archive/release/humble/pal_pro_gripper_wrapper/1.12.5-1.tar.gz";
-    name = "1.12.5-1.tar.gz";
-    sha256 = "d7446b56631905528241bc4ae3fbb022ea33da5ac1c32cc46495f5fa0393ed70";
+    url = "https://github.com/ros2-gbp/pal_pro_gripper-release/archive/release/humble/pal_pro_gripper_wrapper/1.12.6-1.tar.gz";
+    name = "1.12.6-1.tar.gz";
+    sha256 = "4a4df4182f6f68b0187ac3c22a904cd928adee8e95e1045c0f973d1d076eddd2";
   };
 
   buildType = "ament_python";

--- a/distros/humble/pal-pro-gripper/default.nix
+++ b/distros/humble/pal-pro-gripper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pal-pro-gripper-controller-configuration, pal-pro-gripper-description }:
 buildRosPackage {
   pname = "ros-humble-pal-pro-gripper";
-  version = "1.12.5-r1";
+  version = "1.12.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_pro_gripper-release/archive/release/humble/pal_pro_gripper/1.12.5-1.tar.gz";
-    name = "1.12.5-1.tar.gz";
-    sha256 = "707870db49af9c7e52fe7ecc66a7354c22d3739241f664f6b6423af749cc213a";
+    url = "https://github.com/ros2-gbp/pal_pro_gripper-release/archive/release/humble/pal_pro_gripper/1.12.6-1.tar.gz";
+    name = "1.12.6-1.tar.gz";
+    sha256 = "9d3b38ea6c37e8d816ac6fe0d90e3eead46d052e0bfc6722177e7de65bc8eae4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-sea-arm-bringup/default.nix
+++ b/distros/humble/pal-sea-arm-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, joint-state-broadcaster, joint-trajectory-controller, joy, joy-teleop, launch-pal, pal-sea-arm-controller-configuration, pal-sea-arm-description, play-motion2, play-motion2-cli, play-motion2-msgs }:
 buildRosPackage {
   pname = "ros-humble-pal-sea-arm-bringup";
-  version = "2.6.0-r1";
+  version = "2.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_sea_arm-release/archive/release/humble/pal_sea_arm_bringup/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "03b1f5bd78dcc8fecd40445f438fe96211d2f0484e330700dc3e88f81139df6e";
+    url = "https://github.com/ros2-gbp/pal_sea_arm-release/archive/release/humble/pal_sea_arm_bringup/2.8.4-1.tar.gz";
+    name = "2.8.4-1.tar.gz";
+    sha256 = "80352a56cd3b2132593d8950fd53b27db5ce6f83e433cb75cf3762fc1f5c761e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-sea-arm-controller-configuration/default.nix
+++ b/distros/humble/pal-sea-arm-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, joint-trajectory-controller, launch, launch-pal, pal-pro-gripper-controller-configuration, ros2controlcli }:
 buildRosPackage {
   pname = "ros-humble-pal-sea-arm-controller-configuration";
-  version = "2.6.0-r1";
+  version = "2.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_sea_arm-release/archive/release/humble/pal_sea_arm_controller_configuration/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "714bb4fb6f696f5790c2d7a1f8036aca7888cfbc9e7f9e596ccdab5b89d3c84f";
+    url = "https://github.com/ros2-gbp/pal_sea_arm-release/archive/release/humble/pal_sea_arm_controller_configuration/2.8.4-1.tar.gz";
+    name = "2.8.4-1.tar.gz";
+    sha256 = "4d15ad8df2059cbea45428ccabf562b86b3b3c95e89bb8d897b31c1c19e04649";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-sea-arm-description/default.nix
+++ b/distros/humble/pal-sea-arm-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, joint-state-publisher-gui, launch, launch-pal, launch-param-builder, launch-ros, launch-testing-ament-cmake, pal-pro-gripper-description, pal-sea-arm-controller-configuration, pal-urdf-utils, robot-state-publisher, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-pal-sea-arm-description";
-  version = "2.6.0-r1";
+  version = "2.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_sea_arm-release/archive/release/humble/pal_sea_arm_description/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "313a2317d77ae83c82d6b4a019c1ffa0dd3c3fbe6620c15718402937329acdca";
+    url = "https://github.com/ros2-gbp/pal_sea_arm-release/archive/release/humble/pal_sea_arm_description/2.8.4-1.tar.gz";
+    name = "2.8.4-1.tar.gz";
+    sha256 = "247880b299bc168f094bcb63b12a7495f47ffb8ee4d7031e3123f09d044aae13";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-sea-arm/default.nix
+++ b/distros/humble/pal-sea-arm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pal-sea-arm-bringup, pal-sea-arm-controller-configuration, pal-sea-arm-description }:
 buildRosPackage {
   pname = "ros-humble-pal-sea-arm";
-  version = "2.6.0-r1";
+  version = "2.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_sea_arm-release/archive/release/humble/pal_sea_arm/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "ecb05d5f23a475b08308c805646acf3de6b952001bfbc8b060460371fac9f078";
+    url = "https://github.com/ros2-gbp/pal_sea_arm-release/archive/release/humble/pal_sea_arm/2.8.4-1.tar.gz";
+    name = "2.8.4-1.tar.gz";
+    sha256 = "6de4e90ec4f30323d1ef27b57ff9926cfe71846a23073e355fece64196157bcc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-statistics-msgs/default.nix
+++ b/distros/humble/pal-statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-pal-statistics-msgs";
-  version = "2.8.0-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/humble/pal_statistics_msgs/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "5a940907528fd582d7bb7e16600f889894dcb803e270be0d58bae1d8b9c5b965";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/humble/pal_statistics_msgs/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "ea29b8a162c83a5637f54907984394b29d2d5f0068c47983ad30ca296b42240e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-statistics/default.nix
+++ b/distros/humble/pal-statistics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, boost, pal-statistics-msgs, rclcpp, rclcpp-lifecycle, rclpy }:
 buildRosPackage {
   pname = "ros-humble-pal-statistics";
-  version = "2.8.0-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/humble/pal_statistics/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "9e15ebde04c357013e79c800af21311794b50a0b310564f25f4eddcfeb8954e4";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/humble/pal_statistics/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "914e73ebc4143e6c57e5482b89fe2bd868acfe81380d8a3939df89ccc9d63ae9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmw-cyclonedds-cpp/default.nix
+++ b/distros/humble/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, iceoryx-binding-c, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-humble-rmw-cyclonedds-cpp";
-  version = "1.3.4-r1";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/humble/rmw_cyclonedds_cpp/1.3.4-1.tar.gz";
-    name = "1.3.4-1.tar.gz";
-    sha256 = "c12f9488236054acec2221195bcde772869945fa9302360f7c23e6281ac9b8d6";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/humble/rmw_cyclonedds_cpp/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "052e5f142ca3e0579bc0400c6ce74b1a7b5509257a08897e612fcab577a9d5ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmw-int2dds-cpp/default.nix
+++ b/distros/humble/rmw-int2dds-cpp/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, int2dds-ffi-vendor, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, std-msgs, test-msgs }:
+buildRosPackage {
+  pname = "ros-humble-rmw-int2dds-cpp";
+  version = "0.1.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/IntellectusCorp/rmw_int2dds-release/archive/release/humble/rmw_int2dds_cpp/0.1.0-3.tar.gz";
+    name = "0.1.0-3.tar.gz";
+    sha256 = "34f0b67d1c1b55323429852b80833c056497a7b2467a4360465e67db73d63e22";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-ros ];
+  checkInputs = [ ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gtest ament-lint-auto ament-lint-common test-msgs ];
+  propagatedBuildInputs = [ int2dds-ffi-vendor rcpputils rcutils rmw rmw-dds-common rosidl-runtime-c rosidl-runtime-cpp rosidl-typesupport-c rosidl-typesupport-cpp rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp std-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
+
+  meta = {
+    description = "ROS 2 middleware (RMW) implementation that binds the int2DDS DDS/RTPS
+    middleware to the ROS 2 rmw interface.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/rmw-int2dds-validation/default.nix
+++ b/distros/humble/rmw-int2dds-validation/default.nix
@@ -1,0 +1,35 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rcl, rclcpp, rclpy, rcutils, rmw, rmw-int2dds-cpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-rmw-int2dds-validation";
+  version = "0.1.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/IntellectusCorp/rmw_int2dds-release/archive/release/humble/rmw_int2dds_validation/0.1.0-3.tar.gz";
+    name = "0.1.0-3.tar.gz";
+    sha256 = "5307196d77a556e4ce34db43eecc74dc9c1b7579ae2ffbbdf918196d10344359";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ rcl rclcpp rclpy rcutils rmw rmw-int2dds-cpp std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "rclcpp and rclpy validation probes for the int2DDS RMW implementation:
+    QoS behaviour checks (durability, history depth, deadline, liveliness,
+    lifespan), content-filtered topic lifecycle, executor callback smoke checks
+    and latency/throughput/readiness measurements.
+
+    These live outside rmw_int2dds_cpp on purpose. rclcpp sits above the RMW
+    layer (rclcpp -&gt; rcl -&gt; rmw_implementation -&gt; rmw_int2dds_cpp through the
+    rmw_implementation_packages group), so an RMW implementation that depended
+    on rclcpp would close a build dependency cycle. No upstream RMW does it;
+    ros2/rmw_zenoh keeps its rclcpp-based checks in test_rmw_zenoh_cpp for the
+    same reason.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/swri-cli-tools/default.nix
+++ b/distros/humble/swri-cli-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, marti-introspection-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, ros2topic }:
 buildRosPackage {
   pname = "ros-humble-swri-cli-tools";
-  version = "3.9.0-r1";
+  version = "3.9.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_cli_tools/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "8f5c4389b9aba929878945c7f21d5ec41479c2d34eb34f5bb6e0a62130173605";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_cli_tools/3.9.1-2.tar.gz";
+    name = "3.9.1-2.tar.gz";
+    sha256 = "e10ec3f94183313c3da34eff673d0befedbfd9600875424d0203deb9ccb90ef5";
   };
 
   buildType = "ament_python";

--- a/distros/humble/swri-console-util/default.nix
+++ b/distros/humble/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-swri-console-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_console_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "4a27f513abc851beb0b92bdf571f77c745394995a7e0c97a305f7cdf57c3a011";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_console_util/3.9.1-2.tar.gz";
+    name = "3.9.1-2.tar.gz";
+    sha256 = "ed423899fdb63f1d5fe3e0c7af979fc20db24ef39907237f1cb73ab87d92f4b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-dbw-interface/default.nix
+++ b/distros/humble/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-swri-dbw-interface";
-  version = "3.9.0-r1";
+  version = "3.9.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_dbw_interface/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "4f2d54f25b56198511b6af6454997114cb4037c1155bc3ad7bb2876bb502e474";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_dbw_interface/3.9.1-2.tar.gz";
+    name = "3.9.1-2.tar.gz";
+    sha256 = "abf84f5c8aaa743a3d7b394c9c726a13d91a6c4aa5d057dc3bb6c9f5ce20f10d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-geometry-util/default.nix
+++ b/distros/humble/swri-geometry-util/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, geos, opencv, pkg-config, tf2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, geos, opencv, tf2 }:
 buildRosPackage {
   pname = "ros-humble-swri-geometry-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_geometry_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "af7850f4da6c60249091bd1b0c5408e46799ce699b1621c734f0811b34dfeab5";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_geometry_util/3.9.1-2.tar.gz";
+    name = "3.9.1-2.tar.gz";
+    sha256 = "eff7821adeaa51e10a42637df292be39fa1fea3ace970df6c9103e04042675fa";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake pkg-config ];
+  buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ];
   propagatedBuildInputs = [ eigen geos opencv opencv.cxxdev tf2 ];
-  nativeBuildInputs = [ ament-cmake pkg-config ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = "Commonly used geometry routines, implemented in a ROS friendly package.";

--- a/distros/humble/swri-image-util/default.nix
+++ b/distros/humble/swri-image-util/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, camera-calibration-parsers, cv-bridge, eigen, image-geometry, image-transport, message-filters, opencv, pkg-config, rcl-interfaces, rclcpp, rclcpp-components, rclpy, swri-geometry-util, swri-math-util, swri-opencv-util, tf2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, camera-calibration-parsers, cv-bridge, eigen, image-geometry, image-transport, message-filters, opencv, rcl-interfaces, rclcpp, rclcpp-components, rclpy, swri-geometry-util, swri-math-util, swri-opencv-util, tf2 }:
 buildRosPackage {
   pname = "ros-humble-swri-image-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_image_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "02b4ad351e9ce44a1390f4e47bd3dd91ff2b02842869eb15baf29fccc1dafb90";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_image_util/3.9.1-2.tar.gz";
+    name = "3.9.1-2.tar.gz";
+    sha256 = "a94fcd4c370d4bfa9d192d14ccef0f4e413c64bf40ae8375eba7504c182032d5";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake pkg-config ];
+  buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ];
   propagatedBuildInputs = [ ament-index-cpp camera-calibration-parsers cv-bridge eigen image-geometry image-transport message-filters opencv opencv.cxxdev rcl-interfaces rclcpp rclcpp-components rclpy swri-geometry-util swri-math-util swri-opencv-util tf2 ];
-  nativeBuildInputs = [ ament-cmake pkg-config ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = "A package of commonly image manipulation utilities.";

--- a/distros/humble/swri-math-util/default.nix
+++ b/distros/humble/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-swri-math-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_math_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "ce5a677ba22c40ef2de9898b5292e13c09916811d8357af1b823d64e27eb9baf";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_math_util/3.9.1-2.tar.gz";
+    name = "3.9.1-2.tar.gz";
+    sha256 = "674426f91df17b7361365c9704c49d2fef1995e8fddb96d0136ac0063a2a2bb8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-opencv-util/default.nix
+++ b/distros/humble/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, opencv, swri-math-util }:
 buildRosPackage {
   pname = "ros-humble-swri-opencv-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_opencv_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "0afa2c2e973bd0ac5d2bf155b677cdd53d921485fb365364d7e1f585628b6801";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_opencv_util/3.9.1-2.tar.gz";
+    name = "3.9.1-2.tar.gz";
+    sha256 = "86166f2b41d8ac66e31dbb2b2ad969c12c2d2342a77a88c51e5f76b2cd95f796";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-route-util/default.nix
+++ b/distros/humble/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-transform-util, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-swri-route-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_route_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "4ccd78a13ea235e950c970884cd2fe17553d455df2cbd9feb664337e3d282008";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_route_util/3.9.1-2.tar.gz";
+    name = "3.9.1-2.tar.gz";
+    sha256 = "5c1ad3e50df85002a33763672b40c7b9a558a81d4f17b88da72752835c5a1c7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-serial-util/default.nix
+++ b/distros/humble/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-swri-serial-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_serial_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "964aab53d0822de424c4849f524ab2b49559a87a6833f20da0cb3aa085c1e4f1";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_serial_util/3.9.1-2.tar.gz";
+    name = "3.9.1-2.tar.gz";
+    sha256 = "3ff9d79c21c6169a5a4af9f03d083505dbeb50ca1454ea63754265f38cf9948c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-transform-util/default.nix
+++ b/distros/humble/swri-transform-util/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-index-cpp, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geographiclib, geometry-msgs, geos, gps-msgs, launch-ros, launch-testing, launch-testing-ament-cmake, marti-nav-msgs, opencv, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-index-cpp, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geographiclib, geometry-msgs, geos, gps-msgs, launch-ros, launch-testing, launch-testing-ament-cmake, marti-nav-msgs, opencv, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-swri-transform-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_transform_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "7378b636a567bdae1df09cc4c6bd81270743a44a994e4eaeeedd4b7b5a28f28e";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_transform_util/3.9.1-2.tar.gz";
+    name = "3.9.1-2.tar.gz";
+    sha256 = "a4eabc50028f093cb9889f3fdc8ba1112f91dbc54aa0a6a4158d907374c438e4";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python pkg-config ];
   checkInputs = [ ament-cmake-gtest ament-index-cpp launch-ros launch-testing launch-testing-ament-cmake ];
-  propagatedBuildInputs = [ cv-bridge diagnostic-msgs diagnostic-updater geographic-msgs geographiclib geometry-msgs geos gps-msgs marti-nav-msgs opencv opencv.cxxdev proj python3Packages.numpy python3Packages.pyyaml rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util swri-roscpp tf2 tf2-geometry-msgs tf2-ros yaml-cpp-vendor ];
+  propagatedBuildInputs = [ cv-bridge diagnostic-msgs diagnostic-updater geographic-msgs geographiclib geometry-msgs geos gps-msgs marti-nav-msgs opencv opencv.cxxdev proj python3Packages.numpy python3Packages.pyyaml rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util tf2 tf2-geometry-msgs tf2-ros yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python pkg-config ];
 
   meta = {

--- a/distros/humble/tiago-dual-gazebo/default.nix
+++ b/distros/humble/tiago-dual-gazebo/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, _unresolved_gz-sensors6, ament-cmake-auto, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, gazebo-ros2-control, gz-ros2-control, launch, launch-pal, launch-ros, launch-testing-ament-cmake, pal-gazebo-plugins, pal-gazebo-worlds, pal-maps, pal-urdf-utils, play-motion2-msgs, rclcpp, ros-gz-bridge, sensor-msgs, tiago-dual-2dnav, tiago-dual-bringup, tiago-dual-description, tiago-dual-laser-sensors, tiago-dual-moveit-config, tiago-dual-rgbd-sensors, tiago-gazebo }:
+buildRosPackage {
+  pname = "ros-humble-tiago-dual-gazebo";
+  version = "4.13.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/tiago_dual_simulation-release/archive/release/humble/tiago_dual_gazebo/4.13.0-1.tar.gz";
+    name = "4.13.0-1.tar.gz";
+    sha256 = "4e989af866b0d9da5ff35378d3e58638346dbb9dc811c12d36fe2d06a0c1e930";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto ];
+  checkInputs = [ ament-lint-auto ament-lint-common launch-testing-ament-cmake play-motion2-msgs rclcpp sensor-msgs ];
+  propagatedBuildInputs = [ _unresolved_gz-sensors6 gazebo-plugins gazebo-ros gazebo-ros2-control gz-ros2-control launch launch-pal launch-ros pal-gazebo-plugins pal-gazebo-worlds pal-maps pal-urdf-utils play-motion2-msgs ros-gz-bridge tiago-dual-2dnav tiago-dual-bringup tiago-dual-description tiago-dual-laser-sensors tiago-dual-moveit-config tiago-dual-rgbd-sensors tiago-gazebo ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = "The tiago_dual_gazebo package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/tiago-dual-moveit-config/default.nix
+++ b/distros/humble/tiago-dual-moveit-config/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, launch-pal, moveit-configs-utils, moveit-kinematics, moveit-planners-ompl, moveit-ros-control-interface, moveit-ros-move-group, moveit-ros-perception, moveit-ros-visualization, tiago-dual-description }:
+buildRosPackage {
+  pname = "ros-humble-tiago-dual-moveit-config";
+  version = "2.0.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/tiago_dual_moveit_config-release/archive/release/humble/tiago_dual_moveit_config/2.0.11-1.tar.gz";
+    name = "2.0.11-1.tar.gz";
+    sha256 = "57170864176b6451707431361aaa496095484bdf0eb2aa342397545ccd76c145";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ launch-pal moveit-configs-utils moveit-kinematics moveit-planners-ompl moveit-ros-control-interface moveit-ros-move-group moveit-ros-perception moveit-ros-visualization tiago-dual-description ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = "An automatically generated package with all the configuration and launch files for using the tiago dual with the MoveIt Motion Planning Framework";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/tiago-dual-simulation/default.nix
+++ b/distros/humble/tiago-dual-simulation/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, tiago-dual-gazebo }:
+buildRosPackage {
+  pname = "ros-humble-tiago-dual-simulation";
+  version = "4.13.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/tiago_dual_simulation-release/archive/release/humble/tiago_dual_simulation/4.13.0-1.tar.gz";
+    name = "4.13.0-1.tar.gz";
+    sha256 = "b668d48b0366c5e37bb019fc73d32b5f71ff4aef28e0e88893bcab288259439a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ tiago-dual-gazebo ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The tiago_dual_simulation package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/tiago-pro-2dnav/default.nix
+++ b/distros/humble/tiago-pro-2dnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, omni-base-2dnav }:
 buildRosPackage {
   pname = "ros-humble-tiago-pro-2dnav";
-  version = "2.14.0-r1";
+  version = "2.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tiago_pro_navigation-release/archive/release/humble/tiago_pro_2dnav/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "c3fd0f477839d134a9824376717428a18d04f7743e9ceca85cd621f866935dbe";
+    url = "https://github.com/ros2-gbp/tiago_pro_navigation-release/archive/release/humble/tiago_pro_2dnav/2.15.0-1.tar.gz";
+    name = "2.15.0-1.tar.gz";
+    sha256 = "8648597f2c8802337a2072eab929ced383c529b358010615449e02ab9efe6087";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-pro-bringup/default.nix
+++ b/distros/humble/tiago-pro-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-index-python, ament-lint-auto, ament-lint-common, diagnostic-aggregator, joy, joy-teleop, pal-pro-gripper-wrapper, play-motion2, play-motion2-cli, tiago-pro-controller-configuration, tiago-pro-head-bringup, twist-mux }:
 buildRosPackage {
   pname = "ros-humble-tiago-pro-bringup";
-  version = "2.5.0-r1";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tiago_pro_robot-release/archive/release/humble/tiago_pro_bringup/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "30c09c0d798e1389f029794da696a9b461e2823423d50ee75f3c71e972e04978";
+    url = "https://github.com/ros2-gbp/tiago_pro_robot-release/archive/release/humble/tiago_pro_bringup/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "ecebd5eec3b5817d9faa27b97cc04074a1599875f04f14f30e828d5df3189f5a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-pro-controller-configuration/default.nix
+++ b/distros/humble/tiago-pro-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, joint-state-broadcaster, joint-trajectory-controller, launch, launch-pal, omni-base-controller-configuration, pal-pro-gripper-controller-configuration, pal-sea-arm-controller-configuration, ros2controlcli, tiago-pro-head-controller-configuration }:
 buildRosPackage {
   pname = "ros-humble-tiago-pro-controller-configuration";
-  version = "2.5.0-r1";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tiago_pro_robot-release/archive/release/humble/tiago_pro_controller_configuration/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "f208ac227bbc4ead4f91711512be2da4db863e1826792ba5a52128f1ac310af8";
+    url = "https://github.com/ros2-gbp/tiago_pro_robot-release/archive/release/humble/tiago_pro_controller_configuration/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "19c6c0332ee4ec70246ec1096ce4878da65e14924125ddc281bca7e6e37601f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-pro-description/default.nix
+++ b/distros/humble/tiago-pro-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, launch-testing-ament-cmake, omni-base-description, pal-sea-arm-description, pal-urdf-utils, robot-state-publisher, tiago-pro-head-description, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-tiago-pro-description";
-  version = "2.5.0-r1";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tiago_pro_robot-release/archive/release/humble/tiago_pro_description/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "07e6bad4d4ea4c816ee0a1808ae35eee29146e8556e707ac1121199dc9d52aaf";
+    url = "https://github.com/ros2-gbp/tiago_pro_robot-release/archive/release/humble/tiago_pro_description/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "4d2e7c70a25720d9bbe3b896831294e9fe64fc7e8736e7d5c5f1c115e48ff1ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-pro-laser-sensors/default.nix
+++ b/distros/humble/tiago-pro-laser-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, omni-base-laser-sensors }:
 buildRosPackage {
   pname = "ros-humble-tiago-pro-laser-sensors";
-  version = "2.14.0-r1";
+  version = "2.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tiago_pro_navigation-release/archive/release/humble/tiago_pro_laser_sensors/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "27ed843aed0eea46cad75742af29b9703c47f2261efea3a5900aa73a55dc3fed";
+    url = "https://github.com/ros2-gbp/tiago_pro_navigation-release/archive/release/humble/tiago_pro_laser_sensors/2.15.0-1.tar.gz";
+    name = "2.15.0-1.tar.gz";
+    sha256 = "cf67b3c76751ed65f3f53cec5b3347d2b19746eb50f3dba493fae47d2d1682a8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-pro-navigation/default.nix
+++ b/distros/humble/tiago-pro-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, tiago-pro-2dnav, tiago-pro-laser-sensors, tiago-pro-rgbd-sensors }:
 buildRosPackage {
   pname = "ros-humble-tiago-pro-navigation";
-  version = "2.14.0-r1";
+  version = "2.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tiago_pro_navigation-release/archive/release/humble/tiago_pro_navigation/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "659e2e605a3f384eaa77c13205aae27c54e5010b1acb775a0a03664be2fde2a7";
+    url = "https://github.com/ros2-gbp/tiago_pro_navigation-release/archive/release/humble/tiago_pro_navigation/2.15.0-1.tar.gz";
+    name = "2.15.0-1.tar.gz";
+    sha256 = "6dbc9524a1a99e9ef3871861058fce1e395edaa47023a0b1831c74506b98ed90";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-pro-rgbd-sensors/default.nix
+++ b/distros/humble/tiago-pro-rgbd-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-index-python, ament-lint-auto, ament-lint-common, diagnostic-updater, rclcpp-components, realsense2-camera, ros2launch }:
 buildRosPackage {
   pname = "ros-humble-tiago-pro-rgbd-sensors";
-  version = "2.14.0-r1";
+  version = "2.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tiago_pro_navigation-release/archive/release/humble/tiago_pro_rgbd_sensors/2.14.0-1.tar.gz";
-    name = "2.14.0-1.tar.gz";
-    sha256 = "eaef7e8d7f7658ec1bea22209bc83919d56110832bd2c02d2817954f0649275d";
+    url = "https://github.com/ros2-gbp/tiago_pro_navigation-release/archive/release/humble/tiago_pro_rgbd_sensors/2.15.0-1.tar.gz";
+    name = "2.15.0-1.tar.gz";
+    sha256 = "e28b73c73abea02eb5b5790d6f891e1321a9b27169b38b4782b99bdacf1283ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-pro-robot/default.nix
+++ b/distros/humble/tiago-pro-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tiago-pro-bringup, tiago-pro-controller-configuration, tiago-pro-description }:
 buildRosPackage {
   pname = "ros-humble-tiago-pro-robot";
-  version = "2.5.0-r1";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tiago_pro_robot-release/archive/release/humble/tiago_pro_robot/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "f8029005700840b91317053a02910aa793e687a144cda89e20438dd9b529e44c";
+    url = "https://github.com/ros2-gbp/tiago_pro_robot-release/archive/release/humble/tiago_pro_robot/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "9c224ae724bc261159cd1c6d5ede21a5017d57849fe0dd0933497b16b2ba08dd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tile-map/default.nix
+++ b/distros/humble/tile-map/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, jsoncpp, mapviz, pluginlib, qt-gui-cpp, qt5or6, rclcpp, swri-math-util, swri-transform-util, tf2, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-tile-map";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/tile_map/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "1657cb3b8eefd608ecac2de9a1c5aa44db8c826f7d2be23e98cca1bde390725c";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/tile_map/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "51d125e627f543a15543479c8e7c10ac55258dadc9617ff2de6b88c101d2f2a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/unbag/default.nix
+++ b/distros/humble/unbag/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-index-python, ament-lint-auto, ament-lint-common, python3, python3Packages, qt5, rclpy, ros2cli, rosbag2-py, rosidl-runtime-py, sensor-msgs, tf2-msgs }:
+buildRosPackage {
+  pname = "ros-humble-unbag";
+  version = "1.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/unbag-release/archive/release/humble/unbag/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "d495658044cf1a9fd78bd655e52f46cee77e49498fcc83b04e9b559eb13a0bb8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python python3 python3Packages.setuptools qt5.qtbase ];
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-python python3Packages.numpy python3Packages.opencv4 python3Packages.pyyaml python3Packages.tqdm qt5.qtsvg rclpy ros2cli rosbag2-py rosidl-runtime-py sensor-msgs tf2-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "A ROS 2 tool for exporting bags to human readable files. Supports pluggable export routines to handle any message type.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/adi-iio/default.nix
+++ b/distros/jazzy/adi-iio/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-xmllint, ament-copyright, ament-lint-auto, ament-lint-common, ament-pep257, launch, launch-pytest, launch-ros, launch-testing, launch-testing-ament-cmake, libiio, python3Packages, rclcpp, rclpy, ros2launch, rosidl-default-generators, rosidl-default-runtime, rosidl-typesupport-introspection-cpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-adi-iio";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/adi_iio-release/archive/release/jazzy/adi_iio/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "7f6cac6f04be388f3db3190892392d75043d352a8f452a1222355c939c29a488";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-lint-cmake ament-cmake-ros ament-cmake-xmllint ament-copyright ament-lint-auto ament-lint-common ament-pep257 launch launch-pytest launch-ros launch-testing launch-testing-ament-cmake python3Packages.scipy rclpy ];
+  propagatedBuildInputs = [ libiio rclcpp ros2launch rosidl-default-runtime rosidl-typesupport-introspection-cpp std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "ROS package to interface with IIO devices";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/adi-imu/default.nix
+++ b/distros/jazzy/adi-imu/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-copyright, ament-lint-auto, ament-pep257, builtin-interfaces, geometry-msgs, libiio, rclcpp, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-adi-imu";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/adi_imu-release/archive/release/jazzy/adi_imu/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "c8d9ec9b9702263dad952b824ddab7803bc2134b9c8ed7373eb5336f486f483f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-xmllint ament-copyright ament-lint-auto ament-pep257 ];
+  propagatedBuildInputs = [ ament-cmake builtin-interfaces geometry-msgs libiio rclcpp rosidl-default-runtime sensor-msgs std-msgs ];
+
+  meta = {
+    description = "Publisher for ADI IMUs";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/clearpath-bms-broadcaster/default.nix
+++ b/distros/jazzy/clearpath-bms-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-bms-broadcaster";
-  version = "2.9.14-r1";
+  version = "2.9.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bms_broadcaster/2.9.14-1.tar.gz";
-    name = "2.9.14-1.tar.gz";
-    sha256 = "730f42b068291be57385776f88dcbaccda7d0eb142224e67a987f2a007559b53";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bms_broadcaster/2.9.15-1.tar.gz";
+    name = "2.9.15-1.tar.gz";
+    sha256 = "3b87985c8c9282783769af50d0c4af958e175cb35199055a44a3f8d716a2b2a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-bt-joy/default.nix
+++ b/distros/jazzy/clearpath-bt-joy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, bluez, diagnostic-msgs, diagnostic-updater, python3Packages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-bt-joy";
-  version = "2.9.14-r1";
+  version = "2.9.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bt_joy/2.9.14-1.tar.gz";
-    name = "2.9.14-1.tar.gz";
-    sha256 = "b927399200d688173b485f5128f672a174d61e6bd855b15217caa771c7f361d3";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bt_joy/2.9.15-1.tar.gz";
+    name = "2.9.15-1.tar.gz";
+    sha256 = "43e1ee65d4b1994950030a86a247d317f3b5d71f96c5481604e85480e619e9dc";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/clearpath-common/default.nix
+++ b/distros/jazzy/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, rmw-zenoh-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-common";
-  version = "2.9.14-r1";
+  version = "2.9.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_common/2.9.14-1.tar.gz";
-    name = "2.9.14-1.tar.gz";
-    sha256 = "ae64b1f6f04947bbce325b54a79800fc871472dd35548b0f580aeb34c1dadd83";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_common/2.9.15-1.tar.gz";
+    name = "2.9.15-1.tar.gz";
+    sha256 = "e84d642fb61e0e2a2ee2bbb957bde15b604db4009a343e276b5c85a32aead343";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-control/default.nix
+++ b/distros/jazzy/clearpath-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-bt-joy, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, mecanum-drive-controller, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-control";
-  version = "2.9.14-r1";
+  version = "2.9.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_control/2.9.14-1.tar.gz";
-    name = "2.9.14-1.tar.gz";
-    sha256 = "c3b96800fcd063a48547621069ffade72ec3745d6c924702ff8e92875a32c19a";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_control/2.9.15-1.tar.gz";
+    name = "2.9.15-1.tar.gz";
+    sha256 = "2bf7999229cc543b873d70378337ef5a78c06cdf007024c28f365ae27dde01df";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-customization/default.nix
+++ b/distros/jazzy/clearpath-customization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-customization";
-  version = "2.9.14-r1";
+  version = "2.9.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_customization/2.9.14-1.tar.gz";
-    name = "2.9.14-1.tar.gz";
-    sha256 = "e7e97b7297b8572cb98deeda6b8b5da85feec41433e04678a87300ce5c422aec";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_customization/2.9.15-1.tar.gz";
+    name = "2.9.15-1.tar.gz";
+    sha256 = "0d2164d463bb9cbf5c570e318c320071050a0715faf4bc98f1024832f5af503a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-description/default.nix
+++ b/distros/jazzy/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-description";
-  version = "2.9.14-r1";
+  version = "2.9.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_description/2.9.14-1.tar.gz";
-    name = "2.9.14-1.tar.gz";
-    sha256 = "e1e93ccfb7b23f22c0904b59db67147f9efb7df9c8411fbab8ea9715a0044b9b";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_description/2.9.15-1.tar.gz";
+    name = "2.9.15-1.tar.gz";
+    sha256 = "24a7e7250c4c0c2b0124137935ca63e23dd0406aafaae75a8d5122b6b7bafbe1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-diagnostics/default.nix
+++ b/distros/jazzy/clearpath-diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-platform-msgs, diagnostic-aggregator, diagnostic-updater, foxglove-bridge, rclcpp, ros2launch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-diagnostics";
-  version = "2.9.14-r1";
+  version = "2.9.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_diagnostics/2.9.14-1.tar.gz";
-    name = "2.9.14-1.tar.gz";
-    sha256 = "108d67519af8433e46d2a3bf5b944346865bf6fb158f603c6c68cd6e7e308575";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_diagnostics/2.9.15-1.tar.gz";
+    name = "2.9.15-1.tar.gz";
+    sha256 = "07898ca64db5d702b041d9b5ff85afa56dac2f9894c855a7da9ef3eae681958b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-generator-common/default.nix
+++ b/distros/jazzy/clearpath-generator-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, _unresolved_python3-apt, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-diagnostics, clearpath-manipulators, moveit-setup-srdf-plugins }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-generator-common";
-  version = "2.9.14-r1";
+  version = "2.9.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_generator_common/2.9.14-1.tar.gz";
-    name = "2.9.14-1.tar.gz";
-    sha256 = "44f5d24b266202312d689244fb04e903e5d7efe49b8fe6939c9462d2158f8a08";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_generator_common/2.9.15-1.tar.gz";
+    name = "2.9.15-1.tar.gz";
+    sha256 = "3af71297f8f9fab4c676ff85fa1218f6f23b63fd26c2fc3ea7c27d86d47ddc08";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-manipulators-description/default.nix
+++ b/distros/jazzy/clearpath-manipulators-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ewellix-description, robot-state-publisher, robotiq-description, ur-description, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-manipulators-description";
-  version = "2.9.14-r1";
+  version = "2.9.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators_description/2.9.14-1.tar.gz";
-    name = "2.9.14-1.tar.gz";
-    sha256 = "eb87c47c7d305b1afbf03b07db351592c6e73fcea22b89e2053550b9e15544e8";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators_description/2.9.15-1.tar.gz";
+    name = "2.9.15-1.tar.gz";
+    sha256 = "dac01a5a5d9258b4e148bf76a7c15e5096dab942431ae4f4c6187574d3940c38";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-manipulators/default.nix
+++ b/distros/jazzy/clearpath-manipulators/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, gripper-controllers, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-warehouse, moveit-setup-srdf-plugins, moveit-simple-controller-manager, position-controllers, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-manipulators";
-  version = "2.9.14-r1";
+  version = "2.9.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators/2.9.14-1.tar.gz";
-    name = "2.9.14-1.tar.gz";
-    sha256 = "f405f6aec3a475d219c797dc43e14df3ede4f068c230de3d6b05ca154cbc4f81";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators/2.9.15-1.tar.gz";
+    name = "2.9.15-1.tar.gz";
+    sha256 = "ebbd2d2eec8427e878bbbdd785bdfa707c1335ee84153eca1e1b0fdc3bffaf4a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-mounts-description/default.nix
+++ b/distros/jazzy/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-mounts-description";
-  version = "2.9.14-r1";
+  version = "2.9.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_mounts_description/2.9.14-1.tar.gz";
-    name = "2.9.14-1.tar.gz";
-    sha256 = "71675fbce846f034bafe5cb05339242117dbc18af5eb89afe13ddc925295d80a";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_mounts_description/2.9.15-1.tar.gz";
+    name = "2.9.15-1.tar.gz";
+    sha256 = "ea879981bb21eba8d9568b9170b1a98dfc40b71428a38e58b626f21d4223977b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-platform-description/default.nix
+++ b/distros/jazzy/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-platform-description";
-  version = "2.9.14-r1";
+  version = "2.9.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_platform_description/2.9.14-1.tar.gz";
-    name = "2.9.14-1.tar.gz";
-    sha256 = "317b767cf34af1de0bdbb0d29bb2f22f318ad56e57e695e250383743190acd37";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_platform_description/2.9.15-1.tar.gz";
+    name = "2.9.15-1.tar.gz";
+    sha256 = "2b484a21ba1d9ae45f9868a41e5bf18d169494c1b9401fe55696837c7b5b5f70";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-sensors-description/default.nix
+++ b/distros/jazzy/clearpath-sensors-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, axis-description, flir-ptu-description, microstrain-inertial-description, realsense2-description, velodyne-description, zed-description }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-sensors-description";
-  version = "2.9.14-r1";
+  version = "2.9.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_sensors_description/2.9.14-1.tar.gz";
-    name = "2.9.14-1.tar.gz";
-    sha256 = "b3b11a32948b51e5972f27002232ec759792b6808e0b019052a661d01240da82";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_sensors_description/2.9.15-1.tar.gz";
+    name = "2.9.15-1.tar.gz";
+    sha256 = "e880cbd58ace818ad2e431c755aee497acc8e8fd72ece5812443b5c4cd3b5a48";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/crazyflie-description/default.nix
+++ b/distros/jazzy/crazyflie-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-crazyflie-description";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/jazzy/crazyflie_description/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "77b4f320966c7020bd9bb5f488a7483794881dd7cfa39bb2b0f8d8d7f81f8eb6";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/jazzy/crazyflie_description/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "7caa886fc369bbde41c1749663702d2afefe72c72975fff519ec8680ff3a66b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/crazyflie-examples/default.nix
+++ b/distros/jazzy/crazyflie-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, crazyflie-py, geometry-msgs, nav-msgs, python3Packages, rclpy, sensor-msgs, tf-transformations, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-crazyflie-examples";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/jazzy/crazyflie_examples/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "ea16bd51e024c60b9e66d3aff6ff56257ab7300337f912e50d3bd211a88023ed";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/jazzy/crazyflie_examples/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "c9e09e06e3fcb35cc89853efa34eb686fb5fc608c24e696c2268656478695c7a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/crazyflie-interfaces/default.nix
+++ b/distros/jazzy/crazyflie-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-crazyflie-interfaces";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/jazzy/crazyflie_interfaces/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "abb8e9faa4326ea6f9600e4a84e37918a0c01efd3d6a0b465ab021e2aa611411";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/jazzy/crazyflie_interfaces/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "2c1ceb77a790638784eb5080b83d582e434641dc3279aaeff7d43c9893b2a966";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/crazyflie-py/default.nix
+++ b/distros/jazzy/crazyflie-py/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, crazyflie-interfaces, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-crazyflie-py";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/jazzy/crazyflie_py/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "f627c26435d129c5afe53e869d8c3d7ff6bbba45ebf1f180ff98e62e73f9f225";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/jazzy/crazyflie_py/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "0d09a90e552b4ac4fca0a781b950a28dce8f1f002ea47cd09fc09e121192316d";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
-  propagatedBuildInputs = [ crazyflie-interfaces rclpy ];
+  propagatedBuildInputs = [ crazyflie-interfaces python3Packages.transforms3d rclpy ];
 
   meta = {
     description = "Simple Python Interface for Crayzswarm2";

--- a/distros/jazzy/crazyflie-server-cpp/default.nix
+++ b/distros/jazzy/crazyflie-server-cpp/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, crazyflie-interfaces, eigen, geometry-msgs, libusb1, motion-capture-tracking-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, std-srvs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-jazzy-crazyflie-server-cpp";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/jazzy/crazyflie_server_cpp/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "0c4495d5a997ff0781ad7713eee462ac0dc9ea63f4bf8a71ff2daf43fd10c3c2";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ boost crazyflie-interfaces eigen geometry-msgs libusb1 motion-capture-tracking-interfaces nav-msgs rclcpp ros-environment sensor-msgs std-srvs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "C++ ROS 2 server node for Bitcraze Crazyflie robots";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/crazyflie-server-py/default.nix
+++ b/distros/jazzy/crazyflie-server-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, crazyflie-interfaces, geometry-msgs, motion-capture-tracking-interfaces, nav-msgs, python3Packages, rcl-interfaces, rclpy, sensor-msgs, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-crazyflie-server-py";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/jazzy/crazyflie_server_py/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "77a8b0e85176f180b772c10eea68529a5e2ad48c6a00c43d791f19e792b9f6e0";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/jazzy/crazyflie_server_py/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "be3d66b0a17118081986ffcf1bea88e254c81ef575f60089a9d3f5d237f2b460";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/crazyflie-sim/default.nix
+++ b/distros/jazzy/crazyflie-sim/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, crazyflie-interfaces, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-crazyflie-sim";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/jazzy/crazyflie_sim/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "db2f2f94f52dbab05efb65126c556f18c8326ac9eff03885f602b8d9f4fe49a9";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/jazzy/crazyflie_sim/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "055cd2207bf6822c8d259ada4a36fb410e75b935918113ef684247fb231e9fe6";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-cmake-pytest ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
-  propagatedBuildInputs = [ crazyflie-interfaces rclpy ];
+  propagatedBuildInputs = [ crazyflie-interfaces python3Packages.transforms3d rclpy ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/jazzy/crazyflie/default.nix
+++ b/distros/jazzy/crazyflie/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, boost, crazyflie-description, crazyflie-interfaces, eigen, geometry-msgs, libusb1, motion-capture-tracking-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, std-srvs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, crazyflie-description, crazyflie-interfaces, crazyflie-server-cpp, eigen, geometry-msgs, rclcpp, rclpy, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-crazyflie";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/jazzy/crazyflie/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "89f2ea435de0cc33de6789de628e686720c36d56ba14f442cbb5655ae71a75e2";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/jazzy/crazyflie/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "24d21ee2cb18dfb7403aa2415b448f4a9e53f926da2c05032f290071e1d266d0";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ boost crazyflie-description crazyflie-interfaces eigen geometry-msgs libusb1 motion-capture-tracking-interfaces nav-msgs rclcpp ros-environment sensor-msgs std-srvs tf2-ros ];
+  propagatedBuildInputs = [ crazyflie-description crazyflie-interfaces crazyflie-server-cpp eigen geometry-msgs rclcpp rclpy sensor-msgs std-srvs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/jazzy/depthai-v3/default.nix
+++ b/distros/jazzy/depthai-v3/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, curl, fmt, gfortran, libtar, libusb1, nlohmann_json, opencv, ros-environment, spdlog, udev, unzip, zip }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, curl, fmt, gfortran, libusb1, nlohmann_json, opencv, ros-environment, spdlog, udev, unzip, zip }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-v3";
-  version = "3.6.1-r2";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-v3-release/archive/release/jazzy/depthai_v3/3.6.1-2.tar.gz";
-    name = "3.6.1-2.tar.gz";
-    sha256 = "8471c19b5a71b0b08c63e1f66315c8833a6d9e2ba0b678bbb3c19cd73c9b91bc";
+    url = "https://github.com/luxonis/depthai-core-v3-release/archive/release/jazzy/depthai_v3/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "91e167db986b955bf161a00da39af6eeecd2b684d2d99cf219c32a7321ea1429";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ curl fmt gfortran libtar libusb1 nlohmann_json opencv opencv.cxxdev spdlog udev unzip zip ];
+  propagatedBuildInputs = [ curl fmt gfortran libusb1 nlohmann_json opencv opencv.cxxdev spdlog udev unzip zip ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/fuse-constraints/default.nix
+++ b/distros/jazzy/fuse-constraints/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ceres-solver, eigen, fuse-core, fuse-graphs, fuse-variables, gbenchmark, geometry-msgs, pluginlib, rclcpp, suitesparse }:
 buildRosPackage {
   pname = "ros-jazzy-fuse-constraints";
-  version = "1.1.5-r1";
+  version = "1.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse_constraints/1.1.5-1.tar.gz";
-    name = "1.1.5-1.tar.gz";
-    sha256 = "4ec277ea9305110fcc5156a238f6ec9f36e43feb37026d181e68e7ee45447e41";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse_constraints/1.1.6-1.tar.gz";
+    name = "1.1.6-1.tar.gz";
+    sha256 = "6ec441e69d6c69ecdf6562a7b0543357a6b70e2b86c650237f5baeb35d17441c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fuse-core/default.nix
+++ b/distros/jazzy/fuse-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, boost, ceres-solver, eigen, fuse-msgs, geometry-msgs, glog, launch, launch-pytest, pluginlib, rcl-interfaces, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-jazzy-fuse-core";
-  version = "1.1.5-r1";
+  version = "1.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse_core/1.1.5-1.tar.gz";
-    name = "1.1.5-1.tar.gz";
-    sha256 = "990c77eb8e3aab7c7481806e6c39e23ad8c28e4d8a73d70be7c2890218db5124";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse_core/1.1.6-1.tar.gz";
+    name = "1.1.6-1.tar.gz";
+    sha256 = "324c1ee9c96216dabb5baa9027953ea6eaead6652d35a115d9b1d732792abc9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fuse-doc/default.nix
+++ b/distros/jazzy/fuse-doc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros }:
 buildRosPackage {
   pname = "ros-jazzy-fuse-doc";
-  version = "1.1.5-r1";
+  version = "1.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse_doc/1.1.5-1.tar.gz";
-    name = "1.1.5-1.tar.gz";
-    sha256 = "fe41d45e08dab943bace739a3dadde1a8ea6aa5bf2ef25d8c58f5016cb6bda4d";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse_doc/1.1.6-1.tar.gz";
+    name = "1.1.6-1.tar.gz";
+    sha256 = "9be4cf7f7c28054c20d3c80d4a6ddb2c639c8bac2edfa14514c9f35f0cfd2e62";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fuse-graphs/default.nix
+++ b/distros/jazzy/fuse-graphs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ceres-solver, fuse-core, gbenchmark, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-fuse-graphs";
-  version = "1.1.5-r1";
+  version = "1.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse_graphs/1.1.5-1.tar.gz";
-    name = "1.1.5-1.tar.gz";
-    sha256 = "0d0bf8e2ea4ccb2004fb069ad8d33bbb6eb2a17630a7c921f46b34636ec3c3d8";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse_graphs/1.1.6-1.tar.gz";
+    name = "1.1.6-1.tar.gz";
+    sha256 = "5951732598b8c074d7d607ab78d2b1c6d0895d08ec488b0193c830e9aa23b459";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fuse-loss/default.nix
+++ b/distros/jazzy/fuse-loss/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ceres-solver, fuse-core, libsForQt5, pluginlib, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-fuse-loss";
-  version = "1.1.5-r1";
+  version = "1.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse_loss/1.1.5-1.tar.gz";
-    name = "1.1.5-1.tar.gz";
-    sha256 = "33866c93a25a1dd31203c7e5f1d065ee8e1af489374dcb3d53544bc52b88cea7";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse_loss/1.1.6-1.tar.gz";
+    name = "1.1.6-1.tar.gz";
+    sha256 = "7a9a4b760da09cda314155e4cc39ef1aa5a862e841d27f352dda978e7b7c3cd1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fuse-models/default.nix
+++ b/distros/jazzy/fuse-models/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, boost, ceres-solver, eigen, fuse-constraints, fuse-core, fuse-graphs, fuse-msgs, fuse-publishers, fuse-variables, gbenchmark, geometry-msgs, nav-msgs, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-srvs, tf2, tf2-2d, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-fuse-models";
-  version = "1.1.5-r1";
+  version = "1.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse_models/1.1.5-1.tar.gz";
-    name = "1.1.5-1.tar.gz";
-    sha256 = "ab6e8cc9fdb35dc59f47d1d26965345c1fdfe025af40578d005c91a7ee06d511";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse_models/1.1.6-1.tar.gz";
+    name = "1.1.6-1.tar.gz";
+    sha256 = "20295e64f2c0b22058ad7de589eeff59760bca66f85096e61f6ee7f89e43f8d0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fuse-msgs/default.nix
+++ b/distros/jazzy/fuse-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-fuse-msgs";
-  version = "1.1.5-r1";
+  version = "1.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse_msgs/1.1.5-1.tar.gz";
-    name = "1.1.5-1.tar.gz";
-    sha256 = "287e9be9cd9d49dc042e963aa8c5c8985b8794cb889868b2b87b56489d233f1d";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse_msgs/1.1.6-1.tar.gz";
+    name = "1.1.6-1.tar.gz";
+    sha256 = "275b2132a9239e9aab70d2ebeb81cbb3b3dd184e09dc97c3c7a3a6a6da998342";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fuse-optimizers/default.nix
+++ b/distros/jazzy/fuse-optimizers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, boost, ceres-solver, diagnostic-updater, eigen, fuse-constraints, fuse-core, fuse-graphs, fuse-models, fuse-msgs, fuse-variables, geometry-msgs, launch, launch-pytest, launch-ros, nav-msgs, pluginlib, rclcpp, rclcpp-components, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-fuse-optimizers";
-  version = "1.1.5-r1";
+  version = "1.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse_optimizers/1.1.5-1.tar.gz";
-    name = "1.1.5-1.tar.gz";
-    sha256 = "92d02da8c254a4f2dbb0715b7c13873d6eac32181dd1375e45480e849471fc94";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse_optimizers/1.1.6-1.tar.gz";
+    name = "1.1.6-1.tar.gz";
+    sha256 = "84d475abc54c6c319db2da59505aa66772ca675e80479a70c793f492260ddb09";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fuse-publishers/default.nix
+++ b/distros/jazzy/fuse-publishers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fuse-constraints, fuse-core, fuse-graphs, fuse-msgs, fuse-variables, geometry-msgs, nav-msgs, pluginlib, rclcpp, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-fuse-publishers";
-  version = "1.1.5-r1";
+  version = "1.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse_publishers/1.1.5-1.tar.gz";
-    name = "1.1.5-1.tar.gz";
-    sha256 = "c5f026497f1a8fef8fcf2cbeec97af7590b1ba9cea85223e33b8fcc1eef94f2e";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse_publishers/1.1.6-1.tar.gz";
+    name = "1.1.6-1.tar.gz";
+    sha256 = "a5ad6c313a7ee98629e9ad45a7802984bd4f630ec19c7257dc619106681bdb9d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fuse-tutorials/default.nix
+++ b/distros/jazzy/fuse-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, fuse-constraints, fuse-core, fuse-models, fuse-optimizers, fuse-publishers, fuse-variables, nav-msgs, rclcpp, rviz2, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-fuse-tutorials";
-  version = "1.1.5-r1";
+  version = "1.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse_tutorials/1.1.5-1.tar.gz";
-    name = "1.1.5-1.tar.gz";
-    sha256 = "c21b2e34df6feac20cdbc3c6d5c3052484b4cf41dff6cedeed2450501053e815";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse_tutorials/1.1.6-1.tar.gz";
+    name = "1.1.6-1.tar.gz";
+    sha256 = "06f2816af115c39e8337bd80eebbbfb88dba7bf4cb0dc3b94ebe0071d5d04bad";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fuse-variables/default.nix
+++ b/distros/jazzy/fuse-variables/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ceres-solver, fuse-core, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-fuse-variables";
-  version = "1.1.5-r1";
+  version = "1.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse_variables/1.1.5-1.tar.gz";
-    name = "1.1.5-1.tar.gz";
-    sha256 = "090a7c0c036eb697399cd6310789b3cdb6c7a0aecfdd9da584194dc9774a173a";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse_variables/1.1.6-1.tar.gz";
+    name = "1.1.6-1.tar.gz";
+    sha256 = "ac7d7945cf189dbd2cf1aff1a47b2668a0fe4902e63276019c282b3270b91ba5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fuse-viz/default.nix
+++ b/distros/jazzy/fuse-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, eigen, fuse-constraints, fuse-core, fuse-msgs, fuse-variables, geometry-msgs, qt5, rviz-common, rviz-rendering, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-fuse-viz";
-  version = "1.1.5-r1";
+  version = "1.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse_viz/1.1.5-1.tar.gz";
-    name = "1.1.5-1.tar.gz";
-    sha256 = "6dec62a23be5a1cdfcedeec08317815f0ea6b4862ab242d7c4f02676acfdba63";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse_viz/1.1.6-1.tar.gz";
+    name = "1.1.6-1.tar.gz";
+    sha256 = "314aad8aa8a5eac2a584450f773e3943890609cd70b2bc6887e9d718c597b6f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fuse/default.nix
+++ b/distros/jazzy/fuse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fuse-constraints, fuse-core, fuse-doc, fuse-graphs, fuse-models, fuse-msgs, fuse-optimizers, fuse-publishers, fuse-variables, fuse-viz }:
 buildRosPackage {
   pname = "ros-jazzy-fuse";
-  version = "1.1.5-r1";
+  version = "1.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse/1.1.5-1.tar.gz";
-    name = "1.1.5-1.tar.gz";
-    sha256 = "08b1c244272b46d66c2f7e322607d563ccdd85e4c50cc9a6a28c37224b80918d";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/jazzy/fuse/1.1.6-1.tar.gz";
+    name = "1.1.6-1.tar.gz";
+    sha256 = "f4145c66daf926a49a0dd5a1b0a236e861c38bad15076ec90b0efa262780c838";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -30,6 +30,10 @@ self: super: {
 
  adaptive-component = self.callPackage ./adaptive-component {};
 
+ adi-iio = self.callPackage ./adi-iio {};
+
+ adi-imu = self.callPackage ./adi-imu {};
+
  admittance-controller = self.callPackage ./admittance-controller {};
 
  ads-vendor = self.callPackage ./ads-vendor {};
@@ -771,6 +775,8 @@ self: super: {
  crazyflie-interfaces = self.callPackage ./crazyflie-interfaces {};
 
  crazyflie-py = self.callPackage ./crazyflie-py {};
+
+ crazyflie-server-cpp = self.callPackage ./crazyflie-server-cpp {};
 
  crazyflie-server-py = self.callPackage ./crazyflie-server-py {};
 
@@ -2434,6 +2440,8 @@ self: super: {
 
  mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
 
+ mujoco-3d-lidar = self.callPackage ./mujoco-3d-lidar {};
+
  mujoco-ros2-control = self.callPackage ./mujoco-ros2-control {};
 
  mujoco-ros2-control-demos = self.callPackage ./mujoco-ros2-control-demos {};
@@ -4008,8 +4016,6 @@ self: super: {
 
  swri-opencv-util = self.callPackage ./swri-opencv-util {};
 
- swri-roscpp = self.callPackage ./swri-roscpp {};
-
  swri-route-util = self.callPackage ./swri-route-util {};
 
  swri-serial-util = self.callPackage ./swri-serial-util {};
@@ -4329,6 +4335,8 @@ self: super: {
  udp-driver = self.callPackage ./udp-driver {};
 
  udp-msgs = self.callPackage ./udp-msgs {};
+
+ unbag = self.callPackage ./unbag {};
 
  uncrustify-vendor = self.callPackage ./uncrustify-vendor {};
 

--- a/distros/jazzy/gps-msgs/default.nix
+++ b/distros/jazzy/gps-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-gps-msgs";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/jazzy/gps_msgs/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "a945a786170436bd4541063df41e1525f3d41bd1be0342cdd589c8ce32ef241a";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/jazzy/gps_msgs/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "b85a1ac197459ce71cb4d1fbcd0155e3be64852186a919b8dea55e19742c61cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gps-tools/default.nix
+++ b/distros/jazzy/gps-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, gps-msgs, nav-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-gps-tools";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/jazzy/gps_tools/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "e3491f9ffe64af80bda43f391ba4b96dc2af23393b37debaff254e8a98f8662f";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/jazzy/gps_tools/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "ea191850b1058087702422be0b4e4ac1a4a660ff64b86a47a5dbd179ada1f853";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gps-umd/default.nix
+++ b/distros/jazzy/gps-umd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gps-msgs, gps-tools, gpsd-client }:
 buildRosPackage {
   pname = "ros-jazzy-gps-umd";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/jazzy/gps_umd/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "74cab107b62219993599ea083d0021b78a5d37bc09b8093e4e2d408e866d0cd2";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/jazzy/gps_umd/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "456fded4bbc6b2fb3d0dcf89d39936850ba6b00f6af5ace6dcb6f6843693304a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gpsd-client/default.nix
+++ b/distros/jazzy/gpsd-client/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, gps-msgs, gpsd, pkg-config, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, gps-msgs, gpsd, pkg-config, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-gpsd-client";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/jazzy/gpsd_client/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "94d4af71d18505f8ce9f73ba47f3cf8005403f82f83988daeaed08082b7d427b";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/jazzy/gpsd_client/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "464ef5c957cf2fcfa6acb82a60342b4d80445bc05df3e74a620d1fc63325ba17";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ros-environment ];
+  buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ];
   propagatedBuildInputs = [ gps-msgs gpsd pkg-config rclcpp rclcpp-components sensor-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake pkg-config ];
 
   meta = {
     description = "connects to a GPSd server and broadcasts GPS fixes 

--- a/distros/jazzy/gz-tools-vendor/default.nix
+++ b/distros/jazzy/gz-tools-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, ruby }:
 buildRosPackage {
   pname = "ros-jazzy-gz-tools-vendor";
-  version = "0.0.7-r1";
+  version = "0.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_tools_vendor-release/archive/release/jazzy/gz_tools_vendor/0.0.7-1.tar.gz";
-    name = "0.0.7-1.tar.gz";
-    sha256 = "5e681ed7dc3950c586f48b260f66c8fea5046b8537fef4c13cd92e473d2f514d";
+    url = "https://github.com/ros2-gbp/gz_tools_vendor-release/archive/release/jazzy/gz_tools_vendor/0.0.8-1.tar.gz";
+    name = "0.0.8-1.tar.gz";
+    sha256 = "19976d95d77d0c4f505e23541bad410c937f30c5707acdebaee07fc1c4902670";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-tools2 2.0.3
+    description = "Vendor package for: gz-tools2 2.0.4
 
     Gazebo Tools: Entrypoint to Gazebo's command line interface";
     license = with lib.licenses; [ asl20 ];

--- a/distros/jazzy/gz-tools-vendor/vendored-source.json
+++ b/distros/jazzy/gz-tools-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_tools_vendor": {
     "url": "https://github.com/gazebosim/gz-tools.git",
-    "rev": "gz-tools2_2.0.3",
-    "hash": "sha256-xMFJylj7OnDc7zVWiI4a/mvNpu9scz83F3bGopCt8l8="
+    "rev": "gz-tools2_2.0.4",
+    "hash": "sha256-WVeZg7Wreqz0eScbrgELEAsmpfr1Dy7HogZFjGEht/I="
   }
 }

--- a/distros/jazzy/gz-transport-vendor/default.nix
+++ b/distros/jazzy/gz-transport-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, cppzmq, gz-cmake-vendor, gz-math-vendor, gz-msgs-vendor, gz-tools-vendor, gz-utils-vendor, pkg-config, protobuf, python3, python3Packages, sqlite, util-linux }:
 buildRosPackage {
   pname = "ros-jazzy-gz-transport-vendor";
-  version = "0.0.7-r1";
+  version = "0.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_transport_vendor-release/archive/release/jazzy/gz_transport_vendor/0.0.7-1.tar.gz";
-    name = "0.0.7-1.tar.gz";
-    sha256 = "802a3d1aa94e2260ff1d022cf2841c125b39e562ff7590bc962e2b5695a7686a";
+    url = "https://github.com/ros2-gbp/gz_transport_vendor-release/archive/release/jazzy/gz_transport_vendor/0.0.8-1.tar.gz";
+    name = "0.0.8-1.tar.gz";
+    sha256 = "e691ba974be785581313bd7e0667b948c57abe3bf36fa6f5f034faa82d41b3a5";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-transport13 13.5.0
+    description = "Vendor package for: gz-transport13 13.6.0
 
     Gazebo Transport: Provides fast and efficient asynchronous message passing, services, and data logging.";
     license = with lib.licenses; [ asl20 ];

--- a/distros/jazzy/gz-transport-vendor/vendored-source.json
+++ b/distros/jazzy/gz-transport-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_transport_vendor": {
     "url": "https://github.com/gazebosim/gz-transport.git",
-    "rev": "gz-transport13_13.5.0",
-    "hash": "sha256-JTTlV1WdtLbHxNhLtoWyTnAcW6Hoh78lxxyDl1gLVAo="
+    "rev": "gz-transport13_13.6.0",
+    "hash": "sha256-NZnW74cBjZIoPlSlGfFB4llnkEnFTd5JZErhclrYJE0="
   }
 }

--- a/distros/jazzy/jrl-cmakemodules/default.nix
+++ b/distros/jazzy/jrl-cmakemodules/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catch2, cmake, doxygen, eigen, git, matio, pkg-config, python3Packages, simde }:
 buildRosPackage {
   pname = "ros-jazzy-jrl-cmakemodules";
-  version = "2.0.0-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/jrl_cmakemodules-release/archive/release/jazzy/jrl_cmakemodules/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "3cf85013f3388a441d5ecc747fe7d79383ef7ffca8c2d34dc317f87e8939daef";
+    url = "https://github.com/ros2-gbp/jrl_cmakemodules-release/archive/release/jazzy/jrl_cmakemodules/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "5e317bcc475644452b512d29eff4d9975551fe9e0f5fd4540c21221b2f3e88fb";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/laser-filters/default.nix
+++ b/distros/jazzy/laser-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, angles, diagnostic-msgs, diagnostic-updater, filters, laser-geometry, launch-testing-ament-cmake, message-filters, pluginlib, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, tf2, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-laser-filters";
-  version = "2.0.9-r1";
+  version = "2.0.10-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/laser_filters-release/archive/release/jazzy/laser_filters/2.0.9-1.tar.gz";
-    name = "2.0.9-1.tar.gz";
-    sha256 = "a99dfe73fbbf60063833da89700a3bba5a4220efaa3fbd429cfbe6eacd4a177f";
+    url = "https://github.com/ros2-gbp/laser_filters-release/archive/release/jazzy/laser_filters/2.0.10-5.tar.gz";
+    name = "2.0.10-5.tar.gz";
+    sha256 = "caae4813df84d614eaa2d12ac1ceb70e9ba35a1e6b59e86768bcec52f2fd2dc4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/libbno055-linux/default.nix
+++ b/distros/jazzy/libbno055-linux/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, geometry-msgs, lifecycle-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, geometry-msgs, lifecycle-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-libbno055-linux";
-  version = "1.7.2-r1";
+  version = "1.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/lazytatzv/libbno055_linux-release/archive/release/jazzy/libbno055_linux/1.7.2-1.tar.gz";
-    name = "1.7.2-1.tar.gz";
-    sha256 = "ea54cc2ea9b051850424f74c088b67879a4341faebaec9a2730e2be160476d25";
+    url = "https://github.com/lazytatzv/libbno055_linux-release/archive/release/jazzy/libbno055_linux/1.9.0-1.tar.gz";
+    name = "1.9.0-1.tar.gz";
+    sha256 = "0e0e5c8e2c6842602e05925f8f0cdb89411bb50dbdcf66806b7743a5c806f9f2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ diagnostic-msgs geometry-msgs lifecycle-msgs rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs std-srvs ];
+  propagatedBuildInputs = [ diagnostic-msgs geometry-msgs lifecycle-msgs rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/mapviz-interfaces/default.nix
+++ b/distros/jazzy/mapviz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-mapviz-interfaces";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/mapviz_interfaces/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "6a2d03cc5397e3eab2f220b804a7448a3cd1abaffd687955c02407e36ff27d07";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/mapviz_interfaces/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "c284b0ed7de2faf93b774aafb9b3b0a33f5e4e042b431d29f15fb8f057407532";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mapviz-plugins/default.nix
+++ b/distros/jazzy/mapviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, assimp, cv-bridge, geometry-msgs, gps-msgs, image-transport, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-sensor-msgs, marti-visualization-msgs, opencv, pluginlib, qt-gui-cpp, qt5or6, rclcpp, rclcpp-action, sensor-msgs, std-msgs, std-srvs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, tf2, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mapviz-plugins";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/mapviz_plugins/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "9c87d7fce9c1ffa1b35da82cf6054cee03ebbf954b63b6588deccec9f34417d7";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/mapviz_plugins/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "c9bc026c300b1b6ab7273f482515e06ee1f60d403ca1685701ef7406946cced6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mapviz/default.nix
+++ b/distros/jazzy/mapviz/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, image-transport, libxi, libxmu, mapviz-interfaces, opencv, pkg-config, pluginlib, qt5or6, rclcpp, rqt-gui, rqt-gui-cpp, std-srvs, swri-math-util, swri-transform-util, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-mapviz";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/mapviz/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "8301201e2bf734c7dddbb54f1d363063ee26fae208575d3f922a91133d0f6e19";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/mapviz/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "09c8ca59df688bd9ede1131b55fb991c818400dfd86b9e415aa42802e4f54e90";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake pkg-config ];
-  propagatedBuildInputs = [ geometry-msgs image-transport libxi libxmu mapviz-interfaces opencv opencv.cxxdev pluginlib qt5or6.qtbase rclcpp rqt-gui rqt-gui-cpp std-srvs swri-math-util swri-transform-util tf2 tf2-geometry-msgs tf2-ros yaml-cpp ];
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ geometry-msgs image-transport libxi libxmu mapviz-interfaces opencv opencv.cxxdev pkg-config pluginlib qt5or6.qtbase rclcpp rqt-gui rqt-gui-cpp std-srvs swri-math-util swri-transform-util tf2 tf2-geometry-msgs tf2-ros yaml-cpp ];
   nativeBuildInputs = [ ament-cmake pkg-config ];
 
   meta = {

--- a/distros/jazzy/metavision-driver/default.nix
+++ b/distros/jazzy/metavision-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-xmllint, event-camera-msgs, openeb-vendor, rclcpp, rclcpp-components, ros-environment, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-metavision-driver";
-  version = "3.0.0-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/metavision_driver-release/archive/release/jazzy/metavision_driver/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "1dc1ac378215a6f62a12424c2c8f9027d915fb08286540fc1fbc7c51c0e7b2c5";
+    url = "https://github.com/ros2-gbp/metavision_driver-release/archive/release/jazzy/metavision_driver/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "ce62a6066389d6952f97ffc8987591b053c91c7d838b998fed38a8f101e13494";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ros-environment ];
 
   meta = {
-    description = "ROS1 and ROS2 drivers for metavision based event cameras";
+    description = "ROS2 driver for metavision based event cameras";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/jazzy/mola-bridge-ros2/default.nix
+++ b/distros/jazzy/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, diagnostic-msgs, geographic-msgs, geometry-msgs, gps-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-bridge-ros2";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_bridge_ros2/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "ae0ebdc91d591eccf6899fca8febd6e32c35e47e0fe18c33dc17138d7582ba44";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_bridge_ros2/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "777613833664590f35e22f82d2b5b2c33245bae5809d734f398bdfe2ff70a118";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-demos/default.nix
+++ b/distros/jazzy/mola-demos/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, cmake, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-xmllint, ament-lint-auto, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-demos";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_demos/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "880068fc5702a1b5922c752e66b643d28cd6b75130682f7f1be7ee6f8c6e6d6d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_demos/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "56ac1bd938b8c146e97b9c3deeb90d36ddd0151052ca15630354793bbc6391b7";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest cmake ros-environment ];
-  checkInputs = [ ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  checkInputs = [ ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-xmllint ament-lint-auto ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/jazzy/mola-input-lidar-bin-dataset/default.nix
+++ b/distros/jazzy/mola-input-lidar-bin-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-lidar-bin-dataset";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_lidar_bin_dataset/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "6ac2651b814413aa11f0ec99ef5cf7fe074223a922aee0387dfe0b1461c96872";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_lidar_bin_dataset/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "ccb545b965a04e39eec77ff350c6d802bfffcec070553aad5216225c21e47180";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-rawlog/default.nix
+++ b/distros/jazzy/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-rawlog";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rawlog/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "6ae2cf998af2e34e8424e6446ac4cbc48517608bb581d144e26a0fe79c85d67b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rawlog/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "81120f82b52b7f96f01b96b99504f5347fa1d287ec4dbcfbb27f59b0133f94b4";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-rosbag2/default.nix
+++ b/distros/jazzy/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, gps-msgs, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-rosbag2";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rosbag2/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "84f1dbdaaec2b66e80ba1248f2cfe5f6e110f65feada1fb8cd8690fef06d0298";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rosbag2/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "15421689e46a5f4829694c219de2aea0ed5e8ddb219fc0a6e62b041318fc14f4";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-video/default.nix
+++ b/distros/jazzy/mola-input-video/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libhwdrivers, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-video";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_video/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "d3dd94cced6a89f947cd471fe084ee05536443aa67c33db9582e8c771dcfea1c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_video/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "f292929f84b197b5d6c3d5c44fa02828e35e945ebd25ce668b53fdad00665ef5";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-kernel/default.nix
+++ b/distros/jazzy/mola-kernel/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libgui, mrpt-libmaps, mrpt-libobs }:
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-kernel";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_kernel/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "923593197be596af5d32b09ed01c75e0b4cdccfc603770ef44d396e0f8957b88";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_kernel/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "71b19c451793e838fb1bf5eb13f76341b1f0294d121bb744b7c3dce41da4f9d3";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
-  propagatedBuildInputs = [ mola-common mola-yaml mrpt-libgui mrpt-libmaps mrpt-libobs ];
+  propagatedBuildInputs = [ mola-common mola-yaml mrpt-libmaps mrpt-libobs ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/jazzy/mola-launcher/default.nix
+++ b/distros/jazzy/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-xmllint, ament-lint-auto, cli11, cmake, mola-kernel, mrpt-libbase, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-launcher";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_launcher/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "0b1ac3fffa3f4b08cbe2f187fbbf89c19e294186aaab522775e6915772db2725";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_launcher/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "496a1639f111f4506f96b98b20f3c1c3ff25dc329d7974ae836568a48dbd2c38";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-lidar-odometry/default.nix
+++ b/distros/jazzy/mola-lidar-odometry/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cli11, cmake, mola-common, mola-imu-preintegration, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mola-yaml, mp2p-icp, mrpt-libmaps, ros-environment, rosbag2-storage-mcap }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cli11, cmake, mola-bridge-ros2, mola-common, mola-imu-preintegration, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-state-estimation-smoother, mola-test-datasets, mola-viz, mola-viz-imgui, mola-yaml, mp2p-icp, mrpt-libmaps, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-jazzy-mola-lidar-odometry";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/jazzy/mola_lidar_odometry/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "c40e7139cce2b4c1f28161d7df83e89b496e6705acb5747ab915408fc96cb777";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/jazzy/mola_lidar_odometry/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "3b9cee32360723a134ed2b60e624797419ebb474b754c29c2b7e9f1e12f733ef";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-test-datasets rosbag2-storage-mcap ];
-  propagatedBuildInputs = [ cli11 mola-common mola-imu-preintegration mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-pose-list mola-state-estimation-simple mola-viz mola-yaml mp2p-icp mrpt-libmaps ];
+  propagatedBuildInputs = [ cli11 mola-bridge-ros2 mola-common mola-imu-preintegration mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-pose-list mola-state-estimation-simple mola-state-estimation-smoother mola-viz mola-viz-imgui mola-yaml mp2p-icp mrpt-libmaps ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/jazzy/mola-metric-maps/default.nix
+++ b/distros/jazzy/mola-metric-maps/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cli11, cmake, mola-common, mola-kernel, mp2p-icp, mrpt-libmaps, onetbb, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cli11, cmake, mola-common, mola-kernel, mp2p-icp, mrpt-libmaps, nanoflann-vendor, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-metric-maps";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_metric_maps/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "e6688058c7f375dbb191191ea2e4b4eb168b807e4daad2f63210a50c2fdddaf4";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_metric_maps/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "1cedd9c6250b3a46a0b397d03f04b54343d1298c3b8ef322a35ed750f8bcdb92";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ cli11 mola-common mola-kernel mp2p-icp mrpt-libmaps onetbb ];
+  propagatedBuildInputs = [ cli11 mola-common mola-kernel mp2p-icp mrpt-libmaps nanoflann-vendor onetbb ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/jazzy/mola-msgs/default.nix
+++ b/distros/jazzy/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-mola-msgs";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "75d627f427ef558e14f8a2e5baa4d029c28dcacade97e51acfd75bb095396a76";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_msgs/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "b00cbc02805480081f6f4288162f35a305fbb6935b5d4cf9ab95f6a133a39367";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-pose-list/default.nix
+++ b/distros/jazzy/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-jazzy-mola-pose-list";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_pose_list/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "8f70d04db066d92aeeb1fbe533271993151978d49506c66d480292dfc1066461";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_pose_list/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "0e06a6e24bcb2b3e9a08123bbbfb5d1f9939b3bee65643d0a5e515277c353163";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-relocalization/default.nix
+++ b/distros/jazzy/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-jazzy-mola-relocalization";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_relocalization/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "0c02c5c637a203b4884198b5a61480ba8e98a674a27e9307edaf393ceccec199";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_relocalization/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "61347d079144112edb98f80a5dd511a3bc3431316b453ccf4e87493dab00040f";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-traj-tools/default.nix
+++ b/distros/jazzy/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-jazzy-mola-traj-tools";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_traj_tools/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "e17bceffae3226c0c1a60b913e2bce97eb549d188419121cfa73d563a2e391ac";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_traj_tools/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "9230c323ef545601b3b40916d8b1c1758619c1ec89ac4795614946956baf83e5";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-viz-imgui/default.nix
+++ b/distros/jazzy/mola-viz-imgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, freeglut, glfw3, libGL, libGLU, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-jazzy-mola-viz-imgui";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_viz_imgui/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "e88efbfb700f9c787d8f0406eb7573e47e31e71438765e8860471499d341c0a3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_viz_imgui/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "6004847df92d65dbda6f4e16e8915658acc647b4a1b4bd8b8f1125fd259e7e53";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-viz/default.nix
+++ b/distros/jazzy/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-jazzy-mola-viz";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_viz/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "af5ccfd234990c6e89daed35eeb5e46178ff7ba499563160715eb4b2d147a99b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_viz/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "7b52e6890e2d9a6f63a831c65f12f0ae0c4c88f5d4c82ae94eb905f4c34e6eac";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-yaml/default.nix
+++ b/distros/jazzy/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-jazzy-mola-yaml";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_yaml/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "efa1ab81a154076971a2d42e0a7f1f219665964902e52a1738bb5bd65abb0334";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_yaml/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "12ef41769138048dbb8977e683fe613150bbfa82fed5e804eaaefe437c7cd953";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola/default.nix
+++ b/distros/jazzy/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-bridge-ros2, mola-demos, mola-input-rawlog, mola-input-rosbag2, mola-input-video, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-jazzy-mola";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "15a2a5c4203ffdc34d320b90231d0fd4d72c83903e8fed0aecd6f98ab8f62d4b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "b1013899b72e6ba9b0732d2c3afb5d64febd5880c373d6c63f6852b467f56e4b";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mp2p-icp-core/default.nix
+++ b/distros/jazzy/mp2p-icp-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cli11, cmake, mola-common, mola-imu-preintegration, mrpt-libbase, mrpt-libmaps, mrpt-libobs, mrpt-libposes, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mp2p-icp-core";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/jazzy/mp2p_icp_core/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "7c602bf8f6de409f99868f760748b6b5c414f3c25c8c871c3cf398d5e7b35447";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/jazzy/mp2p_icp_core/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "d53488a618ad8728e56cdbaf0999deb156c56249d49e660d00111f312ca7d426";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mp2p-icp-viz/default.nix
+++ b/distros/jazzy/mp2p-icp-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cli11, cmake, mola-common, mp2p-icp-core, mrpt-libgui, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mp2p-icp-viz";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/jazzy/mp2p_icp_viz/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "06d4ebb0c8f876d8274e0dcfc704e11b12e5253c776a741f1f1a9f2e336f3f15";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/jazzy/mp2p_icp_viz/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "1e44e269adde02d3b390a42a139fadecc917e8a0506da602969813bb0104278b";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mp2p-icp/default.nix
+++ b/distros/jazzy/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mp2p-icp-core, mp2p-icp-viz }:
 buildRosPackage {
   pname = "ros-jazzy-mp2p-icp";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/jazzy/mp2p_icp/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "44b6375ac4ad8862bb130c69391dc642ee44503f2cb2efe78e6865c584b7324c";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/jazzy/mp2p_icp/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "0b4204a14f4b2ff36620673bae888f46cc5cf6d45c3a1f40c3a36f094c5d1a27";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mujoco-3d-lidar/default.nix
+++ b/distros/jazzy/mujoco-3d-lidar/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, mujoco-vendor }:
+buildRosPackage {
+  pname = "ros-jazzy-mujoco-3d-lidar";
+  version = "0.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/jazzy/mujoco_3d_lidar/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "3bb5f31e83309194f736a9b029a294b3d0bdcf7917ae582961977a7c388e800b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ mujoco-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Plugin for mujoco to use raycasters to simulate lidar";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/mujoco-ros2-control-demos/default.nix
+++ b/distros/jazzy/mujoco-ros2-control-demos/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, forward-command-controller, joint-state-broadcaster, mujoco-ros2-control, mujoco-ros2-control-msgs, robot-state-publisher, rviz2, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, forward-command-controller, joint-state-broadcaster, launch, launch-ros, mujoco-ros2-control, mujoco-ros2-control-msgs, pose-broadcaster, robot-state-publisher, rviz2, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-mujoco-ros2-control-demos";
-  version = "0.0.3-r1";
+  version = "0.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/jazzy/mujoco_ros2_control_demos/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "3806a132bf492ad827f0225a3f6f4365789a8ab61dd07670fae65f343e57d400";
+    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/jazzy/mujoco_ros2_control_demos/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "43f683898f9fe57f254d79d2531fafe9ea831c53ffc9edd071dc4b5e127b7de1";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ controller-manager forward-command-controller joint-state-broadcaster mujoco-ros2-control mujoco-ros2-control-msgs robot-state-publisher rviz2 xacro ];
+  propagatedBuildInputs = [ controller-manager forward-command-controller joint-state-broadcaster launch launch-ros mujoco-ros2-control mujoco-ros2-control-msgs pose-broadcaster robot-state-publisher rviz2 xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/mujoco-ros2-control-msgs/default.nix
+++ b/distros/jazzy/mujoco-ros2-control-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mujoco-ros2-control-msgs";
-  version = "0.0.3-r1";
+  version = "0.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/jazzy/mujoco_ros2_control_msgs/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "4d48810e66d3ac64ac5e7012787a39744b00c83dbc14c1e170a9022eda19b8b9";
+    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/jazzy/mujoco_ros2_control_msgs/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "ba151c5265289a335dae7030e919d601754855212ed897fb7a2fd0a9361aff11";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime sensor-msgs std-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/jazzy/mujoco-ros2-control-plugins/default.nix
+++ b/distros/jazzy/mujoco-ros2-control-plugins/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, backward-ros, geometry-msgs, mujoco-ros2-control-msgs, mujoco-vendor, pluginlib, rclcpp, realtime-tools, ros2-control-cmake, std-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, backward-ros, geometry-msgs, glfw3, libGL, libGLU, mujoco-3d-lidar, mujoco-ros2-control-msgs, mujoco-vendor, pluginlib, rclcpp, realtime-tools, ros2-control-cmake, sensor-msgs, std-msgs, std-srvs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mujoco-ros2-control-plugins";
-  version = "0.0.3-r1";
+  version = "0.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/jazzy/mujoco_ros2_control_plugins/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "360e0831295836bc302af3a7026b76a12ba564bc6ae18c99ea21e2988baa041a";
+    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/jazzy/mujoco_ros2_control_plugins/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "04d254ce47c155c9ba8d47a060f938bde6e40c84e5dc9045e199e030ae805ee8";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gtest ];
-  propagatedBuildInputs = [ backward-ros geometry-msgs mujoco-ros2-control-msgs mujoco-vendor pluginlib rclcpp realtime-tools ros2-control-cmake std-msgs visualization-msgs ];
+  checkInputs = [ ament-cmake-gtest ament-index-cpp mujoco-3d-lidar ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs glfw3 libGL libGLU mujoco-ros2-control-msgs mujoco-vendor pluginlib rclcpp realtime-tools ros2-control-cmake sensor-msgs std-msgs std-srvs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/mujoco-ros2-control/default.nix
+++ b/distros/jazzy/mujoco-ros2-control/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-index-python, backward-ros, control-toolbox, controller-manager, fmt, git, glfw3, hardware-interface, mujoco-ros2-control-msgs, mujoco-ros2-control-plugins, mujoco-vendor, nav-msgs, pluginlib, python3, python3Packages, rclcpp, rclcpp-lifecycle, ros2-control-cmake, sensor-msgs, transmission-interface, urdfdom-py }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-index-cpp, ament-index-python, backward-ros, control-toolbox, controller-manager, eigen, fmt, geometry-msgs, git, glfw3, hardware-interface, mujoco-ros2-control-msgs, mujoco-ros2-control-plugins, mujoco-vendor, nav-msgs, pluginlib, python3, python3Packages, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2pkg, rosgraph-msgs, sensor-msgs, std-msgs, tinyxml2-vendor, transmission-interface, urdfdom-py }:
 buildRosPackage {
   pname = "ros-jazzy-mujoco-ros2-control";
-  version = "0.0.3-r1";
+  version = "0.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/jazzy/mujoco_ros2_control/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "3631dee42db888d03c36a041868dcdde6634e8f89c209d5f2294fc15c468a16a";
+    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/jazzy/mujoco_ros2_control/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "d38803b77480cd7fc1c09d641a1a421b9211f7229c71c7c45ac27e195b2c7c4c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python git ros2-control-cmake ];
   checkInputs = [ ament-cmake-gtest ament-cmake-pytest ];
-  propagatedBuildInputs = [ ament-index-python backward-ros control-toolbox controller-manager fmt glfw3 hardware-interface mujoco-ros2-control-msgs mujoco-ros2-control-plugins mujoco-vendor nav-msgs pluginlib python3 python3Packages.importlib-resources python3Packages.numpy python3Packages.pip python3Packages.pykdl rclcpp rclcpp-lifecycle sensor-msgs transmission-interface urdfdom-py ];
+  propagatedBuildInputs = [ ament-index-cpp ament-index-python backward-ros control-toolbox controller-manager eigen fmt geometry-msgs glfw3 hardware-interface mujoco-ros2-control-msgs mujoco-ros2-control-plugins mujoco-vendor nav-msgs pluginlib python3 python3Packages.importlib-resources python3Packages.numpy python3Packages.pip python3Packages.pykdl rclcpp rclcpp-lifecycle realtime-tools ros2pkg rosgraph-msgs sensor-msgs std-msgs tinyxml2-vendor transmission-interface urdfdom-py ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python git ];
 
   meta = {

--- a/distros/jazzy/multires-image/default.nix
+++ b/distros/jazzy/multires-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, gps-msgs, mapviz, mapviz-interfaces, marti-common-msgs, pluginlib, python3Packages, qt-gui-cpp, qt5or6, rclcpp, rclpy, swri-math-util, swri-transform-util, tf2 }:
 buildRosPackage {
   pname = "ros-jazzy-multires-image";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/multires_image/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "a068b40309bb6144541508edc593176e979b0dc8cad03cd597353d1346810006";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/multires_image/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "25f49e9f9ed71e9eb2f13c4b99a2a2767a2451ab88f1f8f86893982eb898cf65";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/novatel-gps-driver/default.nix
+++ b/distros/jazzy/novatel-gps-driver/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, boost, diagnostic-msgs, diagnostic-updater, gps-msgs, libpcap, nav-msgs, novatel-gps-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, swri-math-util, swri-roscpp, swri-serial-util, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, _unresolved_swri_roscpp, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, boost, diagnostic-msgs, diagnostic-updater, gps-msgs, libpcap, nav-msgs, novatel-gps-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, swri-math-util, swri-serial-util, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-novatel-gps-driver";
   version = "4.3.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ];
-  propagatedBuildInputs = [ boost diagnostic-msgs diagnostic-updater gps-msgs libpcap nav-msgs novatel-gps-msgs rclcpp rclcpp-components sensor-msgs std-msgs swri-math-util swri-roscpp swri-serial-util tf2 tf2-geometry-msgs ];
+  propagatedBuildInputs = [ _unresolved_swri_roscpp boost diagnostic-msgs diagnostic-updater gps-msgs libpcap nav-msgs novatel-gps-msgs rclcpp rclcpp-components sensor-msgs std-msgs swri-math-util swri-serial-util tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/pal-statistics-msgs/default.nix
+++ b/distros/jazzy/pal-statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-pal-statistics-msgs";
-  version = "2.8.0-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/jazzy/pal_statistics_msgs/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "1d0a4c6c4d04b3960ab61f96c81039aa61aa58d4663c93593022d9f2a3327c36";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/jazzy/pal_statistics_msgs/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "24928e99b5d75610b423f6225a499cb70f9c11d544b0da743086356d6ead9b13";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pal-statistics/default.nix
+++ b/distros/jazzy/pal-statistics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, boost, pal-statistics-msgs, rclcpp, rclcpp-lifecycle, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-pal-statistics";
-  version = "2.8.0-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/jazzy/pal_statistics/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "65cf83a0c34ba7fa06012ed78781625d075547a3d55c5e2fd07110d5aa655e97";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/jazzy/pal_statistics/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "a6c0e1289293dd045ffbd68d7f9fe14ffaec0c8e8e987767ade270f917448268";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pangolin/default.nix
+++ b/distros/jazzy/pangolin/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catch2, cmake, eigen, glew, libGL, libGLU, libepoxy, libjpeg, libpng, libxkbcommon, python3, python3Packages, wayland }:
+{ lib, buildRosPackage, fetchurl, catch2, cmake, eigen, glew, libGL, libGLU, libepoxy, libjpeg, libpng, libxkbcommon, openexr, python3, python3Packages, wayland }:
 buildRosPackage {
   pname = "ros-jazzy-pangolin";
-  version = "0.9.5-r1";
+  version = "0.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Pangolin-release/archive/release/jazzy/pangolin/0.9.5-1.tar.gz";
-    name = "0.9.5-1.tar.gz";
-    sha256 = "202de34075c91adfba07ec8612a1adbe3612d50de4f5ecb79186495ba99baf37";
+    url = "https://github.com/ros2-gbp/Pangolin-release/archive/release/jazzy/pangolin/0.9.6-1.tar.gz";
+    name = "0.9.6-1.tar.gz";
+    sha256 = "7d22ee64242e1bde2b56b3e1fa6aad40d6a99e791020da88bac1704cbec4fcba";
   };
 
   buildType = "cmake";
-  buildInputs = [ cmake eigen python3Packages.wheel ];
+  buildInputs = [ cmake eigen python3Packages.setuptools python3Packages.wheel ];
   checkInputs = [ catch2 ];
-  propagatedBuildInputs = [ glew libGL libGLU libepoxy libjpeg libpng libxkbcommon python3 wayland ];
+  propagatedBuildInputs = [ glew libGL libGLU libepoxy libjpeg libpng libxkbcommon openexr python3 wayland ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/jazzy/rmw-cyclonedds-cpp/default.nix
+++ b/distros/jazzy/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, iceoryx-binding-c, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-jazzy-rmw-cyclonedds-cpp";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/jazzy/rmw_cyclonedds_cpp/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "aba4244bf29f70eda772b65b53de06505f3009b1fd492ee765e45b596e0f13e3";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/jazzy/rmw_cyclonedds_cpp/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "4445946339ab372dfb90f717ce05fa2bf2a1f4cb9e0c815401ad5063fb097a8f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/swri-cli-tools/default.nix
+++ b/distros/jazzy/swri-cli-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, marti-introspection-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, ros2topic }:
 buildRosPackage {
   pname = "ros-jazzy-swri-cli-tools";
-  version = "3.9.0-r1";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_cli_tools/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "4e796467871d2eb7315dae841e69abefa98b25f6e46266d81b22891728d87358";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_cli_tools/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "1963694ab5ad85352ec29a24631de774034e01e7dec17851efeb6bec6e4d1c3a";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/swri-console-util/default.nix
+++ b/distros/jazzy/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-swri-console-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_console_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "427036a43aaa47f3d986ace85e2071bd70b34f88424b28c5d1e450c884018665";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_console_util/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "0915f8b5b146148f5d459fcb944bc4e4ae6baea2596167553247ec08d18d0e66";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/swri-dbw-interface/default.nix
+++ b/distros/jazzy/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-swri-dbw-interface";
-  version = "3.9.0-r1";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_dbw_interface/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "46c990b731a466b947494756167b61caa234c0d6a3ce443bd2ff2e4c60acb9a4";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_dbw_interface/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "cafd8f796cdf9179bfcb94ef05131f04996a777ab78aea232876c5f08a11d636";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/swri-geometry-util/default.nix
+++ b/distros/jazzy/swri-geometry-util/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, geos, opencv, pkg-config, tf2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, geos, opencv, tf2 }:
 buildRosPackage {
   pname = "ros-jazzy-swri-geometry-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_geometry_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "93c32399fa7ce94f5f55bd020fc01d097461ee8efb81ccccedccb0c1252a3cd4";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_geometry_util/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "9ec195fe63ec3b8c144d78bcda0a4b225372d277cc348b9100a0a66d7e575bab";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake pkg-config ];
+  buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ];
   propagatedBuildInputs = [ eigen geos opencv opencv.cxxdev tf2 ];
-  nativeBuildInputs = [ ament-cmake pkg-config ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = "Commonly used geometry routines, implemented in a ROS friendly package.";

--- a/distros/jazzy/swri-image-util/default.nix
+++ b/distros/jazzy/swri-image-util/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, camera-calibration-parsers, cv-bridge, eigen, image-geometry, image-transport, message-filters, opencv, pkg-config, rcl-interfaces, rclcpp, rclcpp-components, rclpy, swri-geometry-util, swri-math-util, swri-opencv-util, tf2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, camera-calibration-parsers, cv-bridge, eigen, image-geometry, image-transport, message-filters, opencv, rcl-interfaces, rclcpp, rclcpp-components, rclpy, swri-geometry-util, swri-math-util, swri-opencv-util, tf2 }:
 buildRosPackage {
   pname = "ros-jazzy-swri-image-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_image_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "0ba0b07706c27a505d07e47f9f04f2a2912e2d17be4f4873243cc37faa788a27";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_image_util/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "ba75efb6203bab5de84cb6bc88d666475539c38870411621ff51cb31d1bc3e69";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake pkg-config ];
+  buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ];
   propagatedBuildInputs = [ ament-index-cpp camera-calibration-parsers cv-bridge eigen image-geometry image-transport message-filters opencv opencv.cxxdev rcl-interfaces rclcpp rclcpp-components rclpy swri-geometry-util swri-math-util swri-opencv-util tf2 ];
-  nativeBuildInputs = [ ament-cmake pkg-config ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = "A package of commonly image manipulation utilities.";

--- a/distros/jazzy/swri-math-util/default.nix
+++ b/distros/jazzy/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-swri-math-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_math_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "3a3380501dfebe321ba8696e0216204721d9a969a30f113dca3a90cabf4a5fbf";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_math_util/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "427f54de9250ccc708583c20fce487a620e5a1447eacfd4d92169a5392edd8c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/swri-opencv-util/default.nix
+++ b/distros/jazzy/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, opencv, swri-math-util }:
 buildRosPackage {
   pname = "ros-jazzy-swri-opencv-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_opencv_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "81e278da9529271d8a2adc38bf376c577fd6d4f82d5dcdb3386436b08ce021d8";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_opencv_util/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "e43b73a075a1317f62488c70b6546f1472495f87c594f60cb39bdd234dddc258";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/swri-route-util/default.nix
+++ b/distros/jazzy/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-transform-util, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-swri-route-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_route_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "1de3e759c8dddee15d3773b044f4a6da5e2990a548c6a5030ef6cc5d864a5505";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_route_util/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "24e23b9546ddfc2df4ff49a99cc4880f4d7e23e045b8b1352e70a93101dcc9ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/swri-serial-util/default.nix
+++ b/distros/jazzy/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-swri-serial-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_serial_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "aa8fac8309c43bfc8b3b7776e2490fd4dfc6c29e311137dff806d8fb5bd7fc66";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_serial_util/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "a3435db4fc542ca47c0688c5e339dbbf6c0fbd09d2a5642670986fcb188dfc25";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/swri-transform-util/default.nix
+++ b/distros/jazzy/swri-transform-util/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-index-cpp, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geographiclib, geometry-msgs, geos, gps-msgs, launch-ros, launch-testing, launch-testing-ament-cmake, marti-nav-msgs, opencv, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-index-cpp, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geographiclib, geometry-msgs, geos, gps-msgs, launch-ros, launch-testing, launch-testing-ament-cmake, marti-nav-msgs, opencv, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-swri-transform-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_transform_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "c8c9e53d6eedc1c251e888b92a23051a6a8491c4f338f4ecdad0238756f73e7f";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_transform_util/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "1514d9690ca259230e5e24ca458ca750506df1a8efef312d2d9cd93470eeb709";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python pkg-config ];
   checkInputs = [ ament-cmake-gtest ament-index-cpp launch-ros launch-testing launch-testing-ament-cmake ];
-  propagatedBuildInputs = [ cv-bridge diagnostic-msgs diagnostic-updater geographic-msgs geographiclib geometry-msgs geos gps-msgs marti-nav-msgs opencv opencv.cxxdev proj python3Packages.numpy python3Packages.pyyaml rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util swri-roscpp tf2 tf2-geometry-msgs tf2-ros yaml-cpp-vendor ];
+  propagatedBuildInputs = [ cv-bridge diagnostic-msgs diagnostic-updater geographic-msgs geographiclib geometry-msgs geos gps-msgs marti-nav-msgs opencv opencv.cxxdev proj python3Packages.numpy python3Packages.pyyaml rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util tf2 tf2-geometry-msgs tf2-ros yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python pkg-config ];
 
   meta = {

--- a/distros/jazzy/tile-map/default.nix
+++ b/distros/jazzy/tile-map/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, jsoncpp, mapviz, pluginlib, qt-gui-cpp, qt5or6, rclcpp, swri-math-util, swri-transform-util, tf2, yaml-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-tile-map";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/tile_map/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "0197eeaed98b4257dc70cb6696387a4f34d06d940716ce6280a1c56b249cdd33";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/tile_map/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "95e456360d20db5380f746264b0ee8c18af71790946c0c7a19259d3c6aefce46";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/unbag/default.nix
+++ b/distros/jazzy/unbag/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-index-python, ament-lint-auto, ament-lint-common, python3, python3Packages, qt5, rclpy, ros2cli, rosbag2-py, rosidl-runtime-py, sensor-msgs, tf2-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-unbag";
+  version = "1.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/unbag-release/archive/release/jazzy/unbag/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "2f1e18ae4497e37d6e723428b13d0037fc627ea5bfea77e1657abc1c0db5df06";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python python3 python3Packages.setuptools qt5.qtbase ];
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-python python3Packages.numpy python3Packages.opencv4 python3Packages.pyyaml python3Packages.tqdm qt5.qtsvg rclpy ros2cli rosbag2-py rosidl-runtime-py sensor-msgs tf2-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "A ROS 2 tool for exporting bags to human readable files. Supports pluggable export routines to handle any message type.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kilted/behaviortree-cpp/default.nix
+++ b/distros/kilted/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, git, rclcpp, ros-environment, sqlite, tinyxml-2, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-kilted-behaviortree-cpp";
-  version = "4.9.1-r1";
+  version = "4.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/kilted/behaviortree_cpp/4.9.1-1.tar.gz";
-    name = "4.9.1-1.tar.gz";
-    sha256 = "46e4c4f10ba2a34a0850126e637cf5da5339a365459f867758a504d17cef9be1";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/kilted/behaviortree_cpp/4.9.0-1.tar.gz";
+    name = "4.9.0-1.tar.gz";
+    sha256 = "9552577128be47a8eefa838437333198f5f8faf2b1b387d3ea61b55931906cb1";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/depthai/default.nix
+++ b/distros/kilted/depthai/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, curl, fmt, gfortran, libtar, libusb1, nlohmann_json, opencv, ros-environment, spdlog, udev, unzip, zip }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, curl, fmt, gfortran, libusb1, nlohmann_json, opencv, ros-environment, spdlog, udev, unzip, zip }:
 buildRosPackage {
   pname = "ros-kilted-depthai";
-  version = "3.7.1-r3";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/kilted/depthai/3.7.1-3.tar.gz";
-    name = "3.7.1-3.tar.gz";
-    sha256 = "b24cf842426d7c9a0919d075ae214ffeca66e18a9e61e0b03550bb5dff893fc3";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/kilted/depthai/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "71a177a429bc1ff61f3e664e3ea9d4b74e06fa2766cd8f87309e35e56ff5aa7a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ curl fmt gfortran libtar libusb1 nlohmann_json opencv opencv.cxxdev spdlog udev unzip zip ];
+  propagatedBuildInputs = [ curl fmt gfortran libusb1 nlohmann_json opencv opencv.cxxdev spdlog udev unzip zip ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/fuse-constraints/default.nix
+++ b/distros/kilted/fuse-constraints/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ceres-solver, eigen, fuse-core, fuse-graphs, fuse-variables, gbenchmark, geometry-msgs, gtest-vendor, pluginlib, rclcpp, suitesparse }:
 buildRosPackage {
   pname = "ros-kilted-fuse-constraints";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse_constraints/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "91434eacb773118de51cf2a4d0d62b2f363d883f547e2bc0580aed8d41caac36";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse_constraints/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "f06bcff7ba6d53c2e4536abb301c5d302c404950ff8a61825cf007213564eeb2";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/fuse-core/default.nix
+++ b/distros/kilted/fuse-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, boost, ceres-solver, eigen, fuse-msgs, geometry-msgs, glog, gtest-vendor, launch, launch-pytest, pluginlib, rcl-interfaces, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-kilted-fuse-core";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse_core/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "c4645ae13f7d40fcb9c8c2d1cff4ba742cc4ffe85e565c061e4abab0576f1edf";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse_core/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "279db0a4005486e0eb5663ac99def2abc176f8926e470f123114fe25f59a6487";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/fuse-doc/default.nix
+++ b/distros/kilted/fuse-doc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, gtest-vendor }:
 buildRosPackage {
   pname = "ros-kilted-fuse-doc";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse_doc/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "6702c8a423035f404182f58fd767af99f299657c72606c9a9487a8cdc205858c";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse_doc/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "53ce8bdfe6fa6ee381f33736a4991b5eb7538c8659222602e196075304ec498b";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/fuse-graphs/default.nix
+++ b/distros/kilted/fuse-graphs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ceres-solver, fuse-core, gbenchmark, gtest-vendor, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-kilted-fuse-graphs";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse_graphs/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "99203002d3dd93333c4e38196482f1d85709cbbeb8b6aa3ee82f913717694424";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse_graphs/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "6858d467670ca5d7ed2d3aa6b23438f213fbbd597febc9444737192acb6c2156";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/fuse-loss/default.nix
+++ b/distros/kilted/fuse-loss/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ceres-solver, fuse-core, gtest-vendor, libsForQt5, pluginlib, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-kilted-fuse-loss";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse_loss/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "e952fd9cfecca1899c3e5d37ff7da211646fc82e412b35530c7264fff61a60db";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse_loss/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "28ba5d3dca2721c157cf6ac70ab21c0402d8b296ac920d12e0d01080bdac1976";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/fuse-models/default.nix
+++ b/distros/kilted/fuse-models/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, boost, ceres-solver, eigen, fuse-constraints, fuse-core, fuse-graphs, fuse-msgs, fuse-publishers, fuse-variables, gbenchmark, geometry-msgs, gtest-vendor, nav-msgs, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-srvs, tf2, tf2-2d, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-fuse-models";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse_models/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "79b5518895c28659a55ceefce981ddedecbd6c21e5b0588c93cd5775b4ffdbe1";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse_models/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "7d329c7c8734cfe53164b5f0fc359e6c45e6479bc390bc041c324cd1f5c6d7e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/fuse-msgs/default.nix
+++ b/distros/kilted/fuse-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, geometry-msgs, gtest-vendor, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-fuse-msgs";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse_msgs/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "b9d0c288cad48e393c0ee31f569a6efede61142fef1bf066f1ff8edfb35ef752";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse_msgs/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "21901be909c0fcc40c64ab2396d4448ece170ae40c6a7ee0c3d85d11e6b99f63";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/fuse-optimizers/default.nix
+++ b/distros/kilted/fuse-optimizers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, boost, ceres-solver, diagnostic-updater, eigen, fuse-constraints, fuse-core, fuse-graphs, fuse-models, fuse-msgs, fuse-variables, geometry-msgs, gtest-vendor, launch, launch-pytest, launch-ros, nav-msgs, pluginlib, rclcpp, rclcpp-components, std-srvs }:
 buildRosPackage {
   pname = "ros-kilted-fuse-optimizers";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse_optimizers/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "555058bd3b69a09ebe65fc0370f9a0a8c1ff617ae92149f279b3651c3268a965";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse_optimizers/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "47a023a2018657811b12d4b5a455d01d5a7f0ef4adff404aa5b5e03687b139b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/fuse-publishers/default.nix
+++ b/distros/kilted/fuse-publishers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fuse-constraints, fuse-core, fuse-graphs, fuse-msgs, fuse-variables, geometry-msgs, gtest-vendor, nav-msgs, pluginlib, rclcpp, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kilted-fuse-publishers";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse_publishers/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "39b8da46b048e1d8b9f092faca030d5362cee527b7359024e58810ed6bc25b60";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse_publishers/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "f0debf2c304890be46ceb38053f508df1d4d8b0cbf718034d8e6e3b086b13e83";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/fuse-tutorials/default.nix
+++ b/distros/kilted/fuse-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fuse-constraints, fuse-core, fuse-models, fuse-optimizers, fuse-publishers, fuse-variables, gtest-vendor, nav-msgs, rclcpp, rviz2, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-fuse-tutorials";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse_tutorials/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "c9fb24c16f3d787fe474874a6f24b28ba368801ba4a94a49ef72d487f9e34c34";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse_tutorials/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "b60a3e6e6ffa80dfeb40f61e6f7b09ca40875edc77be84dd03858637423ce58b";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/fuse-variables/default.nix
+++ b/distros/kilted/fuse-variables/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ceres-solver, fuse-core, fuse-graphs, gtest-vendor, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-kilted-fuse-variables";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse_variables/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "53a3f84a1f07f3a472ce7f909ab6da668adc9cd6c2a0d2a33bcead6ff2311868";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse_variables/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "6f6bf8296e34cda0e92a0b0e9ca9d43948617a83903faf0eef5fbc1bd5311bdb";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/fuse-viz/default.nix
+++ b/distros/kilted/fuse-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, eigen, fuse-constraints, fuse-core, fuse-msgs, fuse-variables, geometry-msgs, gtest-vendor, qt5, rviz-common, rviz-rendering, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-kilted-fuse-viz";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse_viz/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "799bd48d8d8d674e6b5ea8f00609077a5b5fb70ecd90915b876e6819d0f78d78";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse_viz/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "7d37aea00f92cc48215e456186811eb0887e5b3047178678607b764efa1cd7e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/fuse/default.nix
+++ b/distros/kilted/fuse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, fuse-constraints, fuse-core, fuse-doc, fuse-graphs, fuse-models, fuse-msgs, fuse-optimizers, fuse-publishers, fuse-variables, fuse-viz, gtest-vendor }:
 buildRosPackage {
   pname = "ros-kilted-fuse";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "09645c6d1073f32c75deaa518727faa370938229cf85bd7c03e38930f6a69bcc";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/kilted/fuse/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "9c202d6b8b562b1f1fe40e5f82b287145d098f61db7cdbf5bf8fe2aeb6e46ca1";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/generated.nix
+++ b/distros/kilted/generated.nix
@@ -1792,6 +1792,8 @@ self: super: {
 
  mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
 
+ mujoco-3d-lidar = self.callPackage ./mujoco-3d-lidar {};
+
  mujoco-ros2-control = self.callPackage ./mujoco-ros2-control {};
 
  mujoco-ros2-control-demos = self.callPackage ./mujoco-ros2-control-demos {};
@@ -3100,8 +3102,6 @@ self: super: {
 
  swri-opencv-util = self.callPackage ./swri-opencv-util {};
 
- swri-roscpp = self.callPackage ./swri-roscpp {};
-
  swri-route-util = self.callPackage ./swri-route-util {};
 
  swri-serial-util = self.callPackage ./swri-serial-util {};
@@ -3319,6 +3319,8 @@ self: super: {
  udp-driver = self.callPackage ./udp-driver {};
 
  udp-msgs = self.callPackage ./udp-msgs {};
+
+ unbag = self.callPackage ./unbag {};
 
  uncrustify-vendor = self.callPackage ./uncrustify-vendor {};
 

--- a/distros/kilted/gps-msgs/default.nix
+++ b/distros/kilted/gps-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-gps-msgs";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/kilted/gps_msgs/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "93824d4eeafc84d87b80dcee89e7d14c7fa0cde0d61126d2fffbd3eb3f4b7396";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/kilted/gps_msgs/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "3e3793b5978b49feaa08c101d5b000f4ae6d4153c0ae5d972b0570f43cbe17f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/gps-tools/default.nix
+++ b/distros/kilted/gps-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, gps-msgs, nav-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-gps-tools";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/kilted/gps_tools/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "d25f5aeae6ada8bb0ab3224bbc80d3327264fd3559aefadfc80c2492176792d0";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/kilted/gps_tools/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "9d22fceff15c986c93693bb0ac2b43d46d37f24ead915d04851fa490dbaf74c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/gps-umd/default.nix
+++ b/distros/kilted/gps-umd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gps-msgs, gps-tools, gpsd-client }:
 buildRosPackage {
   pname = "ros-kilted-gps-umd";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/kilted/gps_umd/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "fe60d1161f119cc62ca839195a8b08ef7f47f9b24e3f51acc7c73096bbb0abe9";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/kilted/gps_umd/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "6792ebd70506965cd921e02bf141347962907c572db83f3ee870c7cd62930bba";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/gpsd-client/default.nix
+++ b/distros/kilted/gpsd-client/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, gps-msgs, gpsd, pkg-config, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, gps-msgs, gpsd, pkg-config, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kilted-gpsd-client";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/kilted/gpsd_client/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "97ee5335705d6dfe8b4b04cad47e195414858c3b5f60a4ef4ff10f8d74355dad";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/kilted/gpsd_client/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "d1bb817d7e53ea55f923d3160eee4c2134f78dd95a47e4d4441d66717b1745f1";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ros-environment ];
+  buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ];
   propagatedBuildInputs = [ gps-msgs gpsd pkg-config rclcpp rclcpp-components sensor-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake pkg-config ];
 
   meta = {
     description = "connects to a GPSd server and broadcasts GPS fixes 

--- a/distros/kilted/gz-tools-vendor/default.nix
+++ b/distros/kilted/gz-tools-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, ruby }:
 buildRosPackage {
   pname = "ros-kilted-gz-tools-vendor";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_tools_vendor-release/archive/release/kilted/gz_tools_vendor/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "9385936ceef9a71e0585f7964ef729235bb99e5d421aea53382ad487f106dccb";
+    url = "https://github.com/ros2-gbp/gz_tools_vendor-release/archive/release/kilted/gz_tools_vendor/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "eeb39b278a9be9259ac47a609112b18cd6497d95a9aaa8d8e4ae73d0e1cbd384";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-tools2 2.0.3
+    description = "Vendor package for: gz-tools2 2.0.4
 
     Gazebo Tools: Entrypoint to Gazebo's command line interface";
     license = with lib.licenses; [ asl20 ];

--- a/distros/kilted/gz-tools-vendor/vendored-source.json
+++ b/distros/kilted/gz-tools-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_tools_vendor": {
     "url": "https://github.com/gazebosim/gz-tools.git",
-    "rev": "gz-tools2_2.0.3",
-    "hash": "sha256-xMFJylj7OnDc7zVWiI4a/mvNpu9scz83F3bGopCt8l8="
+    "rev": "gz-tools2_2.0.4",
+    "hash": "sha256-WVeZg7Wreqz0eScbrgELEAsmpfr1Dy7HogZFjGEht/I="
   }
 }

--- a/distros/kilted/gz-transport-vendor/default.nix
+++ b/distros/kilted/gz-transport-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, cppzmq, gz-cmake-vendor, gz-math-vendor, gz-msgs-vendor, gz-tools-vendor, gz-utils-vendor, pkg-config, protobuf, python3, python3Packages, sqlite, util-linux }:
 buildRosPackage {
   pname = "ros-kilted-gz-transport-vendor";
-  version = "0.2.4-r1";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_transport_vendor-release/archive/release/kilted/gz_transport_vendor/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "a97c50f307d1efbdca8cb7152cd55a47b1db99f8c19776fe73d1eb2a316f2361";
+    url = "https://github.com/ros2-gbp/gz_transport_vendor-release/archive/release/kilted/gz_transport_vendor/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "a6dcaa99454796a9e9e6dfde0c610f90a9f02671050ea2e2250d0f9edb95e1ba";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-transport14 14.2.0
+    description = "Vendor package for: gz-transport14 14.3.0
 
     Gazebo Transport: Provides fast and efficient asynchronous message passing, services, and data logging.";
     license = with lib.licenses; [ asl20 ];

--- a/distros/kilted/gz-transport-vendor/vendored-source.json
+++ b/distros/kilted/gz-transport-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_transport_vendor": {
     "url": "https://github.com/gazebosim/gz-transport.git",
-    "rev": "gz-transport14_14.2.0",
-    "hash": "sha256-jvEVa0BK7hnYWybNXh30KpNu00+OTtR9bdHCiN8Bpeg="
+    "rev": "gz-transport14_14.3.0",
+    "hash": "sha256-IoUrcPpZGduwK0v/B2XHOsHtWaffJ5BxVoY2P5TtWME="
   }
 }

--- a/distros/kilted/jrl-cmakemodules/default.nix
+++ b/distros/kilted/jrl-cmakemodules/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catch2, cmake, doxygen, eigen, git, matio, pkg-config, python3Packages, simde }:
 buildRosPackage {
   pname = "ros-kilted-jrl-cmakemodules";
-  version = "2.0.0-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/jrl_cmakemodules-release/archive/release/kilted/jrl_cmakemodules/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "1d7debde9a6e192d9252d13348d69f1f091606f25eede1a9aa5ceee172188a7a";
+    url = "https://github.com/ros2-gbp/jrl_cmakemodules-release/archive/release/kilted/jrl_cmakemodules/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "1b6c65242520c095786f88ac1f87096b968278e7da9cb2f82a858696e33aa1d7";
   };
 
   buildType = "cmake";

--- a/distros/kilted/mapviz-interfaces/default.nix
+++ b/distros/kilted/mapviz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-kilted-mapviz-interfaces";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/mapviz_interfaces/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "c65ad5bc1873b1e5d3018b95943f5d88bfd332e4981c032e5226db7902e538dd";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/mapviz_interfaces/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "dcb2d094f00cfb9751e21ceec7a4ea0517537524a7a6b15dab8742a89695fbe1";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mapviz-plugins/default.nix
+++ b/distros/kilted/mapviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, assimp, cv-bridge, geometry-msgs, gps-msgs, image-transport, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-sensor-msgs, marti-visualization-msgs, opencv, pluginlib, qt-gui-cpp, qt5or6, rclcpp, rclcpp-action, sensor-msgs, std-msgs, std-srvs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, tf2, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mapviz-plugins";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/mapviz_plugins/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "33a07f4ec6ced75c1441df298cda767c6c3f7ec57077661a1c21b0a136e2c366";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/mapviz_plugins/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "365cf5703fd6e3fb5022a69698c10a6de3b2d79ee9707d3f3b38e644def1afe4";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mapviz/default.nix
+++ b/distros/kilted/mapviz/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, image-transport, libxi, libxmu, mapviz-interfaces, opencv, pkg-config, pluginlib, qt5or6, rclcpp, rqt-gui, rqt-gui-cpp, std-srvs, swri-math-util, swri-transform-util, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-kilted-mapviz";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/mapviz/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "c7e2958bc4ff0099e4aafafe0ea9583e1f2197aacb78d3d2815329319e053a97";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/mapviz/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "b3835699d78493767f362003884bb02b668d8be66e171ce634b6dc1a18fd4aab";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake pkg-config ];
-  propagatedBuildInputs = [ geometry-msgs image-transport libxi libxmu mapviz-interfaces opencv opencv.cxxdev pluginlib qt5or6.qtbase rclcpp rqt-gui rqt-gui-cpp std-srvs swri-math-util swri-transform-util tf2 tf2-geometry-msgs tf2-ros yaml-cpp ];
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ geometry-msgs image-transport libxi libxmu mapviz-interfaces opencv opencv.cxxdev pkg-config pluginlib qt5or6.qtbase rclcpp rqt-gui rqt-gui-cpp std-srvs swri-math-util swri-transform-util tf2 tf2-geometry-msgs tf2-ros yaml-cpp ];
   nativeBuildInputs = [ ament-cmake pkg-config ];
 
   meta = {

--- a/distros/kilted/metavision-driver/default.nix
+++ b/distros/kilted/metavision-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-xmllint, event-camera-msgs, openeb-vendor, rclcpp, rclcpp-components, ros-environment, std-srvs }:
 buildRosPackage {
   pname = "ros-kilted-metavision-driver";
-  version = "3.0.0-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/metavision_driver-release/archive/release/kilted/metavision_driver/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "1ea432cb106ba6bb6d4192bd0a19085dfcc3cafaf4b9b0a915bb4af6f7bb441d";
+    url = "https://github.com/ros2-gbp/metavision_driver-release/archive/release/kilted/metavision_driver/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "485203a78d90350de1190c41042601bcfd73a09cf8aa7bfb6620be78f04922db";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ros-environment ];
 
   meta = {
-    description = "ROS1 and ROS2 drivers for metavision based event cameras";
+    description = "ROS2 driver for metavision based event cameras";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/kilted/mujoco-3d-lidar/default.nix
+++ b/distros/kilted/mujoco-3d-lidar/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, mujoco-vendor }:
+buildRosPackage {
+  pname = "ros-kilted-mujoco-3d-lidar";
+  version = "0.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/kilted/mujoco_3d_lidar/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "2babbee27202a60e8b81f50745c7f2dd6c5790af5127ed2d1aab5008427abe08";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ mujoco-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Plugin for mujoco to use raycasters to simulate lidar";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kilted/mujoco-ros2-control-demos/default.nix
+++ b/distros/kilted/mujoco-ros2-control-demos/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, forward-command-controller, joint-state-broadcaster, mujoco-ros2-control, mujoco-ros2-control-msgs, robot-state-publisher, rviz2, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, forward-command-controller, joint-state-broadcaster, launch, launch-ros, mujoco-ros2-control, mujoco-ros2-control-msgs, pose-broadcaster, robot-state-publisher, rviz2, xacro }:
 buildRosPackage {
   pname = "ros-kilted-mujoco-ros2-control-demos";
-  version = "0.0.3-r1";
+  version = "0.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/kilted/mujoco_ros2_control_demos/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "330fbc9827324c634f3e55290e8635bc1e484309042c478f0cc3cdee8407c3e3";
+    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/kilted/mujoco_ros2_control_demos/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "51ae6c98617ff48066ed30b44f5d79ccb73b6600450e23112b9629a1b4744941";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ controller-manager forward-command-controller joint-state-broadcaster mujoco-ros2-control mujoco-ros2-control-msgs robot-state-publisher rviz2 xacro ];
+  propagatedBuildInputs = [ controller-manager forward-command-controller joint-state-broadcaster launch launch-ros mujoco-ros2-control mujoco-ros2-control-msgs pose-broadcaster robot-state-publisher rviz2 xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/mujoco-ros2-control-msgs/default.nix
+++ b/distros/kilted/mujoco-ros2-control-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mujoco-ros2-control-msgs";
-  version = "0.0.3-r1";
+  version = "0.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/kilted/mujoco_ros2_control_msgs/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "09d1a7d6013cbb65635a3ed513258b4737ebb8addb2ab686d342ff1740da26fa";
+    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/kilted/mujoco_ros2_control_msgs/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "aa19882d9c6c9214a72dabb7d7e04cd94ba06021b968873b28f33e298e6383a4";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime sensor-msgs std-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/kilted/mujoco-ros2-control-plugins/default.nix
+++ b/distros/kilted/mujoco-ros2-control-plugins/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, backward-ros, geometry-msgs, mujoco-ros2-control-msgs, mujoco-vendor, pluginlib, rclcpp, realtime-tools, ros2-control-cmake, std-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, backward-ros, geometry-msgs, glfw3, libGL, libGLU, mujoco-3d-lidar, mujoco-ros2-control-msgs, mujoco-vendor, pluginlib, rclcpp, realtime-tools, ros2-control-cmake, sensor-msgs, std-msgs, std-srvs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mujoco-ros2-control-plugins";
-  version = "0.0.3-r1";
+  version = "0.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/kilted/mujoco_ros2_control_plugins/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "c2731875dd80398b3c2d0ae458b4eab65c4ee6e07bdae9b63a155f39a123f1e9";
+    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/kilted/mujoco_ros2_control_plugins/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "348d55797c6cb63cb8145de3af15b3e3a5fd0c700f58ed1fb1dc28e3c975ba81";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gtest ];
-  propagatedBuildInputs = [ backward-ros geometry-msgs mujoco-ros2-control-msgs mujoco-vendor pluginlib rclcpp realtime-tools ros2-control-cmake std-msgs visualization-msgs ];
+  checkInputs = [ ament-cmake-gtest ament-index-cpp mujoco-3d-lidar ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs glfw3 libGL libGLU mujoco-ros2-control-msgs mujoco-vendor pluginlib rclcpp realtime-tools ros2-control-cmake sensor-msgs std-msgs std-srvs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/mujoco-ros2-control/default.nix
+++ b/distros/kilted/mujoco-ros2-control/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-index-python, backward-ros, control-toolbox, controller-manager, fmt, git, glfw3, hardware-interface, mujoco-ros2-control-msgs, mujoco-ros2-control-plugins, mujoco-vendor, nav-msgs, pluginlib, python3, python3Packages, rclcpp, rclcpp-lifecycle, ros2-control-cmake, sensor-msgs, transmission-interface, urdfdom-py }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-index-cpp, ament-index-python, backward-ros, control-toolbox, controller-manager, eigen, fmt, geometry-msgs, git, glfw3, hardware-interface, mujoco-ros2-control-msgs, mujoco-ros2-control-plugins, mujoco-vendor, nav-msgs, pluginlib, python3, python3Packages, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2pkg, rosgraph-msgs, sensor-msgs, std-msgs, tinyxml2-vendor, transmission-interface, urdfdom-py }:
 buildRosPackage {
   pname = "ros-kilted-mujoco-ros2-control";
-  version = "0.0.3-r1";
+  version = "0.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/kilted/mujoco_ros2_control/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "bd57ec180d9abc038682855acf702b709617401235ef780f36985715b7188bbe";
+    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/kilted/mujoco_ros2_control/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "c7a92932b4daeb29cce8358b70cdec44c8157c065aa3f4d9e0b3049060d4e3bf";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python git ros2-control-cmake ];
   checkInputs = [ ament-cmake-gtest ament-cmake-pytest ];
-  propagatedBuildInputs = [ ament-index-python backward-ros control-toolbox controller-manager fmt glfw3 hardware-interface mujoco-ros2-control-msgs mujoco-ros2-control-plugins mujoco-vendor nav-msgs pluginlib python3 python3Packages.importlib-resources python3Packages.numpy python3Packages.pip python3Packages.pykdl rclcpp rclcpp-lifecycle sensor-msgs transmission-interface urdfdom-py ];
+  propagatedBuildInputs = [ ament-index-cpp ament-index-python backward-ros control-toolbox controller-manager eigen fmt geometry-msgs glfw3 hardware-interface mujoco-ros2-control-msgs mujoco-ros2-control-plugins mujoco-vendor nav-msgs pluginlib python3 python3Packages.importlib-resources python3Packages.numpy python3Packages.pip python3Packages.pykdl rclcpp rclcpp-lifecycle realtime-tools ros2pkg rosgraph-msgs sensor-msgs std-msgs tinyxml2-vendor transmission-interface urdfdom-py ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python git ];
 
   meta = {

--- a/distros/kilted/multires-image/default.nix
+++ b/distros/kilted/multires-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, gps-msgs, mapviz, mapviz-interfaces, marti-common-msgs, pluginlib, python3Packages, qt-gui-cpp, qt5or6, rclcpp, rclpy, swri-math-util, swri-transform-util, tf2 }:
 buildRosPackage {
   pname = "ros-kilted-multires-image";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/multires_image/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "3e082e22d833dfbc7120deccd3156a679445d49c68650ac09dd73728cd5dee93";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/multires_image/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "63eed643658b12c45706b67b06ad7bd0b648b144c2ff429ee20981c2b58b965d";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/novatel-gps-driver/default.nix
+++ b/distros/kilted/novatel-gps-driver/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, boost, diagnostic-msgs, diagnostic-updater, gps-msgs, libpcap, nav-msgs, novatel-gps-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, swri-math-util, swri-roscpp, swri-serial-util, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, _unresolved_swri_roscpp, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, boost, diagnostic-msgs, diagnostic-updater, gps-msgs, libpcap, nav-msgs, novatel-gps-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, swri-math-util, swri-serial-util, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-kilted-novatel-gps-driver";
   version = "4.3.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ];
-  propagatedBuildInputs = [ boost diagnostic-msgs diagnostic-updater gps-msgs libpcap nav-msgs novatel-gps-msgs rclcpp rclcpp-components sensor-msgs std-msgs swri-math-util swri-roscpp swri-serial-util tf2 tf2-geometry-msgs ];
+  propagatedBuildInputs = [ _unresolved_swri_roscpp boost diagnostic-msgs diagnostic-updater gps-msgs libpcap nav-msgs novatel-gps-msgs rclcpp rclcpp-components sensor-msgs std-msgs swri-math-util swri-serial-util tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kilted/pal-statistics-msgs/default.nix
+++ b/distros/kilted/pal-statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-pal-statistics-msgs";
-  version = "2.8.0-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/kilted/pal_statistics_msgs/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "fee798a54ba929a0c28d6fdf5fbb5b9bd5d17903d81aad4bca1567c73bf80e68";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/kilted/pal_statistics_msgs/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "f9da211b12dce1d9692c4b5bc47a57232b5ea576c83a7d5ae54bc0fca95f4ea2";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/pal-statistics/default.nix
+++ b/distros/kilted/pal-statistics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, boost, pal-statistics-msgs, rclcpp, rclcpp-lifecycle, rclpy }:
 buildRosPackage {
   pname = "ros-kilted-pal-statistics";
-  version = "2.8.0-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/kilted/pal_statistics/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "eeadac496a0c5cf26fbef927d6bb075a50aa0e128ad081ac9b622725aaa75470";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/kilted/pal_statistics/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "13b29159c0df4de8d00550619187151c12187d9bd5a7c6256ff59c90d23ff4c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/swri-cli-tools/default.nix
+++ b/distros/kilted/swri-cli-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, marti-introspection-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, ros2topic }:
 buildRosPackage {
   pname = "ros-kilted-swri-cli-tools";
-  version = "3.9.0-r1";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_cli_tools/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "7cb4a80dc93c909cabc9ed91450419241908ae231b1fcaf53bfca51953442563";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_cli_tools/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "682ae153befcd5201e2b9e8433d9b4170c3240058a67cfe1b29f1954d9418ebb";
   };
 
   buildType = "ament_python";

--- a/distros/kilted/swri-console-util/default.nix
+++ b/distros/kilted/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-kilted-swri-console-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_console_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "1c69cd147047ffa59b4651499099b8a1a7de55fe9e9e48db3ad382c6a9ff8d22";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_console_util/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "197dc594b53c7e4c4b5f77c150fec5a3101cc2c8ce5004597f037185a1c0cef7";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/swri-dbw-interface/default.nix
+++ b/distros/kilted/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-kilted-swri-dbw-interface";
-  version = "3.9.0-r1";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_dbw_interface/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "6e5681a68e215aaea5ba0c1416621b6fdb92d46a07d5477d06d8e3e5df5663c2";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_dbw_interface/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "23ef9d8c90ef4a225b17197c89e8911f7ffcbeb9a6abee54d812ad6206104a99";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/swri-geometry-util/default.nix
+++ b/distros/kilted/swri-geometry-util/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, geos, opencv, pkg-config, tf2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, geos, opencv, tf2 }:
 buildRosPackage {
   pname = "ros-kilted-swri-geometry-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_geometry_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "497017b3b231fc865901b848e787c91b46deccf0da5f8ef62db32761be381546";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_geometry_util/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "40b1a57bce3d3a06706c2a95e418aa94c127e5093b84a8095e76463857a0a8a1";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake pkg-config ];
+  buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ];
   propagatedBuildInputs = [ eigen geos opencv opencv.cxxdev tf2 ];
-  nativeBuildInputs = [ ament-cmake pkg-config ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = "Commonly used geometry routines, implemented in a ROS friendly package.";

--- a/distros/kilted/swri-image-util/default.nix
+++ b/distros/kilted/swri-image-util/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, camera-calibration-parsers, cv-bridge, eigen, image-geometry, image-transport, message-filters, opencv, pkg-config, rcl-interfaces, rclcpp, rclcpp-components, rclpy, swri-geometry-util, swri-math-util, swri-opencv-util, tf2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, camera-calibration-parsers, cv-bridge, eigen, image-geometry, image-transport, message-filters, opencv, rcl-interfaces, rclcpp, rclcpp-components, rclpy, swri-geometry-util, swri-math-util, swri-opencv-util, tf2 }:
 buildRosPackage {
   pname = "ros-kilted-swri-image-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_image_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "869e49caea7012f9bc5ff11e43a1feed6f2ced31eada5b31fd1096fcec8467d8";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_image_util/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "366c3e3cb89a2ecf4975c594fa5adfcbe80f5aa67d69ace530ace95953c92cee";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake pkg-config ];
+  buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ];
   propagatedBuildInputs = [ ament-index-cpp camera-calibration-parsers cv-bridge eigen image-geometry image-transport message-filters opencv opencv.cxxdev rcl-interfaces rclcpp rclcpp-components rclpy swri-geometry-util swri-math-util swri-opencv-util tf2 ];
-  nativeBuildInputs = [ ament-cmake pkg-config ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = "A package of commonly image manipulation utilities.";

--- a/distros/kilted/swri-math-util/default.nix
+++ b/distros/kilted/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, rclcpp }:
 buildRosPackage {
   pname = "ros-kilted-swri-math-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_math_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "d2ae675ffb63d13dddc76c4a87989765b0fb681d5701e37a141304c054028c20";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_math_util/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "0630a50bfc8cd618edd3f5995e70b0ae40a286555e20788e510d78f2413de0e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/swri-opencv-util/default.nix
+++ b/distros/kilted/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, opencv, swri-math-util }:
 buildRosPackage {
   pname = "ros-kilted-swri-opencv-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_opencv_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "f666e44e0d54eebaff946bd21e8b68e9771cd593081c022413da681ad1270750";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_opencv_util/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "d8b1f9368f95bf2253bcc966da4f93e9da32e1ced40e187fbc1f11def42d86b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/swri-route-util/default.nix
+++ b/distros/kilted/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-transform-util, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-swri-route-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_route_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "4c155d53b5bd134722966dda799ef8a736751f8f4241bb8338abac3f478b161c";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_route_util/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "f45acb36144f020b90cb88730dd9496449052e22980b41d16661c782e200598d";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/swri-serial-util/default.nix
+++ b/distros/kilted/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-kilted-swri-serial-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_serial_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "d73a1f46a247ece6279db6c4f38c384cbc0b5edcb1d5e28a106c44561116bbf9";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_serial_util/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "0377a504f9a7a0d3cf3be26fe4563d1d63e1415d7bd1d24129783cc7d7943b2f";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/swri-transform-util/default.nix
+++ b/distros/kilted/swri-transform-util/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-index-cpp, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geographiclib, geometry-msgs, geos, gps-msgs, launch-ros, launch-testing, launch-testing-ament-cmake, marti-nav-msgs, opencv, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-index-cpp, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geographiclib, geometry-msgs, geos, gps-msgs, launch-ros, launch-testing, launch-testing-ament-cmake, marti-nav-msgs, opencv, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-kilted-swri-transform-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_transform_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "ab5fcde89c3fb8d3799987ec2c40b4ebdbba8746f715b8384c399b6c66928e44";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/kilted/swri_transform_util/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "981d3aedb8e844ad5084641ac9c17e9a71d10436378eee7d8f3665c96ac434d0";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python pkg-config ];
   checkInputs = [ ament-cmake-gtest ament-index-cpp launch-ros launch-testing launch-testing-ament-cmake ];
-  propagatedBuildInputs = [ cv-bridge diagnostic-msgs diagnostic-updater geographic-msgs geographiclib geometry-msgs geos gps-msgs marti-nav-msgs opencv opencv.cxxdev proj python3Packages.numpy python3Packages.pyyaml rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util swri-roscpp tf2 tf2-geometry-msgs tf2-ros yaml-cpp-vendor ];
+  propagatedBuildInputs = [ cv-bridge diagnostic-msgs diagnostic-updater geographic-msgs geographiclib geometry-msgs geos gps-msgs marti-nav-msgs opencv opencv.cxxdev proj python3Packages.numpy python3Packages.pyyaml rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util tf2 tf2-geometry-msgs tf2-ros yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python pkg-config ];
 
   meta = {

--- a/distros/kilted/tile-map/default.nix
+++ b/distros/kilted/tile-map/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, jsoncpp, mapviz, pluginlib, qt-gui-cpp, qt5or6, rclcpp, swri-math-util, swri-transform-util, tf2, yaml-cpp }:
 buildRosPackage {
   pname = "ros-kilted-tile-map";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/tile_map/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "05b8729a5f8d6cf338cb1688b207757807ac3da3a799292bf43d40e69b3be964";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/tile_map/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "a2c93eb91d22b0706fcf40893bfaced6bbb2d11a98e02eb21414b5881c629cf7";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/unbag/default.nix
+++ b/distros/kilted/unbag/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-index-python, ament-lint-auto, ament-lint-common, python3, python3Packages, qt5, rclpy, ros2cli, rosbag2-py, rosidl-runtime-py, sensor-msgs, tf2-msgs }:
+buildRosPackage {
+  pname = "ros-kilted-unbag";
+  version = "1.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/unbag-release/archive/release/kilted/unbag/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "accefefd53868214e8ffaa2bab1336707610cc3a6545d4dfd5a46647815f7565";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python python3 python3Packages.setuptools qt5.qtbase ];
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-python python3Packages.numpy python3Packages.opencv4 python3Packages.pyyaml python3Packages.tqdm qt5.qtsvg rclpy ros2cli rosbag2-py rosidl-runtime-py sensor-msgs tf2-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "A ROS 2 tool for exporting bags to human readable files. Supports pluggable export routines to handle any message type.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/lyrical/adi-iio/default.nix
+++ b/distros/lyrical/adi-iio/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-xmllint, ament-copyright, ament-lint-auto, ament-lint-common, ament-pep257, launch, launch-pytest, launch-ros, launch-testing, launch-testing-ament-cmake, libiio, python3Packages, rclcpp, rclpy, ros2launch, rosidl-default-generators, rosidl-default-runtime, rosidl-typesupport-introspection-cpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-adi-iio";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/adi_iio-release/archive/release/lyrical/adi_iio/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "fbe617aa8aa65bf52e84cbdb884cbd922db6872f85c9bc2da8e4fc17d9c4c49b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-lint-cmake ament-cmake-ros ament-cmake-xmllint ament-copyright ament-lint-auto ament-lint-common ament-pep257 launch launch-pytest launch-ros launch-testing launch-testing-ament-cmake python3Packages.scipy rclpy ];
+  propagatedBuildInputs = [ libiio rclcpp ros2launch rosidl-default-runtime rosidl-typesupport-introspection-cpp std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "ROS package to interface with IIO devices";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/adi-imu/default.nix
+++ b/distros/lyrical/adi-imu/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-copyright, ament-lint-auto, ament-pep257, builtin-interfaces, geometry-msgs, libiio, rclcpp, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-adi-imu";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/adi_imu-release/archive/release/lyrical/adi_imu/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "2f152579794fb9a220282ab160ab98039b15a01af1a4466966177c46504f96b5";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-xmllint ament-copyright ament-lint-auto ament-pep257 ];
+  propagatedBuildInputs = [ ament-cmake builtin-interfaces geometry-msgs libiio rclcpp rosidl-default-runtime sensor-msgs std-msgs ];
+
+  meta = {
+    description = "Publisher for ADI IMUs";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/crazyflie-description/default.nix
+++ b/distros/lyrical/crazyflie-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-lyrical-crazyflie-description";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/lyrical/crazyflie_description/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "92ceee20b38477da4e7bb5cb6bd66e156d8c5f6a6fa00b258e7bb4ad7a3f74c6";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/lyrical/crazyflie_description/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "a7f5c413900bc3e94b65e94d9ec53290da7a769a08b3e74b0d358e37d1ba6e0b";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/crazyflie-examples/default.nix
+++ b/distros/lyrical/crazyflie-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, crazyflie-py, geometry-msgs, nav-msgs, python3Packages, rclpy, sensor-msgs, tf-transformations, tf2-ros }:
 buildRosPackage {
   pname = "ros-lyrical-crazyflie-examples";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/lyrical/crazyflie_examples/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "17c752debe27555802e9fa1d9e2b20a0d9694f744e8da8133f8ad67360d29738";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/lyrical/crazyflie_examples/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "6d6678d44250a9247238cd27d5ffeecbfb6214f49ce1f7a72b707c171e083de8";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/crazyflie-interfaces/default.nix
+++ b/distros/lyrical/crazyflie-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-lyrical-crazyflie-interfaces";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/lyrical/crazyflie_interfaces/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "c77533b50e3be27de1b272bb8360ff24ef22a15efb052149d3cc09880314ed77";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/lyrical/crazyflie_interfaces/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "f3eb288992398b11d1f15cf37252164654233cda33edef92bac33a9f27706b89";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/crazyflie-py/default.nix
+++ b/distros/lyrical/crazyflie-py/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, crazyflie-interfaces, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-lyrical-crazyflie-py";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/lyrical/crazyflie_py/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "5acbb3a4dd5df63bf3de23368f3a3faa93ed905efc242fc2d3fb1bfb0931eaa2";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/lyrical/crazyflie_py/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "509b88fc702ec18be2e70dacef9f621441f2a95e42aa3266207e1b2fa7ad8ff6";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
-  propagatedBuildInputs = [ crazyflie-interfaces rclpy ];
+  propagatedBuildInputs = [ crazyflie-interfaces python3Packages.transforms3d rclpy ];
 
   meta = {
     description = "Simple Python Interface for Crayzswarm2";

--- a/distros/lyrical/crazyflie-server-cpp/default.nix
+++ b/distros/lyrical/crazyflie-server-cpp/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, crazyflie-interfaces, eigen, geometry-msgs, libusb1, motion-capture-tracking-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, std-srvs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-lyrical-crazyflie-server-cpp";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/lyrical/crazyflie_server_cpp/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "13e5cf15fbdb21688fbc763b65e2f623d7f593ebd5c56b63e384ea701ca97d04";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ boost crazyflie-interfaces eigen geometry-msgs libusb1 motion-capture-tracking-interfaces nav-msgs rclcpp ros-environment sensor-msgs std-srvs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "C++ ROS 2 server node for Bitcraze Crazyflie robots";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/lyrical/crazyflie-server-py/default.nix
+++ b/distros/lyrical/crazyflie-server-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, crazyflie-interfaces, geometry-msgs, motion-capture-tracking-interfaces, nav-msgs, python3Packages, rcl-interfaces, rclpy, sensor-msgs, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-lyrical-crazyflie-server-py";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/lyrical/crazyflie_server_py/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "8adf6a03d21277beec294100c915f84ad7e667dcfb837d23b4e5bd41d4161b8f";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/lyrical/crazyflie_server_py/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "8855d7394b78daebf48644228c05b4170cf96f175f7fb03a1f187cb57487eb38";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/crazyflie-sim/default.nix
+++ b/distros/lyrical/crazyflie-sim/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, crazyflie-interfaces, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-lyrical-crazyflie-sim";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/lyrical/crazyflie_sim/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "46cb176b21c03d8084f6fc5de648b11207d3e21a3e36e97abd2300f43e6f75cb";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/lyrical/crazyflie_sim/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "08f6f9a76abcc5771f1b000b040232039d64a17d3fa5ac65317ebb3c4d17ca72";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-cmake-pytest ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
-  propagatedBuildInputs = [ crazyflie-interfaces rclpy ];
+  propagatedBuildInputs = [ crazyflie-interfaces python3Packages.transforms3d rclpy ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/lyrical/crazyflie/default.nix
+++ b/distros/lyrical/crazyflie/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, boost, crazyflie-description, crazyflie-interfaces, eigen, geometry-msgs, libusb1, motion-capture-tracking-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, std-srvs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, crazyflie-description, crazyflie-interfaces, crazyflie-server-cpp, eigen, geometry-msgs, rclcpp, rclpy, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-lyrical-crazyflie";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/lyrical/crazyflie/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "2dd8b3f0a6f3a784881e69e4e5a0a091eba0710cb0b5b49c8a09aee6e7873ab5";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/lyrical/crazyflie/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "b90d5f1c38d33dd49edaccfe62f60f86be08579933c5258a1c068e07d181002f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ boost crazyflie-description crazyflie-interfaces eigen geometry-msgs libusb1 motion-capture-tracking-interfaces nav-msgs rclcpp ros-environment sensor-msgs std-srvs tf2-ros ];
+  propagatedBuildInputs = [ crazyflie-description crazyflie-interfaces crazyflie-server-cpp eigen geometry-msgs rclcpp rclpy sensor-msgs std-srvs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/lyrical/fuse-constraints/default.nix
+++ b/distros/lyrical/fuse-constraints/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ceres-solver, eigen, fuse-core, fuse-graphs, fuse-variables, gbenchmark, geometry-msgs, gtest-vendor, pluginlib, rclcpp, suitesparse }:
 buildRosPackage {
   pname = "ros-lyrical-fuse-constraints";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_constraints/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "31b87f8dc069602d3cb8e3342320584673442f7bc2a5f6937f738e2d086acc68";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_constraints/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "3fe786e87339ba9697238aeea205613156415805b64f604f71ea8b876b277bbe";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/fuse-core/default.nix
+++ b/distros/lyrical/fuse-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, boost, ceres-solver, eigen, fuse-msgs, geometry-msgs, glog, gtest-vendor, launch, launch-pytest, pluginlib, rcl-interfaces, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-lyrical-fuse-core";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_core/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "f6b80dfa67dab7d9eb330e0af758b4b92b9c35ea8192c9b601ccc59191507edc";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_core/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "3160830a73b07ad42e3c1f55dd7a1ffc6322bd72dfd926e50e8ace0ade60bdd9";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/fuse-doc/default.nix
+++ b/distros/lyrical/fuse-doc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, gtest-vendor }:
 buildRosPackage {
   pname = "ros-lyrical-fuse-doc";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_doc/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "700e94889b12cb0f0412ca0737d410961233f8df1ad1871070637aea989f500c";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_doc/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "c8f329bf6d0436c5bb7a1a0c81d6c4a38199c23080e62bef86e3d669cb75d4a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/fuse-graphs/default.nix
+++ b/distros/lyrical/fuse-graphs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ceres-solver, fuse-core, gbenchmark, gtest-vendor, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-lyrical-fuse-graphs";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_graphs/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "7108ab40085e0804d754a8ccfe6f4e3d2f8d081e80fec36f6cf86f9ca49f154b";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_graphs/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "1b3056ccbbf8d2d3597dc3b90509df65a03a9dfd6952918ccb603b60e68edc10";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/fuse-loss/default.nix
+++ b/distros/lyrical/fuse-loss/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ceres-solver, fuse-core, gtest-vendor, libsForQt5, pluginlib, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-lyrical-fuse-loss";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_loss/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "8c4ec94c3b874d538fc9d2c7e6d22664be2821015900dc835673998e99f6729d";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_loss/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "1c2eb17d01dab75e6efdffaaeaea234ffe4c30d7967a899658c30d0e0d7d8433";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/fuse-models/default.nix
+++ b/distros/lyrical/fuse-models/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, boost, ceres-solver, eigen, fuse-constraints, fuse-core, fuse-graphs, fuse-msgs, fuse-publishers, fuse-variables, gbenchmark, geometry-msgs, gtest-vendor, nav-msgs, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-srvs, tf2, tf2-2d, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-lyrical-fuse-models";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_models/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "ac0cea4a3673dc376e3319b014c84e8251843101b1cce6f8c152b9809f0640ac";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_models/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "b9312cc03774d91d0cf95066908a23304369017b8d13a10a7a9e447f1ddb16b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/fuse-msgs/default.nix
+++ b/distros/lyrical/fuse-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, geometry-msgs, gtest-vendor, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-fuse-msgs";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_msgs/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "4e9ef65a3cc683fd692a4b263fb62043d3020ca874e0bb9e8957d9416d14c85b";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_msgs/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "a09304d81a432140ccd16e68ce5d333db388894a75e8b3ce965e419d82a2785b";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/fuse-optimizers/default.nix
+++ b/distros/lyrical/fuse-optimizers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, boost, ceres-solver, diagnostic-updater, eigen, fuse-constraints, fuse-core, fuse-graphs, fuse-models, fuse-msgs, fuse-variables, geometry-msgs, gtest-vendor, launch, launch-pytest, launch-ros, nav-msgs, pluginlib, rclcpp, rclcpp-components, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, boost, ceres-solver, diagnostic-updater, eigen, fuse-constraints, fuse-core, fuse-graphs, fuse-models, fuse-msgs, fuse-variables, geometry-msgs, gtest-vendor, launch, launch-pytest, launch-ros, nav-msgs, pluginlib, rclcpp, rclcpp-components, std-srvs }:
 buildRosPackage {
   pname = "ros-lyrical-fuse-optimizers";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_optimizers/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "3b2a7a9de47ab75a93e41af32de7f99eed2d91b4a75932ecffb3688e0f69dcd2";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_optimizers/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "e34231d7f03d202c33d39684dfe461c933344cadb2c1588fd239869904510c77";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common fuse-models geometry-msgs launch launch-pytest launch-ros nav-msgs rclcpp ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common fuse-models geometry-msgs launch launch-pytest launch-ros nav-msgs rclcpp ];
   propagatedBuildInputs = [ ament-cmake-ros boost ceres-solver diagnostic-updater eigen fuse-constraints fuse-core fuse-graphs fuse-msgs fuse-variables gtest-vendor pluginlib rclcpp rclcpp-components std-srvs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/lyrical/fuse-publishers/default.nix
+++ b/distros/lyrical/fuse-publishers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fuse-constraints, fuse-core, fuse-graphs, fuse-msgs, fuse-variables, geometry-msgs, gtest-vendor, nav-msgs, pluginlib, rclcpp, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-lyrical-fuse-publishers";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_publishers/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "780eaa980bf891c39f86a6b321f77c7f678b0031b2652ae78a4897b296d0e84f";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_publishers/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "a0ba4553dad0060a0010c674fceefb3052e5b8732d75c3891d4ea4284df1193e";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/fuse-tutorials/default.nix
+++ b/distros/lyrical/fuse-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fuse-constraints, fuse-core, fuse-models, fuse-optimizers, fuse-publishers, fuse-variables, gtest-vendor, nav-msgs, rclcpp, rviz2, sensor-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-fuse-tutorials";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_tutorials/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "beef551a26b6c576fafcb6132c149cd7bdba1523d27cacfe8d1e2dbdb186de89";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_tutorials/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "85c1eb10591ef3197f5ce4d19492855c8aa6067858fd69e5cc1e968b56d88dad";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/fuse-variables/default.nix
+++ b/distros/lyrical/fuse-variables/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ceres-solver, fuse-core, fuse-graphs, gtest-vendor, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-lyrical-fuse-variables";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_variables/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "d6a632735f34ab293f27df1c640c29322374ebd7a0ed0a7bf79ceda3abf7d673";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_variables/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "ec18122da28f2332988ced8098960f76c04e8a6f3868bece32ee810f304e5e59";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/fuse-viz/default.nix
+++ b/distros/lyrical/fuse-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, eigen, fuse-constraints, fuse-core, fuse-msgs, fuse-variables, geometry-msgs, gtest-vendor, qt5, rviz-common, rviz-rendering, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-fuse-viz";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_viz/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "5e6c71ad126e1627e6c7496f32361c82a3a0559c131d8e4bd1236cc5f8d9fc24";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse_viz/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "fbb33333a1f6954b84cbc97c6243b89b0407b9a43b83174231e85d07d2497bcc";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/fuse/default.nix
+++ b/distros/lyrical/fuse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, fuse-constraints, fuse-core, fuse-doc, fuse-graphs, fuse-models, fuse-msgs, fuse-optimizers, fuse-publishers, fuse-variables, fuse-viz, gtest-vendor }:
 buildRosPackage {
   pname = "ros-lyrical-fuse";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "d8e3f815d4424318bb72a506863874ddd2af38603a52d6e92a19e7b2eb41c0b6";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/lyrical/fuse/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "0ca7efc203f741dd54f00af8dfddd45e0e30fb90c0d4e3a8a965edb10237f10a";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/generated.nix
+++ b/distros/lyrical/generated.nix
@@ -24,6 +24,10 @@ self: super: {
 
  adaptive-component = self.callPackage ./adaptive-component {};
 
+ adi-iio = self.callPackage ./adi-iio {};
+
+ adi-imu = self.callPackage ./adi-imu {};
+
  admittance-controller = self.callPackage ./admittance-controller {};
 
  agni-tf-tools = self.callPackage ./agni-tf-tools {};
@@ -455,6 +459,8 @@ self: super: {
  crazyflie-interfaces = self.callPackage ./crazyflie-interfaces {};
 
  crazyflie-py = self.callPackage ./crazyflie-py {};
+
+ crazyflie-server-cpp = self.callPackage ./crazyflie-server-cpp {};
 
  crazyflie-server-py = self.callPackage ./crazyflie-server-py {};
 
@@ -1762,6 +1768,8 @@ self: super: {
 
  mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
 
+ mujoco-3d-lidar = self.callPackage ./mujoco-3d-lidar {};
+
  mujoco-ros2-control = self.callPackage ./mujoco-ros2-control {};
 
  mujoco-ros2-control-demos = self.callPackage ./mujoco-ros2-control-demos {};
@@ -2029,6 +2037,8 @@ self: super: {
  pal-statistics = self.callPackage ./pal-statistics {};
 
  pal-statistics-msgs = self.callPackage ./pal-statistics-msgs {};
+
+ pal-urdf-utils = self.callPackage ./pal-urdf-utils {};
 
  pangolin = self.callPackage ./pangolin {};
 
@@ -3136,8 +3146,6 @@ self: super: {
 
  swri-opencv-util = self.callPackage ./swri-opencv-util {};
 
- swri-roscpp = self.callPackage ./swri-roscpp {};
-
  swri-route-util = self.callPackage ./swri-route-util {};
 
  swri-serial-util = self.callPackage ./swri-serial-util {};
@@ -3353,6 +3361,8 @@ self: super: {
  udp-driver = self.callPackage ./udp-driver {};
 
  udp-msgs = self.callPackage ./udp-msgs {};
+
+ unbag = self.callPackage ./unbag {};
 
  uncrustify-vendor = self.callPackage ./uncrustify-vendor {};
 

--- a/distros/lyrical/gps-msgs/default.nix
+++ b/distros/lyrical/gps-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-gps-msgs";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/lyrical/gps_msgs/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "68e857c2a467ec5adef90b30c57064b613e5a382953d88531ceaab55c6cfb84c";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/lyrical/gps_msgs/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "8b4476d97cd2a75140410bc3d8600ee938ec3ce23f5ee87e3106bcad650cd087";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/gps-tools/default.nix
+++ b/distros/lyrical/gps-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, gps-msgs, nav-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-gps-tools";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/lyrical/gps_tools/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "ba18a3be640e6a041c87f5749e56a151ccbb1096aba02338dada586493134b34";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/lyrical/gps_tools/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "2860c5ea2e8484a6ae2b2ae253fc6eb5dbb3cd7d775c0fca47ab5251f2ddcd0d";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/gps-umd/default.nix
+++ b/distros/lyrical/gps-umd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gps-msgs, gps-tools, gpsd-client }:
 buildRosPackage {
   pname = "ros-lyrical-gps-umd";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/lyrical/gps_umd/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "e66d2a6a75b0632be7a886ea7f09435957d5d2366cc992ef57a0be385c5e14cd";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/lyrical/gps_umd/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "cbc6f6c5606a8da01590afe7a83a3df28330b86bae335bd8ca797917ff8def09";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/gpsd-client/default.nix
+++ b/distros/lyrical/gpsd-client/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, gps-msgs, gpsd, pkg-config, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, gps-msgs, gpsd, pkg-config, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-gpsd-client";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/lyrical/gpsd_client/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "1318b33b092622b936074917d8f4fca7ef441198489939de585e82aa39627e61";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/lyrical/gpsd_client/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "46ba32c709414e3f96a0474a88b7d56e9f73d1e873c4afb04853f34ba1e7c0d6";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ros-environment ];
+  buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ];
   propagatedBuildInputs = [ gps-msgs gpsd pkg-config rclcpp rclcpp-components sensor-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake pkg-config ];
 
   meta = {
     description = "connects to a GPSd server and broadcasts GPS fixes 

--- a/distros/lyrical/gz-common-vendor/default.nix
+++ b/distros/lyrical/gz-common-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, assimp, cmake, ffmpeg, gdal, gz-cmake-vendor, gz-math-vendor, gz-utils-vendor, pkg-config, spdlog-vendor, tinyxml-2, util-linux }:
 buildRosPackage {
   pname = "ros-lyrical-gz-common-vendor";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_common_vendor-release/archive/release/lyrical/gz_common_vendor/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "6e90fdb274005f67a34ab1fad8ffec77b67c1773b97a6b40ff87d8cc6a38c544";
+    url = "https://github.com/ros2-gbp/gz_common_vendor-release/archive/release/lyrical/gz_common_vendor/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "48c6dabeb765e7331bdb6fe91a92fda7f9bb2690a782d5f384d12f93bd36acd8";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake pkg-config ];
 
   meta = {
-    description = "Vendor package for: gz-common 7.3.0
+    description = "Vendor package for: gz-common 7.3.1
 
     Gazebo Common : AV, Graphics, Events, and much more.";
     license = with lib.licenses; [ asl20 ];

--- a/distros/lyrical/gz-common-vendor/vendored-source.json
+++ b/distros/lyrical/gz-common-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_common_vendor": {
     "url": "https://github.com/gazebosim/gz-common.git",
-    "rev": "gz-common7_7.3.0",
-    "hash": "sha256-LFuXkoGlln9Pj+TRZoZYY2pF8osKt9j1ub1Frzv/loQ="
+    "rev": "gz-common7_7.3.1",
+    "hash": "sha256-igTHae00k4PIWTpc1xzxv8iKtbO6TvDsMA3iM0K/WAc="
   }
 }

--- a/distros/lyrical/gz-tools-vendor/default.nix
+++ b/distros/lyrical/gz-tools-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, ruby }:
 buildRosPackage {
   pname = "ros-lyrical-gz-tools-vendor";
-  version = "0.2.1-r3";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_tools_vendor-release/archive/release/lyrical/gz_tools_vendor/0.2.1-3.tar.gz";
-    name = "0.2.1-3.tar.gz";
-    sha256 = "7434b6a0921e30cc07d66aca796856637e1da2e572a4e40e742eb31a23c8dcd6";
+    url = "https://github.com/ros2-gbp/gz_tools_vendor-release/archive/release/lyrical/gz_tools_vendor/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "a18dd38e50ee765ac245493cfdb4ef9f29f1ae4a738ca67e666f37880402c9af";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-tools2 2.0.3
+    description = "Vendor package for: gz-tools2 2.0.4
 
     Gazebo Tools: Entrypoint to Gazebo's command line interface";
     license = with lib.licenses; [ asl20 ];

--- a/distros/lyrical/gz-tools-vendor/vendored-source.json
+++ b/distros/lyrical/gz-tools-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_tools_vendor": {
     "url": "https://github.com/gazebosim/gz-tools.git",
-    "rev": "gz-tools2_2.0.3",
-    "hash": "sha256-xMFJylj7OnDc7zVWiI4a/mvNpu9scz83F3bGopCt8l8="
+    "rev": "gz-tools2_2.0.4",
+    "hash": "sha256-WVeZg7Wreqz0eScbrgELEAsmpfr1Dy7HogZFjGEht/I="
   }
 }

--- a/distros/lyrical/jrl-cmakemodules/default.nix
+++ b/distros/lyrical/jrl-cmakemodules/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catch2, cmake, doxygen, eigen, git, matio, pkg-config, python3Packages, simde }:
 buildRosPackage {
   pname = "ros-lyrical-jrl-cmakemodules";
-  version = "2.0.0-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/jrl_cmakemodules-release/archive/release/lyrical/jrl_cmakemodules/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "7c15c3435231ccf0c503390208150c280926c469337e57dd60e2eb97aec24fe3";
+    url = "https://github.com/ros2-gbp/jrl_cmakemodules-release/archive/release/lyrical/jrl_cmakemodules/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "18ab0479c08a377978c65de76a8973b6dfda082fda3f37e987236cbdf1839dcb";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/launch-pal/default.nix
+++ b/distros/lyrical/launch-pal/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, python3Packages }:
 buildRosPackage {
   pname = "ros-lyrical-launch-pal";
-  version = "0.20.3-r3";
+  version = "0.22.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_pal-release/archive/release/lyrical/launch_pal/0.20.3-3.tar.gz";
-    name = "0.20.3-3.tar.gz";
-    sha256 = "d54510bf6b371d815503b931cfafe624dde44ddcbccc82c6cf3604a114cc5251";
+    url = "https://github.com/ros2-gbp/launch_pal-release/archive/release/lyrical/launch_pal/0.22.1-1.tar.gz";
+    name = "0.22.1-1.tar.gz";
+    sha256 = "1c2a603d5846869d792e01f8bd9815f94f2e24d733c3e190868496817a428ba0";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/mapviz-interfaces/default.nix
+++ b/distros/lyrical/mapviz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-lyrical-mapviz-interfaces";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/lyrical/mapviz_interfaces/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "ab3cc737856a9ae11372275469506ae3f68350a54984d216339855714dfc7ece";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/lyrical/mapviz_interfaces/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "d7760b86ceb30e1af7c691e9d6232c4fa9d4e2b6a52227869c9685f37d85592e";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/mapviz-plugins/default.nix
+++ b/distros/lyrical/mapviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, assimp, cv-bridge, geometry-msgs, gps-msgs, image-transport, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-sensor-msgs, marti-visualization-msgs, opencv, pluginlib, qt-gui-cpp, qt5or6, rclcpp, rclcpp-action, sensor-msgs, std-msgs, std-srvs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, tf2, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-mapviz-plugins";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/lyrical/mapviz_plugins/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "1933a070ef8f98c06ecf0b6ba191c62fc31f5100350874a3c75edc7c0fb33f6b";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/lyrical/mapviz_plugins/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "903fdd216bca5c0fa6f45914f5407db2a5b76327a744e965029cf5edcf8e330e";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/mapviz/default.nix
+++ b/distros/lyrical/mapviz/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, image-transport, libxi, libxmu, mapviz-interfaces, opencv, pkg-config, pluginlib, qt5or6, rclcpp, rqt-gui, rqt-gui-cpp, std-srvs, swri-math-util, swri-transform-util, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-lyrical-mapviz";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/lyrical/mapviz/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "f7d2367fe34653f104b9b3d05810632e31b2da9173bc9620fdd90f2b1df28f92";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/lyrical/mapviz/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "721a776ab875f39b0a79090e0bc0d191933bf21cc542f7ae775029251b86a28a";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake pkg-config ];
-  propagatedBuildInputs = [ geometry-msgs image-transport libxi libxmu mapviz-interfaces opencv opencv.cxxdev pluginlib qt5or6.qtbase rclcpp rqt-gui rqt-gui-cpp std-srvs swri-math-util swri-transform-util tf2 tf2-geometry-msgs tf2-ros yaml-cpp ];
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ geometry-msgs image-transport libxi libxmu mapviz-interfaces opencv opencv.cxxdev pkg-config pluginlib qt5or6.qtbase rclcpp rqt-gui rqt-gui-cpp std-srvs swri-math-util swri-transform-util tf2 tf2-geometry-msgs tf2-ros yaml-cpp ];
   nativeBuildInputs = [ ament-cmake pkg-config ];
 
   meta = {

--- a/distros/lyrical/metavision-driver/default.nix
+++ b/distros/lyrical/metavision-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-xmllint, event-camera-msgs, openeb-vendor, rclcpp, rclcpp-components, ros-environment, std-srvs }:
 buildRosPackage {
   pname = "ros-lyrical-metavision-driver";
-  version = "3.0.0-r3";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/metavision_driver-release/archive/release/lyrical/metavision_driver/3.0.0-3.tar.gz";
-    name = "3.0.0-3.tar.gz";
-    sha256 = "53221f7d253d12003900148b47a710a1b51f22277c7b47721b7edb4d37b60ff0";
+    url = "https://github.com/ros2-gbp/metavision_driver-release/archive/release/lyrical/metavision_driver/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "ab18f047e9ba0ede44ab6f10407113fae98596ead36671fac7d9ac6dd976d963";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ros-environment ];
 
   meta = {
-    description = "ROS1 and ROS2 drivers for metavision based event cameras";
+    description = "ROS2 driver for metavision based event cameras";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/lyrical/mola-bridge-ros2/default.nix
+++ b/distros/lyrical/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, diagnostic-msgs, geographic-msgs, geometry-msgs, gps-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-mola-bridge-ros2";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_bridge_ros2/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "006f69c0ec5c85b2b195ba4074e59ee4515f1dc82f8bca972b6a74ef82749bd9";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_bridge_ros2/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "685c42d38372aeb8c214cfa166fa328f47463e88d85e787144b0875b6cd59ea9";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/mola-demos/default.nix
+++ b/distros/lyrical/mola-demos/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, cmake, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-xmllint, ament-lint-auto, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-lyrical-mola-demos";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_demos/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "7a21820472df051d758215da9c0f699197ff609ade3aab0f31bbe968ebe67473";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_demos/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "f5c2377e7839127cc22c4390048b1c77ba92dc50a926458d5ff2e0348bffe9ab";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest cmake ros-environment ];
-  checkInputs = [ ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  checkInputs = [ ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-xmllint ament-lint-auto ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/lyrical/mola-input-lidar-bin-dataset/default.nix
+++ b/distros/lyrical/mola-input-lidar-bin-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-lyrical-mola-input-lidar-bin-dataset";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_input_lidar_bin_dataset/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "d70a77e0c2ccd2128fdc9aebeb78b0426d8d9dea11beeba8853f57e1378781ca";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_input_lidar_bin_dataset/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "7d71eae0113556e2e02e2f7e2ce33de1561d8d5e3a950c57cdea7f86df732fb2";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mola-input-rawlog/default.nix
+++ b/distros/lyrical/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-lyrical-mola-input-rawlog";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_input_rawlog/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "2a3aa9a253ab21d3736cffad1a08bee5842dc56d053510ece874e3bf62415e0f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_input_rawlog/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "f1f67c3b162a98198b7b559e2f20a273e4b5c46191baff7a49611de86e2bd556";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mola-input-rosbag2/default.nix
+++ b/distros/lyrical/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, gps-msgs, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-lyrical-mola-input-rosbag2";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_input_rosbag2/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "fd69796a96f48a39dea807273a56fc652de09715398c2764e1dc2627ccb87ea9";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_input_rosbag2/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "c3af018e8e8bc744e4cae3cd55ba11712bf86ad26f00e9e91f16700116e15f9c";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mola-input-video/default.nix
+++ b/distros/lyrical/mola-input-video/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libhwdrivers, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-lyrical-mola-input-video";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_input_video/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "2430147b78e97d472ac3caa3344d7fd237037cb11e885e292ad7f85119e46e5f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_input_video/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "da56027a292cf734410010ef98445d39066fd8ed6adc1f9eccd8e31a0f5bc8b0";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mola-kernel/default.nix
+++ b/distros/lyrical/mola-kernel/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libgui, mrpt-libmaps, mrpt-libobs }:
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-lyrical-mola-kernel";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_kernel/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "69ee8f5ba944238d0e41c784c5e3b46d22b2df97583b64c8d622f37cacae5096";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_kernel/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "7b9df41f367d24eb19dff39ab71ef9841299a847111cf8ca7eeb116865f742c7";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
-  propagatedBuildInputs = [ mola-common mola-yaml mrpt-libgui mrpt-libmaps mrpt-libobs ];
+  propagatedBuildInputs = [ mola-common mola-yaml mrpt-libmaps mrpt-libobs ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/lyrical/mola-launcher/default.nix
+++ b/distros/lyrical/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-xmllint, ament-lint-auto, cli11, cmake, mola-kernel, mrpt-libbase, ros-environment }:
 buildRosPackage {
   pname = "ros-lyrical-mola-launcher";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_launcher/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "3e3e743e1bc31692c5ebd6364c467e879bc59991fa1dbc716a4c841faa38e2cd";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_launcher/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "1b86affdd84c7e7a727690c56626b7830a5b2f57f34a6b96b69d909e60e42b4c";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/mola-lidar-odometry/default.nix
+++ b/distros/lyrical/mola-lidar-odometry/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cli11, cmake, mola-common, mola-imu-preintegration, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mola-yaml, mp2p-icp, mrpt-libmaps, ros-environment, rosbag2-storage-mcap }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cli11, cmake, mola-bridge-ros2, mola-common, mola-imu-preintegration, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-state-estimation-smoother, mola-test-datasets, mola-viz, mola-viz-imgui, mola-yaml, mp2p-icp, mrpt-libmaps, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-lyrical-mola-lidar-odometry";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/lyrical/mola_lidar_odometry/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "cbeeed29057c3db06c7479032bf21f87247f58a76a3c0015c3794800db70ab41";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/lyrical/mola_lidar_odometry/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "c9da61cc9358c73fe5bfb2528ec89c2936c0da82bb541bdf74b3d3bfd384bcbc";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-test-datasets rosbag2-storage-mcap ];
-  propagatedBuildInputs = [ cli11 mola-common mola-imu-preintegration mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-pose-list mola-state-estimation-simple mola-viz mola-yaml mp2p-icp mrpt-libmaps ];
+  propagatedBuildInputs = [ cli11 mola-bridge-ros2 mola-common mola-imu-preintegration mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-pose-list mola-state-estimation-simple mola-state-estimation-smoother mola-viz mola-viz-imgui mola-yaml mp2p-icp mrpt-libmaps ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/lyrical/mola-metric-maps/default.nix
+++ b/distros/lyrical/mola-metric-maps/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cli11, cmake, mola-common, mola-kernel, mp2p-icp, mrpt-libmaps, onetbb, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cli11, cmake, mola-common, mola-kernel, mp2p-icp, mrpt-libmaps, nanoflann-vendor, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-lyrical-mola-metric-maps";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_metric_maps/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "5805a5bb472b96c1764a6c7d74854c03263a7e8caa882d9e34954bd3f52a5dd6";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_metric_maps/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "0cb6ed32562554624dae87854056c48724f5bdaadfa8c5456a8cdf40746e8d0f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ cli11 mola-common mola-kernel mp2p-icp mrpt-libmaps onetbb ];
+  propagatedBuildInputs = [ cli11 mola-common mola-kernel mp2p-icp mrpt-libmaps nanoflann-vendor onetbb ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/lyrical/mola-msgs/default.nix
+++ b/distros/lyrical/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-lyrical-mola-msgs";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "f1c74ab70c092e784f7d51158fd73aa3cb8a7db813051dc918e01c0fcfa2d9ad";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_msgs/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "245ebb93e013c94d47a0106e4b21a85f017615725310d124192da2e00f44cc2b";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/mola-pose-list/default.nix
+++ b/distros/lyrical/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-lyrical-mola-pose-list";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_pose_list/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "b329a4eb55814afed83935606fcb9466ccd68a931363573e8c1e723bf34c23bd";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_pose_list/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "a71132adbe1c2312cdc594ae0deeb0b16ca4b796f6529faeff76bea1a5d37ff7";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mola-relocalization/default.nix
+++ b/distros/lyrical/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-lyrical-mola-relocalization";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_relocalization/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "ecf7d235fa4c72962bb64b6e0e67b7af794e70bc5f51059c50915122534b7f09";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_relocalization/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "92c99a8d5ceb981c8b0314397fdb87f9ef532968800ec405b67e25e45f4834f6";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mola-traj-tools/default.nix
+++ b/distros/lyrical/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-lyrical-mola-traj-tools";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_traj_tools/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "44c01beaedc643fc1013d03e171855e7d9f07cc7ab6ba45d3361e8822d27768d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_traj_tools/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "b81ed7cdbace568cc229dff15fdcc4ff1a142d79c5d784adb992e4e9a4d6e470";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mola-viz-imgui/default.nix
+++ b/distros/lyrical/mola-viz-imgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, freeglut, glfw3, libGL, libGLU, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-lyrical-mola-viz-imgui";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_viz_imgui/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "59c2ea9cee488f3ad3390af79533c4f99c26c9e29c435c5ed6b7a758e84e042f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_viz_imgui/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "eedfe07aed3b1630691ae92f0d3e28fcdb6861b9650f70a8e68c68f3a54d4906";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mola-viz/default.nix
+++ b/distros/lyrical/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-lyrical-mola-viz";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_viz/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "ee0cbb27b92220967e5735f9d887b0887fb34fda5dfce46f41d31250e96d1f75";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_viz/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "d330fc1c49acfa08600ad0227b222b267fda48365eebe33fea5116591fae817c";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mola-yaml/default.nix
+++ b/distros/lyrical/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-lyrical-mola-yaml";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_yaml/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "8128fe4f46f1492eae7820614fe6600dca1bae1c3ef6cb403e058eb156854338";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola_yaml/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "b6d48040d1478ee977e7e213ae2ba879348811094deb822028b7883ad5fada0f";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mola/default.nix
+++ b/distros/lyrical/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-bridge-ros2, mola-demos, mola-input-rawlog, mola-input-rosbag2, mola-input-video, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-lyrical-mola";
-  version = "3.0.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "f0d064803d30d611fd2e1623810f59e3d1c2e53f477d39d48c76ba7aed3fb47c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/lyrical/mola/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "3a8321c60d10295fddc1c4d5fc16409d58b555ecc8392231d943d6f6a0334141";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/moveit-task-constructor-capabilities/default.nix
+++ b/distros/lyrical/moveit-task-constructor-capabilities/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, controller-manager, fmt, launch-testing, launch-testing-ament-cmake, moveit-configs-utils, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-task-constructor-core, moveit-task-constructor-msgs, pluginlib, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-moveit-task-constructor-capabilities";
-  version = "0.1.5-r3";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/lyrical/moveit_task_constructor_capabilities/0.1.5-3.tar.gz";
-    name = "0.1.5-3.tar.gz";
-    sha256 = "560597847bcc88464c1dc134370aee5d3a191965138b507934deeeb9773ac27e";
+    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/lyrical/moveit_task_constructor_capabilities/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "99bf2030775a98b5fc129ce23942858e4af91b2e22e6f43384e5fc7f5a0416c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/moveit-task-constructor-core/default.nix
+++ b/distros/lyrical/moveit-task-constructor-core/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, fmt, geometry-msgs, launch-testing-ament-cmake, moveit-configs-utils, moveit-core, moveit-planners, moveit-py, moveit-resources-fanuc-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, moveit-task-constructor-msgs, py-binding-tools, rclcpp, rviz-marker-tools, tf2-eigen, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, fmt, geometry-msgs, launch-testing-ament-cmake, moveit-configs-utils, moveit-core, moveit-planners-ompl, moveit-py, moveit-resources-fanuc-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, moveit-task-constructor-msgs, py-binding-tools, rclcpp, rviz-marker-tools, tf2-eigen, visualization-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-moveit-task-constructor-core";
-  version = "0.1.5-r3";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/lyrical/moveit_task_constructor_core/0.1.5-3.tar.gz";
-    name = "0.1.5-3.tar.gz";
-    sha256 = "5bcaf53aa028f367a7dd7651a1d89b0862445ca156d78966f7f6e58526e98fe7";
+    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/lyrical/moveit_task_constructor_core/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "a216c406860823c6cf4ed6c124d84481be1bbf0265d9526f74c198ed8eb2c026";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
-  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-cmake-pytest launch-testing-ament-cmake moveit-configs-utils moveit-planners moveit-resources-fanuc-moveit-config ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-cmake-pytest launch-testing-ament-cmake moveit-configs-utils moveit-planners-ompl moveit-resources-fanuc-moveit-config ];
   propagatedBuildInputs = [ fmt geometry-msgs moveit-core moveit-py moveit-ros-planning moveit-ros-planning-interface moveit-task-constructor-msgs py-binding-tools rclcpp rviz-marker-tools tf2-eigen visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 

--- a/distros/lyrical/moveit-task-constructor-demo/default.nix
+++ b/distros/lyrical/moveit-task-constructor-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, generate-parameter-library, moveit-configs-utils, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, moveit-task-constructor-capabilities, moveit-task-constructor-core, moveit-task-constructor-visualization, py-binding-tools }:
 buildRosPackage {
   pname = "ros-lyrical-moveit-task-constructor-demo";
-  version = "0.1.5-r3";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/lyrical/moveit_task_constructor_demo/0.1.5-3.tar.gz";
-    name = "0.1.5-3.tar.gz";
-    sha256 = "826b731af5535e09bbf9ccf4ae257d9d108c5b872156fe8843628f4b49054e2e";
+    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/lyrical/moveit_task_constructor_demo/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "09f74070d55e9d214165e1aca3b74cb6e60cf666f00fe42d8136547a1f8b5a15";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/moveit-task-constructor-msgs/default.nix
+++ b/distros/lyrical/moveit-task-constructor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-msgs, rosidl-default-generators, rosidl-default-runtime, visualization-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-moveit-task-constructor-msgs";
-  version = "0.1.5-r3";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/lyrical/moveit_task_constructor_msgs/0.1.5-3.tar.gz";
-    name = "0.1.5-3.tar.gz";
-    sha256 = "c1e798d5637c24070e1cb90c0f84f99d5d0872927b0ad05dce184450f3d343ac";
+    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/lyrical/moveit_task_constructor_msgs/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "5c3ae0775a8b11f9081b102e36f875687dbbd45d64d868a8eaa0dccc771002e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/moveit-task-constructor-visualization/default.nix
+++ b/distros/lyrical/moveit-task-constructor-visualization/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, fmt, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, libyaml-vendor, moveit-core, moveit-ros-visualization, moveit-task-constructor-core, moveit-task-constructor-msgs, qt5, rclcpp, rviz2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, fmt, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, libyaml-vendor, moveit-core, moveit-ros-visualization, moveit-task-constructor-core, moveit-task-constructor-msgs, qt5or6, rclcpp, rviz2 }:
 buildRosPackage {
   pname = "ros-lyrical-moveit-task-constructor-visualization";
-  version = "0.1.5-r3";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/lyrical/moveit_task_constructor_visualization/0.1.5-3.tar.gz";
-    name = "0.1.5-3.tar.gz";
-    sha256 = "586c027b9771a1cf9032637fe54f307e22beed29cc3382aa1935aabe157e2eeb";
+    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/lyrical/moveit_task_constructor_visualization/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "7e9fcfa3ce511263acf8f42990a2ac498a5e90721cb8457cbad586696358f100";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake qt5.qtbase ];
+  buildInputs = [ ament-cmake qt5or6.qtbase ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest launch launch-testing launch-testing-ament-cmake launch-testing-ros ];
   propagatedBuildInputs = [ fmt libyaml-vendor moveit-core moveit-ros-visualization moveit-task-constructor-core moveit-task-constructor-msgs rclcpp rviz2 ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/lyrical/mp2p-icp-core/default.nix
+++ b/distros/lyrical/mp2p-icp-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cli11, cmake, mola-common, mola-imu-preintegration, mrpt-libbase, mrpt-libmaps, mrpt-libobs, mrpt-libposes, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-lyrical-mp2p-icp-core";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/lyrical/mp2p_icp_core/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "dfeaec795a9b842c70c94b1e58cd83ff57ef2ded0237f5d8fc3cf825988734f7";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/lyrical/mp2p_icp_core/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "24c9d9aa2c0a30f23455901c756f3543da8896cbb2f17bae54cf3084ccd76674";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mp2p-icp-viz/default.nix
+++ b/distros/lyrical/mp2p-icp-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cli11, cmake, mola-common, mp2p-icp-core, mrpt-libgui, ros-environment }:
 buildRosPackage {
   pname = "ros-lyrical-mp2p-icp-viz";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/lyrical/mp2p_icp_viz/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "bfa055c9c88ef78d77526e50e57883c2c49d5e47ec9edce222621bf4457b0014";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/lyrical/mp2p_icp_viz/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "29d22e408314315d76d83c9623768ca2989c6b7c329ab3f8bec6727bc22a7908";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mp2p-icp/default.nix
+++ b/distros/lyrical/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mp2p-icp-core, mp2p-icp-viz }:
 buildRosPackage {
   pname = "ros-lyrical-mp2p-icp";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/lyrical/mp2p_icp/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "ba439c40df2d87ecbdd7c7e06d6d8140ebe6f1b8e510cf0a4ddab249b2b5941b";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/lyrical/mp2p_icp/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "7caba36e75f4a14ec258c84a377186a635f35da5744bb99cd73219d893247ca4";
   };
 
   buildType = "cmake";

--- a/distros/lyrical/mujoco-3d-lidar/default.nix
+++ b/distros/lyrical/mujoco-3d-lidar/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, mujoco-vendor }:
+buildRosPackage {
+  pname = "ros-lyrical-mujoco-3d-lidar";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/lyrical/mujoco_3d_lidar/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "6cd8ade7fbda1235c53f4193d8e4d7f3304c8197fa9f465acc28f16388a83360";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ mujoco-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Plugin for mujoco to use raycasters to simulate lidar";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/mujoco-ros2-control-demos/default.nix
+++ b/distros/lyrical/mujoco-ros2-control-demos/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_position_controllers, ament-cmake, controller-manager, joint-state-broadcaster, mujoco-ros2-control, mujoco-ros2-control-msgs, robot-state-publisher, rviz2, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, forward-command-controller, joint-state-broadcaster, launch, launch-ros, mujoco-ros2-control, mujoco-ros2-control-msgs, pose-broadcaster, robot-state-publisher, rviz2, xacro }:
 buildRosPackage {
   pname = "ros-lyrical-mujoco-ros2-control-demos";
-  version = "0.0.2-r3";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/lyrical/mujoco_ros2_control_demos/0.0.2-3.tar.gz";
-    name = "0.0.2-3.tar.gz";
-    sha256 = "331d2da12b0d1600a0ce77bba57c624f7b0bc16dfa15b602909352c345a5e7d4";
+    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/lyrical/mujoco_ros2_control_demos/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "592da31c55a4d0134dfae30c4786ef7b07d60b6a8ead3dbf94bd07bfccc4e8b0";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ _unresolved_position_controllers controller-manager joint-state-broadcaster mujoco-ros2-control mujoco-ros2-control-msgs robot-state-publisher rviz2 xacro ];
+  propagatedBuildInputs = [ controller-manager forward-command-controller joint-state-broadcaster launch launch-ros mujoco-ros2-control mujoco-ros2-control-msgs pose-broadcaster robot-state-publisher rviz2 xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/lyrical/mujoco-ros2-control-msgs/default.nix
+++ b/distros/lyrical/mujoco-ros2-control-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-mujoco-ros2-control-msgs";
-  version = "0.0.2-r3";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/lyrical/mujoco_ros2_control_msgs/0.0.2-3.tar.gz";
-    name = "0.0.2-3.tar.gz";
-    sha256 = "93ff9455104f843e64b8f9fe13c7921d8d61a325569920b38affccb2361515b8";
+    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/lyrical/mujoco_ros2_control_msgs/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "2eb949e227844dc95e7e6c0c6ba1fb40aa1a08cd9a0248cb155e32ccf0aee424";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime sensor-msgs std-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/lyrical/mujoco-ros2-control-plugins/default.nix
+++ b/distros/lyrical/mujoco-ros2-control-plugins/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, mujoco-vendor, pluginlib, rclcpp, ros2-control-cmake, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, backward-ros, geometry-msgs, glfw3, libGL, libGLU, mujoco-3d-lidar, mujoco-ros2-control-msgs, mujoco-vendor, pluginlib, rclcpp, realtime-tools, ros2-control-cmake, sensor-msgs, std-msgs, std-srvs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-mujoco-ros2-control-plugins";
-  version = "0.0.2-r3";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/lyrical/mujoco_ros2_control_plugins/0.0.2-3.tar.gz";
-    name = "0.0.2-3.tar.gz";
-    sha256 = "00f580d3a3c16a1a567a90cc62d4e2f48cca06c02a4c94d63b69c479349c5521";
+    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/lyrical/mujoco_ros2_control_plugins/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "330c112af53a7e840cd99eda5e5617a1a641ba5b36536cbab972fbf90b34fc7c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gtest ];
-  propagatedBuildInputs = [ mujoco-vendor pluginlib rclcpp ros2-control-cmake std-msgs ];
+  checkInputs = [ ament-cmake-gtest ament-index-cpp mujoco-3d-lidar ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs glfw3 libGL libGLU mujoco-ros2-control-msgs mujoco-vendor pluginlib rclcpp realtime-tools ros2-control-cmake sensor-msgs std-msgs std-srvs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/lyrical/mujoco-ros2-control/default.nix
+++ b/distros/lyrical/mujoco-ros2-control/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, backward-ros, control-toolbox, controller-manager, fmt, git, glfw3, hardware-interface, mujoco-ros2-control-msgs, mujoco-ros2-control-plugins, mujoco-vendor, nav-msgs, pluginlib, python3, python3Packages, rclcpp, rclcpp-lifecycle, ros2-control-cmake, sensor-msgs, transmission-interface }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-index-cpp, ament-index-python, backward-ros, control-toolbox, controller-manager, eigen, fmt, geometry-msgs, git, glfw3, hardware-interface, mujoco-ros2-control-msgs, mujoco-ros2-control-plugins, mujoco-vendor, nav-msgs, pluginlib, python3, python3Packages, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2pkg, rosgraph-msgs, sensor-msgs, std-msgs, tinyxml2-vendor, transmission-interface, urdfdom-py }:
 buildRosPackage {
   pname = "ros-lyrical-mujoco-ros2-control";
-  version = "0.0.2-r3";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/lyrical/mujoco_ros2_control/0.0.2-3.tar.gz";
-    name = "0.0.2-3.tar.gz";
-    sha256 = "853b80195ffe8c624847bdc27b9b9fc6aae72e429ff781ffeb68d94319ad5c79";
+    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/lyrical/mujoco_ros2_control/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "f9f14321162f0f37bf1d5653bbe7762e3856c13db26540863bdc2ed506d125e5";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python git ros2-control-cmake ];
   checkInputs = [ ament-cmake-gtest ament-cmake-pytest ];
-  propagatedBuildInputs = [ backward-ros control-toolbox controller-manager fmt glfw3 hardware-interface mujoco-ros2-control-msgs mujoco-ros2-control-plugins mujoco-vendor nav-msgs pluginlib python3 python3Packages.pip python3Packages.pykdl rclcpp rclcpp-lifecycle sensor-msgs transmission-interface ];
+  propagatedBuildInputs = [ ament-index-cpp ament-index-python backward-ros control-toolbox controller-manager eigen fmt geometry-msgs glfw3 hardware-interface mujoco-ros2-control-msgs mujoco-ros2-control-plugins mujoco-vendor nav-msgs pluginlib python3 python3Packages.importlib-resources python3Packages.numpy python3Packages.pip python3Packages.pykdl rclcpp rclcpp-lifecycle realtime-tools ros2pkg rosgraph-msgs sensor-msgs std-msgs tinyxml2-vendor transmission-interface urdfdom-py ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python git ];
 
   meta = {

--- a/distros/lyrical/multires-image/default.nix
+++ b/distros/lyrical/multires-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, gps-msgs, mapviz, mapviz-interfaces, marti-common-msgs, pluginlib, python3Packages, qt-gui-cpp, qt5or6, rclcpp, rclpy, swri-math-util, swri-transform-util, tf2 }:
 buildRosPackage {
   pname = "ros-lyrical-multires-image";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/lyrical/multires_image/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "8412520961e0f6a548c7d99e0b823a218e16efa8410d7d7b625eda454513e371";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/lyrical/multires_image/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "2877dcf4a388a10ead339fbc0748c2632718bb0d9e6284d4f4b51d3e9c1d9141";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/novatel-gps-driver/default.nix
+++ b/distros/lyrical/novatel-gps-driver/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, boost, diagnostic-msgs, diagnostic-updater, gps-msgs, libpcap, nav-msgs, novatel-gps-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, swri-math-util, swri-roscpp, swri-serial-util, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, _unresolved_swri_roscpp, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, boost, diagnostic-msgs, diagnostic-updater, gps-msgs, libpcap, nav-msgs, novatel-gps-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, swri-math-util, swri-serial-util, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-novatel-gps-driver";
   version = "4.3.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ];
-  propagatedBuildInputs = [ boost diagnostic-msgs diagnostic-updater gps-msgs libpcap nav-msgs novatel-gps-msgs rclcpp rclcpp-components sensor-msgs std-msgs swri-math-util swri-roscpp swri-serial-util tf2 tf2-geometry-msgs ];
+  propagatedBuildInputs = [ _unresolved_swri_roscpp boost diagnostic-msgs diagnostic-updater gps-msgs libpcap nav-msgs novatel-gps-msgs rclcpp rclcpp-components sensor-msgs std-msgs swri-math-util swri-serial-util tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/lyrical/pal-statistics-msgs/default.nix
+++ b/distros/lyrical/pal-statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-pal-statistics-msgs";
-  version = "2.8.0-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/lyrical/pal_statistics_msgs/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "6395675c389a69f9bf00fed8f8e0d11ac74107404e0c6f46418480d2ba1437f3";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/lyrical/pal_statistics_msgs/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "d2f2a771299e75d21cd2b5199300ce8390e9b9de4712ce05b1c635222e686bb3";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/pal-statistics/default.nix
+++ b/distros/lyrical/pal-statistics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, boost, pal-statistics-msgs, rclcpp, rclcpp-lifecycle, rclpy }:
 buildRosPackage {
   pname = "ros-lyrical-pal-statistics";
-  version = "2.8.0-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/lyrical/pal_statistics/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "2e432d0cd5e17a9a7ebe4ed5e00a1d479a2e341e978eae6b5e316415ad4f5b6a";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/lyrical/pal_statistics/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "ee058cfd44d65fbbb258f42e07d539791f76289c73f0fc54a4a18927b7ce6dd3";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/pal-urdf-utils/default.nix
+++ b/distros/lyrical/pal-urdf-utils/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, realsense2-description, xacro }:
+buildRosPackage {
+  pname = "ros-lyrical-pal-urdf-utils";
+  version = "2.9.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/pal_urdf_utils-release/archive/release/lyrical/pal_urdf_utils/2.9.2-1.tar.gz";
+    name = "2.9.2-1.tar.gz";
+    sha256 = "65ee24f692072761912d3a2b91e646508c722315aa8653f1e1d3fa03de3b5853";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ realsense2-description xacro ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = "This package contains the color materials of common elements of PAL Robotics' robot.
+      The files in this package are parsed and used by
+      a variety of other components.  Most users will not interact directly
+      with this package.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/lyrical/pangolin/default.nix
+++ b/distros/lyrical/pangolin/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catch2, cmake, eigen, glew, libGL, libGLU, libepoxy, libjpeg, libpng, libxkbcommon, python3, python3Packages, wayland }:
+{ lib, buildRosPackage, fetchurl, catch2, cmake, eigen, glew, libGL, libGLU, libepoxy, libjpeg, libpng, libxkbcommon, openexr, python3, python3Packages, wayland }:
 buildRosPackage {
   pname = "ros-lyrical-pangolin";
-  version = "0.9.5-r3";
+  version = "0.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Pangolin-release/archive/release/lyrical/pangolin/0.9.5-3.tar.gz";
-    name = "0.9.5-3.tar.gz";
-    sha256 = "95022ccefd9b9c34304a25e2d8aaae8a3a2c5957e2b85d1224d0c9013fe96a72";
+    url = "https://github.com/ros2-gbp/Pangolin-release/archive/release/lyrical/pangolin/0.9.6-1.tar.gz";
+    name = "0.9.6-1.tar.gz";
+    sha256 = "cd014d43ee5fd654c9f16dcd696020c85326bd429bdf347fab51dded2b89e906";
   };
 
   buildType = "cmake";
-  buildInputs = [ cmake eigen python3Packages.wheel ];
+  buildInputs = [ cmake eigen python3Packages.setuptools python3Packages.wheel ];
   checkInputs = [ catch2 ];
-  propagatedBuildInputs = [ glew libGL libGLU libepoxy libjpeg libpng libxkbcommon python3 wayland ];
+  propagatedBuildInputs = [ glew libGL libGLU libepoxy libjpeg libpng libxkbcommon openexr python3 wayland ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/lyrical/rmw-cyclonedds-cpp/default.nix
+++ b/distros/lyrical/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros-core, ament-lint-auto, ament-lint-common, cyclonedds, iceoryx-binding-c, rcpputils, rcutils, rmw, rmw-dds-common, rmw-security-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-lyrical-rmw-cyclonedds-cpp";
-  version = "4.1.4-r3";
+  version = "4.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/lyrical/rmw_cyclonedds_cpp/4.1.4-3.tar.gz";
-    name = "4.1.4-3.tar.gz";
-    sha256 = "4c26c927f3ebb847ce6b35d85f710a0a92222183fc52ca0396276a5614d9abe0";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/lyrical/rmw_cyclonedds_cpp/4.1.5-1.tar.gz";
+    name = "4.1.5-1.tar.gz";
+    sha256 = "6043e0976c97e40373d6b1c6b49f4824ce96411e3a7fefff72bbd448ab6c4603";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/rviz-marker-tools/default.nix
+++ b/distros/lyrical/rviz-marker-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, rclcpp, std-msgs, tf2-eigen, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-rviz-marker-tools";
-  version = "0.1.5-r3";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/lyrical/rviz_marker_tools/0.1.5-3.tar.gz";
-    name = "0.1.5-3.tar.gz";
-    sha256 = "bcb81b859c7c5226201f474436d7da8c8e2ab5171f237455ea013526809b127c";
+    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/lyrical/rviz_marker_tools/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "5c2d94e7fb54583d5a6a00267022f444190ffca7b98ec336debbf2cddad29474";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/swri-cli-tools/default.nix
+++ b/distros/lyrical/swri-cli-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, marti-introspection-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, ros2topic }:
 buildRosPackage {
   pname = "ros-lyrical-swri-cli-tools";
-  version = "3.9.0-r1";
+  version = "3.9.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_cli_tools/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "e7e849d026e60f80d85c976265a886d2ebfb951eefe5c7389460bc3616e56ae8";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_cli_tools/3.9.1-2.tar.gz";
+    name = "3.9.1-2.tar.gz";
+    sha256 = "75b532e7fb5b1b9bb66d79fa97af65980a20a7c13545472cfc76595d6ef74542";
   };
 
   buildType = "ament_python";

--- a/distros/lyrical/swri-console-util/default.nix
+++ b/distros/lyrical/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-lyrical-swri-console-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_console_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "eb69481bafefb47362ad73632b215820e60dc79b21f5f548aa729b8b0d5fcb99";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_console_util/3.9.1-2.tar.gz";
+    name = "3.9.1-2.tar.gz";
+    sha256 = "5b38a051025f54b3f6bb255df42a9fd4b9b6f091c94763cade73f8328e409370";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/swri-dbw-interface/default.nix
+++ b/distros/lyrical/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-lyrical-swri-dbw-interface";
-  version = "3.9.0-r1";
+  version = "3.9.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_dbw_interface/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "e54ce73c410728007e6021180d7c3583c8beba9ea4b84f074f29018932074ecd";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_dbw_interface/3.9.1-2.tar.gz";
+    name = "3.9.1-2.tar.gz";
+    sha256 = "26507217112bec715034f8c4229641c373c4b49e2d7f6b177288775abf05127e";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/swri-geometry-util/default.nix
+++ b/distros/lyrical/swri-geometry-util/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, geos, opencv, pkg-config, tf2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, geos, opencv, tf2 }:
 buildRosPackage {
   pname = "ros-lyrical-swri-geometry-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_geometry_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "151ce188a6d23bff0bfb09a6a10e3cac34b37057fbad3106186f4e158842edc6";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_geometry_util/3.9.1-2.tar.gz";
+    name = "3.9.1-2.tar.gz";
+    sha256 = "eb30ae04ae43fb8ee34b233aabc8852a92a850c0d18354245e38dbc1228a20a7";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake pkg-config ];
+  buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ];
   propagatedBuildInputs = [ eigen geos opencv opencv.cxxdev tf2 ];
-  nativeBuildInputs = [ ament-cmake pkg-config ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = "Commonly used geometry routines, implemented in a ROS friendly package.";

--- a/distros/lyrical/swri-image-util/default.nix
+++ b/distros/lyrical/swri-image-util/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, camera-calibration-parsers, cv-bridge, eigen, image-geometry, image-transport, message-filters, opencv, pkg-config, rcl-interfaces, rclcpp, rclcpp-components, rclpy, swri-geometry-util, swri-math-util, swri-opencv-util, tf2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, camera-calibration-parsers, cv-bridge, eigen, image-geometry, image-transport, message-filters, opencv, rcl-interfaces, rclcpp, rclcpp-components, rclpy, swri-geometry-util, swri-math-util, swri-opencv-util, tf2 }:
 buildRosPackage {
   pname = "ros-lyrical-swri-image-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_image_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "1e3322d76aa02250363ba693aa5bc53aad68c9d388b081e28e16f336a76d1274";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_image_util/3.9.1-2.tar.gz";
+    name = "3.9.1-2.tar.gz";
+    sha256 = "0a06ed674ebc77a0fbe9d4cbcb83a7680ad14a34f148c3574ac6da15baaa364e";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake pkg-config ];
+  buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ];
   propagatedBuildInputs = [ ament-index-cpp camera-calibration-parsers cv-bridge eigen image-geometry image-transport message-filters opencv opencv.cxxdev rcl-interfaces rclcpp rclcpp-components rclpy swri-geometry-util swri-math-util swri-opencv-util tf2 ];
-  nativeBuildInputs = [ ament-cmake pkg-config ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = "A package of commonly image manipulation utilities.";

--- a/distros/lyrical/swri-math-util/default.nix
+++ b/distros/lyrical/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, rclcpp }:
 buildRosPackage {
   pname = "ros-lyrical-swri-math-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_math_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "af3c747f2c0a4f6d8b8c3ba2b7d4b86197a40443185369e1d1e5467325fb3361";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_math_util/3.9.1-2.tar.gz";
+    name = "3.9.1-2.tar.gz";
+    sha256 = "77af48943704f899ba2a66e7ee21b459f1832c5ef59352ad93adf51099e3cf9e";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/swri-opencv-util/default.nix
+++ b/distros/lyrical/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, opencv, swri-math-util }:
 buildRosPackage {
   pname = "ros-lyrical-swri-opencv-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_opencv_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "4af892ade2ef2b1e981c1b1ad0f0c4bd3a558eb774cbd432e51ff30ea60c2e5e";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_opencv_util/3.9.1-2.tar.gz";
+    name = "3.9.1-2.tar.gz";
+    sha256 = "2fcf17563a3dfb0af97e4431b25dcd6ce54242c0d24f055aafd729bd49db5e45";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/swri-route-util/default.nix
+++ b/distros/lyrical/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-transform-util, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-lyrical-swri-route-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_route_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "0d77e66678c15e7e73feba3ac5f6c97bdb6f4d902c1a0c9ccbcb806d9ec05805";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_route_util/3.9.1-2.tar.gz";
+    name = "3.9.1-2.tar.gz";
+    sha256 = "e903c0648b09d9a41939098b35b4760d2d63fe47d2dcaf774d9e0830cfc9d6f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/swri-serial-util/default.nix
+++ b/distros/lyrical/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-lyrical-swri-serial-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_serial_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "55733b42fedcc2495f82047649f58886a3ce6b3bd24873f9ccd42b9a327c3d8c";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_serial_util/3.9.1-2.tar.gz";
+    name = "3.9.1-2.tar.gz";
+    sha256 = "cb825a2c24648f71ec45154b7dde0a37b04548311cc469379bfd1b4eeb751ef1";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/swri-transform-util/default.nix
+++ b/distros/lyrical/swri-transform-util/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-index-cpp, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geographiclib, geometry-msgs, geos, gps-msgs, launch-ros, launch-testing, launch-testing-ament-cmake, marti-nav-msgs, opencv, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-index-cpp, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geographiclib, geometry-msgs, geos, gps-msgs, launch-ros, launch-testing, launch-testing-ament-cmake, marti-nav-msgs, opencv, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-lyrical-swri-transform-util";
-  version = "3.9.0-r1";
+  version = "3.9.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_transform_util/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "37dd76b3b930e5f72e46cc575ff04ee7b8000aa3cc37e58014eb8ad0f5d460df";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/lyrical/swri_transform_util/3.9.1-2.tar.gz";
+    name = "3.9.1-2.tar.gz";
+    sha256 = "d3d71bfc8c47ab51ea0a2ad5709e4a16ea7d2d75fa342ec59b5ba894d0f79423";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python pkg-config ];
   checkInputs = [ ament-cmake-gtest ament-index-cpp launch-ros launch-testing launch-testing-ament-cmake ];
-  propagatedBuildInputs = [ cv-bridge diagnostic-msgs diagnostic-updater geographic-msgs geographiclib geometry-msgs geos gps-msgs marti-nav-msgs opencv opencv.cxxdev proj python3Packages.numpy python3Packages.pyyaml rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util swri-roscpp tf2 tf2-geometry-msgs tf2-ros yaml-cpp-vendor ];
+  propagatedBuildInputs = [ cv-bridge diagnostic-msgs diagnostic-updater geographic-msgs geographiclib geometry-msgs geos gps-msgs marti-nav-msgs opencv opencv.cxxdev proj python3Packages.numpy python3Packages.pyyaml rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util tf2 tf2-geometry-msgs tf2-ros yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python pkg-config ];
 
   meta = {

--- a/distros/lyrical/tf2-2d/default.nix
+++ b/distros/lyrical/tf2-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, eigen, rclcpp, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-lyrical-tf2-2d";
-  version = "1.6.1-r3";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tf2_2d-release/archive/release/lyrical/tf2_2d/1.6.1-3.tar.gz";
-    name = "1.6.1-3.tar.gz";
-    sha256 = "87081d05fdf1dc8385aa9e72c523b6acd1cbb475e48b0201f1e7ea1f37f29cf5";
+    url = "https://github.com/ros2-gbp/tf2_2d-release/archive/release/lyrical/tf2_2d/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "e698f7f85764fea3eefe27decf567af5f637ab6eb651d66cbc086c69e773cf13";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/tile-map/default.nix
+++ b/distros/lyrical/tile-map/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, jsoncpp, mapviz, pluginlib, qt-gui-cpp, qt5or6, rclcpp, swri-math-util, swri-transform-util, tf2, yaml-cpp }:
 buildRosPackage {
   pname = "ros-lyrical-tile-map";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/lyrical/tile_map/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "7db3fa9b39f379e6c632d20adb96e745bfe12fe1bfcb5155263362a2cefd0d87";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/lyrical/tile_map/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "9b01b27205566aac62b2f90c9d4edf9a37367e4e0dbc89a16521d5a263dcba10";
   };
 
   buildType = "ament_cmake";

--- a/distros/lyrical/unbag/default.nix
+++ b/distros/lyrical/unbag/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-index-python, ament-lint-auto, ament-lint-common, python3, python3Packages, qt5, rclpy, ros2cli, rosbag2-py, rosidl-runtime-py, sensor-msgs, tf2-msgs }:
+buildRosPackage {
+  pname = "ros-lyrical-unbag";
+  version = "1.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/unbag-release/archive/release/lyrical/unbag/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "6f6841e2f12e01d90ac9ec67598d7cc97fb8d92f1764eb81fc1da76a17265c0b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python python3 python3Packages.setuptools qt5.qtbase ];
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-python python3Packages.numpy python3Packages.opencv4 python3Packages.pyyaml python3Packages.tqdm qt5.qtsvg rclpy ros2cli rosbag2-py rosidl-runtime-py sensor-msgs tf2-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "A ROS 2 tool for exporting bags to human readable files. Supports pluggable export routines to handle any message type.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/lyrical/urdf-test/default.nix
+++ b/distros/lyrical/urdf-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, rclpy, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-lyrical-urdf-test";
-  version = "2.1.1-r3";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/urdf_test-release/archive/release/lyrical/urdf_test/2.1.1-3.tar.gz";
-    name = "2.1.1-3.tar.gz";
-    sha256 = "b823de1f98bcc7e67539fb106aa35c36a310bb295dbc8186d9d9514f9c2d1c90";
+    url = "https://github.com/ros2-gbp/urdf_test-release/archive/release/lyrical/urdf_test/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "a4550b6d7e993f8e1f70ca51632fe5f22cdc1c0950d2676d6f54c30038da79e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/crazyflie-description/default.nix
+++ b/distros/rolling/crazyflie-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-crazyflie-description";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/rolling/crazyflie_description/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "6b51d6224c0ac2b8ff029c0230cf8e5cddb9d69285d3651c1048bb447209d0ae";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/rolling/crazyflie_description/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "bb6809614ffaf08bba2f7fdecabddb03cd720f144d990a038097e391b4544826";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/crazyflie-examples/default.nix
+++ b/distros/rolling/crazyflie-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, crazyflie-py, geometry-msgs, nav-msgs, python3Packages, rclpy, sensor-msgs, tf-transformations, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-crazyflie-examples";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/rolling/crazyflie_examples/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "a7372fc15b782996752736027fad1d44073a7f72f1441df3ca74159c49062259";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/rolling/crazyflie_examples/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "a0e0478d9ab1afa188ee4295df50e4da5afaeabb162d59ee86884fd3c0675513";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/crazyflie-interfaces/default.nix
+++ b/distros/rolling/crazyflie-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-crazyflie-interfaces";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/rolling/crazyflie_interfaces/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "06c3c2550953b74b49f1a384ad134ea09f809932f193c1115b4709726bcc7407";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/rolling/crazyflie_interfaces/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "8fbe8e9deaf5bdb916ec1a0098844744fe7ce360a98a5ca4ceaf5a049e62e98f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/crazyflie-py/default.nix
+++ b/distros/rolling/crazyflie-py/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, crazyflie-interfaces, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-crazyflie-py";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/rolling/crazyflie_py/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "605ff69642c33138dc1663860ffee6a66f1bfb44abead817e1c31908fac5c99f";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/rolling/crazyflie_py/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "a3150b71b1dec9bd3827b22ec8d0e86188d137f8a0956b67a3e614559200a0c1";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
-  propagatedBuildInputs = [ crazyflie-interfaces rclpy ];
+  propagatedBuildInputs = [ crazyflie-interfaces python3Packages.transforms3d rclpy ];
 
   meta = {
     description = "Simple Python Interface for Crayzswarm2";

--- a/distros/rolling/crazyflie-server-cpp/default.nix
+++ b/distros/rolling/crazyflie-server-cpp/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, crazyflie-interfaces, eigen, geometry-msgs, libusb1, motion-capture-tracking-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, std-srvs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-rolling-crazyflie-server-cpp";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/rolling/crazyflie_server_cpp/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "9988f5a46618cecd2796dcb0fb155c089bd8c2997057eaa59f60c7230070d62d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ boost crazyflie-interfaces eigen geometry-msgs libusb1 motion-capture-tracking-interfaces nav-msgs rclcpp ros-environment sensor-msgs std-srvs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "C++ ROS 2 server node for Bitcraze Crazyflie robots";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/crazyflie-server-py/default.nix
+++ b/distros/rolling/crazyflie-server-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, crazyflie-interfaces, geometry-msgs, motion-capture-tracking-interfaces, nav-msgs, python3Packages, rcl-interfaces, rclpy, sensor-msgs, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-crazyflie-server-py";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/rolling/crazyflie_server_py/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "1774d52034e1ccec511bc6c87bf05a334398b21cafada50468d06f073989b1be";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/rolling/crazyflie_server_py/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "371e0eb96506b28d12cc2d35f7aee224a58ea9b3a6782708fde88055c171fa61";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/crazyflie-sim/default.nix
+++ b/distros/rolling/crazyflie-sim/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, crazyflie-interfaces, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-crazyflie-sim";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/rolling/crazyflie_sim/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "b346c3a24d8dfea272ca1507b33b088862bd9c55deb36351486f6600d9620f8c";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/rolling/crazyflie_sim/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "ea33edec0ea9faeb2ce8f4eca23e0f92d78f4f41f0899fe70496f628d6e402f3";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-cmake-pytest ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
-  propagatedBuildInputs = [ crazyflie-interfaces rclpy ];
+  propagatedBuildInputs = [ crazyflie-interfaces python3Packages.transforms3d rclpy ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/rolling/crazyflie/default.nix
+++ b/distros/rolling/crazyflie/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, boost, crazyflie-description, crazyflie-interfaces, eigen, geometry-msgs, libusb1, motion-capture-tracking-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, std-srvs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, crazyflie-description, crazyflie-interfaces, crazyflie-server-cpp, eigen, geometry-msgs, rclcpp, rclpy, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-crazyflie";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/rolling/crazyflie/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "2cf00fabce93f70caab6565cadadcb364578be85a1e998e9d764a38a416d381e";
+    url = "https://github.com/ros2-gbp/crazyswarm2-release/archive/release/rolling/crazyflie/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "cc30f9997d96360d2106f2767d19e6b5f86bde0ffe6999caf222158b4ed8c118";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ boost crazyflie-description crazyflie-interfaces eigen geometry-msgs libusb1 motion-capture-tracking-interfaces nav-msgs rclcpp ros-environment sensor-msgs std-srvs tf2-ros ];
+  propagatedBuildInputs = [ crazyflie-description crazyflie-interfaces crazyflie-server-cpp eigen geometry-msgs rclcpp rclpy sensor-msgs std-srvs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/rolling/fuse-constraints/default.nix
+++ b/distros/rolling/fuse-constraints/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ceres-solver, eigen, fuse-core, fuse-graphs, fuse-variables, gbenchmark, geometry-msgs, gtest-vendor, pluginlib, rclcpp, suitesparse }:
 buildRosPackage {
   pname = "ros-rolling-fuse-constraints";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_constraints/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "7dd2d5edd70f9d55e017c69a75a09d3dfd63518f17780aa67147ea7b68868078";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_constraints/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "c1740a0cd83073efa4108257929497058ff7dcff3964409c19aa392086e8a498";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fuse-core/default.nix
+++ b/distros/rolling/fuse-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, boost, ceres-solver, eigen, fuse-msgs, geometry-msgs, glog, gtest-vendor, launch, launch-pytest, pluginlib, rcl-interfaces, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-rolling-fuse-core";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_core/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "b01b8d166cb64ac02f34c02e2d332a82a0c61695dd350bba013ad986cd1bb92e";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_core/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "a72ad7411290558f0884cd8705ff3046b3bc46019df75a71722967a633d3cba7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fuse-doc/default.nix
+++ b/distros/rolling/fuse-doc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, gtest-vendor }:
 buildRosPackage {
   pname = "ros-rolling-fuse-doc";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_doc/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "f80e7bb4ead58df44b6cdb8978d217b9b9143308c9c1d6336dfb0bc9c55e910c";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_doc/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "4bceed700787175e59d7b4b34d72ea764515a05121b25232e0e56f9532f89c66";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fuse-graphs/default.nix
+++ b/distros/rolling/fuse-graphs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ceres-solver, fuse-core, gbenchmark, gtest-vendor, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-fuse-graphs";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_graphs/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "d130553d0e119bd045d9a64dc6883605d425d9eacfff10c70ba7caab79c72908";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_graphs/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "33a69aa83f27b2bf822120e27f867e83382baa3e30337a354cd6cb887a57d0b2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fuse-loss/default.nix
+++ b/distros/rolling/fuse-loss/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ceres-solver, fuse-core, gtest-vendor, libsForQt5, pluginlib, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-fuse-loss";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_loss/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "373a0e21fcdd068cda5587eccc15d59955a58b215a93a20550f577467c560df8";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_loss/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "d868b4ce3cb9917bf6178aeced428eaef5036a06ada596dd2687ab965500cce3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fuse-models/default.nix
+++ b/distros/rolling/fuse-models/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, boost, ceres-solver, eigen, fuse-constraints, fuse-core, fuse-graphs, fuse-msgs, fuse-publishers, fuse-variables, gbenchmark, geometry-msgs, gtest-vendor, nav-msgs, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-srvs, tf2, tf2-2d, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-fuse-models";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_models/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "7faebcd2263c811a2bc8dcc97806a5efed627e0641f3911e2b9ee1457ccf376a";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_models/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "beb0833761b0ebf3a621cb989c05ce05090f2d5ee8d2a36657db43dbde30f5d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fuse-msgs/default.nix
+++ b/distros/rolling/fuse-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, geometry-msgs, gtest-vendor, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-fuse-msgs";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_msgs/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "9742419880df7f90013ca4d92580652299749b93aefef95f99255ad71a06b47d";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_msgs/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "58e7ed46dc93883d392708f3522a38c6e9fa9c61468635ef8c19bf2438e9fcfb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fuse-optimizers/default.nix
+++ b/distros/rolling/fuse-optimizers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, boost, ceres-solver, diagnostic-updater, eigen, fuse-constraints, fuse-core, fuse-graphs, fuse-models, fuse-msgs, fuse-variables, geometry-msgs, gtest-vendor, launch, launch-pytest, launch-ros, nav-msgs, pluginlib, rclcpp, rclcpp-components, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, boost, ceres-solver, diagnostic-updater, eigen, fuse-constraints, fuse-core, fuse-graphs, fuse-models, fuse-msgs, fuse-variables, geometry-msgs, gtest-vendor, launch, launch-pytest, launch-ros, nav-msgs, pluginlib, rclcpp, rclcpp-components, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-fuse-optimizers";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_optimizers/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "d00cfc42e2d6b5dc98392eed2a71ee832674db760d417c963d4433a4b2e2b22a";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_optimizers/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "929a4eb8f7fcb9f058d0e4a5ff560f45cbccb8000d0efb144e9eddbac5e13619";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common fuse-models geometry-msgs launch launch-pytest launch-ros nav-msgs rclcpp ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common fuse-models geometry-msgs launch launch-pytest launch-ros nav-msgs rclcpp ];
   propagatedBuildInputs = [ ament-cmake-ros boost ceres-solver diagnostic-updater eigen fuse-constraints fuse-core fuse-graphs fuse-msgs fuse-variables gtest-vendor pluginlib rclcpp rclcpp-components std-srvs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/fuse-publishers/default.nix
+++ b/distros/rolling/fuse-publishers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fuse-constraints, fuse-core, fuse-graphs, fuse-msgs, fuse-variables, geometry-msgs, gtest-vendor, nav-msgs, pluginlib, rclcpp, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-fuse-publishers";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_publishers/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "32068b98b1bc5400852936e0bb94d60ee9d4cb9253637e80a21904a9881db9d6";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_publishers/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "93152c624a871fd14c6a9a0f1af9c3cce353c4617c45393062fe07024ae3181f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fuse-tutorials/default.nix
+++ b/distros/rolling/fuse-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fuse-constraints, fuse-core, fuse-models, fuse-optimizers, fuse-publishers, fuse-variables, gtest-vendor, nav-msgs, rclcpp, rviz2, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-fuse-tutorials";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_tutorials/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "bd601e5b9f08264de3c51b93e69fce94f85a45d9c5405dba09853c2ddc54e02c";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_tutorials/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "64560b6bfb47579c77c3e8108aa15d0a483e8de1bb1ecc41be4986717fa197d2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fuse-variables/default.nix
+++ b/distros/rolling/fuse-variables/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ceres-solver, fuse-core, fuse-graphs, gtest-vendor, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-fuse-variables";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_variables/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "e30fe2e0b904caf7e54961fdecee217c19b033a7e37d69d5d0454f7a6dea4fa1";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_variables/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "796bf6f5681013e3b1ec3912780ac53f3f50ae23d9c31a07f26b35ff0b4e4e18";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fuse-viz/default.nix
+++ b/distros/rolling/fuse-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, eigen, fuse-constraints, fuse-core, fuse-msgs, fuse-variables, geometry-msgs, gtest-vendor, qt5, rviz-common, rviz-rendering, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-fuse-viz";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_viz/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "5ae3d4537115d53b918734c0cf0cab23f5c2bd352f8c77fa6428487b21ce7b2c";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_viz/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "35a5035d082376882091226c2090ce418ff53949a98158c84128b37735078dcd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fuse/default.nix
+++ b/distros/rolling/fuse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, fuse-constraints, fuse-core, fuse-doc, fuse-graphs, fuse-models, fuse-msgs, fuse-optimizers, fuse-publishers, fuse-variables, fuse-viz, gtest-vendor }:
 buildRosPackage {
   pname = "ros-rolling-fuse";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "d093a0ca5379d288e73426d65bbed651246c3699c022eda6f5cf70be7c82b475";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "c4ada279ce47aa2555fbfd1a086c9fd91bbdab4dbfb4d79d3c00bacc62d2657d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -452,6 +452,8 @@ self: super: {
 
  crazyflie-py = self.callPackage ./crazyflie-py {};
 
+ crazyflie-server-cpp = self.callPackage ./crazyflie-server-cpp {};
+
  crazyflie-server-py = self.callPackage ./crazyflie-server-py {};
 
  crazyflie-sim = self.callPackage ./crazyflie-sim {};
@@ -1634,6 +1636,8 @@ self: super: {
 
  mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
 
+ mujoco-3d-lidar = self.callPackage ./mujoco-3d-lidar {};
+
  mujoco-ros2-control = self.callPackage ./mujoco-ros2-control {};
 
  mujoco-ros2-control-demos = self.callPackage ./mujoco-ros2-control-demos {};
@@ -1805,6 +1809,8 @@ self: super: {
  pal-statistics = self.callPackage ./pal-statistics {};
 
  pal-statistics-msgs = self.callPackage ./pal-statistics-msgs {};
+
+ pal-urdf-utils = self.callPackage ./pal-urdf-utils {};
 
  pangolin = self.callPackage ./pangolin {};
 
@@ -2783,8 +2789,6 @@ self: super: {
  swri-math-util = self.callPackage ./swri-math-util {};
 
  swri-opencv-util = self.callPackage ./swri-opencv-util {};
-
- swri-roscpp = self.callPackage ./swri-roscpp {};
 
  swri-route-util = self.callPackage ./swri-route-util {};
 

--- a/distros/rolling/gps-msgs/default.nix
+++ b/distros/rolling/gps-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-gps-msgs";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/rolling/gps_msgs/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "564e3a29b482cd1f75e5f6eb837c5cf8b45c0052e727843b6de5d3ba8716613b";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/rolling/gps_msgs/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "2907ed3434b96f1fc80b9dad54032bd84941db2efb7be281393f3bce55f17651";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gps-tools/default.nix
+++ b/distros/rolling/gps-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, gps-msgs, nav-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-gps-tools";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/rolling/gps_tools/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "e181b52fe73e88ce564c7498cfb2d2a32c85e0888c3a18d0310f6db0f6d37666";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/rolling/gps_tools/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "7672078c82a0e0c7f3c0db29b042f824efc8edef8127aa3aa7c1af8230a069f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gps-umd/default.nix
+++ b/distros/rolling/gps-umd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gps-msgs, gps-tools, gpsd-client }:
 buildRosPackage {
   pname = "ros-rolling-gps-umd";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/rolling/gps_umd/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "66224bbbf9dcc98e19753d8edb48ac921e19885def38b2fb858c98bc368086ed";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/rolling/gps_umd/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "7c655898df41473ff1f1f7f199e262a9ee28403c5e797a9d272285296a75f7cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gpsd-client/default.nix
+++ b/distros/rolling/gpsd-client/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, gps-msgs, gpsd, pkg-config, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, gps-msgs, gpsd, pkg-config, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-gpsd-client";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/rolling/gpsd_client/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "2f90717f2dad3fb3f403a351d921270b212112d73555ac0974629b21699f381e";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/rolling/gpsd_client/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "af82b3e8319be008065ab1bd190475eb1e900f7534f5f2680485909b83cb581d";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ros-environment ];
+  buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ];
   propagatedBuildInputs = [ gps-msgs gpsd pkg-config rclcpp rclcpp-components sensor-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake pkg-config ];
 
   meta = {
     description = "connects to a GPSd server and broadcasts GPS fixes 

--- a/distros/rolling/gz-common-vendor/default.nix
+++ b/distros/rolling/gz-common-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, assimp, cmake, ffmpeg, gdal, gz-cmake-vendor, gz-math-vendor, gz-utils-vendor, pkg-config, spdlog-vendor, tinyxml-2, util-linux }:
 buildRosPackage {
   pname = "ros-rolling-gz-common-vendor";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_common_vendor-release/archive/release/rolling/gz_common_vendor/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "b3e6ccdf08a9278ea01a773e4dc3e8fa2b76360f31ed98cbc8b8473f141f6031";
+    url = "https://github.com/ros2-gbp/gz_common_vendor-release/archive/release/rolling/gz_common_vendor/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "d55d4fc85e380596a0ef15aacf5a8f365101a6055db7790d85f7c5f3f2ef16e6";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake pkg-config ];
 
   meta = {
-    description = "Vendor package for: gz-common 7.3.0
+    description = "Vendor package for: gz-common 7.3.1
 
     Gazebo Common : AV, Graphics, Events, and much more.";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-common-vendor/vendored-source.json
+++ b/distros/rolling/gz-common-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_common_vendor": {
     "url": "https://github.com/gazebosim/gz-common.git",
-    "rev": "gz-common7_7.3.0",
-    "hash": "sha256-LFuXkoGlln9Pj+TRZoZYY2pF8osKt9j1ub1Frzv/loQ="
+    "rev": "gz-common7_7.3.1",
+    "hash": "sha256-igTHae00k4PIWTpc1xzxv8iKtbO6TvDsMA3iM0K/WAc="
   }
 }

--- a/distros/rolling/gz-tools-vendor/default.nix
+++ b/distros/rolling/gz-tools-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, ruby }:
 buildRosPackage {
   pname = "ros-rolling-gz-tools-vendor";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_tools_vendor-release/archive/release/rolling/gz_tools_vendor/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "d175d87794c87a815886471ee85bb65b83e56819d358ac0e235e843c5b73a40f";
+    url = "https://github.com/ros2-gbp/gz_tools_vendor-release/archive/release/rolling/gz_tools_vendor/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "69207a343b305da4bd4f27664661d2c2c98f3f5474bbdff76671b173699eec83";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-tools2 2.0.3
+    description = "Vendor package for: gz-tools2 2.0.4
 
     Gazebo Tools: Entrypoint to Gazebo's command line interface";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-tools-vendor/vendored-source.json
+++ b/distros/rolling/gz-tools-vendor/vendored-source.json
@@ -1,7 +1,7 @@
 {
   "gz_tools_vendor": {
     "url": "https://github.com/gazebosim/gz-tools.git",
-    "rev": "gz-tools2_2.0.3",
-    "hash": "sha256-xMFJylj7OnDc7zVWiI4a/mvNpu9scz83F3bGopCt8l8="
+    "rev": "gz-tools2_2.0.4",
+    "hash": "sha256-WVeZg7Wreqz0eScbrgELEAsmpfr1Dy7HogZFjGEht/I="
   }
 }

--- a/distros/rolling/jrl-cmakemodules/default.nix
+++ b/distros/rolling/jrl-cmakemodules/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catch2, cmake, doxygen, eigen, git, matio, pkg-config, python3Packages, simde }:
 buildRosPackage {
   pname = "ros-rolling-jrl-cmakemodules";
-  version = "2.0.0-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/jrl_cmakemodules-release/archive/release/rolling/jrl_cmakemodules/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "bee3e497b6ba334a05078830c5d21902bc953cc9b3d077e6366a40947dd7c00e";
+    url = "https://github.com/ros2-gbp/jrl_cmakemodules-release/archive/release/rolling/jrl_cmakemodules/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "04c3b22c0288db1c5b901267ff84ea198a34260f7a2b0397e6041d15bdfaaa84";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mapviz-interfaces/default.nix
+++ b/distros/rolling/mapviz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-mapviz-interfaces";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/mapviz_interfaces/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "2562da6a031586affecc2fa0e1f48c9b8bbb3de3f6372efd2f588bda3881836b";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/mapviz_interfaces/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "53c011dea56c894f4c8d74d6d877a135215dda7d66e32519b93016460c9fae41";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mapviz-plugins/default.nix
+++ b/distros/rolling/mapviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, assimp, cv-bridge, geometry-msgs, gps-msgs, image-transport, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-sensor-msgs, marti-visualization-msgs, opencv, pluginlib, qt-gui-cpp, qt5or6, rclcpp, rclcpp-action, sensor-msgs, std-msgs, std-srvs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, tf2, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mapviz-plugins";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/mapviz_plugins/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "b96d947a5b8ed78d3aa8609c555ced5e8c05f20334dec0cfb3ada51b0196244b";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/mapviz_plugins/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "c0875ea2bc4901487b200684ff12005d0ac6aa7b9d25e019a6b0b459418a4900";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mapviz/default.nix
+++ b/distros/rolling/mapviz/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, image-transport, libxi, libxmu, mapviz-interfaces, opencv, pkg-config, pluginlib, qt5or6, rclcpp, rqt-gui, rqt-gui-cpp, std-srvs, swri-math-util, swri-transform-util, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-mapviz";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/mapviz/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "0f11f107f7b92e138a55623d1973c30525a82661f954179f42343abd7ef8afcd";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/mapviz/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "610bebe5410555b1b28f35f455ee5023f67a568583d0012a35c414a08faf0155";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake pkg-config ];
-  propagatedBuildInputs = [ geometry-msgs image-transport libxi libxmu mapviz-interfaces opencv opencv.cxxdev pluginlib qt5or6.qtbase rclcpp rqt-gui rqt-gui-cpp std-srvs swri-math-util swri-transform-util tf2 tf2-geometry-msgs tf2-ros yaml-cpp ];
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ geometry-msgs image-transport libxi libxmu mapviz-interfaces opencv opencv.cxxdev pkg-config pluginlib qt5or6.qtbase rclcpp rqt-gui rqt-gui-cpp std-srvs swri-math-util swri-transform-util tf2 tf2-geometry-msgs tf2-ros yaml-cpp ];
   nativeBuildInputs = [ ament-cmake pkg-config ];
 
   meta = {

--- a/distros/rolling/mola-bridge-ros2/default.nix
+++ b/distros/rolling/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, diagnostic-msgs, geographic-msgs, geometry-msgs, gps-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mola-bridge-ros2";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_bridge_ros2/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "b8e520f1654d1882c5468528c28b1eac836cc173c1485bdca8a035551fc8e959";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_bridge_ros2/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "daeab9872f1ddbbf13d0478280cde58c0664d011c409705ae35a4a1035dc3cfc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-demos/default.nix
+++ b/distros/rolling/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-xmllint, ament-lint-auto, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-demos";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_demos/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "de85301a85cd43905cfdfbc1fd2207406947a85bfdad40dd3d0936db9747d764";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_demos/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "ef84358a2edb7922fa6087eb149dc71ff5bb5a4ebaaf6af961176d06ff9af556";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-input-lidar-bin-dataset/default.nix
+++ b/distros/rolling/mola-input-lidar-bin-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-lidar-bin-dataset";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_lidar_bin_dataset/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "c9a997c999baa904e15c03310c4869032135b1ef0d9a0464a67522f66e246d69";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_lidar_bin_dataset/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "bb34fad666760f6149bb825151519030419db3eb9981aea5ba46273dffec2519";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-rawlog/default.nix
+++ b/distros/rolling/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-rawlog";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rawlog/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "298bf15b556fa8919e4347543af10ab6eddecbbad1ba9ad1e37e70328f6b07a8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rawlog/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "6e1319fcaab2ab3cdbc54f56066ac219cf2cf750bfdf506964b2b76b807033a6";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-rosbag2/default.nix
+++ b/distros/rolling/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, gps-msgs, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-rosbag2";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rosbag2/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "bb5bd0435613a1e0f121d14ff8daee4726e1decdfdeeb2a28d035753c4724da4";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rosbag2/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "fd721d5b190ebf465a32b00a840ae8f4d2015ddd2274398dfe1fbac97d426628";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-video/default.nix
+++ b/distros/rolling/mola-input-video/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libhwdrivers, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-video";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_video/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "f7e47514c4b5e113bc83f48c2092ff456ef2255a7007b5174ea8d5bb277e0918";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_video/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "75a62cf7f5e8f8b3d3b11dba404354000d4affc748c72c03d5f7bc166217d476";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-kernel/default.nix
+++ b/distros/rolling/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-kernel";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_kernel/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "503b6f96e7a99c5784a96f6be8118b250e80449bb22c481bee5963c3621d8cfc";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_kernel/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "e664f099d642cd7a7fc79cbe7c259cf2c6fdbe6aa226bdd3b467cd19d16e3830";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-launcher/default.nix
+++ b/distros/rolling/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-xmllint, ament-lint-auto, cli11, cmake, mola-kernel, mrpt-libbase, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-launcher";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_launcher/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "e150be7f87c3b084f81146c2abd405534ea211e4c3fe2b36c6f711b2e120af6e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_launcher/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "f8dc8c59c83f54613041c3eaa0dd062920e769f12f8319ece7aa51616589a397";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-lidar-odometry/default.nix
+++ b/distros/rolling/mola-lidar-odometry/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cli11, cmake, mola-common, mola-imu-preintegration, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mola-yaml, mp2p-icp, mrpt-libmaps, ros-environment, rosbag2-storage-mcap }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cli11, cmake, mola-bridge-ros2, mola-common, mola-imu-preintegration, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-state-estimation-smoother, mola-test-datasets, mola-viz, mola-viz-imgui, mola-yaml, mp2p-icp, mrpt-libmaps, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-rolling-mola-lidar-odometry";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/rolling/mola_lidar_odometry/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "02f585ff07c8d120a1ef03e795ad96ade63506dd1fab38ff8ff3c6eaf265f903";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/rolling/mola_lidar_odometry/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "176a663d39a9347359aaa072047551c978f65a263cce3f00a58be33a8cda1928";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-test-datasets rosbag2-storage-mcap ];
-  propagatedBuildInputs = [ cli11 mola-common mola-imu-preintegration mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-pose-list mola-state-estimation-simple mola-viz mola-yaml mp2p-icp mrpt-libmaps ];
+  propagatedBuildInputs = [ cli11 mola-bridge-ros2 mola-common mola-imu-preintegration mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-pose-list mola-state-estimation-simple mola-state-estimation-smoother mola-viz mola-viz-imgui mola-yaml mp2p-icp mrpt-libmaps ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/rolling/mola-metric-maps/default.nix
+++ b/distros/rolling/mola-metric-maps/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cli11, cmake, mola-common, mola-kernel, mp2p-icp, mrpt-libmaps, nanoflann, onetbb, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cli11, cmake, mola-common, mola-kernel, mp2p-icp, mrpt-libmaps, nanoflann-vendor, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-metric-maps";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_metric_maps/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "777ef89bd7d6f64ac289eb7dcbbd2287486d1aeed3e64a2ea537a38450de4329";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_metric_maps/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "c1dc05b3440658dc8b277f6e891a301e6986e00cf44f98291dd19dac562dd626";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ cli11 mola-common mola-kernel mp2p-icp mrpt-libmaps nanoflann onetbb ];
+  propagatedBuildInputs = [ cli11 mola-common mola-kernel mp2p-icp mrpt-libmaps nanoflann-vendor onetbb ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/rolling/mola-msgs/default.nix
+++ b/distros/rolling/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-mola-msgs";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_msgs/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "2e1693bebfc60d8da41cacb21b617914322298454c8c8065529cc969563b99e2";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_msgs/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "5ae29a64541cb253b4cea78c9dc6b4814d62e8bd177a691a0534c58dde3a1ff4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-pose-list/default.nix
+++ b/distros/rolling/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-rolling-mola-pose-list";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_pose_list/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "b29eff5ab311851b64109d2300bd64aea0d1a633aa6885b3bb5ed41c8a748576";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_pose_list/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "1d0acdbe5c80457d9d6d17f3e6f58f53b6703e33384bd4241cbb240f2dc6aeb5";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-relocalization/default.nix
+++ b/distros/rolling/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-rolling-mola-relocalization";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_relocalization/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "b7d594184cb803526d6a62e07e8e4135992e7d5b05e0df095f9b8342926a5cdf";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_relocalization/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "45555f2b91a89aeafe43c63ae5a5febaccb99635f475fd584d09dc5970b3235a";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-traj-tools/default.nix
+++ b/distros/rolling/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-rolling-mola-traj-tools";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_traj_tools/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "40e4c750dbd1718d5995d7300ac7c84bfc1ca39226ea8c735ade1bcb32619b38";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_traj_tools/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "62283d782626ccb39e5e9847529de55a5724bbec50a00a19aa2093da89e8b4aa";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-viz-imgui/default.nix
+++ b/distros/rolling/mola-viz-imgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, freeglut, glfw3, libGL, libGLU, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-rolling-mola-viz-imgui";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz_imgui/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "3b60676528a4898894ddb4eaae0c36d4ac2e440ea7f7f56fa7bc82b544179560";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz_imgui/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "57a232e37dbacd9df97512a6c00666a5c5b3a299458535d4843cd9a031818370";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-viz/default.nix
+++ b/distros/rolling/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-rolling-mola-viz";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "3eaaa9a76d35e931d6931cacd8319a213d70aa39769c4de07db10bc828e022b1";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "54549c3edf6431576f0b7b83fdec89f4278feee33531378831f5bd36ec62fe65";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-yaml/default.nix
+++ b/distros/rolling/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-rolling-mola-yaml";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_yaml/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "483effcdffb57aa10a4405f4de17c537db05e514c743b2785fe5f55585e97b1e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_yaml/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "50c44f5e67822d576fbe30b31abffe50edf3fb9ea402ff48517cc5bdc3fe2ce5";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola/default.nix
+++ b/distros/rolling/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-bridge-ros2, mola-demos, mola-input-rawlog, mola-input-rosbag2, mola-input-video, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-rolling-mola";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "6278c567deb4deba288caba8014031d729d8bca4aefc040744f67e682e38289d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "1f9f006213cdd8e84d502db90f707b5fd4a9a6721ce43c4c7c0634705584bc50";
   };
 
   buildType = "cmake";

--- a/distros/rolling/moveit-task-constructor-capabilities/default.nix
+++ b/distros/rolling/moveit-task-constructor-capabilities/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, controller-manager, fmt, launch-testing, launch-testing-ament-cmake, moveit-configs-utils, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-task-constructor-core, moveit-task-constructor-msgs, pluginlib, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-task-constructor-capabilities";
-  version = "0.1.5-r2";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/rolling/moveit_task_constructor_capabilities/0.1.5-2.tar.gz";
-    name = "0.1.5-2.tar.gz";
-    sha256 = "9236d128302e5e5739f5cb5bb111c423b134c508ef99e8754306aa7ac0df3df0";
+    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/rolling/moveit_task_constructor_capabilities/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "2a0e3ab9eefbe4f993b9ec426463d663d3fc347316d86c28a1e2a9e5ef10353c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-task-constructor-core/default.nix
+++ b/distros/rolling/moveit-task-constructor-core/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, fmt, geometry-msgs, launch-testing-ament-cmake, moveit-configs-utils, moveit-core, moveit-planners, moveit-py, moveit-resources-fanuc-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, moveit-task-constructor-msgs, py-binding-tools, rclcpp, rviz-marker-tools, tf2-eigen, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, fmt, geometry-msgs, launch-testing-ament-cmake, moveit-configs-utils, moveit-core, moveit-planners-ompl, moveit-py, moveit-resources-fanuc-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, moveit-task-constructor-msgs, py-binding-tools, rclcpp, rviz-marker-tools, tf2-eigen, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-task-constructor-core";
-  version = "0.1.5-r2";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/rolling/moveit_task_constructor_core/0.1.5-2.tar.gz";
-    name = "0.1.5-2.tar.gz";
-    sha256 = "82a96e45a1348fcb3ca29cafe2d956ad688889e36607fe59d0015d42f1e92779";
+    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/rolling/moveit_task_constructor_core/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "7c7c76cadbeb72c2567655fba7197858f5cd9db480edf1bebdb36c11879b1db0";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
-  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-cmake-pytest launch-testing-ament-cmake moveit-configs-utils moveit-planners moveit-resources-fanuc-moveit-config ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-cmake-pytest launch-testing-ament-cmake moveit-configs-utils moveit-planners-ompl moveit-resources-fanuc-moveit-config ];
   propagatedBuildInputs = [ fmt geometry-msgs moveit-core moveit-py moveit-ros-planning moveit-ros-planning-interface moveit-task-constructor-msgs py-binding-tools rclcpp rviz-marker-tools tf2-eigen visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 

--- a/distros/rolling/moveit-task-constructor-demo/default.nix
+++ b/distros/rolling/moveit-task-constructor-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, generate-parameter-library, moveit-configs-utils, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, moveit-task-constructor-capabilities, moveit-task-constructor-core, moveit-task-constructor-visualization, py-binding-tools }:
 buildRosPackage {
   pname = "ros-rolling-moveit-task-constructor-demo";
-  version = "0.1.5-r2";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/rolling/moveit_task_constructor_demo/0.1.5-2.tar.gz";
-    name = "0.1.5-2.tar.gz";
-    sha256 = "ced952acb614e74f5b4b4a1eb85718641b4f06b7d0f0a3e86de14495a5ec9a3f";
+    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/rolling/moveit_task_constructor_demo/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "22a0f2022ddf9778de8fda35dab623d8f4998b2c60fa11a22ea43ce5e1b4b602";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-task-constructor-msgs/default.nix
+++ b/distros/rolling/moveit-task-constructor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-msgs, rosidl-default-generators, rosidl-default-runtime, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-task-constructor-msgs";
-  version = "0.1.5-r2";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/rolling/moveit_task_constructor_msgs/0.1.5-2.tar.gz";
-    name = "0.1.5-2.tar.gz";
-    sha256 = "65225dbaa012aaab83d62f6028e662b943da7123c588f538bb7ee8c2c84fc646";
+    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/rolling/moveit_task_constructor_msgs/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "8296d5c38443158aff5f763be70c94b458be341dafde1a096e505d062333ce21";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-task-constructor-visualization/default.nix
+++ b/distros/rolling/moveit-task-constructor-visualization/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, fmt, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, libyaml-vendor, moveit-core, moveit-ros-visualization, moveit-task-constructor-core, moveit-task-constructor-msgs, qt5, rclcpp, rviz2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, fmt, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, libyaml-vendor, moveit-core, moveit-ros-visualization, moveit-task-constructor-core, moveit-task-constructor-msgs, qt5or6, rclcpp, rviz2 }:
 buildRosPackage {
   pname = "ros-rolling-moveit-task-constructor-visualization";
-  version = "0.1.5-r2";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/rolling/moveit_task_constructor_visualization/0.1.5-2.tar.gz";
-    name = "0.1.5-2.tar.gz";
-    sha256 = "09d51ffe10e5a63dcae045475a9402cc8e2daba92654ca5b18e3393d71abc87b";
+    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/rolling/moveit_task_constructor_visualization/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "7c1c14ddfa28845000c022cbd78735ef70df37127f6c8b02466c43a51fee6072";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake qt5.qtbase ];
+  buildInputs = [ ament-cmake qt5or6.qtbase ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest launch launch-testing launch-testing-ament-cmake launch-testing-ros ];
   propagatedBuildInputs = [ fmt libyaml-vendor moveit-core moveit-ros-visualization moveit-task-constructor-core moveit-task-constructor-msgs rclcpp rviz2 ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/rolling/mp2p-icp-core/default.nix
+++ b/distros/rolling/mp2p-icp-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cli11, cmake, mola-common, mola-imu-preintegration, mrpt-libbase, mrpt-libmaps, mrpt-libobs, mrpt-libposes, onetbb, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mp2p-icp-core";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp_core/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "9e88e32b1031112a251c1eb810ba2e83274701150673ddc8362bc19f90705116";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp_core/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "e1b05d644cc8fcc4b2481e2d89a07ff98cc95f928b9d19dd6fa97fd65504285c";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mp2p-icp-viz/default.nix
+++ b/distros/rolling/mp2p-icp-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cli11, cmake, mola-common, mp2p-icp-core, mrpt-libgui, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mp2p-icp-viz";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp_viz/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "655824c7615c078819a441e287e5228f4da7a561fd18db208791756981167596";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp_viz/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "05ceeb653af8a2cf1b11a0c96f0ecfa33f0bfaa9bb0e2307a4ecbc7afbb790a3";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mp2p-icp/default.nix
+++ b/distros/rolling/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mp2p-icp-core, mp2p-icp-viz }:
 buildRosPackage {
   pname = "ros-rolling-mp2p-icp";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "0731414894f6ffb2bb4ead3f64b45e25433655c0c3c21bd3e36f5be18e2f12f4";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "9dd0b6990babbc8c44a9613a5330663d84a5071f96f426dc3a49ad4e864f3401";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mujoco-3d-lidar/default.nix
+++ b/distros/rolling/mujoco-3d-lidar/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, mujoco-vendor }:
+buildRosPackage {
+  pname = "ros-rolling-mujoco-3d-lidar";
+  version = "0.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/rolling/mujoco_3d_lidar/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "a8f3c9e1a22c5f08d0d2cf1a24e32309dc8a386c44aa36221ad09b3caf2b90cc";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ mujoco-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Plugin for mujoco to use raycasters to simulate lidar";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/mujoco-ros2-control-demos/default.nix
+++ b/distros/rolling/mujoco-ros2-control-demos/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, _unresolved_position_controllers, ament-cmake, controller-manager, joint-state-broadcaster, mujoco-ros2-control, mujoco-ros2-control-msgs, robot-state-publisher, rviz2, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, forward-command-controller, joint-state-broadcaster, launch, launch-ros, mujoco-ros2-control, mujoco-ros2-control-msgs, pose-broadcaster, robot-state-publisher, rviz2, xacro }:
 buildRosPackage {
   pname = "ros-rolling-mujoco-ros2-control-demos";
-  version = "0.0.2-r2";
+  version = "0.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/rolling/mujoco_ros2_control_demos/0.0.2-2.tar.gz";
-    name = "0.0.2-2.tar.gz";
-    sha256 = "d537f06478f2439634e243f411992ab0f0ca7dc1f9a00898cf3ae8d9fc542b75";
+    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/rolling/mujoco_ros2_control_demos/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "8f0a51840fad0180ff8008f64270516584a7887a2f2800f2d4431d3e125710c4";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ _unresolved_position_controllers controller-manager joint-state-broadcaster mujoco-ros2-control mujoco-ros2-control-msgs robot-state-publisher rviz2 xacro ];
+  propagatedBuildInputs = [ controller-manager forward-command-controller joint-state-broadcaster launch launch-ros mujoco-ros2-control mujoco-ros2-control-msgs pose-broadcaster robot-state-publisher rviz2 xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/mujoco-ros2-control-msgs/default.nix
+++ b/distros/rolling/mujoco-ros2-control-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mujoco-ros2-control-msgs";
-  version = "0.0.2-r2";
+  version = "0.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/rolling/mujoco_ros2_control_msgs/0.0.2-2.tar.gz";
-    name = "0.0.2-2.tar.gz";
-    sha256 = "4b0d589dca6c49511a4d0f5512ea715fb5d457df59a7ef72cea7d5bf470507d9";
+    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/rolling/mujoco_ros2_control_msgs/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "c7411463e2eaacc14eb2c9ed68485a10d70605737d74c3422be235c932df6424";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime sensor-msgs std-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/rolling/mujoco-ros2-control-plugins/default.nix
+++ b/distros/rolling/mujoco-ros2-control-plugins/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, mujoco-vendor, pluginlib, rclcpp, ros2-control-cmake, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, backward-ros, geometry-msgs, glfw3, libGL, libGLU, mujoco-3d-lidar, mujoco-ros2-control-msgs, mujoco-vendor, pluginlib, rclcpp, realtime-tools, ros2-control-cmake, sensor-msgs, std-msgs, std-srvs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mujoco-ros2-control-plugins";
-  version = "0.0.2-r2";
+  version = "0.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/rolling/mujoco_ros2_control_plugins/0.0.2-2.tar.gz";
-    name = "0.0.2-2.tar.gz";
-    sha256 = "6ecd909c5802ba3ee4a5276f6e0ea9d4ee744a43c4e6c28667eb9d346ea2eab8";
+    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/rolling/mujoco_ros2_control_plugins/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "2905ef6bcb33afbc525b81e975d767e0d88ce0c93b433affcace6cc9e2c69b83";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gtest ];
-  propagatedBuildInputs = [ mujoco-vendor pluginlib rclcpp ros2-control-cmake std-msgs ];
+  checkInputs = [ ament-cmake-gtest ament-index-cpp mujoco-3d-lidar ];
+  propagatedBuildInputs = [ backward-ros geometry-msgs glfw3 libGL libGLU mujoco-ros2-control-msgs mujoco-vendor pluginlib rclcpp realtime-tools ros2-control-cmake sensor-msgs std-msgs std-srvs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/mujoco-ros2-control/default.nix
+++ b/distros/rolling/mujoco-ros2-control/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, backward-ros, control-toolbox, controller-manager, fmt, git, glfw3, hardware-interface, mujoco-ros2-control-msgs, mujoco-ros2-control-plugins, mujoco-vendor, nav-msgs, pluginlib, python3, python3Packages, rclcpp, rclcpp-lifecycle, ros2-control-cmake, sensor-msgs, transmission-interface }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-index-cpp, ament-index-python, backward-ros, control-toolbox, controller-manager, eigen, fmt, geometry-msgs, git, glfw3, hardware-interface, mujoco-ros2-control-msgs, mujoco-ros2-control-plugins, mujoco-vendor, nav-msgs, pluginlib, python3, python3Packages, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2pkg, rosgraph-msgs, sensor-msgs, std-msgs, tinyxml2-vendor, transmission-interface, urdfdom-py }:
 buildRosPackage {
   pname = "ros-rolling-mujoco-ros2-control";
-  version = "0.0.2-r2";
+  version = "0.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/rolling/mujoco_ros2_control/0.0.2-2.tar.gz";
-    name = "0.0.2-2.tar.gz";
-    sha256 = "73b4bf224bb2095fdc612bcb8f8a82b8d9924c658aca28fb725d8deb0a632e97";
+    url = "https://github.com/ros2-gbp/mujoco_ros2_control-release/archive/release/rolling/mujoco_ros2_control/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "6b63163dacc146481dfbf8f8642807d01baf21b70386d2d07f74fb60d9d66e96";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python git ros2-control-cmake ];
   checkInputs = [ ament-cmake-gtest ament-cmake-pytest ];
-  propagatedBuildInputs = [ backward-ros control-toolbox controller-manager fmt glfw3 hardware-interface mujoco-ros2-control-msgs mujoco-ros2-control-plugins mujoco-vendor nav-msgs pluginlib python3 python3Packages.pip python3Packages.pykdl rclcpp rclcpp-lifecycle sensor-msgs transmission-interface ];
+  propagatedBuildInputs = [ ament-index-cpp ament-index-python backward-ros control-toolbox controller-manager eigen fmt geometry-msgs glfw3 hardware-interface mujoco-ros2-control-msgs mujoco-ros2-control-plugins mujoco-vendor nav-msgs pluginlib python3 python3Packages.importlib-resources python3Packages.numpy python3Packages.pip python3Packages.pykdl rclcpp rclcpp-lifecycle realtime-tools ros2pkg rosgraph-msgs sensor-msgs std-msgs tinyxml2-vendor transmission-interface urdfdom-py ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python git ];
 
   meta = {

--- a/distros/rolling/multires-image/default.nix
+++ b/distros/rolling/multires-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, gps-msgs, mapviz, mapviz-interfaces, marti-common-msgs, pluginlib, python3Packages, qt-gui-cpp, qt5or6, rclcpp, rclpy, swri-math-util, swri-transform-util, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-multires-image";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/multires_image/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "1f50a44c3d42281e156d9ed110ce39feb7204d0b1c0ce059f12166c1a6b5ba6a";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/multires_image/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "9c35ebca489d3182fda743def65a60e352a5274722bc001b071019ff8f483cc2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/novatel-gps-driver/default.nix
+++ b/distros/rolling/novatel-gps-driver/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, boost, diagnostic-msgs, diagnostic-updater, gps-msgs, libpcap, nav-msgs, novatel-gps-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, swri-math-util, swri-roscpp, swri-serial-util, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, _unresolved_swri_roscpp, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, boost, diagnostic-msgs, diagnostic-updater, gps-msgs, libpcap, nav-msgs, novatel-gps-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, swri-math-util, swri-serial-util, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-novatel-gps-driver";
   version = "4.3.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ];
-  propagatedBuildInputs = [ boost diagnostic-msgs diagnostic-updater gps-msgs libpcap nav-msgs novatel-gps-msgs rclcpp rclcpp-components sensor-msgs std-msgs swri-math-util swri-roscpp swri-serial-util tf2 tf2-geometry-msgs ];
+  propagatedBuildInputs = [ _unresolved_swri_roscpp boost diagnostic-msgs diagnostic-updater gps-msgs libpcap nav-msgs novatel-gps-msgs rclcpp rclcpp-components sensor-msgs std-msgs swri-math-util swri-serial-util tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/pal-statistics-msgs/default.nix
+++ b/distros/rolling/pal-statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-pal-statistics-msgs";
-  version = "2.8.0-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/rolling/pal_statistics_msgs/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "b1fe8897bb58eb6a19074f978aa004feb6c22c0697bdc9256af7f2f65ad25e9b";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/rolling/pal_statistics_msgs/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "21e17f92d5e4c1cea485208b4d80584af3adcf8f769c630530b0d1d4d464053b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pal-statistics/default.nix
+++ b/distros/rolling/pal-statistics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, boost, pal-statistics-msgs, rclcpp, rclcpp-lifecycle, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-pal-statistics";
-  version = "2.8.0-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/rolling/pal_statistics/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "750634689f8d48823c0fa87125864fd85d442c2a29fec3ab72a0866e81011e7a";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/rolling/pal_statistics/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "20cb9a11eed706780e85a167d54c7e1269ea8685b76984f32c58c86e736bfe98";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pal-urdf-utils/default.nix
+++ b/distros/rolling/pal-urdf-utils/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2026 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, realsense2-description, xacro }:
+buildRosPackage {
+  pname = "ros-rolling-pal-urdf-utils";
+  version = "2.9.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/pal_urdf_utils-release/archive/release/rolling/pal_urdf_utils/2.9.2-1.tar.gz";
+    name = "2.9.2-1.tar.gz";
+    sha256 = "0d1a19643fa90c053ce0a2e763b9369c36b9cb4e26f5d1518d75fc5298fb53cf";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ realsense2-description xacro ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = "This package contains the color materials of common elements of PAL Robotics' robot.
+      The files in this package are parsed and used by
+      a variety of other components.  Most users will not interact directly
+      with this package.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/pangolin/default.nix
+++ b/distros/rolling/pangolin/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catch2, cmake, eigen, glew, libGL, libGLU, libepoxy, libjpeg, libpng, libxkbcommon, python3, python3Packages, wayland }:
+{ lib, buildRosPackage, fetchurl, catch2, cmake, eigen, glew, libGL, libGLU, libepoxy, libjpeg, libpng, libxkbcommon, openexr, python3, python3Packages, wayland }:
 buildRosPackage {
   pname = "ros-rolling-pangolin";
-  version = "0.9.5-r2";
+  version = "0.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Pangolin-release/archive/release/rolling/pangolin/0.9.5-2.tar.gz";
-    name = "0.9.5-2.tar.gz";
-    sha256 = "2fd0bf9deddeffe4b642ab46f2d685e87c5413aab52fc13787eedd28ff400ac4";
+    url = "https://github.com/ros2-gbp/Pangolin-release/archive/release/rolling/pangolin/0.9.6-1.tar.gz";
+    name = "0.9.6-1.tar.gz";
+    sha256 = "4d3b128a4c8d9a67fbaeaa633da39ac9a422cf5a769aa67aa1edae6f8c96b5b1";
   };
 
   buildType = "cmake";
-  buildInputs = [ cmake eigen python3Packages.wheel ];
+  buildInputs = [ cmake eigen python3Packages.setuptools python3Packages.wheel ];
   checkInputs = [ catch2 ];
-  propagatedBuildInputs = [ glew libGL libGLU libepoxy libjpeg libpng libxkbcommon python3 wayland ];
+  propagatedBuildInputs = [ glew libGL libGLU libepoxy libjpeg libpng libxkbcommon openexr python3 wayland ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/rolling/rmw-cyclonedds-cpp/default.nix
+++ b/distros/rolling/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros-core, ament-lint-auto, ament-lint-common, cyclonedds, iceoryx-binding-c, rcpputils, rcutils, rmw, rmw-dds-common, rmw-security-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-cyclonedds-cpp";
-  version = "4.2.0-r1";
+  version = "4.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/rolling/rmw_cyclonedds_cpp/4.2.0-1.tar.gz";
-    name = "4.2.0-1.tar.gz";
-    sha256 = "3ecf43277ed598cc51cb4988a8bc85c5a7cd5af929febe7abd0d6ad32f318780";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/rolling/rmw_cyclonedds_cpp/4.2.1-1.tar.gz";
+    name = "4.2.1-1.tar.gz";
+    sha256 = "db7bd39a4ebbaf284bfaed7c6672ff11456af87e726224a3f8c1e9aac3a973cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-industrial-cmake-boilerplate/default.nix
+++ b/distros/rolling/ros-industrial-cmake-boilerplate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, clang, cmake, cppcheck, gtest, include-what-you-use, lcov }:
 buildRosPackage {
   pname = "ros-rolling-ros-industrial-cmake-boilerplate";
-  version = "0.5.4-r2";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_industrial_cmake_boilerplate-release/archive/release/rolling/ros_industrial_cmake_boilerplate/0.5.4-2.tar.gz";
-    name = "0.5.4-2.tar.gz";
-    sha256 = "3fd42540263975aa87a65ba4f7b7c3a3d22bc6b98c16180058af7a0dfc4df4bc";
+    url = "https://github.com/ros2-gbp/ros_industrial_cmake_boilerplate-release/archive/release/rolling/ros_industrial_cmake_boilerplate/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "613dc466fae3693ecd4349cc1d6f615123c27d1e3d0edfc1e267d9a406e508c2";
   };
 
   buildType = "cmake";

--- a/distros/rolling/rviz-marker-tools/default.nix
+++ b/distros/rolling/rviz-marker-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, rclcpp, std-msgs, tf2-eigen, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz-marker-tools";
-  version = "0.1.5-r2";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/rolling/rviz_marker_tools/0.1.5-2.tar.gz";
-    name = "0.1.5-2.tar.gz";
-    sha256 = "cfe24b2a1a90ad43dd5419fd2476c09f6a8b26f230172f006e99d01e907351c1";
+    url = "https://github.com/ros2-gbp/moveit_task_constructor-release/archive/release/rolling/rviz_marker_tools/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "f867a1a1d7b98df4491ff50db13bd29006154730ab3b2af3759e87e75962dc38";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-cli-tools/default.nix
+++ b/distros/rolling/swri-cli-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, marti-introspection-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, ros2topic }:
 buildRosPackage {
   pname = "ros-rolling-swri-cli-tools";
-  version = "3.9.0-r2";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_cli_tools/3.9.0-2.tar.gz";
-    name = "3.9.0-2.tar.gz";
-    sha256 = "48f3401c61c3db3702e81f3b2dcdde74c6766993403a22431975003e929e0839";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_cli_tools/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "d85727ec78a3f75919f9127227aad2d6e90bd46f920572d7a6dd09e0cc1ddfca";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/swri-console-util/default.nix
+++ b/distros/rolling/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-swri-console-util";
-  version = "3.9.0-r2";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_console_util/3.9.0-2.tar.gz";
-    name = "3.9.0-2.tar.gz";
-    sha256 = "fb0b60ddccf97325ef7f1df05ec38d8cad25acffa9eb24cd4a3d29a43155c01f";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_console_util/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "f1cc47f84a92db697c5e910eecef69d68657906bd55ba3bfb1df0544895b3131";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-dbw-interface/default.nix
+++ b/distros/rolling/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-swri-dbw-interface";
-  version = "3.9.0-r2";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_dbw_interface/3.9.0-2.tar.gz";
-    name = "3.9.0-2.tar.gz";
-    sha256 = "c9eadf815a5c235521625d61063652c2ad90dd84ffebf9ea409da9edb06ac25d";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_dbw_interface/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "f4f4f681068974ceb820af96f9977aa2828735f18a2ae96e07ce54044af23f70";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-geometry-util/default.nix
+++ b/distros/rolling/swri-geometry-util/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, geos, opencv, pkg-config, tf2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, geos, opencv, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-swri-geometry-util";
-  version = "3.9.0-r2";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_geometry_util/3.9.0-2.tar.gz";
-    name = "3.9.0-2.tar.gz";
-    sha256 = "4071da8de4aebb58284fdb587fcb8db93e4c1fb5ed9318c75d23e50c4b9e92df";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_geometry_util/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "b7d3e70c3cd6e52699aa1eca7e34f92e6c60174f66477d07ea5a323bd21192e4";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake pkg-config ];
+  buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ];
   propagatedBuildInputs = [ eigen geos opencv opencv.cxxdev tf2 ];
-  nativeBuildInputs = [ ament-cmake pkg-config ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = "Commonly used geometry routines, implemented in a ROS friendly package.";

--- a/distros/rolling/swri-image-util/default.nix
+++ b/distros/rolling/swri-image-util/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, camera-calibration-parsers, cv-bridge, eigen, image-geometry, image-transport, message-filters, opencv, pkg-config, rcl-interfaces, rclcpp, rclcpp-components, rclpy, swri-geometry-util, swri-math-util, swri-opencv-util, tf2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, camera-calibration-parsers, cv-bridge, eigen, image-geometry, image-transport, message-filters, opencv, rcl-interfaces, rclcpp, rclcpp-components, rclpy, swri-geometry-util, swri-math-util, swri-opencv-util, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-swri-image-util";
-  version = "3.9.0-r2";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_image_util/3.9.0-2.tar.gz";
-    name = "3.9.0-2.tar.gz";
-    sha256 = "562a6f43122c792983a75612445d54d080d57a74b7edc0ba61604b296594a524";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_image_util/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "e7aa3bd52bf08fd2e2bd9084e229e94ac899f0977f3e299f42ffeb4e589f21da";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake pkg-config ];
+  buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ];
   propagatedBuildInputs = [ ament-index-cpp camera-calibration-parsers cv-bridge eigen image-geometry image-transport message-filters opencv opencv.cxxdev rcl-interfaces rclcpp rclcpp-components rclpy swri-geometry-util swri-math-util swri-opencv-util tf2 ];
-  nativeBuildInputs = [ ament-cmake pkg-config ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = "A package of commonly image manipulation utilities.";

--- a/distros/rolling/swri-math-util/default.nix
+++ b/distros/rolling/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-swri-math-util";
-  version = "3.9.0-r2";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_math_util/3.9.0-2.tar.gz";
-    name = "3.9.0-2.tar.gz";
-    sha256 = "657aefac784f95b235074ecec1382cd312e6c77d5f1beb600c0c017169206a37";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_math_util/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "3c9366a69ee74f5fcd64a358326a7793513b8d0d5991c0c4999b88453addf396";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-opencv-util/default.nix
+++ b/distros/rolling/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, opencv, swri-math-util }:
 buildRosPackage {
   pname = "ros-rolling-swri-opencv-util";
-  version = "3.9.0-r2";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_opencv_util/3.9.0-2.tar.gz";
-    name = "3.9.0-2.tar.gz";
-    sha256 = "719757f9c827369b89004bd1f674dcba1e5751385e1f7ef5e0c143ca6dd521ef";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_opencv_util/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "fa6c04212d408e900272c9756a7cdc7234ef25c2b227f12d85a3d5a4518aa38f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-route-util/default.nix
+++ b/distros/rolling/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-transform-util, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-swri-route-util";
-  version = "3.9.0-r2";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_route_util/3.9.0-2.tar.gz";
-    name = "3.9.0-2.tar.gz";
-    sha256 = "2e1c9f9cd888d7f9db9e83f55adf948588516f4029151542b81efba99af8b26b";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_route_util/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "c2afae2d474d2e2dae6fafb417231de522cf0975b6a7d9e26db39047adc07f11";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-serial-util/default.nix
+++ b/distros/rolling/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-swri-serial-util";
-  version = "3.9.0-r2";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_serial_util/3.9.0-2.tar.gz";
-    name = "3.9.0-2.tar.gz";
-    sha256 = "c751fea9483ef42e7c405a7031cb957f51b1423f498febcb5ccd007e70642ef6";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_serial_util/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "d41f90261927ceafe0f5f85411f962de5a2b42eedbd4c3d2f72c8ee5c15b0bf5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-transform-util/default.nix
+++ b/distros/rolling/swri-transform-util/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2026 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-index-cpp, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geographiclib, geometry-msgs, geos, gps-msgs, launch-ros, launch-testing, launch-testing-ament-cmake, marti-nav-msgs, opencv, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-index-cpp, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geographiclib, geometry-msgs, geos, gps-msgs, launch-ros, launch-testing, launch-testing-ament-cmake, marti-nav-msgs, opencv, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-swri-transform-util";
-  version = "3.9.0-r2";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_transform_util/3.9.0-2.tar.gz";
-    name = "3.9.0-2.tar.gz";
-    sha256 = "d3880523255e5d010a5027cd935a2fe2aa86e711eca90fd60b0a7c1d0dc2789f";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_transform_util/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "2f504c05a315a2fd4f2033a2d271d1c7f4e1498d7457a01efdf534289d9d334b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python pkg-config ];
   checkInputs = [ ament-cmake-gtest ament-index-cpp launch-ros launch-testing launch-testing-ament-cmake ];
-  propagatedBuildInputs = [ cv-bridge diagnostic-msgs diagnostic-updater geographic-msgs geographiclib geometry-msgs geos gps-msgs marti-nav-msgs opencv opencv.cxxdev proj python3Packages.numpy python3Packages.pyyaml rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util swri-roscpp tf2 tf2-geometry-msgs tf2-ros yaml-cpp-vendor ];
+  propagatedBuildInputs = [ cv-bridge diagnostic-msgs diagnostic-updater geographic-msgs geographiclib geometry-msgs geos gps-msgs marti-nav-msgs opencv opencv.cxxdev proj python3Packages.numpy python3Packages.pyyaml rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util tf2 tf2-geometry-msgs tf2-ros yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python pkg-config ];
 
   meta = {

--- a/distros/rolling/tf2-2d/default.nix
+++ b/distros/rolling/tf2-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, eigen, rclcpp, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-tf2-2d";
-  version = "1.6.1-r2";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tf2_2d-release/archive/release/rolling/tf2_2d/1.6.1-2.tar.gz";
-    name = "1.6.1-2.tar.gz";
-    sha256 = "c6f71f36e4788a3ed47a224c1a453e8651291f70e5a07994ccb53ffb2629ab2a";
+    url = "https://github.com/ros2-gbp/tf2_2d-release/archive/release/rolling/tf2_2d/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "7b8d7e737d8b152a20867d90f1f2ba104b6ca4b0ab5a7d205d55a8073cbf5d7b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tile-map/default.nix
+++ b/distros/rolling/tile-map/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, jsoncpp, mapviz, pluginlib, qt-gui-cpp, qt5or6, rclcpp, swri-math-util, swri-transform-util, tf2, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-tile-map";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/tile_map/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "9cf623fe930aaebeef4cbca42ffd6a23141ff491983af8d998049195a823e0b7";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/tile_map/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "0ff0449d07be1861ff1a8cdb60d280b672647a9875eac41e425e4940afdfd384";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/unbag/default.nix
+++ b/distros/rolling/unbag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-index-python, ament-lint-auto, ament-lint-common, python3, python3Packages, qt5, rclpy, ros2cli, rosbag2-py, rosidl-runtime-py, sensor-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-unbag";
-  version = "1.3.0-r1";
+  version = "1.3.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/unbag-release/archive/release/rolling/unbag/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "9060387fbdc6963e698f8c507ca68fc6bd5f3f98ec38ae4420b46b0d894c1bf4";
+    url = "https://github.com/ros2-gbp/unbag-release/archive/release/rolling/unbag/1.3.1-2.tar.gz";
+    name = "1.3.1-2.tar.gz";
+    sha256 = "ef32a38944cc7fc5ef9de9f0296457c956324c25c4e7618e885cb4114d3fc4ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -250,6 +250,16 @@ with rosSelf.lib; {
     '';
   });
 
+  mujoco-3d-lidar = rosSuper.mujoco-3d-lidar.overrideAttrs ({
+    postPatch ? "", ...
+  }: {
+    # See https://github.com/google-deepmind/mujoco/commit/2810edd27ab70d86d297b91430a1d0903745abe3
+    postPatch = postPatch + ''
+      substituteInPlace include/mujoco_3d_lidar/3dlidar.h src/3dlidar.cpp \
+        --replace-fail '#include <mujoco/mjtnum.h>' '#include <mujoco/mjtype.h>'
+    '';
+  });
+
   plotjuggler = rosSuper.plotjuggler.override {
     lz4 = self.lz4.overrideAttrs ({
       cmakeFlags ? [], ...

--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
     "rosdistro": {
       "flake": false,
       "locked": {
-        "lastModified": 1786735438,
-        "narHash": "sha256-rxCA2+gTQYkpngm9cY3s9gTNtStPbzlts0U3HuTtarg=",
+        "lastModified": 1787326473,
+        "narHash": "sha256-IQOaqN/0BtAmas5MHvo1NTAlEOSzMxcIIm35pqLM8ZU=",
         "owner": "ros",
         "repo": "rosdistro",
-        "rev": "b045bb798698b128867db5a3a81e515ecf32d38e",
+        "rev": "82eefa281fd5702f1869408c66606d395cd635ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'kilted', 'lyrical', 'rolling'] from nix-ros-overlay commit 8ad65e04b628e8700eb5348372cff6f3230b4690.
This pull request was generated by running the following command:

```
superflore-gen-nix --dry-run --output-repository-path . --all --tar-archive-dir /home/runner/.ros/tar --upstream-branch develop
```

Changes:
========
Humble Changes:
---------------
* *adi-imu 1.0.0-r1 --> 1.0.1-r1*
* *crazyflie 1.0.5-r1 --> 1.0.7-r1*
* *crazyflie-description 1.0.5-r1 --> 1.0.7-r1*
* *crazyflie-examples 1.0.5-r1 --> 1.0.7-r1*
* *crazyflie-interfaces 1.0.5-r1 --> 1.0.7-r1*
* *crazyflie-py 1.0.5-r1 --> 1.0.7-r1*
* *crazyflie-server-cpp 1.0.7-r1*
* *crazyflie-server-py 1.0.5-r1 --> 1.0.7-r1*
* *crazyflie-sim 1.0.5-r1 --> 1.0.7-r1*
* *depthai-v3 3.7.1-r1 --> 3.9.0-r1*
* *elite-robots 1.0.0-r1*
* *elite-robots-calibration 1.0.0-r1*
* *elite-robots-controllers 1.0.0-r1*
* *elite-robots-dashboard-msgs 1.0.0-r1*
* *elite-robots-driver 1.0.0-r1*
* *elite-robots-moveit-config 1.0.0-r1*
* *elite-robots-msgs 1.0.0-r1*
* *gps-msgs 3.1.0-r1 --> 3.1.1-r1*
* *gps-tools 3.1.0-r1 --> 3.1.1-r1*
* *gps-umd 3.1.0-r1 --> 3.1.1-r1*
* *gpsd-client 3.1.0-r1 --> 3.1.1-r1*
* *int2dds-ffi-vendor 0.1.0-r3*
* *jrl-cmakemodules 2.0.0-r1 --> 2.2.4-r1*
* *kangaroo-bringup 2.14.1-r1 --> 2.15.0-r1*
* *kangaroo-controller-configuration 2.14.1-r1 --> 2.15.0-r1*
* *kangaroo-description 2.14.1-r1 --> 2.15.0-r1*
* *kangaroo-moveit-config 2.2.2-r1*
* *kangaroo-mujoco 2.7.0-r1*
* *kangaroo-robot 2.14.1-r1 --> 2.15.0-r1*
* *kangaroo-simulation 2.7.0-r1*
* *launch-pal 0.22.0-r1 --> 0.22.1-r1*
* *libbno055-linux 1.7.2-r1 --> 1.9.0-r3*
* *mapviz 4.0.1-r1 --> 4.0.2-r1*
* *mapviz-interfaces 4.0.1-r1 --> 4.0.2-r1*
* *mapviz-plugins 4.0.1-r1 --> 4.0.2-r1*
* *metavision-driver 3.0.0-r1 --> 3.0.2-r1*
* *mola 3.1.0-r1 --> 3.2.0-r1*
* *mola-bridge-ros2 3.1.0-r1 --> 3.2.0-r1*
* *mola-demos 3.1.0-r1 --> 3.2.0-r1*
* *mola-input-lidar-bin-dataset 3.1.0-r1 --> 3.2.0-r1*
* *mola-input-rawlog 3.1.0-r1 --> 3.2.0-r1*
* *mola-input-rosbag2 3.1.0-r1 --> 3.2.0-r1*
* *mola-input-video 3.1.0-r1 --> 3.2.0-r1*
* *mola-kernel 3.1.0-r1 --> 3.2.0-r1*
* *mola-launcher 3.1.0-r1 --> 3.2.0-r1*
* *mola-lidar-odometry 3.1.0-r1 --> 3.2.0-r1*
* *mola-metric-maps 3.1.0-r1 --> 3.2.0-r1*
* *mola-msgs 3.1.0-r1 --> 3.2.0-r1*
* *mola-pose-list 3.1.0-r1 --> 3.2.0-r1*
* *mola-relocalization 3.1.0-r1 --> 3.2.0-r1*
* *mola-traj-tools 3.1.0-r1 --> 3.2.0-r1*
* *mola-viz 3.1.0-r1 --> 3.2.0-r1*
* *mola-viz-imgui 3.1.0-r1 --> 3.2.0-r1*
* *mola-yaml 3.1.0-r1 --> 3.2.0-r1*
* *mp2p-icp 2.12.0-r1 --> 2.13.0-r1*
* *mp2p-icp-core 2.12.0-r1 --> 2.13.0-r1*
* *mp2p-icp-viz 2.12.0-r1 --> 2.13.0-r1*
* *mujoco-3d-lidar 0.1.0-r2*
* *mujoco-ros2-control 0.0.3-r1 --> 0.1.0-r2*
* *mujoco-ros2-control-demos 0.0.3-r1 --> 0.1.0-r2*
* *mujoco-ros2-control-msgs 0.0.3-r1 --> 0.1.0-r2*
* *mujoco-ros2-control-plugins 0.0.3-r1 --> 0.1.0-r2*
* *mujoco-vendor 0.0.9-r1 --> 0.0.9-r2*
* *multires-image 4.0.1-r1 --> 4.0.2-r1*
* *pal-pro-gripper 1.12.5-r1 --> 1.12.6-r1*
* *pal-pro-gripper-bringup 1.12.5-r1 --> 1.12.6-r1*
* *pal-pro-gripper-controller-configuration 1.12.5-r1 --> 1.12.6-r1*
* *pal-pro-gripper-description 1.12.5-r1 --> 1.12.6-r1*
* *pal-pro-gripper-simulation 1.12.5-r1 --> 1.12.6-r1*
* *pal-pro-gripper-wrapper 1.12.5-r1 --> 1.12.6-r1*
* *pal-sea-arm 2.6.0-r1 --> 2.8.4-r1*
* *pal-sea-arm-bringup 2.6.0-r1 --> 2.8.4-r1*
* *pal-sea-arm-controller-configuration 2.6.0-r1 --> 2.8.4-r1*
* *pal-sea-arm-description 2.6.0-r1 --> 2.8.4-r1*
* *pal-statistics 2.8.0-r1 --> 2.8.2-r1*
* *pal-statistics-msgs 2.8.0-r1 --> 2.8.2-r1*
* *rmw-cyclonedds-cpp 1.3.4-r1 --> 1.3.5-r1*
* *rmw-int2dds-cpp 0.1.0-r3*
* *rmw-int2dds-validation 0.1.0-r3*
* *swri-cli-tools 3.9.0-r1 --> 3.9.1-r2*
* *swri-console-util 3.9.0-r1 --> 3.9.1-r2*
* *swri-dbw-interface 3.9.0-r1 --> 3.9.1-r2*
* *swri-geometry-util 3.9.0-r1 --> 3.9.1-r2*
* *swri-image-util 3.9.0-r1 --> 3.9.1-r2*
* *swri-math-util 3.9.0-r1 --> 3.9.1-r2*
* *swri-opencv-util 3.9.0-r1 --> 3.9.1-r2*
* *swri-route-util 3.9.0-r1 --> 3.9.1-r2*
* *swri-serial-util 3.9.0-r1 --> 3.9.1-r2*
* *swri-transform-util 3.9.0-r1 --> 3.9.1-r2*
* *tiago-dual-gazebo 4.13.0-r1*
* *tiago-dual-moveit-config 2.0.11-r1*
* *tiago-dual-simulation 4.13.0-r1*
* *tiago-pro-2dnav 2.14.0-r1 --> 2.15.0-r1*
* *tiago-pro-bringup 2.5.0-r1 --> 2.5.1-r1*
* *tiago-pro-controller-configuration 2.5.0-r1 --> 2.5.1-r1*
* *tiago-pro-description 2.5.0-r1 --> 2.5.1-r1*
* *tiago-pro-laser-sensors 2.14.0-r1 --> 2.15.0-r1*
* *tiago-pro-navigation 2.14.0-r1 --> 2.15.0-r1*
* *tiago-pro-rgbd-sensors 2.14.0-r1 --> 2.15.0-r1*
* *tiago-pro-robot 2.5.0-r1 --> 2.5.1-r1*
* *tile-map 4.0.1-r1 --> 4.0.2-r1*
* *unbag 1.3.1-r1*

Jazzy Changes:
--------------
* *adi-iio 1.1.0-r1*
* *adi-imu 1.1.0-r1*
* *clearpath-bms-broadcaster 2.9.14-r1 --> 2.9.15-r1*
* *clearpath-bt-joy 2.9.14-r1 --> 2.9.15-r1*
* *clearpath-common 2.9.14-r1 --> 2.9.15-r1*
* *clearpath-control 2.9.14-r1 --> 2.9.15-r1*
* *clearpath-customization 2.9.14-r1 --> 2.9.15-r1*
* *clearpath-description 2.9.14-r1 --> 2.9.15-r1*
* *clearpath-diagnostics 2.9.14-r1 --> 2.9.15-r1*
* *clearpath-generator-common 2.9.14-r1 --> 2.9.15-r1*
* *clearpath-manipulators 2.9.14-r1 --> 2.9.15-r1*
* *clearpath-manipulators-description 2.9.14-r1 --> 2.9.15-r1*
* *clearpath-mounts-description 2.9.14-r1 --> 2.9.15-r1*
* *clearpath-platform-description 2.9.14-r1 --> 2.9.15-r1*
* *clearpath-sensors-description 2.9.14-r1 --> 2.9.15-r1*
* *crazyflie 1.0.5-r1 --> 1.0.7-r1*
* *crazyflie-description 1.0.5-r1 --> 1.0.7-r1*
* *crazyflie-examples 1.0.5-r1 --> 1.0.7-r1*
* *crazyflie-interfaces 1.0.5-r1 --> 1.0.7-r1*
* *crazyflie-py 1.0.5-r1 --> 1.0.7-r1*
* *crazyflie-server-cpp 1.0.7-r1*
* *crazyflie-server-py 1.0.5-r1 --> 1.0.7-r1*
* *crazyflie-sim 1.0.5-r1 --> 1.0.7-r1*
* *depthai-v3 3.6.1-r2 --> 3.9.0-r1*
* *fuse 1.1.5-r1 --> 1.1.6-r1*
* *fuse-constraints 1.1.5-r1 --> 1.1.6-r1*
* *fuse-core 1.1.5-r1 --> 1.1.6-r1*
* *fuse-doc 1.1.5-r1 --> 1.1.6-r1*
* *fuse-graphs 1.1.5-r1 --> 1.1.6-r1*
* *fuse-loss 1.1.5-r1 --> 1.1.6-r1*
* *fuse-models 1.1.5-r1 --> 1.1.6-r1*
* *fuse-msgs 1.1.5-r1 --> 1.1.6-r1*
* *fuse-optimizers 1.1.5-r1 --> 1.1.6-r1*
* *fuse-publishers 1.1.5-r1 --> 1.1.6-r1*
* *fuse-tutorials 1.1.5-r1 --> 1.1.6-r1*
* *fuse-variables 1.1.5-r1 --> 1.1.6-r1*
* *fuse-viz 1.1.5-r1 --> 1.1.6-r1*
* *gps-msgs 3.1.0-r1 --> 3.1.1-r1*
* *gps-tools 3.1.0-r1 --> 3.1.1-r1*
* *gps-umd 3.1.0-r1 --> 3.1.1-r1*
* *gpsd-client 3.1.0-r1 --> 3.1.1-r1*
* *gz-tools-vendor 0.0.7-r1 --> 0.0.8-r1*
* *gz-transport-vendor 0.0.7-r1 --> 0.0.8-r1*
* *jrl-cmakemodules 2.0.0-r1 --> 2.2.4-r1*
* *laser-filters 2.0.9-r1 --> 2.0.10-r5*
* *libbno055-linux 1.7.2-r1 --> 1.9.0-r1*
* *mapviz 4.0.1-r1 --> 4.0.2-r1*
* *mapviz-interfaces 4.0.1-r1 --> 4.0.2-r1*
* *mapviz-plugins 4.0.1-r1 --> 4.0.2-r1*
* *metavision-driver 3.0.0-r1 --> 3.0.2-r1*
* *mola 3.0.0-r1 --> 3.2.0-r1*
* *mola-bridge-ros2 3.0.0-r1 --> 3.2.0-r1*
* *mola-demos 3.0.0-r1 --> 3.2.0-r1*
* *mola-input-lidar-bin-dataset 3.0.0-r1 --> 3.2.0-r1*
* *mola-input-rawlog 3.0.0-r1 --> 3.2.0-r1*
* *mola-input-rosbag2 3.0.0-r1 --> 3.2.0-r1*
* *mola-input-video 3.0.0-r1 --> 3.2.0-r1*
* *mola-kernel 3.0.0-r1 --> 3.2.0-r1*
* *mola-launcher 3.0.0-r1 --> 3.2.0-r1*
* *mola-lidar-odometry 3.1.0-r1 --> 3.2.0-r1*
* *mola-metric-maps 3.0.0-r1 --> 3.2.0-r1*
* *mola-msgs 3.0.0-r1 --> 3.2.0-r1*
* *mola-pose-list 3.0.0-r1 --> 3.2.0-r1*
* *mola-relocalization 3.0.0-r1 --> 3.2.0-r1*
* *mola-traj-tools 3.0.0-r1 --> 3.2.0-r1*
* *mola-viz 3.0.0-r1 --> 3.2.0-r1*
* *mola-viz-imgui 3.0.0-r1 --> 3.2.0-r1*
* *mola-yaml 3.0.0-r1 --> 3.2.0-r1*
* *mp2p-icp 2.12.0-r1 --> 2.13.0-r1*
* *mp2p-icp-core 2.12.0-r1 --> 2.13.0-r1*
* *mp2p-icp-viz 2.12.0-r1 --> 2.13.0-r1*
* *mujoco-3d-lidar 0.1.0-r2*
* *mujoco-ros2-control 0.0.3-r1 --> 0.1.0-r2*
* *mujoco-ros2-control-demos 0.0.3-r1 --> 0.1.0-r2*
* *mujoco-ros2-control-msgs 0.0.3-r1 --> 0.1.0-r2*
* *mujoco-ros2-control-plugins 0.0.3-r1 --> 0.1.0-r2*
* *multires-image 4.0.1-r1 --> 4.0.2-r1*
* *pal-statistics 2.8.0-r1 --> 2.8.2-r1*
* *pal-statistics-msgs 2.8.0-r1 --> 2.8.2-r1*
* *pangolin 0.9.5-r1 --> 0.9.6-r1*
* *rmw-cyclonedds-cpp 2.2.3-r1 --> 2.2.4-r1*
* *swri-cli-tools 3.9.0-r1 --> 3.9.1-r1*
* *swri-console-util 3.9.0-r1 --> 3.9.1-r1*
* *swri-dbw-interface 3.9.0-r1 --> 3.9.1-r1*
* *swri-geometry-util 3.9.0-r1 --> 3.9.1-r1*
* *swri-image-util 3.9.0-r1 --> 3.9.1-r1*
* *swri-math-util 3.9.0-r1 --> 3.9.1-r1*
* *swri-opencv-util 3.9.0-r1 --> 3.9.1-r1*
* *swri-route-util 3.9.0-r1 --> 3.9.1-r1*
* *swri-serial-util 3.9.0-r1 --> 3.9.1-r1*
* *swri-transform-util 3.9.0-r1 --> 3.9.1-r1*
* *tile-map 4.0.1-r1 --> 4.0.2-r1*
* *unbag 1.3.1-r1*

Kilted Changes:
---------------
* *behaviortree-cpp 4.9.1-r1 --> 4.9.0-r1*
* *depthai 3.7.1-r3 --> 3.9.0-r1*
* *fuse 1.2.6-r1 --> 1.2.7-r1*
* *fuse-constraints 1.2.6-r1 --> 1.2.7-r1*
* *fuse-core 1.2.6-r1 --> 1.2.7-r1*
* *fuse-doc 1.2.6-r1 --> 1.2.7-r1*
* *fuse-graphs 1.2.6-r1 --> 1.2.7-r1*
* *fuse-loss 1.2.6-r1 --> 1.2.7-r1*
* *fuse-models 1.2.6-r1 --> 1.2.7-r1*
* *fuse-msgs 1.2.6-r1 --> 1.2.7-r1*
* *fuse-optimizers 1.2.6-r1 --> 1.2.7-r1*
* *fuse-publishers 1.2.6-r1 --> 1.2.7-r1*
* *fuse-tutorials 1.2.6-r1 --> 1.2.7-r1*
* *fuse-variables 1.2.6-r1 --> 1.2.7-r1*
* *fuse-viz 1.2.6-r1 --> 1.2.7-r1*
* *gps-msgs 3.1.0-r1 --> 3.1.1-r1*
* *gps-tools 3.1.0-r1 --> 3.1.1-r1*
* *gps-umd 3.1.0-r1 --> 3.1.1-r1*
* *gpsd-client 3.1.0-r1 --> 3.1.1-r1*
* *gz-tools-vendor 0.1.3-r1 --> 0.1.4-r1*
* *gz-transport-vendor 0.2.4-r1 --> 0.2.5-r1*
* *jrl-cmakemodules 2.0.0-r1 --> 2.2.4-r1*
* *mapviz 4.0.1-r1 --> 4.0.2-r1*
* *mapviz-interfaces 4.0.1-r1 --> 4.0.2-r1*
* *mapviz-plugins 4.0.1-r1 --> 4.0.2-r1*
* *metavision-driver 3.0.0-r1 --> 3.0.2-r1*
* *mujoco-3d-lidar 0.1.0-r2*
* *mujoco-ros2-control 0.0.3-r1 --> 0.1.0-r2*
* *mujoco-ros2-control-demos 0.0.3-r1 --> 0.1.0-r2*
* *mujoco-ros2-control-msgs 0.0.3-r1 --> 0.1.0-r2*
* *mujoco-ros2-control-plugins 0.0.3-r1 --> 0.1.0-r2*
* *multires-image 4.0.1-r1 --> 4.0.2-r1*
* *pal-statistics 2.8.0-r1 --> 2.8.2-r1*
* *pal-statistics-msgs 2.8.0-r1 --> 2.8.2-r1*
* *swri-cli-tools 3.9.0-r1 --> 3.9.1-r1*
* *swri-console-util 3.9.0-r1 --> 3.9.1-r1*
* *swri-dbw-interface 3.9.0-r1 --> 3.9.1-r1*
* *swri-geometry-util 3.9.0-r1 --> 3.9.1-r1*
* *swri-image-util 3.9.0-r1 --> 3.9.1-r1*
* *swri-math-util 3.9.0-r1 --> 3.9.1-r1*
* *swri-opencv-util 3.9.0-r1 --> 3.9.1-r1*
* *swri-route-util 3.9.0-r1 --> 3.9.1-r1*
* *swri-serial-util 3.9.0-r1 --> 3.9.1-r1*
* *swri-transform-util 3.9.0-r1 --> 3.9.1-r1*
* *tile-map 4.0.1-r1 --> 4.0.2-r1*
* *unbag 1.3.1-r1*

Lyrical Changes:
----------------
* *adi-iio 1.1.0-r1*
* *adi-imu 1.1.0-r1*
* *crazyflie 1.0.5-r1 --> 1.0.7-r1*
* *crazyflie-description 1.0.5-r1 --> 1.0.7-r1*
* *crazyflie-examples 1.0.5-r1 --> 1.0.7-r1*
* *crazyflie-interfaces 1.0.5-r1 --> 1.0.7-r1*
* *crazyflie-py 1.0.5-r1 --> 1.0.7-r1*
* *crazyflie-server-cpp 1.0.7-r1*
* *crazyflie-server-py 1.0.5-r1 --> 1.0.7-r1*
* *crazyflie-sim 1.0.5-r1 --> 1.0.7-r1*
* *fuse 1.3.3-r1 --> 1.3.4-r1*
* *fuse-constraints 1.3.3-r1 --> 1.3.4-r1*
* *fuse-core 1.3.3-r1 --> 1.3.4-r1*
* *fuse-doc 1.3.3-r1 --> 1.3.4-r1*
* *fuse-graphs 1.3.3-r1 --> 1.3.4-r1*
* *fuse-loss 1.3.3-r1 --> 1.3.4-r1*
* *fuse-models 1.3.3-r1 --> 1.3.4-r1*
* *fuse-msgs 1.3.3-r1 --> 1.3.4-r1*
* *fuse-optimizers 1.3.3-r1 --> 1.3.4-r1*
* *fuse-publishers 1.3.3-r1 --> 1.3.4-r1*
* *fuse-tutorials 1.3.3-r1 --> 1.3.4-r1*
* *fuse-variables 1.3.3-r1 --> 1.3.4-r1*
* *fuse-viz 1.3.3-r1 --> 1.3.4-r1*
* *gps-msgs 3.1.0-r1 --> 3.1.1-r1*
* *gps-tools 3.1.0-r1 --> 3.1.1-r1*
* *gps-umd 3.1.0-r1 --> 3.1.1-r1*
* *gpsd-client 3.1.0-r1 --> 3.1.1-r1*
* *gz-common-vendor 0.3.6-r1 --> 0.3.7-r1*
* *gz-tools-vendor 0.2.1-r3 --> 0.2.2-r1*
* *jrl-cmakemodules 2.0.0-r1 --> 2.2.4-r1*
* *launch-pal 0.20.3-r3 --> 0.22.1-r1*
* *mapviz 4.0.1-r1 --> 4.0.2-r1*
* *mapviz-interfaces 4.0.1-r1 --> 4.0.2-r1*
* *mapviz-plugins 4.0.1-r1 --> 4.0.2-r1*
* *metavision-driver 3.0.0-r3 --> 3.0.2-r1*
* *mola 3.0.0-r1 --> 3.2.0-r1*
* *mola-bridge-ros2 3.0.0-r1 --> 3.2.0-r1*
* *mola-demos 3.0.0-r1 --> 3.2.0-r1*
* *mola-input-lidar-bin-dataset 3.0.0-r1 --> 3.2.0-r1*
* *mola-input-rawlog 3.0.0-r1 --> 3.2.0-r1*
* *mola-input-rosbag2 3.0.0-r1 --> 3.2.0-r1*
* *mola-input-video 3.0.0-r1 --> 3.2.0-r1*
* *mola-kernel 3.0.0-r1 --> 3.2.0-r1*
* *mola-launcher 3.0.0-r1 --> 3.2.0-r1*
* *mola-lidar-odometry 3.1.0-r1 --> 3.2.0-r1*
* *mola-metric-maps 3.0.0-r1 --> 3.2.0-r1*
* *mola-msgs 3.0.0-r1 --> 3.2.0-r1*
* *mola-pose-list 3.0.0-r1 --> 3.2.0-r1*
* *mola-relocalization 3.0.0-r1 --> 3.2.0-r1*
* *mola-traj-tools 3.0.0-r1 --> 3.2.0-r1*
* *mola-viz 3.0.0-r1 --> 3.2.0-r1*
* *mola-viz-imgui 3.0.0-r1 --> 3.2.0-r1*
* *mola-yaml 3.0.0-r1 --> 3.2.0-r1*
* *moveit-task-constructor-capabilities 0.1.5-r3 --> 0.1.6-r1*
* *moveit-task-constructor-core 0.1.5-r3 --> 0.1.6-r1*
* *moveit-task-constructor-demo 0.1.5-r3 --> 0.1.6-r1*
* *moveit-task-constructor-msgs 0.1.5-r3 --> 0.1.6-r1*
* *moveit-task-constructor-visualization 0.1.5-r3 --> 0.1.6-r1*
* *mp2p-icp 2.12.0-r1 --> 2.13.0-r1*
* *mp2p-icp-core 2.12.0-r1 --> 2.13.0-r1*
* *mp2p-icp-viz 2.12.0-r1 --> 2.13.0-r1*
* *mujoco-3d-lidar 0.1.0-r1*
* *mujoco-ros2-control 0.0.2-r3 --> 0.1.0-r1*
* *mujoco-ros2-control-demos 0.0.2-r3 --> 0.1.0-r1*
* *mujoco-ros2-control-msgs 0.0.2-r3 --> 0.1.0-r1*
* *mujoco-ros2-control-plugins 0.0.2-r3 --> 0.1.0-r1*
* *multires-image 4.0.1-r1 --> 4.0.2-r1*
* *pal-statistics 2.8.0-r1 --> 2.8.2-r1*
* *pal-statistics-msgs 2.8.0-r1 --> 2.8.2-r1*
* *pal-urdf-utils 2.9.2-r1*
* *pangolin 0.9.5-r3 --> 0.9.6-r1*
* *rmw-cyclonedds-cpp 4.1.4-r3 --> 4.1.5-r1*
* *rviz-marker-tools 0.1.5-r3 --> 0.1.6-r1*
* *swri-cli-tools 3.9.0-r1 --> 3.9.1-r2*
* *swri-console-util 3.9.0-r1 --> 3.9.1-r2*
* *swri-dbw-interface 3.9.0-r1 --> 3.9.1-r2*
* *swri-geometry-util 3.9.0-r1 --> 3.9.1-r2*
* *swri-image-util 3.9.0-r1 --> 3.9.1-r2*
* *swri-math-util 3.9.0-r1 --> 3.9.1-r2*
* *swri-opencv-util 3.9.0-r1 --> 3.9.1-r2*
* *swri-route-util 3.9.0-r1 --> 3.9.1-r2*
* *swri-serial-util 3.9.0-r1 --> 3.9.1-r2*
* *swri-transform-util 3.9.0-r1 --> 3.9.1-r2*
* *tf2-2d 1.6.1-r3 --> 1.6.2-r1*
* *tile-map 4.0.1-r1 --> 4.0.2-r1*
* *unbag 1.3.1-r1*
* *urdf-test 2.1.1-r3 --> 2.1.2-r1*

Rolling Changes:
----------------
* *crazyflie 1.0.5-r1 --> 1.0.7-r1*
* *crazyflie-description 1.0.5-r1 --> 1.0.7-r1*
* *crazyflie-examples 1.0.5-r1 --> 1.0.7-r1*
* *crazyflie-interfaces 1.0.5-r1 --> 1.0.7-r1*
* *crazyflie-py 1.0.5-r1 --> 1.0.7-r1*
* *crazyflie-server-cpp 1.0.7-r1*
* *crazyflie-server-py 1.0.5-r1 --> 1.0.7-r1*
* *crazyflie-sim 1.0.5-r1 --> 1.0.7-r1*
* *fuse 1.3.3-r1 --> 1.3.4-r1*
* *fuse-constraints 1.3.3-r1 --> 1.3.4-r1*
* *fuse-core 1.3.3-r1 --> 1.3.4-r1*
* *fuse-doc 1.3.3-r1 --> 1.3.4-r1*
* *fuse-graphs 1.3.3-r1 --> 1.3.4-r1*
* *fuse-loss 1.3.3-r1 --> 1.3.4-r1*
* *fuse-models 1.3.3-r1 --> 1.3.4-r1*
* *fuse-msgs 1.3.3-r1 --> 1.3.4-r1*
* *fuse-optimizers 1.3.3-r1 --> 1.3.4-r1*
* *fuse-publishers 1.3.3-r1 --> 1.3.4-r1*
* *fuse-tutorials 1.3.3-r1 --> 1.3.4-r1*
* *fuse-variables 1.3.3-r1 --> 1.3.4-r1*
* *fuse-viz 1.3.3-r1 --> 1.3.4-r1*
* *gps-msgs 3.1.0-r1 --> 3.1.1-r1*
* *gps-tools 3.1.0-r1 --> 3.1.1-r1*
* *gps-umd 3.1.0-r1 --> 3.1.1-r1*
* *gpsd-client 3.1.0-r1 --> 3.1.1-r1*
* *gz-common-vendor 0.4.1-r1 --> 0.4.2-r1*
* *gz-tools-vendor 0.3.0-r1 --> 0.3.1-r1*
* *jrl-cmakemodules 2.0.0-r1 --> 2.2.4-r1*
* *mapviz 4.0.1-r1 --> 4.0.2-r1*
* *mapviz-interfaces 4.0.1-r1 --> 4.0.2-r1*
* *mapviz-plugins 4.0.1-r1 --> 4.0.2-r1*
* *mola 3.1.0-r1 --> 3.2.0-r1*
* *mola-bridge-ros2 3.1.0-r1 --> 3.2.0-r1*
* *mola-demos 3.1.0-r1 --> 3.2.0-r1*
* *mola-input-lidar-bin-dataset 3.1.0-r1 --> 3.2.0-r1*
* *mola-input-rawlog 3.1.0-r1 --> 3.2.0-r1*
* *mola-input-rosbag2 3.1.0-r1 --> 3.2.0-r1*
* *mola-input-video 3.1.0-r1 --> 3.2.0-r1*
* *mola-kernel 3.1.0-r1 --> 3.2.0-r1*
* *mola-launcher 3.1.0-r1 --> 3.2.0-r1*
* *mola-lidar-odometry 3.1.0-r1 --> 3.2.0-r1*
* *mola-metric-maps 3.1.0-r1 --> 3.2.0-r1*
* *mola-msgs 3.1.0-r1 --> 3.2.0-r1*
* *mola-pose-list 3.1.0-r1 --> 3.2.0-r1*
* *mola-relocalization 3.1.0-r1 --> 3.2.0-r1*
* *mola-traj-tools 3.1.0-r1 --> 3.2.0-r1*
* *mola-viz 3.1.0-r1 --> 3.2.0-r1*
* *mola-viz-imgui 3.1.0-r1 --> 3.2.0-r1*
* *mola-yaml 3.1.0-r1 --> 3.2.0-r1*
* *moveit-task-constructor-capabilities 0.1.5-r2 --> 0.1.6-r1*
* *moveit-task-constructor-core 0.1.5-r2 --> 0.1.6-r1*
* *moveit-task-constructor-demo 0.1.5-r2 --> 0.1.6-r1*
* *moveit-task-constructor-msgs 0.1.5-r2 --> 0.1.6-r1*
* *moveit-task-constructor-visualization 0.1.5-r2 --> 0.1.6-r1*
* *mp2p-icp 2.12.0-r1 --> 2.13.0-r1*
* *mp2p-icp-core 2.12.0-r1 --> 2.13.0-r1*
* *mp2p-icp-viz 2.12.0-r1 --> 2.13.0-r1*
* *mujoco-3d-lidar 0.1.0-r2*
* *mujoco-ros2-control 0.0.2-r2 --> 0.1.0-r2*
* *mujoco-ros2-control-demos 0.0.2-r2 --> 0.1.0-r2*
* *mujoco-ros2-control-msgs 0.0.2-r2 --> 0.1.0-r2*
* *mujoco-ros2-control-plugins 0.0.2-r2 --> 0.1.0-r2*
* *multires-image 4.0.1-r1 --> 4.0.2-r1*
* *pal-statistics 2.8.0-r1 --> 2.8.2-r1*
* *pal-statistics-msgs 2.8.0-r1 --> 2.8.2-r1*
* *pal-urdf-utils 2.9.2-r1*
* *pangolin 0.9.5-r2 --> 0.9.6-r1*
* *rmw-cyclonedds-cpp 4.2.0-r1 --> 4.2.1-r1*
* *ros-industrial-cmake-boilerplate 0.5.4-r2 --> 0.7.5-r1*
* *rviz-marker-tools 0.1.5-r2 --> 0.1.6-r1*
* *swri-cli-tools 3.9.0-r2 --> 3.9.1-r1*
* *swri-console-util 3.9.0-r2 --> 3.9.1-r1*
* *swri-dbw-interface 3.9.0-r2 --> 3.9.1-r1*
* *swri-geometry-util 3.9.0-r2 --> 3.9.1-r1*
* *swri-image-util 3.9.0-r2 --> 3.9.1-r1*
* *swri-math-util 3.9.0-r2 --> 3.9.1-r1*
* *swri-opencv-util 3.9.0-r2 --> 3.9.1-r1*
* *swri-route-util 3.9.0-r2 --> 3.9.1-r1*
* *swri-serial-util 3.9.0-r2 --> 3.9.1-r1*
* *swri-transform-util 3.9.0-r2 --> 3.9.1-r1*
* *tf2-2d 1.6.1-r2 --> 1.6.2-r1*
* *tile-map 4.0.1-r1 --> 4.0.2-r1*
* *unbag 1.3.0-r1 --> 1.3.1-r2*


No missing dependencies.