### PR TITLE
gtsam: Remove overrides adding boost

### DIFF
--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -156,11 +156,8 @@ in {
   };
 
   gtsam = rosSuper.gtsam.overrideAttrs ({
-    nativeBuildInputs ? [], patches ? [], cmakeFlags ? [], ...
+    patches ? [], cmakeFlags ? [], ...
   }: {
-    # https://github.com/borglab/gtsam/pull/2171
-    # boost is optional but enabled by default
-    nativeBuildInputs = nativeBuildInputs ++ [ self.boost ];
     patches = [
       # https://github.com/borglab/gtsam/pull/2232 merged upstream
       (self.fetchpatch2 {

--- a/distros/lyrical/overrides.nix
+++ b/distros/lyrical/overrides.nix
@@ -114,14 +114,6 @@ in {
     fetchgitArgs.hash = "sha256-gztnxui9Fe/FTieMjdvfJjWHjkImtlsHn6fM1FruyME=";
   };
 
-  gtsam = rosSuper.gtsam.overrideAttrs ({
-    nativeBuildInputs ? [], ...
-  }: {
-    # https://github.com/borglab/gtsam/pull/2171
-    # boost is optional but enabled by default
-    nativeBuildInputs = nativeBuildInputs ++ [ self.boost ];
-  });
-
   gz-cmake-vendor = lib.patchAmentVendorGit rosSuper.gz-cmake-vendor { };
 
   gz-common-vendor = (lib.patchAmentVendorGit rosSuper.gz-common-vendor { }).overrideAttrs({

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -82,14 +82,6 @@ in {
     fetchgitArgs.hash = "sha256-gztnxui9Fe/FTieMjdvfJjWHjkImtlsHn6fM1FruyME=";
   };
 
-  gtsam = rosSuper.gtsam.overrideAttrs ({
-    nativeBuildInputs ? [], ...
-  }: {
-    # https://github.com/borglab/gtsam/pull/2171
-    # boost is optional but enabled by default
-    nativeBuildInputs = nativeBuildInputs ++ [ self.boost ];
-  });
-
   gz-cmake-vendor = lib.patchAmentVendorGit rosSuper.gz-cmake-vendor { };
 
   gz-common-vendor = (lib.patchAmentVendorGit rosSuper.gz-common-vendor { }).overrideAttrs({


### PR DESCRIPTION
It's no longer necessary since the previous commit (#922).

### Hydra build and evaluation statistics  <sub><sup>([source](https://github.com/wentasah/ros-hydra-stats))</sup></sub>
<details>
<summary>✅ Still succeeding builds: 8710</summary>


[Hydra comparison](https://hydra.iid.ciirc.cvut.cz/eval/13332?compare=13345#tabs-still-succeed)
</details>

<details>
<summary>✅ Still unbuilt attributes: 5</summary>


[Hydra comparison](https://hydra.iid.ciirc.cvut.cz/eval/13332?compare=13345)
</details>

<details>
<summary>⚠️ Still present eval errors: 246</summary>


  | Reason | Attributes |
  |--------|------------|
  | Unrecognized eval error | [rosPackages.humble.buildRosPackage](https://index.ros.org/p/buildRosPackage/#humble), [rosPackages.jazzy.buildRosPackage](https://index.ros.org/p/buildRosPackage/#jazzy), [rosPackages.kilted.buildRosPackage](https://index.ros.org/p/buildRosPackage/#kilted), [rosPackages.lyrical.buildRosPackage](https://index.ros.org/p/buildRosPackage/#lyrical), [rosPackages.rolling.buildRosPackage](https://index.ros.org/p/buildRosPackage/#rolling) |
  | ``` callPackageWith: Function called without required argument "_unresolved_ament_python" ``` | [rosPackages.humble.trackdlo-bringup](https://index.ros.org/p/trackdlo_bringup/#humble), [rosPackages.humble.trackdlo-segmentation](https://index.ros.org/p/trackdlo_segmentation/#humble), [rosPackages.humble.trackdlo-utils](https://index.ros.org/p/trackdlo_utils/#humble), [rosPackages.jazzy.trackdlo-bringup](https://index.ros.org/p/trackdlo_bringup/#jazzy), [rosPackages.jazzy.trackdlo-segmentation](https://index.ros.org/p/trackdlo_segmentation/#jazzy), [rosPackages.jazzy.trackdlo-utils](https://index.ros.org/p/trackdlo_utils/#jazzy) |
  | ``` callPackageWith: Function called without required argument "_unresolved_gazebo_ros_pkgs" ``` | [rosPackages.jazzy.dolly](https://index.ros.org/p/dolly/#jazzy), [rosPackages.jazzy.dolly-gazebo](https://index.ros.org/p/dolly_gazebo/#jazzy) |
  | ``` callPackageWith: Function called without required argument "_unresolved_gurumdds-3" ``` | [rosPackages.humble.gurumdds-cmake-module](https://index.ros.org/p/gurumdds_cmake_module/#humble), [rosPackages.humble.rmw-gurumdds-cpp](https://index.ros.org/p/rmw_gurumdds_cpp/#humble), [rosPackages.jazzy.gurumdds-cmake-module](https://index.ros.org/p/gurumdds_cmake_module/#jazzy), [rosPackages.jazzy.rmw-gurumdds-cpp](https://index.ros.org/p/rmw_gurumdds_cpp/#jazzy), [rosPackages.kilted.gurumdds-cmake-module](https://index.ros.org/p/gurumdds_cmake_module/#kilted), [rosPackages.kilted.rmw-gurumdds-cpp](https://index.ros.org/p/rmw_gurumdds_cpp/#kilted), [rosPackages.lyrical.gurumdds-cmake-module](https://index.ros.org/p/gurumdds_cmake_module/#lyrical), [rosPackages.lyrical.rmw-gurumdds-cpp](https://index.ros.org/p/rmw_gurumdds_cpp/#lyrical) |
  | ``` callPackageWith: Function called without required argument "_unresolved_gz-plugin" ``` | [rosPackages.humble.leo-gz-bringup](https://index.ros.org/p/leo_gz_bringup/#humble), [rosPackages.humble.leo-gz-plugins](https://index.ros.org/p/leo_gz_plugins/#humble), [rosPackages.humble.leo-simulator](https://index.ros.org/p/leo_simulator/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_gz-sensors6" ``` | [rosPackages.humble.pal-sea-arm-gazebo](https://index.ros.org/p/pal_sea_arm_gazebo/#humble), [rosPackages.humble.pal-sea-arm-simulation](https://index.ros.org/p/pal_sea_arm_simulation/#humble), [rosPackages.humble.pmb2-gazebo](https://index.ros.org/p/pmb2_gazebo/#humble), [rosPackages.humble.pmb2-simulation](https://index.ros.org/p/pmb2_simulation/#humble), [rosPackages.humble.tiago-dual-gazebo](https://index.ros.org/p/tiago_dual_gazebo/#humble), [rosPackages.humble.tiago-dual-simulation](https://index.ros.org/p/tiago_dual_simulation/#humble), [rosPackages.humble.tiago-gazebo](https://index.ros.org/p/tiago_gazebo/#humble), [rosPackages.humble.tiago-pro-gazebo](https://index.ros.org/p/tiago_pro_gazebo/#humble), [rosPackages.humble.tiago-pro-simulation](https://index.ros.org/p/tiago_pro_simulation/#humble), [rosPackages.humble.tiago-simulation](https://index.ros.org/p/tiago_simulation/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_ignition-common4" ``` | [rosPackages.humble.irobot-create-ignition-bringup](https://index.ros.org/p/irobot_create_ignition_bringup/#humble), [rosPackages.humble.irobot-create-ignition-plugins](https://index.ros.org/p/irobot_create_ignition_plugins/#humble), [rosPackages.humble.irobot-create-ignition-sim](https://index.ros.org/p/irobot_create_ignition_sim/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_ignition-fortress" ``` | [rosPackages.humble.rmf-building-sim-gz-plugins](https://index.ros.org/p/rmf_building_sim_gz_plugins/#humble), [rosPackages.humble.rmf-robot-sim-gz-plugins](https://index.ros.org/p/rmf_robot_sim_gz_plugins/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_ignition-fuel-tools7" ``` | [rosPackages.humble.rmf-building-map-tools](https://index.ros.org/p/rmf_building_map_tools/#humble), [rosPackages.humble.rmf-dev](https://index.ros.org/p/rmf_dev/#humble), [rosPackages.humble.rmf-traffic-editor-test-maps](https://index.ros.org/p/rmf_traffic_editor_test_maps/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_ignition-gazebo6" ``` | examples.ros2-desktop-full-humble, [rosPackages.humble.andino-gz](https://index.ros.org/p/andino_gz/#humble), [rosPackages.humble.as2-gazebo-assets](https://index.ros.org/p/as2_gazebo_assets/#humble), [rosPackages.humble.as2-platform-gazebo](https://index.ros.org/p/as2_platform_gazebo/#humble), [rosPackages.humble.as2-visualization](https://index.ros.org/p/as2_visualization/#humble), [rosPackages.humble.clearpath-gz](https://index.ros.org/p/clearpath_gz/#humble), [rosPackages.humble.clearpath-simulator](https://index.ros.org/p/clearpath_simulator/#humble), [rosPackages.humble.desktop-full](https://index.ros.org/p/desktop_full/#humble), [rosPackages.humble.dolly-ignition](https://index.ros.org/p/dolly_ignition/#humble), [rosPackages.humble.ewellix-sim](https://index.ros.org/p/ewellix_sim/#humble), [rosPackages.humble.franka-gazebo-bringup](https://index.ros.org/p/franka_gazebo_bringup/#humble), [rosPackages.humble.franka-ign-ros2-control](https://index.ros.org/p/franka_ign_ros2_control/#humble), [rosPackages.humble.franka-ros2](https://index.ros.org/p/franka_ros2/#humble), [rosPackages.humble.fusioncore-gazebo](https://index.ros.org/p/fusioncore_gazebo/#humble), [rosPackages.humble.gz-ros2-control](https://index.ros.org/p/gz_ros2_control/#humble), [rosPackages.humble.gz-ros2-control-demos](https://index.ros.org/p/gz_ros2_control_demos/#humble), [rosPackages.humble.ign-ros2-control](https://index.ros.org/p/ign_ros2_control/#humble), [rosPackages.humble.ign-ros2-control-demos](https://index.ros.org/p/ign_ros2_control_demos/#humble), [rosPackages.humble.kuka-gazebo](https://index.ros.org/p/kuka_gazebo/#humble), [rosPackages.humble.kuka-robot-descriptions](https://index.ros.org/p/kuka_robot_descriptions/#humble), [rosPackages.humble.nicla-vision-ros2](https://index.ros.org/p/nicla_vision_ros2/#humble), [rosPackages.humble.omni-base-gazebo](https://index.ros.org/p/omni_base_gazebo/#humble), [rosPackages.humble.omni-base-simulation](https://index.ros.org/p/omni_base_simulation/#humble), [rosPackages.humble.raspimouse-description](https://index.ros.org/p/raspimouse_description/#humble), [rosPackages.humble.raspimouse-gazebo](https://index.ros.org/p/raspimouse_gazebo/#humble), [rosPackages.humble.raspimouse-navigation](https://index.ros.org/p/raspimouse_navigation/#humble), [rosPackages.humble.raspimouse-sim](https://index.ros.org/p/raspimouse_sim/#humble), [rosPackages.humble.raspimouse-slam](https://index.ros.org/p/raspimouse_slam/#humble), [rosPackages.humble.raspimouse-slam-navigation](https://index.ros.org/p/raspimouse_slam_navigation/#humble), [rosPackages.humble.ros-gz](https://index.ros.org/p/ros_gz/#humble), [rosPackages.humble.ros-gz-sim](https://index.ros.org/p/ros_gz_sim/#humble), [rosPackages.humble.ros-gz-sim-demos](https://index.ros.org/p/ros_gz_sim_demos/#humble), [rosPackages.humble.ros-ign](https://index.ros.org/p/ros_ign/#humble), [rosPackages.humble.ros-ign-gazebo](https://index.ros.org/p/ros_ign_gazebo/#humble), [rosPackages.humble.ros-ign-gazebo-demos](https://index.ros.org/p/ros_ign_gazebo_demos/#humble), [rosPackages.humble.simulation](https://index.ros.org/p/simulation/#humble), [rosPackages.humble.ur-simulation-gz](https://index.ros.org/p/ur_simulation_gz/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_ignition-gui6" ``` | [rosPackages.humble.turtlebot4-ignition-bringup](https://index.ros.org/p/turtlebot4_ignition_bringup/#humble), [rosPackages.humble.turtlebot4-ignition-gui-plugins](https://index.ros.org/p/turtlebot4_ignition_gui_plugins/#humble), [rosPackages.humble.turtlebot4-simulator](https://index.ros.org/p/turtlebot4_simulator/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_ignition-plugin" ``` | [rosPackages.humble.bcr-arm](https://index.ros.org/p/bcr_arm/#humble), [rosPackages.humble.bcr-arm-gazebo](https://index.ros.org/p/bcr_arm_gazebo/#humble), [rosPackages.humble.bcr-arm-ros2](https://index.ros.org/p/bcr_arm_ros2/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_libopen3d-dev" ``` | [rosPackages.humble.open3d-conversions](https://index.ros.org/p/open3d_conversions/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_libpointmatcher" ``` | [rosPackages.rolling.rtabmap](https://index.ros.org/p/rtabmap/#rolling) |
  | ``` callPackageWith: Function called without required argument "_unresolved_libserial-dev" ``` | [rosPackages.humble.andino-apps](https://index.ros.org/p/andino_apps/#humble), [rosPackages.humble.andino-base](https://index.ros.org/p/andino_base/#humble), [rosPackages.humble.andino-bringup](https://index.ros.org/p/andino_bringup/#humble), [rosPackages.humble.andino-control](https://index.ros.org/p/andino_control/#humble), [rosPackages.humble.andino-gz-classic](https://index.ros.org/p/andino_gz_classic/#humble), [rosPackages.humble.feetech-ros2-driver](https://index.ros.org/p/feetech_ros2_driver/#humble), [rosPackages.jazzy.feetech-ros2-driver](https://index.ros.org/p/feetech_ros2_driver/#jazzy), [rosPackages.kilted.feetech-ros2-driver](https://index.ros.org/p/feetech_ros2_driver/#kilted), [rosPackages.lyrical.feetech-ros2-driver](https://index.ros.org/p/feetech_ros2_driver/#lyrical), [rosPackages.rolling.feetech-ros2-driver](https://index.ros.org/p/feetech_ros2_driver/#rolling) |
  | ``` callPackageWith: Function called without required argument "_unresolved_picknik_reset_fault_controller" ``` | [rosPackages.rolling.kinova-gen3-6dof-robotiq-2f-85-moveit-config](https://index.ros.org/p/kinova_gen3_6dof_robotiq_2f_85_moveit_config/#rolling), [rosPackages.rolling.kinova-gen3-7dof-robotiq-2f-85-moveit-config](https://index.ros.org/p/kinova_gen3_7dof_robotiq_2f_85_moveit_config/#rolling), [rosPackages.rolling.kinova-gen3-lite-moveit-config](https://index.ros.org/p/kinova_gen3_lite_moveit_config/#rolling), [rosPackages.rolling.kortex-bringup](https://index.ros.org/p/kortex_bringup/#rolling), [rosPackages.rolling.kortex-description](https://index.ros.org/p/kortex_description/#rolling) |
  | ``` callPackageWith: Function called without required argument "_unresolved_pybind11-json-dev" ``` | [rosPackages.rolling.rmf-demos](https://index.ros.org/p/rmf_demos/#rolling), [rosPackages.rolling.rmf-demos-fleet-adapter](https://index.ros.org/p/rmf_demos_fleet_adapter/#rolling), [rosPackages.rolling.rmf-demos-gz](https://index.ros.org/p/rmf_demos_gz/#rolling), [rosPackages.rolling.rmf-fleet-adapter-python](https://index.ros.org/p/rmf_fleet_adapter_python/#rolling) |
  | ``` callPackageWith: Function called without required argument "_unresolved_python3-apt" ``` | [rosPackages.jazzy.clearpath-common](https://index.ros.org/p/clearpath_common/#jazzy), [rosPackages.jazzy.clearpath-config-live](https://index.ros.org/p/clearpath_config_live/#jazzy), [rosPackages.jazzy.clearpath-desktop](https://index.ros.org/p/clearpath_desktop/#jazzy), [rosPackages.jazzy.clearpath-generator-common](https://index.ros.org/p/clearpath_generator_common/#jazzy), [rosPackages.jazzy.clearpath-generator-gz](https://index.ros.org/p/clearpath_generator_gz/#jazzy), [rosPackages.jazzy.clearpath-gz](https://index.ros.org/p/clearpath_gz/#jazzy), [rosPackages.jazzy.clearpath-simulator](https://index.ros.org/p/clearpath_simulator/#jazzy), [rosPackages.jazzy.clearpath-tests](https://index.ros.org/p/clearpath_tests/#jazzy), [rosPackages.jazzy.clearpath-viz](https://index.ros.org/p/clearpath_viz/#jazzy) |
  | ``` callPackageWith: Function called without required argument "_unresolved_python3-colcon-common-extensions" ``` | [rosPackages.jazzy.colcon-rclgd](https://index.ros.org/p/colcon_rclgd/#jazzy), [rosPackages.jazzy.rclgd](https://index.ros.org/p/rclgd/#jazzy) |
  | ``` callPackageWith: Function called without required argument "_unresolved_python3-jsonpickle" ``` | [rosPackages.humble.namosim](https://index.ros.org/p/namosim/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_python3-junitparser" ``` | [rosPackages.humble.replay-testing](https://index.ros.org/p/replay_testing/#humble), [rosPackages.jazzy.replay-testing](https://index.ros.org/p/replay_testing/#jazzy), [rosPackages.kilted.replay-testing](https://index.ros.org/p/replay_testing/#kilted), [rosPackages.lyrical.replay-testing](https://index.ros.org/p/replay_testing/#lyrical), [rosPackages.rolling.replay-testing](https://index.ros.org/p/replay_testing/#rolling) |
  | ``` callPackageWith: Function called without required argument "_unresolved_python3-open3d" ``` | [rosPackages.humble.pointcloud-to-ply](https://index.ros.org/p/pointcloud_to_ply/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_python3-openai-pip" ``` | [rosPackages.humble.ros2ai](https://index.ros.org/p/ros2ai/#humble), [rosPackages.jazzy.ros2ai](https://index.ros.org/p/ros2ai/#jazzy), [rosPackages.kilted.ros2ai](https://index.ros.org/p/ros2ai/#kilted) |
  | ``` callPackageWith: Function called without required argument "_unresolved_python3-pymap3d" ``` | [rosPackages.humble.aerostack2](https://index.ros.org/p/aerostack2/#humble), [rosPackages.humble.as2-keyboard-teleoperation](https://index.ros.org/p/as2_keyboard_teleoperation/#humble), [rosPackages.humble.as2-python-api](https://index.ros.org/p/as2_python_api/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_python3-pytorch-pip" ``` | [rosPackages.humble.lidar-situational-graphs](https://index.ros.org/p/lidar_situational_graphs/#humble), [rosPackages.humble.situational-graphs-reasoning](https://index.ros.org/p/situational_graphs_reasoning/#humble) |
  | ``` callPackageWith: Function called without required argument "_unresolved_ros_ign_bridge" ``` | [rosPackages.jazzy.dolly-ignition](https://index.ros.org/p/dolly_ignition/#jazzy) |
  | ``` callPackageWith: Function called without required argument "_unresolved_ros_image_to_qimage" ``` | [rosPackages.rolling.rqt-image-overlay](https://index.ros.org/p/rqt_image_overlay/#rolling) |
  | ``` callPackageWith: Function called without required argument "_unresolved_swri_roscpp" ``` | [rosPackages.humble.novatel-gps-driver](https://index.ros.org/p/novatel_gps_driver/#humble), [rosPackages.jazzy.novatel-gps-driver](https://index.ros.org/p/novatel_gps_driver/#jazzy), [rosPackages.kilted.novatel-gps-driver](https://index.ros.org/p/novatel_gps_driver/#kilted), [rosPackages.lyrical.novatel-gps-driver](https://index.ros.org/p/novatel_gps_driver/#lyrical), [rosPackages.rolling.novatel-gps-driver](https://index.ros.org/p/novatel_gps_driver/#rolling) |
  | ``` callPackageWith: Function called without required argument "_unresolved_tl_expected" ``` | [rosPackages.lyrical.om-gravity-compensation-controller](https://index.ros.org/p/om_gravity_compensation_controller/#lyrical), [rosPackages.lyrical.open-manipulator](https://index.ros.org/p/open_manipulator/#lyrical), [rosPackages.rolling.om-gravity-compensation-controller](https://index.ros.org/p/om_gravity_compensation_controller/#rolling), [rosPackages.rolling.open-manipulator](https://index.ros.org/p/open_manipulator/#rolling) |
  | ``` callPackageWith: Function called without required argument "gazebo" ``` | [rosPackages.humble.aws-robomaker-small-warehouse-world](https://index.ros.org/p/aws_robomaker_small_warehouse_world/#humble) |
  | ``` callPackageWith: Function called without required argument "gazebo_11" ``` | [rosPackages.humble.crane-plus](https://index.ros.org/p/crane_plus/#humble), [rosPackages.humble.crane-plus-control](https://index.ros.org/p/crane_plus_control/#humble), [rosPackages.humble.crane-plus-description](https://index.ros.org/p/crane_plus_description/#humble), [rosPackages.humble.crane-plus-examples](https://index.ros.org/p/crane_plus_examples/#humble), [rosPackages.humble.crane-plus-gazebo](https://index.ros.org/p/crane_plus_gazebo/#humble), [rosPackages.humble.dolly](https://index.ros.org/p/dolly/#humble), [rosPackages.humble.dolly-gazebo](https://index.ros.org/p/dolly_gazebo/#humble), [rosPackages.humble.gazebo-dev](https://index.ros.org/p/gazebo_dev/#humble), [rosPackages.humble.gazebo-model-attachment-plugin](https://index.ros.org/p/gazebo_model_attachment_plugin/#humble), [rosPackages.humble.gazebo-no-physics-plugin](https://index.ros.org/p/gazebo_no_physics_plugin/#humble), [rosPackages.humble.gazebo-planar-move-plugin](https://index.ros.org/p/gazebo_planar_move_plugin/#humble), [rosPackages.humble.gazebo-plugins](https://index.ros.org/p/gazebo_plugins/#humble), [rosPackages.humble.gazebo-ros](https://index.ros.org/p/gazebo_ros/#humble), [rosPackages.humble.gazebo-ros-pkgs](https://index.ros.org/p/gazebo_ros_pkgs/#humble), [rosPackages.humble.gazebo-ros2-control](https://index.ros.org/p/gazebo_ros2_control/#humble), [rosPackages.humble.gazebo-ros2-control-demos](https://index.ros.org/p/gazebo_ros2_control_demos/#humble), [rosPackages.humble.gazebo-set-joint-positions-plugin](https://index.ros.org/p/gazebo_set_joint_positions_plugin/#humble), [rosPackages.humble.gazebo-video-monitor-plugins](https://index.ros.org/p/gazebo_video_monitor_plugins/#humble), [rosPackages.humble.gazebo-video-monitors](https://index.ros.org/p/gazebo_video_monitors/#humble), [rosPackages.humble.irobot-create-gazebo-bringup](https://index.ros.org/p/irobot_create_gazebo_bringup/#humble), [rosPackages.humble.irobot-create-gazebo-plugins](https://index.ros.org/p/irobot_create_gazebo_plugins/#humble), [rosPackages.humble.irobot-create-gazebo-sim](https://index.ros.org/p/irobot_create_gazebo_sim/#humble), [rosPackages.humble.kortex-bringup](https://index.ros.org/p/kortex_bringup/#humble), [rosPackages.humble.mapoi-turtlebot3-example](https://index.ros.org/p/mapoi_turtlebot3_example/#humble), [rosPackages.humble.nav2-system-tests](https://index.ros.org/p/nav2_system_tests/#humble), [rosPackages.humble.omni-base-bringup](https://index.ros.org/p/omni_base_bringup/#humble), [rosPackages.humble.omni-base-description](https://index.ros.org/p/omni_base_description/#humble), [rosPackages.humble.omni-base-robot](https://index.ros.org/p/omni_base_robot/#humble), [rosPackages.humble.open-manipulator](https://index.ros.org/p/open_manipulator/#humble), [rosPackages.humble.open-manipulator-x-bringup](https://index.ros.org/p/open_manipulator_x_bringup/#humble), [rosPackages.humble.open-manipulator-x-teleop](https://index.ros.org/p/open_manipulator_x_teleop/#humble), [rosPackages.humble.pal-gazebo-plugins](https://index.ros.org/p/pal_gazebo_plugins/#humble), [rosPackages.humble.rmf-building-sim-gz-classic-plugins](https://index.ros.org/p/rmf_building_sim_gz_classic_plugins/#humble), [rosPackages.humble.rmf-robot-sim-gz-classic-plugins](https://index.ros.org/p/rmf_robot_sim_gz_classic_plugins/#humble), [rosPackages.humble.talos-gazebo](https://index.ros.org/p/talos_gazebo/#humble), [rosPackages.humble.tiago-bringup](https://index.ros.org/p/tiago_bringup/#humble), [rosPackages.humble.tiago-description](https://index.ros.org/p/tiago_description/#humble), [rosPackages.humble.tiago-dual-bringup](https://index.ros.org/p/tiago_dual_bringup/#humble), [rosPackages.humble.tiago-dual-description](https://index.ros.org/p/tiago_dual_description/#humble), [rosPackages.humble.tiago-dual-moveit-config](https://index.ros.org/p/tiago_dual_moveit_config/#humble), [rosPackages.humble.tiago-dual-robot](https://index.ros.org/p/tiago_dual_robot/#humble), [rosPackages.humble.tiago-moveit-config](https://index.ros.org/p/tiago_moveit_config/#humble), [rosPackages.humble.tiago-pro-description](https://index.ros.org/p/tiago_pro_description/#humble), [rosPackages.humble.tiago-pro-head-gazebo](https://index.ros.org/p/tiago_pro_head_gazebo/#humble), [rosPackages.humble.tiago-pro-head-simulation](https://index.ros.org/p/tiago_pro_head_simulation/#humble), [rosPackages.humble.tiago-pro-moveit-config](https://index.ros.org/p/tiago_pro_moveit_config/#humble), [rosPackages.humble.tiago-pro-mujoco](https://index.ros.org/p/tiago_pro_mujoco/#humble), [rosPackages.humble.tiago-pro-robot](https://index.ros.org/p/tiago_pro_robot/#humble), [rosPackages.humble.tiago-robot](https://index.ros.org/p/tiago_robot/#humble), [rosPackages.humble.turtlebot3-gazebo](https://index.ros.org/p/turtlebot3_gazebo/#humble), [rosPackages.humble.turtlebot3-manipulation-gazebo](https://index.ros.org/p/turtlebot3_manipulation_gazebo/#humble), [rosPackages.humble.turtlebot3-simulations](https://index.ros.org/p/turtlebot3_simulations/#humble), [rosPackages.humble.urdf-sim-tutorial](https://index.ros.org/p/urdf_sim_tutorial/#humble), [rosPackages.humble.velodyne-gazebo-plugins](https://index.ros.org/p/velodyne_gazebo_plugins/#humble), [rosPackages.humble.velodyne-simulator](https://index.ros.org/p/velodyne_simulator/#humble) |
  | ``` error: 'cwiid' was removed because it depended on the deprecated GTK2 engine. ``` | [rosPackages.humble.wiimote](https://index.ros.org/p/wiimote/#humble), [rosPackages.jazzy.wiimote](https://index.ros.org/p/wiimote/#jazzy), [rosPackages.kilted.wiimote](https://index.ros.org/p/wiimote/#kilted), [rosPackages.lyrical.wiimote](https://index.ros.org/p/wiimote/#lyrical), [rosPackages.rolling.wiimote](https://index.ros.org/p/wiimote/#rolling) |
  | ``` error: Refusing to evaluate package 'cuda-merged-12.9' in /nix/store/ysmvzxkvfyzjix8llqsvjiwnhfl5kpyf-source/pkgs/development/cuda-modules/packages/cudatoolkit.nix:81 because it has an unfree license (‘CUDA EULA’) ``` | [rosPackages.lyrical.cuda-buffer](https://index.ros.org/p/cuda_buffer/#lyrical), [rosPackages.lyrical.cuda-buffer-backend](https://index.ros.org/p/cuda_buffer_backend/#lyrical), [rosPackages.lyrical.robot-arm-demo](https://index.ros.org/p/robot_arm_demo/#lyrical), [rosPackages.rolling.cuda-buffer](https://index.ros.org/p/cuda_buffer/#rolling), [rosPackages.rolling.cuda-buffer-backend](https://index.ros.org/p/cuda_buffer_backend/#rolling), [rosPackages.rolling.robot-arm-demo](https://index.ros.org/p/robot_arm_demo/#rolling) |
  | ``` error: Refusing to evaluate package 'ros-humble-mola-test-datasets-0.5.0-r1' in /nix/store/357hvamkij0kvcblnifp1jyccj11y10f-source/distros/humble/mola-test-datasets/default.nix:22 because it has an unfree license (‘bsd3 bsd3 unknown unknown unknown cc-by-nc-sa-40’) ``` | [rosPackages.humble.mola-test-datasets](https://index.ros.org/p/mola_test_datasets/#humble) |
  | ``` error: Refusing to evaluate package 'ros-humble-visp-3.7.0-r8' in /nix/store/357hvamkij0kvcblnifp1jyccj11y10f-source/distros/humble/visp/default.nix:22 because it has problems: ``` | [rosPackages.humble.visp](https://index.ros.org/p/visp/#humble) |
  | ``` error: Refusing to evaluate package 'ros-jazzy-mola-test-datasets-0.5.0-r1' in /nix/store/357hvamkij0kvcblnifp1jyccj11y10f-source/distros/jazzy/mola-test-datasets/default.nix:22 because it has an unfree license (‘bsd3 bsd3 unknown unknown unknown cc-by-nc-sa-40’) ``` | [rosPackages.jazzy.mola-test-datasets](https://index.ros.org/p/mola_test_datasets/#jazzy) |
  | ``` error: Refusing to evaluate package 'ros-jazzy-visp-3.7.0-r1' in /nix/store/357hvamkij0kvcblnifp1jyccj11y10f-source/distros/jazzy/visp/default.nix:22 because it has problems: ``` | [rosPackages.jazzy.visp](https://index.ros.org/p/visp/#jazzy) |
  | ``` error: Refusing to evaluate package 'ros-kilted-mola-test-datasets-0.5.0-r1' in /nix/store/357hvamkij0kvcblnifp1jyccj11y10f-source/distros/kilted/mola-test-datasets/default.nix:22 because it has an unfree license (‘bsd3 bsd3 unknown unknown unknown cc-by-nc-sa-40’) ``` | [rosPackages.kilted.mola-test-datasets](https://index.ros.org/p/mola_test_datasets/#kilted) |
  | ``` error: Refusing to evaluate package 'ros-kilted-visp-3.7.0-r7' in /nix/store/357hvamkij0kvcblnifp1jyccj11y10f-source/distros/kilted/visp/default.nix:22 because it has problems: ``` | [rosPackages.kilted.visp](https://index.ros.org/p/visp/#kilted) |
  | ``` error: Refusing to evaluate package 'ros-lyrical-mola-test-datasets-0.5.0-r1' in /nix/store/357hvamkij0kvcblnifp1jyccj11y10f-source/distros/lyrical/mola-test-datasets/default.nix:22 because it has an unfree license (‘bsd3 bsd3 unknown unknown unknown cc-by-nc-sa-40’) ``` | [rosPackages.lyrical.mola-test-datasets](https://index.ros.org/p/mola_test_datasets/#lyrical) |
  | ``` error: Refusing to evaluate package 'ros-lyrical-visp-3.7.0-r8' in /nix/store/357hvamkij0kvcblnifp1jyccj11y10f-source/distros/lyrical/visp/default.nix:22 because it has problems: ``` | [rosPackages.lyrical.visp](https://index.ros.org/p/visp/#lyrical) |
  | ``` error: Refusing to evaluate package 'ros-rolling-mola-test-datasets-0.5.0-r1' in /nix/store/357hvamkij0kvcblnifp1jyccj11y10f-source/distros/rolling/mola-test-datasets/default.nix:22 because it has an unfree license (‘bsd3 bsd3 unknown unknown unknown cc-by-nc-sa-40’) ``` | [rosPackages.rolling.mola-test-datasets](https://index.ros.org/p/mola_test_datasets/#rolling) |
  | ``` error: Refusing to evaluate package 'ros-rolling-visp-3.7.0-r7' in /nix/store/357hvamkij0kvcblnifp1jyccj11y10f-source/distros/rolling/visp/default.nix:22 because it has problems: ``` | [rosPackages.rolling.visp](https://index.ros.org/p/visp/#rolling) |
  | ``` error: attribute 'ardrone-sdk' missing ``` | [rosPackages.kilted.ardrone-sdk](https://index.ros.org/p/ardrone_sdk/#kilted) |
  | ``` error: attribute 'azure-iot-sdk-c' missing ``` | [rosPackages.lyrical.azure-iot-sdk-c](https://index.ros.org/p/azure_iot_sdk_c/#lyrical) |
  | ``` error: attribute 'cloudini-lib' missing ``` | [rosPackages.lyrical.cloudini-lib](https://index.ros.org/p/cloudini_lib/#lyrical), [rosPackages.rolling.cloudini-lib](https://index.ros.org/p/cloudini_lib/#rolling) |
  | ``` error: attribute 'fastrtps' missing ``` | [rosPackages.kilted.fastrtps](https://index.ros.org/p/fastrtps/#kilted), [rosPackages.lyrical.fastrtps](https://index.ros.org/p/fastrtps/#lyrical), [rosPackages.rolling.fastrtps](https://index.ros.org/p/fastrtps/#rolling) |
  | ``` error: attribute 'fmilibrary-vendor' missing ``` | [rosPackages.lyrical.fmilibrary-vendor](https://index.ros.org/p/fmilibrary_vendor/#lyrical), [rosPackages.rolling.fmilibrary-vendor](https://index.ros.org/p/fmilibrary_vendor/#rolling) |
  | ``` error: attribute 'gazebo-ros' missing ``` | [rosPackages.jazzy.gazebo-ros](https://index.ros.org/p/gazebo_ros/#jazzy), [rosPackages.kilted.gazebo-ros](https://index.ros.org/p/gazebo_ros/#kilted), [rosPackages.lyrical.gazebo-ros](https://index.ros.org/p/gazebo_ros/#lyrical), [rosPackages.rolling.gazebo-ros](https://index.ros.org/p/gazebo_ros/#rolling) |
  | ``` error: attribute 'gz-tools-vendor' missing ``` | [rosPackages.humble.gz-tools-vendor](https://index.ros.org/p/gz_tools_vendor/#humble) |
  | ``` error: attribute 'nose' missing ``` | [rosPackages.humble.ament-cmake-nose](https://index.ros.org/p/ament_cmake_nose/#humble) |
  | ``` error: attribute 'popf' missing ``` | [rosPackages.rolling.popf](https://index.ros.org/p/popf/#rolling) |
  | ``` error: attribute 'rtabmap-conversions' missing ``` | [rosPackages.rolling.rtabmap-conversions](https://index.ros.org/p/rtabmap_conversions/#rolling) |
  | ``` error: attribute 'rtabmap-msgs' missing ``` | [rosPackages.rolling.rtabmap-msgs](https://index.ros.org/p/rtabmap_msgs/#rolling) |
  | ``` error: attribute 'rtabmap-odom' missing ``` | [rosPackages.rolling.rtabmap-odom](https://index.ros.org/p/rtabmap_odom/#rolling) |
  | ``` error: attribute 'rtabmap-rviz-plugins' missing ``` | [rosPackages.rolling.rtabmap-rviz-plugins](https://index.ros.org/p/rtabmap_rviz_plugins/#rolling) |
  | ``` error: attribute 'rtabmap-slam' missing ``` | [rosPackages.rolling.rtabmap-slam](https://index.ros.org/p/rtabmap_slam/#rolling) |
  | ``` error: attribute 'rtabmap-sync' missing ``` | [rosPackages.rolling.rtabmap-sync](https://index.ros.org/p/rtabmap_sync/#rolling) |
  | ``` error: attribute 'rtabmap-viz' missing ``` | [rosPackages.rolling.rtabmap-viz](https://index.ros.org/p/rtabmap_viz/#rolling) |
  | ``` error: attribute 'shared-queues-vendor' missing ``` | [rosPackages.kilted.shared-queues-vendor](https://index.ros.org/p/shared_queues_vendor/#kilted), [rosPackages.lyrical.shared-queues-vendor](https://index.ros.org/p/shared_queues_vendor/#lyrical) |
  | ``` error: undefined variable 'gz-launch-vendor' ``` | examples.ros2-gz-humble |
</details>

<details>
<summary>⚠️ Still failing builds: 851</summary>


[Hydra comparison](https://hydra.iid.ciirc.cvut.cz/eval/13332?compare=13345#tabs-still-fail)
</details>

