### PR TITLE
gtsam: Don't depend on boost as in ROS buildfarm

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -110,9 +110,16 @@ let
     gtsam = rosSuper.gtsam.overrideAttrs ({
       cmakeFlags ? [], ...
     }: {
-      # Don't use vendored version of Eigen, which can collide with
-      # Eigen version in dependent packages.
-      cmakeFlags = cmakeFlags ++ [ "-DGTSAM_USE_SYSTEM_EIGEN=ON" ];
+      cmakeFlags = cmakeFlags ++ [
+        # Don't use vendored version of Eigen, which can collide with
+        # Eigen version in dependent packages.
+        "-DGTSAM_USE_SYSTEM_EIGEN=ON"
+        # Don't depend on Boost. This is in line with
+        # https://github.com/borglab/gtsam/pull/2543, which disabled
+        # Boost dependency in ROS builds.
+        "-DGTSAM_ENABLE_BOOST_SERIALIZATION=OFF"
+        "-DGTSAM_USE_BOOST_FEATURES=OFF"
+      ];
     });
 
     # hpp-fcl was renamed to coal and we use the version from nixpkgs (see above)


### PR DESCRIPTION
GTSAM built by ROS buildfarm has boost dependency disabled. See https://github.com/borglab/gtsam/pull/2543. Doing the same here fixes dependent ROS packages, which do not declare boost dependency, because they don't need it in ROS buildfarm. One fixed example is ros-lyrical-mola-gtsam-factors-2.4.2-r1, which currently fails with the following error:

    CMake Error at /nix/store/jfdn7bk2k40afmmaqv85b8v043jrigm5-cmake-4.3.4/share/cmake-4.3/Modules/CMakeFindDependencyMacro.cmake:93 (find_package):
      By not providing "FindBoost.cmake" in CMAKE_MODULE_PATH this project has
      asked CMake to find a package configuration file provided by "Boost", but
      CMake did not find one.
          Could not find a package configuration file provided by "Boost" (requested
      version 1.70) with any of the following names:
            Boost.cps
        boost.cps
        BoostConfig.cmake
        boost-config.cmake
          Add the installation prefix of "Boost" to CMAKE_PREFIX_PATH or set
      "Boost_DIR" to a directory containing one of the above files.  If "Boost"
      provides a separate development package or SDK, be sure it has been
      installed.
    Call Stack (most recent call first):
      /nix/store/jfdn7bk2k40afmmaqv85b8v043jrigm5-cmake-4.3.4/share/cmake-4.3/Modules/CMakeFindDependencyMacro.cmake:125 (__find_dependency_common)
      /nix/store/qncq8412626jvfzaylhaiaq9vqsqan77-ros-lyrical-gtsam-4.3.0-r5/lib/cmake/GTSAM/GTSAMConfig.cmake:22 (find_dependency)
      CMakeLists.txt:37 (find_package)